### PR TITLE
fix(ci): private app token

### DIFF
--- a/.github/workflows/add-chart.yaml
+++ b/.github/workflows/add-chart.yaml
@@ -15,18 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.issue.labels.*.name, 'new-chart')
     steps:
-      - name: Decode the GitHub App Private Key
-        id: decode
-        run: |
-          private_key=$(echo "${{ secrets.RELEASE_APP_PEM }}" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2) &> /dev/null
-          echo "::add-mask::$private_key"
-          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ steps.decode.outputs.private-key }}
+          private-key: ${{ secrets.RELEASE_APP_PEM }}
 
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
This pull request simplifies the way the GitHub App private key is handled in the `.github/workflows/add-chart.yaml` workflow. Instead of decoding the private key manually in a separate step, the workflow now passes the secret directly to the action that needs it.

**Workflow simplification:**

* Removed the manual step for decoding the `RELEASE_APP_PEM` secret and now directly passes `secrets.RELEASE_APP_PEM` as the `private-key` input to the `actions/create-github-app-token` action, reducing complexity and potential points of failure.