### PR TITLE
fix: prevent Renovate from updating generated wrapper charts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,13 @@
   "separateMultipleMajor": true,
   "packageRules": [
     {
+      "description": "Ignore generated wrapper charts — managed by verity",
+      "matchFileNames": [
+        "charts/**"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Helm chart dependencies in root Chart.yaml",
       "matchManagers": [
         "helmv3"


### PR DESCRIPTION
## Summary
- Add `packageRules` entry to disable Renovate for all files under `charts/` — the existing `ignorePaths` alone doesn't stop the helmv3 manager from discovering and bumping dependencies in generated wrapper charts (see #9)

## Test plan
- [ ] Verify Renovate no longer modifies `charts/` files in future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)