### PR TITLE
fix: normalize chart repository URL when protocol is missing

### DIFF
--- a/.github/scripts/add-chart-dependency.sh
+++ b/.github/scripts/add-chart-dependency.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 : "${CHART_REPOSITORY:?CHART_REPOSITORY is required}"
 : "${ISSUE_NUMBER:?ISSUE_NUMBER is required}"
 
+# Normalize repository URL: prepend https:// if no protocol specified
+if [[ ! "${CHART_REPOSITORY}" =~ ^(oci|https?):// ]]; then
+  CHART_REPOSITORY="https://${CHART_REPOSITORY}"
+  echo "Normalized repository URL to: ${CHART_REPOSITORY}"
+fi
+
 # Check for duplicate
 if yq e ".dependencies[] | select(.name == strenv(CHART_NAME))" Chart.yaml | grep -q name; then
   echo "Chart ${CHART_NAME} already exists in Chart.yaml"


### PR DESCRIPTION
## Summary
- Prepend `https://` to chart repository URLs that don't include a protocol prefix (`oci://` or `https://`) in `add-chart-dependency.sh`
- Prevents Helm download failures (`could not find protocol handler for:`) when users submit the issue form without a protocol — see #17

Also pushed a fix directly to the `add-chart/victoria-logs-single` branch to unblock #17.

## Test plan
- [x] PR #17 should pass CI after the direct Chart.yaml fix
- [ ] Future issue-form submissions without a protocol prefix get auto-normalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)