### PR TITLE
fix: enable Trivy DB cache and warm Go cache on main

### DIFF
--- a/.github/workflows/patch-on-pr.yaml
+++ b/.github/workflows/patch-on-pr.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: aquasecurity/setup-trivy@v0.2.5
         with:
           version: latest
+          cache: true
 
       - name: Install Copa
         run: ./.github/scripts/install-copa.sh

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Build verity (warms Go cache for PR branches)
+        run: go build -o verity .
+
+      - name: Set up Trivy (warms DB cache for PR branches)
+        uses: aquasecurity/setup-trivy@v0.2.5
+        with:
+          version: latest
+          cache: true
+
       - name: Login to GHCR (Docker)
         uses: docker/login-action@v3.7.0
         with:

--- a/.github/workflows/scheduled-scan.yaml
+++ b/.github/workflows/scheduled-scan.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: aquasecurity/setup-trivy@v0.2.5
         with:
           version: latest
+          cache: true
 
       - name: Install Copa
         run: ./.github/scripts/install-copa.sh


### PR DESCRIPTION
## Summary
- Enable Trivy vulnerability DB caching (`cache: true`) in `patch-on-pr` and `scheduled-scan` workflows — was downloading ~500MB fresh every run
- Add `go build` step to `publish` workflow so the Go module + build cache is warm on `main` — PR branches fall back to the default branch cache

## Test plan
- [ ] Next `patch-on-pr` run should show Trivy cache restore
- [ ] Next PR build should show Go cache hit with non-trivial size

🤖 Generated with [Claude Code](https://claude.com/claude-code)