### PR TITLE
fix: use appVersion as-is instead of prepending v prefix

### DIFF
--- a/internal/scanner.go
+++ b/internal/scanner.go
@@ -74,14 +74,9 @@ func findImages(values map[string]interface{}, prefix, appVersion string) []Imag
 	var images []Image
 	walk(values, prefix, "", func(path string, img Image) {
 		img.Path = path
-		// If tag is empty and appVersion is available, use "v" + appVersion
+		// If tag is empty and appVersion is available, use it as-is
 		if img.Tag == "" && appVersion != "" {
-			// Check if appVersion already has "v" prefix
-			if strings.HasPrefix(appVersion, "v") {
-				img.Tag = appVersion
-			} else {
-				img.Tag = "v" + appVersion
-			}
+			img.Tag = appVersion
 		}
 		images = append(images, img)
 	})

--- a/internal/scanner_test.go
+++ b/internal/scanner_test.go
@@ -137,14 +137,14 @@ func TestFindImagesWithEmptyTag(t *testing.T) {
 		t.Errorf("expected image with tag from appVersion (v prefix): got %v", refs)
 	}
 
-	// Test with appVersion without "v" prefix
+	// Test with appVersion without "v" prefix — should be used as-is
 	images = findImages(values, "", "2.10.1")
 	refs = map[string]bool{}
 	for _, img := range images {
 		refs[img.Reference()] = true
 	}
-	if !refs["registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.1"] {
-		t.Errorf("expected image with tag from appVersion (no v prefix): got %v", refs)
+	if !refs["registry.k8s.io/kube-state-metrics/kube-state-metrics:2.10.1"] {
+		t.Errorf("expected image with tag from appVersion (as-is): got %v", refs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Stop prepending `v` to image tags derived from chart `appVersion` — use the value as-is
- Charts like vector use `appVersion: 0.50.0-distroless-libc` which maps directly to the Docker Hub tag; prepending `v` caused `MANIFEST_UNKNOWN` errors (see #17)

## Test plan
- [x] `go test -v ./...` — all tests pass
- [ ] PR #17 re-run should successfully pull `timberio/vector:0.50.0-distroless-libc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)