### PR TITLE
fix(ci): use runner token for pr scan

### DIFF
--- a/.github/workflows/patch-on-pr.yaml
+++ b/.github/workflows/patch-on-pr.yaml
@@ -20,16 +20,10 @@ jobs:
     # Only run on PRs from Renovate or other automation
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PEM }}
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for patching pull requests. The change replaces the use of a generated GitHub App token with the default `GITHUB_TOKEN` secret for the checkout step.

* The checkout step in `.github/workflows/patch-on-pr.yaml` now uses `${{ secrets.GITHUB_TOKEN }}` instead of a token generated by the `actions/create-github-app-token` action, simplifying authentication and reducing complexity.