### PR TITLE
Add crane installation step to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,6 +47,9 @@ jobs:
       - name: Verify patched images
         run: ./.github/scripts/verify-images.sh . ghcr.io ${{ github.repository_owner }}
 
+      - name: Install crane
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 


### PR DESCRIPTION
## Summary
Added the `crane` CLI tool installation step to the publish workflow, positioning it before the cosign installation step.

## Changes
- Install crane using the `imjasonh/setup-crane` action (v0.4) in the publish workflow
- This step is now executed after image verification and before cosign installation

## Details
The crane tool is a utility for interacting with container registries. By adding this installation step to the workflow, subsequent steps in the publish job will have access to crane commands for registry operations.

https://claude.ai/code/session_014CEai8jCUHCxC8LcAnbEB2