### PR TITLE
fix(site): prevent null charts in catalog.json when OCI is empty

### DIFF
--- a/internal/sitedata.go
+++ b/internal/sitedata.go
@@ -222,7 +222,7 @@ func discoverCharts(chartsDir, registry string) ([]SiteChart, error) {
 		return nil, err
 	}
 
-	charts := make([]SiteChart, 0)
+	charts := []SiteChart{}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -271,7 +271,7 @@ func discoverRegistryVersions(chartName, skipVersion, repository, registry strin
 
 	const maxConsecutiveFailures = 5
 
-	charts := make([]SiteChart, 0)
+	charts := []SiteChart{}
 	var consecutiveFailures int
 	for _, tag := range tags {
 		if skipVersion != "" && tag == skipVersion {


### PR DESCRIPTION
Fixes the Astro build failure when no charts exist in OCI.

## Problem
Site build fails with `Cannot read properties of null (reading 'map')` because `catalog.json` has `"charts": null`.

## Fix
Initialize all chart slices to empty arrays instead of nil:
- listChartTags: `return []string{}` when repo not found
- discoverCharts: `charts := make([]SiteChart, 0)`
- discoverRegistryVersions: `charts := make([]SiteChart, 0)`

## Testing
✅ Unit tests pass
✅ Generates `"charts": []` not `null`
✅ Astro builds successfully (11 pages)

Fixes https://github.com/descope/verity/actions/runs/22023200535