### PR TITLE
fix(ci): prevent data loss from failed patch jobs

### DIFF
--- a/.github/workflows/scan-and-patch.yaml
+++ b/.github/workflows/scan-and-patch.yaml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
-      fail-fast: false
+      fail-fast: true  # Fail entire workflow if ANY image fails to patch
     steps:
       - uses: actions/checkout@v6
         with:
@@ -234,7 +234,8 @@ jobs:
   assemble:
     name: Assemble Wrapper Charts
     needs: [discover, patch]
-    if: always() && needs.discover.outputs.has_images == 'true' && needs.patch.result != 'cancelled'
+    # Only run if ALL patch jobs succeeded - prevents data loss from failed patches
+    if: needs.discover.outputs.has_images == 'true' && needs.patch.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/internal/matrix.go
+++ b/internal/matrix.go
@@ -226,6 +226,13 @@ func PatchSingleImage(ctx context.Context, imageRef string, opts PatchOptions, r
 		return fmt.Errorf("writing result: %w", err)
 	}
 
+	// Fail if the patch operation had an error (push failure, Copa error, etc.)
+	// This ensures matrix jobs fail loudly instead of silently writing error
+	// to JSON and causing data loss in the assemble step.
+	if result.Error != nil {
+		return fmt.Errorf("patch failed for %s: %w", imageRef, result.Error)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Problem

In PR #46, `victoria-logs server.image` was **silently deleted** from values.yaml after a patch job failed.

**Root cause:** `PatchSingleImage()` always returns `nil`, even when patching fails:

```go
// internal/matrix.go:229
return nil  // ← Always success, even if result.Error != nil!
```

### What Happened (PR #46)

1. Matrix job for `victoriametrics/victoria-logs:v1.43.1` tried to patch
2. **Push failed:** `"error from registry: manifest invalid"`
3. `PatchSingleImage()` returned `nil` → job marked SUCCESS ✅
4. Assemble step ran (didn't find result for victoria-logs)
5. **Deleted image from values.yaml** (treated as "not patched") ❌

**Silent data loss!**

## Fix

**3-layer defense against data loss:**

### 1. Return error on patch failure (internal/matrix.go)
```go
if result.Error != nil {
    return fmt.Errorf("patch failed for %s: %w", imageRef, result.Error)
}
```
Matrix jobs now properly fail when patching fails.

### 2. Enable fail-fast (scan-and-patch.yaml)
```yaml
fail-fast: true  # Stop workflow on ANY patch failure
```
No wasted CI time, immediate feedback.

### 3. Strict assemble condition (scan-and-patch.yaml)
```yaml
# Before: needs.patch.result != 'cancelled' (runs on failure)
# After:  needs.patch.result == 'success' (only if ALL succeed)
```
Final safety net - won't assemble partial results.

## Before vs After

| Event | Before | After |
|-------|--------|-------|
| Patch fails | Job: ✅ Success | Job: ❌ Failed |
| Workflow | ✅ Continues | ❌ Stops |
| Assemble | ✅ Runs (partial) | ⏭️ Skipped |
| values.yaml | ❌ Corrupted | ✅ Unchanged |
| Developer | 😵 Confusion | 🔍 Investigates |

## Developer Workflow

When a patch fails, developers can:
1. **Investigate** - Check logs for root cause (manifest invalid, registry issue, etc.)
2. **Override** - Add to image overrides if base image incompatible with Copa
3. **Remove** - Temporarily remove problematic image until resolved
4. **Fix upstream** - Report issue to image maintainer

## Testing

Verified the "manifest invalid" error from PR #46 would now **fail the workflow** instead of silently deleting configuration.

Fixes:
- https://github.com/descope/verity/pull/46 (data loss)
- https://github.com/descope/verity/actions/runs/22023572272 (silent failure)

---

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>