### PR TITLE
fix(ci): correct artifact download path for v7 compatibility

### DIFF
--- a/.github/workflows/scan-and-patch.yaml
+++ b/.github/workflows/scan-and-patch.yaml
@@ -281,12 +281,12 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: verity-manifest
-          path: .verity
+          path: .
 
       - name: Use updated values.yaml from discover
         run: |
-          if [ -f .verity/values.yaml ]; then
-            cp .verity/values.yaml values.yaml
+          # values.yaml is already extracted to the correct location from artifact
+          if [ -f values.yaml ]; then
             echo "Using updated values.yaml from discover step"
           fi
 


### PR DESCRIPTION
## Problem

The workflow was failing with:
```
Assembly failed: reading manifest: open .verity/manifest.json: no such file or directory
```

This occurred after upgrading to `actions/download-artifact@v7` in commit a6eb26e.

## Root Cause

The upload step packages files with different base paths:
- `.verity/manifest.json` (subdirectory)
- `values.yaml` (root)

When `upload-artifact@v6` creates the artifact, it preserves directory structure relative to the workspace root. When `download-artifact@v7` extracted to `.verity`, this caused double-nesting:
- `.verity/.verity/manifest.json` ❌ (expected: `.verity/manifest.json`)
- `.verity/values.yaml` ❌ (expected: `values.yaml`)

## Solution

Changed the download path from `.verity` to `.` (workspace root) to match the artifact's internal structure:
- `.verity/manifest.json` ✅
- `values.yaml` ✅

Also updated the values.yaml verification step to reflect the correct extraction location.

## Testing

This fix resolves the artifact path mismatch that was introduced with the v7 upgrade. The assemble job should now correctly find the manifest file.

## Related

- Fixes workflow run: https://github.com/descope/verity/actions/runs/22035803140/job/63668502430
- Related to: #58 (download-artifact v7 upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)