### PR TITLE
fix: catalog now includes all images, not just newly patched

### DIFF
--- a/.github/scripts/copa-discover.sh
+++ b/.github/scripts/copa-discover.sh
@@ -47,3 +47,11 @@ else
   echo "has_images=false" >> "$OUTPUT_FILE"
   echo "✓ No images need patching (all up to date)"
 fi
+
+# Check if any images should appear in the catalog (WouldPatch or Skipped)
+catalog_count=$(jq '[.[] | select(.status == "WouldPatch" or .status == "Skipped")] | length' results.json)
+if [ "$catalog_count" -gt 0 ]; then
+  echo "has_catalog_images=true" >> "$OUTPUT_FILE"
+else
+  echo "has_catalog_images=false" >> "$OUTPUT_FILE"
+fi

--- a/.github/scripts/pr-summary.sh
+++ b/.github/scripts/pr-summary.sh
@@ -21,7 +21,7 @@ cat >> "$GITHUB_STEP_SUMMARY" <<EOF
 ✅ Copa matrix pipeline tested successfully
 
 **Test Registry:** \`$REGISTRY\`
-**Images Patched:** \`$IMAGE_COUNT\`
+**Images in Catalog:** \`$IMAGE_COUNT\`
 
 **Pipeline Steps Validated:**
 - ✅ Trivy scanning (parallel with server)

--- a/.github/workflows/patch-matrix.yaml
+++ b/.github/workflows/patch-matrix.yaml
@@ -38,6 +38,7 @@ jobs:
     outputs:
       matrix: ${{ steps.discover.outputs.matrix }}
       has_images: ${{ steps.discover.outputs.has_images }}
+      has_catalog_images: ${{ steps.discover.outputs.has_catalog_images }}
 
     steps:
       - uses: actions/checkout@v4
@@ -322,7 +323,7 @@ jobs:
   assemble:
     name: Generate Catalog
     needs: [scan, patch, combine]
-    if: always() && needs.scan.outputs.has_images == 'true' && needs.patch.result != 'cancelled'
+    if: always() && needs.scan.outputs.has_catalog_images == 'true' && needs.patch.result != 'cancelled'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -352,7 +353,7 @@ jobs:
           path: .
 
       - name: Generate catalog
-        run: .github/scripts/generate-catalog.sh patch-results/ reports/ "$TARGET_REGISTRY" site/src/data/catalog.json
+        run: .github/scripts/generate-catalog.sh results.json reports/ "$TARGET_REGISTRY" site/src/data/catalog.json
 
       - name: Build site
         working-directory: site

--- a/internal/sitedata.go
+++ b/internal/sitedata.go
@@ -167,11 +167,15 @@ func GenerateSiteDataFromJSON(imagesJSON, reportsDir, registry, outputPath strin
 
 		// Try to find and parse the report
 		var si SiteImage
-		if entry.Report != "" && fileExists(entry.Report) {
-			if report, err := parseTrivyReportFull(entry.Report); err == nil {
+		reportPath := entry.Report
+		if reportsDir != "" && reportPath != "" {
+			reportPath = filepath.Join(reportsDir, reportPath)
+		}
+		if reportPath != "" && fileExists(reportPath) {
+			if report, err := parseTrivyReportFull(reportPath); err == nil {
 				si = buildSiteImage(sanitizedRef, originalRef, patchedRef, "", report)
 			} else {
-				fmt.Fprintf(os.Stderr, "Warning: failed to parse Trivy report %s: %v\n", entry.Report, err)
+				fmt.Fprintf(os.Stderr, "Warning: failed to parse Trivy report %s: %v\n", reportPath, err)
 			}
 		}
 

--- a/internal/sitedata_test.go
+++ b/internal/sitedata_test.go
@@ -1,0 +1,160 @@
+package internal
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateSiteDataFromJSON_WithReportsDir(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+	reportsDir := filepath.Join(tmpDir, "reports")
+	if err := os.MkdirAll(reportsDir, 0o755); err != nil {
+		t.Fatalf("failed to create reports dir: %v", err)
+	}
+
+	// Create a sample Trivy report with one vulnerability
+	trivyReport := map[string]any{
+		"Metadata": map[string]any{
+			"OS": map[string]any{
+				"Family": "alpine",
+				"Name":   "3.18",
+			},
+		},
+		"Results": []map[string]any{
+			{
+				"Vulnerabilities": []map[string]any{
+					{
+						"VulnerabilityID":  "CVE-2024-TEST",
+						"PkgName":          "test-pkg",
+						"InstalledVersion": "1.0.0",
+						"FixedVersion":     "1.0.1",
+						"Severity":         "HIGH",
+						"Title":            "Test vulnerability",
+					},
+				},
+			},
+		},
+	}
+
+	reportPath := filepath.Join(reportsDir, "docker.io_library_nginx_1.27.3.json")
+	reportData, err := json.Marshal(trivyReport)
+	if err != nil {
+		t.Fatalf("failed to marshal report: %v", err)
+	}
+	if err := os.WriteFile(reportPath, reportData, 0o644); err != nil {
+		t.Fatalf("failed to write report: %v", err)
+	}
+
+	// Create images.json with report filename (without reports/ prefix)
+	imagesJSON := filepath.Join(tmpDir, "images.json")
+	images := []ImageEntry{
+		{
+			Original: "docker.io/library/nginx:1.27.3",
+			Patched:  "ghcr.io/verity-org/nginx:1.27.3-patched",
+			Report:   "docker.io_library_nginx_1.27.3.json",
+		},
+	}
+	imagesData, err := json.Marshal(images)
+	if err != nil {
+		t.Fatalf("failed to marshal images: %v", err)
+	}
+	if err := os.WriteFile(imagesJSON, imagesData, 0o644); err != nil {
+		t.Fatalf("failed to write images.json: %v", err)
+	}
+
+	// Generate catalog
+	outputPath := filepath.Join(tmpDir, "catalog.json")
+	err = GenerateSiteDataFromJSON(imagesJSON, reportsDir, "ghcr.io/verity-org", outputPath)
+	if err != nil {
+		t.Fatalf("GenerateSiteDataFromJSON failed: %v", err)
+	}
+
+	// Read and verify catalog
+	catalogData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read catalog: %v", err)
+	}
+
+	var catalog SiteData
+	if err := json.Unmarshal(catalogData, &catalog); err != nil {
+		t.Fatalf("failed to unmarshal catalog: %v", err)
+	}
+
+	// Verify the report was read and vulnerability data is present
+	if len(catalog.Images) != 1 {
+		t.Fatalf("expected 1 image in catalog, got %d", len(catalog.Images))
+	}
+
+	img := catalog.Images[0]
+	if img.VulnSummary.Total == 0 {
+		t.Error("expected non-zero vulnerabilities (report should have been loaded)")
+	}
+	if img.VulnSummary.Total != 1 {
+		t.Errorf("expected 1 vulnerability, got %d", img.VulnSummary.Total)
+	}
+	if len(img.Vulnerabilities) != 1 {
+		t.Errorf("expected 1 vulnerability entry, got %d", len(img.Vulnerabilities))
+	}
+	if img.OS != "alpine 3.18" {
+		t.Errorf("expected OS 'alpine 3.18', got '%s'", img.OS)
+	}
+}
+
+func TestGenerateSiteDataFromJSON_FallbackWithoutReportsDir(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+
+	// Create images.json with no report
+	imagesJSON := filepath.Join(tmpDir, "images.json")
+	images := []ImageEntry{
+		{
+			Original: "docker.io/library/nginx:1.27.3",
+			Patched:  "ghcr.io/verity-org/nginx:1.27.3-patched",
+			Report:   "",
+		},
+	}
+	imagesData, err := json.Marshal(images)
+	if err != nil {
+		t.Fatalf("failed to marshal images: %v", err)
+	}
+	if err := os.WriteFile(imagesJSON, imagesData, 0o644); err != nil {
+		t.Fatalf("failed to write images.json: %v", err)
+	}
+
+	// Generate catalog without reportsDir
+	outputPath := filepath.Join(tmpDir, "catalog.json")
+	err = GenerateSiteDataFromJSON(imagesJSON, "", "ghcr.io/verity-org", outputPath)
+	if err != nil {
+		t.Fatalf("GenerateSiteDataFromJSON failed: %v", err)
+	}
+
+	// Read and verify catalog
+	catalogData, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read catalog: %v", err)
+	}
+
+	var catalog SiteData
+	if err := json.Unmarshal(catalogData, &catalog); err != nil {
+		t.Fatalf("failed to unmarshal catalog: %v", err)
+	}
+
+	// Verify fallback to zero vulnerabilities
+	if len(catalog.Images) != 1 {
+		t.Fatalf("expected 1 image in catalog, got %d", len(catalog.Images))
+	}
+
+	img := catalog.Images[0]
+	if img.VulnSummary.Total != 0 {
+		t.Errorf("expected zero vulnerabilities (no report), got %d", img.VulnSummary.Total)
+	}
+	if img.OriginalRef != "docker.io/library/nginx:1.27.3" {
+		t.Errorf("wrong original ref: %s", img.OriginalRef)
+	}
+	if img.PatchedRef != "ghcr.io/verity-org/nginx:1.27.3-patched" {
+		t.Errorf("wrong patched ref: %s", img.PatchedRef)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the catalog generation to include **all images** on every run, not just the ones that were re-patched. Previously, when only some images needed patching, the website catalog would only show those images, dropping all previously patched images.

## Root Cause

The catalog was built from `patch-results/` which only contains images patched in the current run. Meanwhile, `results.json` (from Copa dry-run) contains ALL images with their status (`WouldPatch` / `Skipped`), and the `reports/` directory has vulnerability scan data for all images.

## Changes

### Primary Fix: Complete Catalog Generation
- **`generate-catalog.sh`**: Now reads from `results.json` (all images) instead of `patch-results/` (only newly patched)
- Includes both `WouldPatch` (newly patched) and `Skipped` (already up-to-date) images
- Simplified to use a single `jq` command instead of shell loop

### Secondary Fix: Report Path Resolution
- **`internal/sitedata.go`**: Fixed unused `reportsDir` parameter - now properly prepends it to report filenames
- Vulnerability reports are now correctly loaded from `reports/` directory
- Previously all images showed zero vulnerabilities because reports were never found

### Workflow Updates
- **`copa-discover.sh`**: Added `has_catalog_images` output to distinguish catalog generation from patching needs
- **`patch-matrix.yaml`**: 
  - Added `has_catalog_images` to scan job outputs
  - Updated assemble job condition to use `has_catalog_images`
  - Updated `generate-catalog.sh` invocation to pass `results.json`
- **`pr-summary.sh`**: Changed label from "Images Patched" to "Images in Catalog"

### Testing
- Added comprehensive unit tests in `internal/sitedata_test.go`
- Tests verify report path resolution with `reportsDir`
- Tests verify fallback to zero vulns when reports are missing
- All existing tests continue to pass

## Test Plan

- [x] Unit tests pass locally
- [x] Linting, formatting, and quality checks pass
- [ ] CI workflow runs successfully on this PR
- [ ] Verify catalog includes all images (not just patched subset)
- [ ] Verify vulnerability data is loaded correctly

## Example Scenario

**Before this fix:**
- Day 1: Patch nginx, postgres, redis → catalog has 3 images
- Day 2: Only nginx needs re-patching → catalog has **only 1 image** (postgres and redis disappear)

**After this fix:**
- Day 1: Patch nginx, postgres, redis → catalog has 3 images  
- Day 2: Only nginx needs re-patching → catalog has **all 3 images** (nginx updated, postgres and redis retained)