### PR TITLE
fix: post-patch report lookup uses patched image ref

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -93,6 +93,10 @@ var ScanCommand = &cli.Command{
 		trivyServer := c.String("trivy-server")
 		patchedOnly := c.Bool("patched-only")
 
+		if patchedOnly && targetRegistry == "" {
+			return errPatchedOnlyNeedsTarget
+		}
+
 		// Read and parse copa-config.yaml
 		yamlFile, err := os.ReadFile(configPath)
 		if err != nil {
@@ -248,7 +252,10 @@ func sanitizeFilename(filename string) string {
 	return filename
 }
 
-var errUnknownStrategy = errors.New("unknown tag strategy")
+var (
+	errUnknownStrategy        = errors.New("unknown tag strategy")
+	errPatchedOnlyNeedsTarget = errors.New("--patched-only requires --target-registry to be set")
+)
 
 // findTagsToPatch discovers tags for an image (reused from discover logic).
 func findTagsToPatch(spec *ImageSpec) ([]string, error) {

--- a/internal/sitedata.go
+++ b/internal/sitedata.go
@@ -133,9 +133,12 @@ func GenerateSiteDataFromJSON(imagesJSON, reportsDir, postReportsDir, registry, 
 			}
 		}
 
-		// Post-patch report — sets AfterVulns + remaining Vulnerabilities
-		if postReportsDir != "" && entry.Report != "" {
-			applyPostPatchReport(&si, filepath.Join(postReportsDir, entry.Report))
+		// Post-patch report — sets AfterVulns + remaining Vulnerabilities.
+		// The post-scan job scans the patched image ref, so the report filename
+		// is derived from patchedRef, not the source report name.
+		if postReportsDir != "" && patchedRef != "" {
+			postReportName := sanitize(patchedRef) + ".json"
+			applyPostPatchReport(&si, filepath.Join(postReportsDir, postReportName))
 		}
 
 		allImages = append(allImages, si)

--- a/internal/sitedata_test.go
+++ b/internal/sitedata_test.go
@@ -111,7 +111,9 @@ func TestGenerateSiteDataFromJSON_BeforeAfter(t *testing.T) {
 		}
 	}
 
-	reportName := "docker.io_library_nginx_1.27.3.json"
+	// Pre-patch report named after source ref; post-patch report named after patched ref.
+	preReportName := "docker.io_library_nginx_1.27.3.json"
+	postReportName := "ghcr.io_verity-org_nginx_1.27.3-patched.json" // sanitize("ghcr.io/verity-org/nginx:1.27.3-patched")
 
 	// Pre-patch: 3 vulns
 	preReport := map[string]any{
@@ -135,17 +137,18 @@ func TestGenerateSiteDataFromJSON_BeforeAfter(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		dir  string
-		data any
+		dir      string
+		data     any
+		filename string
 	}{
-		{preDir, preReport},
-		{postDir, postReport},
+		{preDir, preReport, preReportName},
+		{postDir, postReport, postReportName},
 	} {
 		d, err := json.Marshal(tc.data)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(tc.dir, reportName), d, 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(tc.dir, tc.filename), d, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -154,7 +157,7 @@ func TestGenerateSiteDataFromJSON_BeforeAfter(t *testing.T) {
 	images := []ImageEntry{{
 		Original: "docker.io/library/nginx:1.27.3",
 		Patched:  "ghcr.io/verity-org/nginx:1.27.3-patched",
-		Report:   reportName,
+		Report:   preReportName,
 	}}
 	d, err := json.Marshal(images)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Root cause**: `sitedata.go` was looking for post-patch Trivy reports using `entry.Report` (the *source* image filename, e.g. `ghcr.io_kiwigrid_k8s-sidecar_2.5.0.json`), but the `post-scan` job scans the *patched* image, so reports are named after the patched ref (e.g. `ghcr.io_verity-org_kiwigrid_k8s-sidecar_2.5.0-patched.json`). The lookup always missed, leaving `afterVulns` at zero and the "Remaining vulnerabilities" section empty on every image page.
- **Fix**: derive post-patch report filename from `sanitize(patchedRef) + ".json"` instead of `entry.Report`
- **Also**: add `--patched-only` validation requiring `--target-registry`, and fix test to use separate pre/post report filenames matching production behaviour

## Test plan

- [ ] Trigger workflow manually and confirm `post-scan` artifacts contain reports named after patched refs
- [ ] Confirm image pages with unfixable vulns (e.g. k8s-sidecar Python pkgs) now show "Remaining vulnerabilities" section
- [ ] Confirm images with 0 remaining vulns still show clean state