### PR TITLE
ci: deploy site on workflow_dispatch as well as push

### DIFF
--- a/.github/workflows/patch-matrix.yaml
+++ b/.github/workflows/patch-matrix.yaml
@@ -461,7 +461,7 @@ jobs:
   deploy-site:
     name: Deploy Site
     needs: assemble
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     environment:
       name: github-pages


### PR DESCRIPTION
This pull request makes a small but important update to the deployment workflow, allowing the site to be deployed not only on `push` events but also when triggered manually via `workflow_dispatch`.

- Deployment workflow update:
  * [`.github/workflows/patch-matrix.yaml`](diffhunk://#diff-8275cdf1f8307b6a7e74a93a099c861fdf3ca5819df7f99ae877c69194c09b3dL464-R464): Modified the `deploy-site` job to run on both `push` and `workflow_dispatch` events, enabling manual deployments in addition to automatic ones.