### PR TITLE
feat: split remaining vulns by fix availability on image detail pages

### DIFF
--- a/site/src/pages/images/[id].astro
+++ b/site/src/pages/images/[id].astro
@@ -133,8 +133,8 @@ const awaitingFixVulns = image.vulnerabilities.filter((v) => !v.fixedVersion);
           Fix available — pending patch
         </h2>
         <p class="text-sm text-verity-text-muted mb-3">
-          These vulnerabilities have upstream fixes but could not be automatically patched.
-          Manual remediation may be required.
+          These vulnerabilities have upstream fixes but could not be automatically patched. Manual
+          remediation may be required.
         </p>
         <VulnTable vulnerabilities={pendingVulns} />
       </section>


### PR DESCRIPTION
## Summary

- Splits the \"Remaining vulnerabilities\" section into two distinct groups:
  - **Fix available — pending patch**: upstream fix exists but Copa could not automatically apply it; manual remediation may be required
  - **Awaiting upstream fix**: no upstream fix released yet; can be suppressed in compliance tooling until a patch ships
- Removes the venv-specific example from the pending patch description now that Copa handles virtual environment packages automatically

## Test plan

- [ ] Verify image pages with remaining vulns (e.g. k8s-sidecar) show two separate sections after next workflow run
- [ ] Verify images with no remaining vulns show neither section
- [ ] Verify images where all remaining vulns have no fix only show the \"Awaiting upstream fix\" section
- [ ] Verify images where all remaining vulns have a fix only show the \"Fix available\" section