### PR TITLE
fix: prefer versioned -patched-N over bare -patched

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -269,7 +269,7 @@ func scanImage(imageRef, outputFile string, isPatched bool, trivyServer string) 
 
 // latestPatchedTagFromList finds the highest-versioned patched tag matching
 // "<sourceTag>-patched" or "<sourceTag>-patched-N" from a list of tags.
-// The bare "-patched" suffix counts as version 1.
+// The bare "-patched" suffix counts as version 0; explicitly numbered tags start at 1.
 //
 // Copa's verity fork automatically increments the patch counter on each run:
 // first patch → <tag>-patched, second → <tag>-patched-2, third → <tag>-patched-3, etc.
@@ -278,14 +278,14 @@ func latestPatchedTagFromList(tags []string, sourceTag string) string {
 	base := regexp.QuoteMeta(sourceTag) + `-patched`
 	pattern := regexp.MustCompile(`^` + base + `(-(\d+))?$`)
 
-	bestN := 0
+	bestN := -1
 	bestTag := ""
 	for _, t := range tags {
 		m := pattern.FindStringSubmatch(t)
 		if m == nil {
 			continue
 		}
-		n := 1
+		n := 0
 		if m[2] != "" {
 			parsed, err := strconv.Atoi(m[2])
 			if err != nil {

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -52,10 +52,16 @@ func TestLatestPatchedTagFromList(t *testing.T) {
 			want:      "1.29.3-patched-2",
 		},
 		{
-			name:      "explicit -patched-1 treated same as bare -patched",
+			name:      "highest numbered wins among explicit versions",
 			tags:      []string{"1.29.3-patched-1", "1.29.3-patched-2"},
 			sourceTag: "1.29.3",
 			want:      "1.29.3-patched-2",
+		},
+		{
+			name:      "explicit -patched-1 beats bare -patched",
+			tags:      []string{"2.5.0-patched", "2.5.0-patched-1"},
+			sourceTag: "2.5.0",
+			want:      "2.5.0-patched-1",
 		},
 		{
 			name:      "unparseable patch number skipped",


### PR DESCRIPTION
This pull request updates the logic for identifying the highest-versioned patched tag in image scanning, clarifying the patch numbering scheme and adjusting the implementation and tests accordingly. The main change is that the bare `-patched` suffix now counts as version 0, and explicitly numbered tags (e.g., `-patched-1`) start at 1 and take precedence over the bare suffix.

Patch tag versioning logic:

* The comment in `scan.go` was updated to clarify that the bare `-patched` suffix counts as version 0, while explicitly numbered tags start at 1.
* The implementation in `latestPatchedTagFromList` was changed so that the bare `-patched` is treated as version 0, and the highest numbered tag is selected, even if it is `-patched-1`.

Test coverage:

* The test suite was updated to reflect the new logic, including a new test case confirming that `-patched-1` beats the bare `-patched` suffix.