### PR TITLE
feat: major library patching

### DIFF
--- a/.github/scripts/copa-discover.sh
+++ b/.github/scripts/copa-discover.sh
@@ -13,7 +13,7 @@ COPA_EXPERIMENTAL=1 copa patch \
   --config "$CONFIG_FILE" \
   --report "$REPORTS_DIR" \
   --pkg-types os,library \
-  --library-patch-level minor \
+  --library-patch-level major \
   --dry-run \
   --output-json results.json
 

--- a/.github/workflows/patch-matrix.yaml
+++ b/.github/workflows/patch-matrix.yaml
@@ -248,13 +248,13 @@ jobs:
           # Copa will patch the native platform of this runner (amd64 or arm64)
           # BuildKit configured with GHCR credentials to push
           # --pkg-types os,library patches both OS packages and app-level deps (pip, npm)
-          # --library-patch-level minor allows minor version bumps for library fixes
+          # --library-patch-level major allows major version bumps for library fixes (patch everything)
           copa patch \
             --image "${{ matrix.source }}" \
             --tag "$PLATFORM_TAG" \
             --report "$REPORT_FILE" \
             --pkg-types os,library \
-            --library-patch-level minor \
+            --library-patch-level major \
             --push \
             --addr buildx://copa-builder \
             --timeout 30m


### PR DESCRIPTION
This pull request updates the patching strategy in the Copa workflow to allow for major version upgrades of libraries, rather than limiting updates to minor versions. This change will enable broader and potentially more impactful dependency updates during patching.

**Patch strategy changes:**

* Updated the `copa patch` command in both `.github/scripts/copa-discover.sh` and `.github/workflows/patch-matrix.yaml` to use `--library-patch-level major`, allowing major version upgrades for library dependencies instead of only minor version bumps. [[1]](diffhunk://#diff-268efa96ae49725b07d09b97200fc12e2cfab446b3e84475051ec66002bc3459L16-R16) [[2]](diffhunk://#diff-8275cdf1f8307b6a7e74a93a099c861fdf3ca5819df7f99ae877c69194c09b3dL251-R257)