### PR TITLE
fix(ci): patch-image attest subject-name and run-name

### DIFF
--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -1,4 +1,5 @@
 name: Patch Image
+run-name: "Patch ${{ inputs.image-name }} (${{ inputs.source-ref }})"
 
 # Reusable per-image lifecycle: scan → patch (matrix) → finalize.
 # Supports both workflow_call (PR inline) and workflow_dispatch (orchestrator).


### PR DESCRIPTION
# User description
## Summary

- **Fix `actions/attest` invalid image name error** — `subject-name` must be the repository name without a tag when `subject-digest` is also provided. Previously passing `ghcr.io/verity-org/nginx:1.29.3-patched` caused `Error: Invalid image name`. Now passes `ghcr.io/verity-org/nginx` (tag-less `FINAL_REPO`) and keeps `FINAL_TAG` for cosign signing and syft SBOM steps.
- **Add `run-name` to distinguish concurrent runs** — `patch-image.yaml` now shows `Patch nginx (mirror.gcr.io/library/nginx:1.29.3)` in the Actions run list instead of a wall of identical "Patch Image" entries.

## Test plan

- [ ] Trigger `patch-image.yaml` manually and confirm the Attest SBOM step completes without "Invalid image name"
- [ ] Confirm run list shows `Patch <name> (<source-ref>)` for each dispatched run

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes an invalid image name error in the attestation step by separating the repository name from the tag and improves the visibility of concurrent workflow runs. Updates the <code>patch-image.yaml</code> workflow to use a tag-less repository name for <code>actions/attest</code> and adds a dynamic <code>run-name</code> for better identification.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/verity-org/verity/112?tool=ast&topic=Workflow+UX>Workflow UX</a>
        </td><td>Implements a dynamic <code>run-name</code> in the workflow definition to distinguish between different image patching runs in the GitHub Actions dashboard.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/patch-image.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>omercnet</td><td>feat-scale-decompose-m...</td><td>February 28, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/verity-org/verity/112?tool=ast&topic=Attestation+Fix>Attestation Fix</a>
        </td><td>Resolves an <code>Error: Invalid image name</code> by passing the tag-less <code>FINAL_REPO</code> to the <code>subject-name</code> input of the <code>actions/attest</code> action.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/patch-image.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>omercnet</td><td>feat-scale-decompose-m...</td><td>February 28, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/verity-org/verity/112?tool=ast>(Baz)</a>.