### PR TITLE
Revert "chore(ci): update mise tools"

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,22 +1,22 @@
 [tools]
 # Core tools
-go = "1.26.0"
+go = "1.25.7"
 node = { version = "24.14.0", postinstall = "corepack enable" }
 crane = "0.21.0"
 claude-code = {version = "2.1.59", os = ["darwin"]}
 
 # Security & container tools (used in patch-matrix.yaml)
-trivy = "0.69.1"
+trivy = "0.68.2"
 cosign = "2.6.2"
 syft = "1.21.0"
 
 # Go tools (pinned for reproducibility)
-"go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint" = "2.10.1"
+"go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint" = "2.9.0"
 "go:mvdan.cc/gofumpt" = "0.9.2"
 "go:golang.org/x/vuln/cmd/govulncheck" = "1.1.4"
 
 # Linting tools (pinned for reproducibility)
-yq = "4.52.4"
+yq = "4.47.1"
 actionlint = "1.7.11"
 shellcheck = "0.11.0"
 yamllint = "1.38.0"


### PR DESCRIPTION
# User description
Reverts verity-org/verity#115

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Reverts recent updates to development and CI tools within the <code>mise.toml</code> configuration to restore previous stable versions. Adjusts the versions for Go, Trivy, golangci-lint, and yq to ensure environment consistency across the project.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>renovate[bot]</td><td>chore-ci-update-mise-t...</td><td>March 01, 2026</td></tr>
<tr><td>omercnet</td><td>chore-ci-optimize-GitH...</td><td>February 27, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/verity-org/verity/125?tool=ast>(Baz)</a>.