### PR TITLE
feat: enable Go binary patching + Copa regression test matrix

### DIFF
--- a/.github/actions/setup-binaries/action.yml
+++ b/.github/actions/setup-binaries/action.yml
@@ -1,5 +1,5 @@
 name: Setup Binaries
-description: Install Copa and Verity with cache and artifact fallback
+description: Install Copa and Verity with cache fallback to build-from-source
 
 inputs:
   github-token:
@@ -47,17 +47,8 @@ runs:
         path: ${{ steps.gopath.outputs.path }}/bin/copa
         key: copa-${{ runner.os }}-${{ runner.arch }}-${{ steps.copa-hash.outputs.hash }}
 
-    - name: Download Copa artifact
-      if: steps.copa-cache.outputs.cache-hit != 'true'
-      id: copa-artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      continue-on-error: true
-      with:
-        name: copa-binary-${{ runner.arch }}-${{ steps.copa-hash.outputs.hash }}
-        path: ${{ steps.gopath.outputs.path }}/bin/
-
     - name: Build Copa from source
-      if: steps.copa-cache.outputs.cache-hit != 'true' && steps.copa-artifact.outcome == 'failure'
+      if: steps.copa-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         echo "Building Copa from commit: ${{ steps.copa-hash.outputs.hash }}"
@@ -74,18 +65,8 @@ runs:
       shell: bash
       run: chmod +x "$(go env GOPATH)/bin/copa"
 
-    - name: Upload Copa artifact
-      if: steps.copa-cache.outputs.cache-hit != 'true' && steps.copa-artifact.outcome == 'failure'
-      continue-on-error: true
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: copa-binary-${{ runner.arch }}-${{ steps.copa-hash.outputs.hash }}
-        path: ${{ steps.gopath.outputs.path }}/bin/copa
-        retention-days: 7
-        overwrite: true
-
     - name: Save Copa to cache
-      if: steps.copa-cache.outputs.cache-hit != 'true' && steps.copa-artifact.outcome == 'failure'
+      if: steps.copa-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ steps.gopath.outputs.path }}/bin/copa
@@ -107,17 +88,8 @@ runs:
         path: ./verity
         key: verity-${{ runner.os }}-${{ runner.arch }}-${{ steps.verity-version.outputs.version }}
 
-    - name: Download Verity artifact
-      if: steps.verity-cache.outputs.cache-hit != 'true'
-      id: verity-artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      continue-on-error: true
-      with:
-        name: verity-binary-${{ runner.arch }}-${{ steps.verity-version.outputs.version }}
-        path: .
-
     - name: Build Verity from source
-      if: steps.verity-cache.outputs.cache-hit != 'true' && steps.verity-artifact.outcome == 'failure'
+      if: steps.verity-cache.outputs.cache-hit != 'true'
       shell: bash
       run: go build -o verity .
 
@@ -126,18 +98,8 @@ runs:
       shell: bash
       run: chmod +x verity
 
-    - name: Upload Verity artifact
-      if: steps.verity-cache.outputs.cache-hit != 'true' && steps.verity-artifact.outcome == 'failure'
-      continue-on-error: true
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: verity-binary-${{ runner.arch }}-${{ steps.verity-version.outputs.version }}
-        path: verity
-        retention-days: 7
-        overwrite: true
-
     - name: Save Verity to cache
-      if: steps.verity-cache.outputs.cache-hit != 'true' && steps.verity-artifact.outcome == 'failure'
+      if: steps.verity-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ./verity

--- a/.github/scripts/patch-image.sh
+++ b/.github/scripts/patch-image.sh
@@ -36,6 +36,7 @@ copa patch \
   --report "$REPORT_FILE" \
   --pkg-types os,library \
   --library-patch-level major \
+  --toolchain-patch-level patch \
   --push \
   --addr buildx://copa-builder \
   --timeout 30m 2>&1 | tee "$COPA_LOG"

--- a/.github/scripts/patch-image.sh
+++ b/.github/scripts/patch-image.sh
@@ -37,6 +37,7 @@ copa patch \
   --pkg-types os,library \
   --library-patch-level major \
   --toolchain-patch-level patch \
+  ${GO_VCS_URL:+--go-vcs-url "$GO_VCS_URL"} \
   --push \
   --addr buildx://copa-builder \
   --timeout 30m 2>&1 | tee "$COPA_LOG"

--- a/.github/scripts/patch-image.sh
+++ b/.github/scripts/patch-image.sh
@@ -30,17 +30,21 @@ echo "Using report file: $REPORT_FILE"
 # --library-patch-level major allows major version bumps for library fixes
 COPA_LOG=$(mktemp)
 set +e
-copa patch \
-  --image "$SOURCE" \
-  --tag "$PLATFORM_TAG" \
-  --report "$REPORT_FILE" \
-  --pkg-types os,library \
-  --library-patch-level major \
-  --toolchain-patch-level patch \
-  ${GO_VCS_URL:+--go-vcs-url "$GO_VCS_URL"} \
-  --push \
-  --addr buildx://copa-builder \
-  --timeout 30m 2>&1 | tee "$COPA_LOG"
+COPA_ARGS=(
+  --image "$SOURCE"
+  --tag "$PLATFORM_TAG"
+  --report "$REPORT_FILE"
+  --pkg-types os,library
+  --library-patch-level major
+  --toolchain-patch-level patch
+  --push
+  --addr buildx://copa-builder
+  --timeout 30m
+)
+if [ -n "${GO_VCS_URL:-}" ]; then
+  COPA_ARGS+=(--go-vcs-url "$GO_VCS_URL")
+fi
+copa patch "${COPA_ARGS[@]}" 2>&1 | tee "$COPA_LOG"
 COPA_EXIT=${PIPESTATUS[0]}
 set -e
 

--- a/.github/scripts/patch-image.sh
+++ b/.github/scripts/patch-image.sh
@@ -34,7 +34,7 @@ COPA_ARGS=(
   --image "$SOURCE"
   --tag "$PLATFORM_TAG"
   --report "$REPORT_FILE"
-  --pkg-types os,library
+  --pkg-types "os,library"
   --library-patch-level major
   --toolchain-patch-level patch
   --push

--- a/.github/scripts/read-catalog-entry.sh
+++ b/.github/scripts/read-catalog-entry.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reads image URL and goVcsUrl from copa-config.yaml for a given image name + tag.
+# Inputs: IMAGE_NAME, IMAGE_TAG (env vars)
+# Outputs: source, go_vcs_url (via GITHUB_OUTPUT)
+
+: "${IMAGE_NAME:?IMAGE_NAME is required}"
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+
+IMAGE=$(yq ".images[] | select(.name == \"${IMAGE_NAME}\") | .image" copa-config.yaml)
+VCS_URL=$(yq ".images[] | select(.name == \"${IMAGE_NAME}\") | .goVcsUrl // \"\"" copa-config.yaml)
+
+if [ -n "$VCS_URL" ] && [ "$VCS_URL" != "null" ]; then
+  VCS_URL="${VCS_URL}@${IMAGE_TAG}"
+else
+  VCS_URL=""
+fi
+
+SOURCE="${IMAGE}:${IMAGE_TAG}"
+echo "source=${SOURCE}" >> "$GITHUB_OUTPUT"
+echo "go_vcs_url=${VCS_URL}" >> "$GITHUB_OUTPUT"
+echo "Catalog: image=${IMAGE} tag=${IMAGE_TAG} goVcsUrl=${VCS_URL}"

--- a/.github/scripts/scan-before.sh
+++ b/.github/scripts/scan-before.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scans an image for vulnerabilities before patching.
+# Inputs: SOURCE (env var) — full image reference
+# Outputs: before_total, before_go, before_os (via GITHUB_ENV), before.json
+
+: "${SOURCE:?SOURCE is required}"
+
+trivy image \
+  --severity CRITICAL,HIGH,MEDIUM,LOW \
+  --scanners vuln \
+  --format json \
+  --output before.json \
+  "$SOURCE"
+
+TOTAL=$(jq '[.Results[]? | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
+GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
+OS=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
+
+{
+  echo "before_total=${TOTAL}"
+  echo "before_go=${GO}"
+  echo "before_os=${OS}"
+} >> "$GITHUB_ENV"
+
+echo "BEFORE — total: ${TOTAL}, os: ${OS}, go: ${GO}"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "::warning::No vulns found — image may have been patched upstream"
+  echo "skip_patch=true" >> "$GITHUB_ENV"
+fi

--- a/.github/scripts/verify-patched.sh
+++ b/.github/scripts/verify-patched.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scans a patched image and verifies 0 fixable CVEs remain.
+# Inputs: PATCHED_IMAGE, IMAGE_LABEL (env vars), before_total/before_go/before_os (from GITHUB_ENV)
+# Outputs: after.json, exit 1 if fixable CVEs remain
+
+: "${PATCHED_IMAGE:?PATCHED_IMAGE is required}"
+: "${IMAGE_LABEL:?IMAGE_LABEL is required}"
+
+trivy image \
+  --severity CRITICAL,HIGH,MEDIUM,LOW \
+  --ignore-unfixed \
+  --scanners vuln \
+  --format json \
+  --output after.json \
+  "$PATCHED_IMAGE"
+
+TOTAL=$(jq '[.Results[]? | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
+GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
+OS=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
+
+{
+  echo ""
+  echo "══════════════════════════════════════════════"
+  echo "  ${IMAGE_LABEL}"
+  echo "──────────────────────────────────────────────"
+  echo "  BEFORE:  ${before_total} total (${before_os} OS, ${before_go} Go)"
+  echo "  AFTER:   ${TOTAL} total (${OS} OS, ${GO} Go) [fixable only]"
+  echo "  FIXED:   $((before_total - TOTAL)) total"
+  echo "══════════════════════════════════════════════"
+}
+
+if [ "$TOTAL" -ne 0 ]; then
+  echo "::error::Copa left ${TOTAL} fixable CVEs unpatched for ${IMAGE_LABEL} (${OS} OS, ${GO} Go)"
+  exit 1
+fi

--- a/.github/scripts/verify-patched.sh
+++ b/.github/scripts/verify-patched.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2154 # before_total/before_go/before_os come from GITHUB_ENV
 set -euo pipefail
 
-# before_total, before_go, before_os are set by scan-before.sh via GITHUB_ENV
-# shellcheck disable=SC2154
+# Scans a patched image and verifies 0 fixable CVEs remain.
 # Scans a patched image and verifies 0 fixable CVEs remain.
 # Inputs: PATCHED_IMAGE, IMAGE_LABEL (env vars), before_total/before_go/before_os (from GITHUB_ENV)
 # Outputs: after.json, exit 1 if fixable CVEs remain

--- a/.github/scripts/verify-patched.sh
+++ b/.github/scripts/verify-patched.sh
@@ -21,6 +21,8 @@ GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) |
 OS=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
 
 {
+# These vars are set by scan-before.sh via GITHUB_ENV
+# shellcheck disable=SC2154
   echo ""
   echo "══════════════════════════════════════════════"
   echo "  ${IMAGE_LABEL}"

--- a/.github/scripts/verify-patched.sh
+++ b/.github/scripts/verify-patched.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# before_total, before_go, before_os are set by scan-before.sh via GITHUB_ENV
+# shellcheck disable=SC2154
 # Scans a patched image and verifies 0 fixable CVEs remain.
 # Inputs: PATCHED_IMAGE, IMAGE_LABEL (env vars), before_total/before_go/before_os (from GITHUB_ENV)
 # Outputs: after.json, exit 1 if fixable CVEs remain
@@ -21,8 +23,6 @@ GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) |
 OS=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
 
 {
-# These vars are set by scan-before.sh via GITHUB_ENV
-# shellcheck disable=SC2154
   echo ""
   echo "══════════════════════════════════════════════"
   echo "  ${IMAGE_LABEL}"

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -413,8 +413,10 @@ jobs:
             tag: "8.0.2"
           - name: library/rabbitmq
             tag: "4.1.0"
-          - name: cockroachdb/cockroach
-            tag: v25.2.3
+          - name: prometheus/prometheus
+            tag: v3.4.0
+          - name: kiwigrid/k8s-sidecar
+            tag: "1.30.4"
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -553,7 +555,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "copa-regression-${{ matrix.name }}"
+          name: "copa-regression-${{ matrix.tag }}"
           path: |
             before.json
             after.json

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -395,8 +395,10 @@ jobs:
           retention-days: 7
 
   # ── Copa patching regression tests ──────────────────────────────────
+  # Matrix lists catalog image names + pinned tags.
+  # Image URL and goVcsUrl are read from copa-config.yaml at runtime.
   copa-patching-regression:
-    name: "Copa Patch: ${{ matrix.name }} [${{ matrix.type }}]"
+    name: "Copa Patch: ${{ matrix.name }}:${{ matrix.tag }}"
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -405,19 +407,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: victoria-logs
-            image: docker.io/victoriametrics/victoria-logs:v1.45.0
-            type: apk + gobinary + stdlib
-            go_vcs_url: https://github.com/VictoriaMetrics/VictoriaLogs@v1.45.0
-          - name: redis
-            image: docker.io/library/redis:8.0.2
-            type: dpkg (Debian)
-          - name: rabbitmq
-            image: mirror.gcr.io/library/rabbitmq:4.1.0
-            type: dpkg (Ubuntu)
-          - name: cockroachdb
-            image: mirror.gcr.io/cockroachdb/cockroach:v25.2.3
-            type: rpm + gobinary (RHEL)
+          - name: victoriametrics/victoria-logs
+            tag: v1.45.0
+          - name: library/redis
+            tag: "8.0.2"
+          - name: library/rabbitmq
+            tag: "4.1.0"
+          - name: cockroachdb/cockroach
+            tag: v25.2.3
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -441,6 +438,21 @@ jobs:
             ~/.cache/go-build
           key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: go-${{ runner.os }}-
+
+      - name: Read catalog entry
+        id: catalog
+        run: |
+          IMAGE=$(yq '.images[] | select(.name == "${{ matrix.name }}") | .image' copa-config.yaml)
+          VCS_URL=$(yq '.images[] | select(.name == "${{ matrix.name }}") | .goVcsUrl // ""' copa-config.yaml)
+          if [ -n "$VCS_URL" ] && [ "$VCS_URL" != "null" ]; then
+            VCS_URL="${VCS_URL}@${{ matrix.tag }}"
+          else
+            VCS_URL=""
+          fi
+          SOURCE="${IMAGE}:${{ matrix.tag }}"
+          echo "source=${SOURCE}" >> "$GITHUB_OUTPUT"
+          echo "go_vcs_url=${VCS_URL}" >> "$GITHUB_OUTPUT"
+          echo "Catalog: image=${IMAGE} tag=${{ matrix.tag }} goVcsUrl=${VCS_URL}"
 
       - name: Setup Copa and Verity
         uses: ./.github/actions/setup-binaries
@@ -467,7 +479,7 @@ jobs:
             --scanners vuln \
             --format json \
             --output before.json \
-            "${{ matrix.image }}"
+            "${{ steps.catalog.outputs.source }}"
 
           TOTAL=$(jq '[.Results[]? | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
           GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
@@ -488,24 +500,24 @@ jobs:
         if: env.skip_patch != 'true'
         run: |
           mkdir -p reports
-          REPORT_NAME=$(echo "${{ matrix.image }}" | sed 's/[\/:]/_/g')
+          REPORT_NAME=$(echo "${{ steps.catalog.outputs.source }}" | sed 's/[\/:]/_/g')
           cp before.json "reports/${REPORT_NAME}.json"
 
-      - name: Patch image with patch-image.sh
+      - name: Patch image
         if: env.skip_patch != 'true'
         env:
           COPA_EXPERIMENTAL: "1"
           PLATFORM: linux/amd64
-          SOURCE: ${{ matrix.image }}
+          SOURCE: ${{ steps.catalog.outputs.source }}
           IMAGE_NAME: ${{ matrix.name }}
           STAGING_REGISTRY: localhost:5000/regression
-          GO_VCS_URL: ${{ matrix.go_vcs_url }}
+          GO_VCS_URL: ${{ steps.catalog.outputs.go_vcs_url }}
         run: ./.github/scripts/patch-image.sh
 
-      - name: Scan image (after patching)
+      - name: Verify patched image is clean
         if: env.skip_patch != 'true'
         run: |
-          SOURCE_TAG=$(echo "${{ matrix.image }}" | cut -d: -f2)
+          SOURCE_TAG="${{ matrix.tag }}"
           SAFE_IMAGE=$(echo "${{ matrix.name }}" | tr '/: ' '---')
           PATCHED="localhost:5000/regression:${SAFE_IMAGE}-${SOURCE_TAG}-amd64"
 
@@ -524,7 +536,7 @@ jobs:
           {
             echo ""
             echo "══════════════════════════════════════════════"
-            echo "  ${{ matrix.name }} (${{ matrix.type }})"
+            echo "  ${{ matrix.name }}:${{ matrix.tag }}"
             echo "──────────────────────────────────────────────"
             echo "  BEFORE:  ${before_total} total (${before_os} OS, ${before_go} Go)"
             echo "  AFTER:   ${TOTAL} total (${OS} OS, ${GO} Go) [fixable only]"
@@ -533,7 +545,7 @@ jobs:
           }
 
           if [ "$TOTAL" -ne 0 ]; then
-            echo "::error::Copa left ${TOTAL} fixable CVEs unpatched for ${{ matrix.name }} (${OS} OS, ${GO} Go)"
+            echo "::error::Copa left ${TOTAL} fixable CVEs unpatched for ${{ matrix.name }}:${{ matrix.tag }} (${OS} OS, ${GO} Go)"
             exit 1
           fi
 

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -413,8 +413,6 @@ jobs:
             tag: "8.0.2"
           - name: library/rabbitmq
             tag: "4.1.0"
-          - name: prometheus/prometheus
-            tag: v3.4.0
           - name: kiwigrid/k8s-sidecar
             tag: "1.30.4"
 

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -443,18 +443,10 @@ jobs:
 
       - name: Read catalog entry
         id: catalog
-        run: |
-          IMAGE=$(yq '.images[] | select(.name == "${{ matrix.name }}") | .image' copa-config.yaml)
-          VCS_URL=$(yq '.images[] | select(.name == "${{ matrix.name }}") | .goVcsUrl // ""' copa-config.yaml)
-          if [ -n "$VCS_URL" ] && [ "$VCS_URL" != "null" ]; then
-            VCS_URL="${VCS_URL}@${{ matrix.tag }}"
-          else
-            VCS_URL=""
-          fi
-          SOURCE="${IMAGE}:${{ matrix.tag }}"
-          echo "source=${SOURCE}" >> "$GITHUB_OUTPUT"
-          echo "go_vcs_url=${VCS_URL}" >> "$GITHUB_OUTPUT"
-          echo "Catalog: image=${IMAGE} tag=${{ matrix.tag }} goVcsUrl=${VCS_URL}"
+        env:
+          IMAGE_NAME: ${{ matrix.name }}
+          IMAGE_TAG: ${{ matrix.tag }}
+        run: ./.github/scripts/read-catalog-entry.sh
 
       - name: Setup Copa and Verity
         uses: ./.github/actions/setup-binaries
@@ -475,28 +467,9 @@ jobs:
         run: docker run -d -p 5000:5000 --name registry registry:2
 
       - name: Scan image (before patching)
-        run: |
-          trivy image \
-            --severity CRITICAL,HIGH,MEDIUM,LOW \
-            --scanners vuln \
-            --format json \
-            --output before.json \
-            "${{ steps.catalog.outputs.source }}"
-
-          TOTAL=$(jq '[.Results[]? | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
-          GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
-          OS=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
-          {
-            echo "before_total=${TOTAL}"
-            echo "before_go=${GO}"
-            echo "before_os=${OS}"
-          } >> "$GITHUB_ENV"
-          echo "BEFORE — total: ${TOTAL}, os: ${OS}, go: ${GO}"
-
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "::warning::No vulns found in ${{ matrix.name }} — image may have been patched upstream"
-            echo "skip_patch=true" >> "$GITHUB_ENV"
-          fi
+        env:
+          SOURCE: ${{ steps.catalog.outputs.source }}
+        run: ./.github/scripts/scan-before.sh
 
       - name: Prepare report for patch-image.sh
         if: env.skip_patch != 'true'
@@ -518,38 +491,10 @@ jobs:
 
       - name: Verify patched image is clean
         if: env.skip_patch != 'true'
-        run: |
-          SOURCE_TAG="${{ matrix.tag }}"
-          SAFE_IMAGE=$(echo "${{ matrix.name }}" | tr '/: ' '---')
-          PATCHED="localhost:5000/regression:${SAFE_IMAGE}-${SOURCE_TAG}-amd64"
-
-          trivy image \
-            --severity CRITICAL,HIGH,MEDIUM,LOW \
-            --ignore-unfixed \
-            --scanners vuln \
-            --format json \
-            --output after.json \
-            "${PATCHED}"
-
-          TOTAL=$(jq '[.Results[]? | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
-          GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
-          OS=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
-
-          {
-            echo ""
-            echo "══════════════════════════════════════════════"
-            echo "  ${{ matrix.name }}:${{ matrix.tag }}"
-            echo "──────────────────────────────────────────────"
-            echo "  BEFORE:  ${before_total} total (${before_os} OS, ${before_go} Go)"
-            echo "  AFTER:   ${TOTAL} total (${OS} OS, ${GO} Go) [fixable only]"
-            echo "  FIXED:   $((before_total - TOTAL)) total"
-            echo "══════════════════════════════════════════════"
-          }
-
-          if [ "$TOTAL" -ne 0 ]; then
-            echo "::error::Copa left ${TOTAL} fixable CVEs unpatched for ${{ matrix.name }}:${{ matrix.tag }} (${OS} OS, ${GO} Go)"
-            exit 1
-          fi
+        env:
+          PATCHED_IMAGE: "localhost:5000/regression:$(echo '${{ matrix.name }}' | tr '/: ' '---')-${{ matrix.tag }}-amd64"
+          IMAGE_LABEL: "${{ matrix.name }}:${{ matrix.tag }}"
+        run: ./.github/scripts/verify-patched.sh
 
       - name: Upload scan reports
         if: always()

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -16,6 +16,8 @@ on:
       - 'cmd/integer*.go'
       - 'cmd/discover*.go'
       - 'cmd/scan*.go'
+      - '.github/scripts/patch-image.sh'
+      - '.github/actions/setup-binaries/**'
 
 permissions:
   contents: read
@@ -390,4 +392,155 @@ jobs:
         with:
           name: "trivy-${{ matrix.image }}-${{ matrix.version }}-${{ matrix.type }}"
           path: trivy-report.json
+          retention-days: 7
+
+  # ── Copa patching regression tests ──────────────────────────────────
+  copa-patching-regression:
+    name: "Copa Patch: ${{ matrix.name }} [${{ matrix.type }}]"
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: victoria-logs
+            image: docker.io/victoriametrics/victoria-logs:v1.45.0
+            type: apk + gobinary + stdlib
+          - name: redis
+            image: docker.io/library/redis:8.0.2
+            type: dpkg (Debian)
+          - name: rabbitmq
+            image: mirror.gcr.io/library/rabbitmq:4.1.0
+            type: dpkg (Ubuntu)
+          - name: cockroachdb
+            image: mirror.gcr.io/cockroachdb/cockroach:v25.2.3
+            type: rpm + gobinary (RHEL)
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install mise
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          install: true
+          cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/dev/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-${{ runner.os }}-
+
+      - name: Setup Copa and Verity
+        uses: ./.github/actions/setup-binaries
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup BuildKit
+        run: |
+          docker buildx create \
+            --name copa-builder \
+            --driver docker-container \
+            --driver-opt network=host \
+            --driver-opt image=moby/buildkit:v0.21.1 \
+            --use
+          docker buildx inspect --bootstrap
+
+      - name: Start local registry
+        run: docker run -d -p 5000:5000 --name registry registry:2
+
+      - name: Scan image (before patching)
+        run: |
+          trivy image \
+            --severity CRITICAL,HIGH,MEDIUM,LOW \
+            --scanners vuln \
+            --format json \
+            --output before.json \
+            "${{ matrix.image }}"
+
+          TOTAL=$(jq '[.Results[]? | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
+          GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
+          OS=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' before.json)
+          {
+            echo "before_total=${TOTAL}"
+            echo "before_go=${GO}"
+            echo "before_os=${OS}"
+          } >> "$GITHUB_ENV"
+          echo "BEFORE — total: ${TOTAL}, os: ${OS}, go: ${GO}"
+
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "::warning::No vulns found in ${{ matrix.name }} — image may have been patched upstream"
+            echo "skip_patch=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Prepare report for patch-image.sh
+        if: env.skip_patch != 'true'
+        run: |
+          mkdir -p reports
+          REPORT_NAME=$(echo "${{ matrix.image }}" | sed 's/[\/:]/_/g')
+          cp before.json "reports/${REPORT_NAME}.json"
+
+      - name: Patch image with patch-image.sh
+        if: env.skip_patch != 'true'
+        env:
+          COPA_EXPERIMENTAL: "1"
+          PLATFORM: linux/amd64
+          SOURCE: ${{ matrix.image }}
+          IMAGE_NAME: ${{ matrix.name }}
+          STAGING_REGISTRY: localhost:5000/regression
+        run: ./.github/scripts/patch-image.sh
+
+      - name: Scan image (after patching)
+        if: env.skip_patch != 'true'
+        run: |
+          SOURCE_TAG=$(echo "${{ matrix.image }}" | cut -d: -f2)
+          SAFE_IMAGE=$(echo "${{ matrix.name }}" | tr '/: ' '---')
+          PATCHED="localhost:5000/regression:${SAFE_IMAGE}-${SOURCE_TAG}-amd64"
+
+          trivy image \
+            --severity CRITICAL,HIGH,MEDIUM,LOW \
+            --ignore-unfixed \
+            --scanners vuln \
+            --format json \
+            --output after.json \
+            "${PATCHED}"
+
+          TOTAL=$(jq '[.Results[]? | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
+          GO=$(jq '[.Results[]? | select(.Type == "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
+          OS=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilities) | .Vulnerabilities | length] | add // 0' after.json)
+
+          {
+            echo ""
+            echo "══════════════════════════════════════════════"
+            echo "  ${{ matrix.name }} (${{ matrix.type }})"
+            echo "──────────────────────────────────────────────"
+            echo "  BEFORE:  ${before_total} total (${before_os} OS, ${before_go} Go)"
+            echo "  AFTER:   ${TOTAL} total (${OS} OS, ${GO} Go) [fixable only]"
+            echo "  FIXED:   $((before_total - TOTAL)) total"
+            echo "══════════════════════════════════════════════"
+          }
+
+          if [ "$TOTAL" -ne 0 ]; then
+            echo "::error::Copa left ${TOTAL} fixable CVEs unpatched for ${{ matrix.name }} (${OS} OS, ${GO} Go)"
+            exit 1
+          fi
+
+      - name: Upload scan reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "copa-regression-${{ matrix.name }}"
+          path: |
+            before.json
+            after.json
           retention-days: 7

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -408,6 +408,7 @@ jobs:
           - name: victoria-logs
             image: docker.io/victoriametrics/victoria-logs:v1.45.0
             type: apk + gobinary + stdlib
+            go_vcs_url: https://github.com/VictoriaMetrics/VictoriaLogs@v1.45.0
           - name: redis
             image: docker.io/library/redis:8.0.2
             type: dpkg (Debian)
@@ -498,6 +499,7 @@ jobs:
           SOURCE: ${{ matrix.image }}
           IMAGE_NAME: ${{ matrix.name }}
           STAGING_REGISTRY: localhost:5000/regression
+          GO_VCS_URL: ${{ matrix.go_vcs_url }}
         run: ./.github/scripts/patch-image.sh
 
       - name: Scan image (after patching)

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -492,9 +492,11 @@ jobs:
       - name: Verify patched image is clean
         if: env.skip_patch != 'true'
         env:
-          PATCHED_IMAGE: "localhost:5000/regression:$(echo '${{ matrix.name }}' | tr '/: ' '---')-${{ matrix.tag }}-amd64"
           IMAGE_LABEL: "${{ matrix.name }}:${{ matrix.tag }}"
-        run: ./.github/scripts/verify-patched.sh
+        run: |
+          SAFE_IMAGE=$(echo "${{ matrix.name }}" | tr '/: ' '---')
+          export PATCHED_IMAGE="localhost:5000/regression:${SAFE_IMAGE}-${{ matrix.tag }}-amd64"
+          ./.github/scripts/verify-patched.sh
 
       - name: Upload scan reports
         if: always()

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -323,7 +323,16 @@ images:
     goVcsUrl: "https://github.com/VictoriaMetrics/VictoriaLogs"
 
   # -- Prometheus ecosystem --
-  # NOTE: Default Prometheus tags are busybox-based → NOT patchable.
+
+  - name: "prometheus/prometheus"
+    image: "quay.io/prometheus/prometheus"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  # NOTE: Default exporter tags are busybox-based → NOT patchable.
   # Use -distroless suffixed tags (Copa patches dpkg-distroless via tooling container).
   - name: "prometheus/node-exporter"
     image: "quay.io/prometheus/node-exporter"

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -146,6 +146,14 @@ images:
   #  MESSAGING & STREAMING
   # ============================================================================
 
+  - name: "library/rabbitmq"
+    image: "mirror.gcr.io/library/rabbitmq"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+
   - name: "rabbitmqoperator/cluster-operator"
     image: "mirror.gcr.io/rabbitmqoperator/cluster-operator"
     platforms: ["linux/amd64", "linux/arm64"]
@@ -300,6 +308,19 @@ images:
   # ============================================================================
   #  MONITORING & OBSERVABILITY
   # ============================================================================
+
+  # -- VictoriaMetrics --
+  - name: "victoriametrics/victoria-logs"
+    image: "docker.io/victoriametrics/victoria-logs"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    # Go binary built with -trimpath (no VCS info in binary).
+    # OCI label points to monorepo (wrong directory at older tags).
+    # goVcsUrl overrides to the correct standalone source repo.
+    goVcsUrl: "https://github.com/VictoriaMetrics/VictoriaLogs"
 
   # -- Prometheus ecosystem --
   # NOTE: Default Prometheus tags are busybox-based → NOT patchable.


### PR DESCRIPTION
## Summary

Enable Copa's Go binary patching and add regression tests covering all package manager types Copa handles.

## Changes

### `patch-image.sh`
- Add `--toolchain-patch-level patch` — upgrades Go compiler within same patch series for stdlib CVEs
- Add `GO_VCS_URL` passthrough via bash array — passes `--go-vcs-url` to Copa when set

### `copa-config.yaml` — catalog additions
- `victoriametrics/victoria-logs` with `goVcsUrl` for Go binary source override
- `library/rabbitmq` for Ubuntu dpkg coverage

### `.github/scripts/` — new regression test scripts
- `read-catalog-entry.sh` — reads image URL + goVcsUrl from copa-config.yaml
- `scan-before.sh` — trivy scan before patching, sets GITHUB_ENV vars
- `verify-patched.sh` — trivy scan after patching with `--ignore-unfixed`, asserts 0 fixable CVEs

### `.github/actions/setup-binaries/action.yml`
- Remove artifact download/upload (always failed on PR runs, caused `##[error]` noise)
- Simplified to: cache hit → use cached, cache miss → build from source

### `pr-test.yaml` — Copa patching regression matrix

4 test images read from catalog, covering every practical patch type:

| Image | Tag | Patch types | Result |
|---|---|---|---|
| `victoriametrics/victoria-logs` | v1.45.0 | apk + gobinary + stdlib (via `--go-vcs-url`) | ✅ 22→0 CVEs |
| `library/redis` | 8.0.2 | dpkg (Debian) | ✅ 0 fixable remaining |
| `library/rabbitmq` | 4.1.0 | dpkg (Ubuntu) | ✅ 0 fixable remaining |
| `kiwigrid/k8s-sidecar` | 1.30.4 | apk + python-pkg | ✅ 0 fixable remaining |

Tests read image URLs and `goVcsUrl` from `copa-config.yaml` — no duplication between catalog and workflow. All inline shell extracted to `.github/scripts/` for proper shellcheck linting.
