### PR TITLE
fix: add goVcsUrl for rabbitmq operators and cap victoria-logs to latest tag

### DIFF
--- a/.github/scripts/read-catalog-entry.sh
+++ b/.github/scripts/read-catalog-entry.sh
@@ -10,9 +10,10 @@ set -euo pipefail
 
 IMAGE=$(yq ".images[] | select(.name == \"${IMAGE_NAME}\") | .image" copa-config.yaml)
 VCS_URL=$(yq ".images[] | select(.name == \"${IMAGE_NAME}\") | .goVcsUrl // \"\"" copa-config.yaml)
+VCS_PREFIX=$(yq ".images[] | select(.name == \"${IMAGE_NAME}\") | .goVcsTagPrefix // \"\"" copa-config.yaml)
 
 if [ -n "$VCS_URL" ] && [ "$VCS_URL" != "null" ]; then
-  VCS_URL="${VCS_URL}@${IMAGE_TAG}"
+  VCS_URL="${VCS_URL}@${VCS_PREFIX}${IMAGE_TAG}"
 else
   VCS_URL=""
 fi

--- a/.github/scripts/read-catalog-entry.sh
+++ b/.github/scripts/read-catalog-entry.sh
@@ -8,11 +8,11 @@ set -euo pipefail
 : "${IMAGE_NAME:?IMAGE_NAME is required}"
 : "${IMAGE_TAG:?IMAGE_TAG is required}"
 
-IMAGE=$(yq ".images[] | select(.name == \"${IMAGE_NAME}\") | .image" copa-config.yaml)
-VCS_URL=$(yq ".images[] | select(.name == \"${IMAGE_NAME}\") | .goVcsUrl // \"\"" copa-config.yaml)
-VCS_PREFIX=$(yq ".images[] | select(.name == \"${IMAGE_NAME}\") | .goVcsTagPrefix // \"\"" copa-config.yaml)
+IMAGE=$(yq -r ".images[] | select(.name == \"${IMAGE_NAME}\") | .image" copa-config.yaml)
+VCS_URL=$(yq -r ".images[] | select(.name == \"${IMAGE_NAME}\") | .goVcsUrl // \"\"" copa-config.yaml)
+VCS_PREFIX=$(yq -r ".images[] | select(.name == \"${IMAGE_NAME}\") | .goVcsTagPrefix // \"\"" copa-config.yaml)
 
-if [ -n "$VCS_URL" ] && [ "$VCS_URL" != "null" ]; then
+if [ -n "$VCS_URL" ]; then
   VCS_URL="${VCS_URL}@${VCS_PREFIX}${IMAGE_TAG}"
 else
   VCS_URL=""

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -408,7 +408,7 @@ jobs:
       matrix:
         include:
           - name: victoriametrics/victoria-logs
-            tag: v1.45.0
+            tag: v1.49.0
           - name: library/redis
             tag: "8.0.2"
           - name: library/rabbitmq

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -161,6 +161,10 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
+    # Go binary built with -trimpath (no VCS info). Image tags lack 'v' prefix
+    # but upstream git tags are v-prefixed (e.g., image 2.19.0 → git v2.19.0).
+    goVcsUrl: "https://github.com/rabbitmq/cluster-operator"
+    goVcsTagPrefix: "v"
 
   - name: "rabbitmqoperator/messaging-topology-operator"
     image: "mirror.gcr.io/rabbitmqoperator/messaging-topology-operator"
@@ -169,6 +173,9 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
+    # Same -trimpath + tag-prefix issue as cluster-operator above.
+    goVcsUrl: "https://github.com/rabbitmq/messaging-topology-operator"
+    goVcsTagPrefix: "v"
 
   # ============================================================================
   #  KUBERNETES TOOLS
@@ -316,7 +323,7 @@ images:
     tags:
       strategy: "pattern"
       pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
+      maxTags: 1
     # Go binary built with -trimpath (no VCS info in binary).
     # OCI label points to monorepo (wrong directory at older tags).
     # goVcsUrl overrides to the correct standalone source repo.


### PR DESCRIPTION
## Summary

Fixes 5 nightly Copa patching failures introduced by the Go binary patching feature (#176).

## Failures Fixed

### rabbitmqoperator/cluster-operator (v2.19.0, v2.19.1, v2.19.2) — 3 jobs

**Root cause:** Binary `/manager` built with `-trimpath` (no VCS info). Image tags lack `v` prefix (`2.19.0`) but upstream git tags are v-prefixed (`v2.19.0`). Copa can't resolve the source ref.

**Fix:** Add `goVcsUrl` pointing to `github.com/rabbitmq/cluster-operator` + new `goVcsTagPrefix: "v"` field so `read-catalog-entry.sh` constructs the correct ref (e.g., `@v2.19.2`).

### victoriametrics/victoria-logs (v1.45.0, v1.47.0) — 2 jobs

**Root cause:** Older versions produce invalid rebuilt Go binaries (`copa_verify.sh` rejects them). Newer versions (v1.48.0, v1.49.0) patch successfully.

**Fix:** Reduce `maxTags: 3` → `1` so only the latest version is patched. Update PR regression test tag from v1.45.0 → v1.49.0.

## Changes

| File | Change |
|---|---|
| `copa-config.yaml` | Add `goVcsUrl` + `goVcsTagPrefix` for both rabbitmq operators; reduce victoria-logs `maxTags` to 1 |
| `.github/scripts/read-catalog-entry.sh` | Read `goVcsTagPrefix` and prepend to image tag when building VCS URL |
| `.github/workflows/pr-test.yaml` | Update Copa regression test to victoria-logs v1.49.0 |

## Proactive

Also added `goVcsUrl` + `goVcsTagPrefix` for `rabbitmqoperator/messaging-topology-operator` (same upstream build pattern — will fail the same way once it hits Go patching).