### PR TITLE
chore(deps): bump victoria-logs-single chart to 0.11.31 and enable Renovate helmv3

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":semanticCommits", ":dependencyDashboard"],
-  "enabledManagers": ["gomod", "github-actions", "npm", "mise"],
+  "enabledManagers": ["gomod", "github-actions", "npm", "mise", "helmv3"],
   "labels": ["dependencies"],
   "rangeStrategy": "pin",
   "separateMajorMinor": true,
@@ -49,9 +49,17 @@
     },
     {
       "description": "Automerge non-major updates",
-      "matchManagers": ["gomod", "github-actions", "mise", "npm"],
+      "matchManagers": ["gomod", "github-actions", "mise", "npm", "helmv3"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "description": "Helm chart dependencies",
+      "matchManagers": ["helmv3"],
+      "labels": ["helm", "dependencies"],
+      "groupName": "helm charts",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
     }
   ],
   "vulnerabilityAlerts": {

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: "oci://ghcr.io/prometheus-community/charts"
 
   - name: victoria-logs-single
-    version: "0.11.26"
+    version: "0.11.31"
     repository: "https://victoriametrics.github.io/helm-charts"
 
   - name: postgres-operator


### PR DESCRIPTION
## Summary

- **Bump victoria-logs-single** chart `0.11.26` → `0.11.31` (app version v1.45.0 → v1.49.0)
- **Enable `helmv3` Renovate manager** so Chart.yaml dependencies are tracked going forward

## Why

The victoria-logs-single chart pinned app version v1.45.0, which fails Copa Go binary rebuild because the source lived in the VictoriaMetrics monorepo at that tag. Chart 0.11.31 uses v1.49.0 which exists in the standalone VictoriaLogs repo and patches cleanly.

Renovate was missing `helmv3` in `enabledManagers`, so Chart.yaml deps were never updated automatically.

## Note

Prometheus chart is also behind (28.9.1 → 29.2.0) but that's a major bump — Renovate will create a separate PR for it now that helmv3 is enabled.