### PR TITLE
fix: revert verify to warn-only on Go CVEs

### DIFF
--- a/.github/scripts/verify-patched.sh
+++ b/.github/scripts/verify-patched.sh
@@ -2,9 +2,9 @@
 # shellcheck disable=SC2154 # before_total/before_go/before_non_go come from GITHUB_ENV
 set -euo pipefail
 
-# Scans a patched image and verifies 0 fixable CVEs remain.
+# Scans a patched image and verifies 0 fixable non-Go CVEs remain.
 # Inputs: PATCHED_IMAGE, IMAGE_LABEL (env vars), before_total/before_go/before_non_go (from GITHUB_ENV)
-# Outputs: after.json, exit 1 if any fixable CVEs remain
+# Outputs: after.json, exit 1 if fixable non-Go CVEs remain (Go CVEs warn only)
 
 : "${PATCHED_IMAGE:?PATCHED_IMAGE is required}"
 : "${IMAGE_LABEL:?IMAGE_LABEL is required}"
@@ -33,7 +33,11 @@ NON_GO=$(jq '[.Results[]? | select(.Type != "gobinary") | select(.Vulnerabilitie
   echo "══════════════════════════════════════════════"
 }
 
-if [ "$TOTAL" -ne 0 ]; then
-  echo "::error::Copa left ${TOTAL} fixable CVEs unpatched for ${IMAGE_LABEL} (${NON_GO} non-Go, ${GO} Go)"
+if [ "$NON_GO" -ne 0 ]; then
+  echo "::error::Copa left ${NON_GO} fixable non-Go CVEs unpatched for ${IMAGE_LABEL}"
   exit 1
+fi
+
+if [ "$GO" -ne 0 ]; then
+  echo "::warning::${GO} fixable Go CVEs remain for ${IMAGE_LABEL} (Go binary patching is best-effort)"
 fi


### PR DESCRIPTION
## Summary

The strict zero-CVE verify from #224 breaks nightly patching for cert-manager and promtail which have main-module Go CVEs that Copa cannot fix (requires upstream releases).

**9 nightly patch jobs failing on main** — all from Go CVEs in images where the project itself has a CVE (e.g., consul needing 1.22.5, cert-manager components, promtail).

## Fix

Revert `verify-patched.sh` to warn-only on Go CVEs:
- **Fail** on non-Go CVEs (OS packages, Python libs) — Copa reliably patches these
- **Warn** on Go CVEs — best-effort, limited by main-module constraints and Go MVS