### PR TITLE
fix(site): remove extra space in catalog pull reference column

### DIFF
--- a/site/src/components/ImageCatalog.astro
+++ b/site/src/components/ImageCatalog.astro
@@ -102,6 +102,7 @@ function getVulnSummary(image: FullCatalogImage): VulnSummary {
           <div>
             {category.images.map((image: FullCatalogImage) => {
               const vulnSummary = getVulnSummary(image);
+              const pullRef = `${REGISTRY}/${image.source === "integer" ? (image.integerName ?? image.name) : upstreamPath(image)}`;
               return (
                 <a
                   href={`${base}catalog/${image.name}/`}
@@ -155,7 +156,7 @@ function getVulnSummary(image: FullCatalogImage): VulnSummary {
                     <SeverityBadges summary={vulnSummary} />
                   </div>
 
-                  <div class="text-xs text-verity-text-secondary font-mono truncate">{REGISTRY}/{image.source === "integer" ? (image.integerName ?? image.name) : upstreamPath(image)}</div>
+                  <div class="text-xs text-verity-text-secondary font-mono truncate">{pullRef}</div>
                 </a>
               );
             })}

--- a/site/src/components/ImageCatalog.astro
+++ b/site/src/components/ImageCatalog.astro
@@ -155,12 +155,7 @@ function getVulnSummary(image: FullCatalogImage): VulnSummary {
                     <SeverityBadges summary={vulnSummary} />
                   </div>
 
-                  <div class="text-xs text-verity-text-secondary font-mono truncate">
-                    {REGISTRY}/
-                    {image.source === "integer"
-                      ? (image.integerName ?? image.name)
-                      : upstreamPath(image)}
-                  </div>
+                  <div class="text-xs text-verity-text-secondary font-mono truncate">{REGISTRY}/{image.source === "integer" ? (image.integerName ?? image.name) : upstreamPath(image)}</div>
                 </a>
               );
             })}


### PR DESCRIPTION
## Summary

- Fixes a rendering bug where the "Pull Reference" column in the image catalog showed an extra space between the registry prefix and image name (e.g. `ghcr.io/verity-org/ golang` instead of `ghcr.io/verity-org/golang`)
- Root cause: In Astro/JSX, a newline + indentation between `{REGISTRY}/` and the next `{...}` expression creates a whitespace text node in the rendered HTML
- Fix: collapse the two expressions into a single inline element on one line