### PR TITLE
fix(config): switch rabbitmq cluster-operator upstream to GHCR

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -142,7 +142,7 @@ images:
       maxTags: 3
 
   - name: "rabbitmqoperator/cluster-operator"
-    image: "mirror.gcr.io/rabbitmqoperator/cluster-operator"
+    image: "ghcr.io/rabbitmq/cluster-operator"
     platforms: ["linux/amd64", "linux/arm64"]
     tags:
       strategy: "pattern"

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -175,7 +175,7 @@ func TestDiscoverStandaloneImage_PerImageRegistryOverride(t *testing.T) {
 func TestDiscoverStandaloneImage_GoVcsUrl(t *testing.T) {
 	spec := &config.ImageSpec{
 		Name:           "rabbitmqoperator/cluster-operator",
-		Image:          "mirror.gcr.io/rabbitmqoperator/cluster-operator",
+		Image:          "ghcr.io/rabbitmq/cluster-operator",
 		Tags:           config.TagStrategy{Strategy: "list", List: []string{"2.19.0"}},
 		Platforms:      []string{"linux/amd64", "linux/arm64"},
 		GoVcsURL:       "https://github.com/rabbitmq/cluster-operator",
@@ -242,7 +242,7 @@ target:
   registry: ghcr.io/test-org
 images:
   - name: rabbitmqoperator/cluster-operator
-    image: mirror.gcr.io/rabbitmqoperator/cluster-operator
+    image: ghcr.io/rabbitmq/cluster-operator
     platforms: [linux/amd64, linux/arm64]
     tags:
       strategy: list

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -210,7 +210,7 @@ export const fullCatalog: FullCatalogCategory[] = [
         name: "rabbitmqoperator/cluster-operator",
         label: "rabbitmq-cluster-operator",
         source: "copa",
-        upstream: "mirror.gcr.io/rabbitmqoperator/cluster-operator",
+        upstream: "ghcr.io/rabbitmq/cluster-operator",
       },
       {
         name: "rabbitmqoperator/messaging-topology-operator",


### PR DESCRIPTION
## Summary

- Switch `rabbitmqoperator/cluster-operator` upstream from `mirror.gcr.io/rabbitmqoperator/cluster-operator` to `ghcr.io/rabbitmq/cluster-operator` (the official GitHub Container Registry source)
- Updates `copa-config.yaml`, `full-catalog.ts` upstream display, and discovery tests

## Why

The canonical source for the RabbitMQ cluster operator container image is the [GitHub Container Registry package](https://github.com/rabbitmq/cluster-operator/pkgs/container/cluster-operator), not the Docker Hub mirror via GCR.