### PR TITLE
feat(site): adopt Verity Design System tokens and layouts

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,10 +1,12 @@
 ---
 import { catalog } from "../lib/catalog";
 
+const base = import.meta.env.BASE_URL;
 const generated = new Date(catalog.generatedAt).toLocaleDateString("en-US", {
   year: "numeric",
   month: "long",
   day: "numeric",
+  timeZone: "UTC",
 });
 ---
 
@@ -28,22 +30,22 @@ const generated = new Date(catalog.generatedAt).toLocaleDateString("en-US", {
     <div>
       <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">REGISTRY</div>
       <a
-        href="https://github.com/verity-org"
+        href="https://ghcr.io/verity-org"
         class="block py-1 hover:text-verity-nucleus transition-colors"
       >
         ghcr.io/verity-org ↗
       </a>
-      <a href="/charts/" class="block py-1 hover:text-verity-nucleus transition-colors">
+      <a href={`${base}charts/`} class="block py-1 hover:text-verity-nucleus transition-colors">
         OCI Helm charts
       </a>
     </div>
 
     <div>
       <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">DOCS</div>
-      <a href="/llms.txt" class="block py-1 hover:text-verity-nucleus transition-colors">
+      <a href={`${base}llms.txt`} class="block py-1 hover:text-verity-nucleus transition-colors">
         LLM reference
       </a>
-      <a href="/compliance/" class="block py-1 hover:text-verity-nucleus transition-colors">
+      <a href={`${base}compliance/`} class="block py-1 hover:text-verity-nucleus transition-colors">
         Compliance mapping
       </a>
       <a

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,29 +1,68 @@
 ---
 import { catalog } from "../lib/catalog";
+
+const generated = new Date(catalog.generatedAt).toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
 ---
 
-<footer class="bg-verity-surface border-t border-verity-border mt-12">
+<footer class="border-t border-verity-border mt-12">
   <div
-    class="max-w-6xl mx-auto px-4 py-6 text-sm text-verity-text-secondary flex flex-col sm:flex-row justify-between gap-2"
+    class="max-w-[1120px] mx-auto px-6 py-12 grid grid-cols-2 sm:grid-cols-4 gap-8 text-xs text-verity-text-secondary"
   >
-    <span>
-      Generated {
-        new Date(catalog.generatedAt).toLocaleDateString("en-US", {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        })
-      }
-    </span>
-    <span>
-      Powered by <a
-        href="https://github.com/project-copacetic/copacetic"
-        class="text-verity-orbit hover:text-verity-nucleus transition-colors underline">Copa</a
-      > &middot;
-      <a
-        href="https://github.com/verity-org/verity"
-        class="text-verity-orbit hover:text-verity-nucleus transition-colors underline">Source</a
+    <div class="col-span-2 sm:col-span-1">
+      <div
+        class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3 flex items-baseline gap-1.5"
       >
-    </span>
+        <span>VERITY</span>
+        <span class="text-verity-border-2">/</span>
+        <span class="text-verity-text-secondary">SUPPLY</span>
+      </div>
+      <p class="text-verity-text-muted leading-relaxed">
+        Self-maintaining registry of security-patched container images.
+      </p>
+    </div>
+
+    <div>
+      <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">REGISTRY</div>
+      <a
+        href="https://github.com/verity-org"
+        class="block py-1 hover:text-verity-nucleus transition-colors"
+      >
+        ghcr.io/verity-org ↗
+      </a>
+      <a href="/charts/" class="block py-1 hover:text-verity-nucleus transition-colors">
+        OCI Helm charts
+      </a>
+    </div>
+
+    <div>
+      <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">DOCS</div>
+      <a href="/llms.txt" class="block py-1 hover:text-verity-nucleus transition-colors">
+        LLM reference
+      </a>
+      <a href="/compliance/" class="block py-1 hover:text-verity-nucleus transition-colors">
+        Compliance mapping
+      </a>
+      <a
+        href="https://github.com/verity-org/verity/blob/main/ARCHITECTURE.md"
+        class="block py-1 hover:text-verity-nucleus transition-colors"
+      >
+        Architecture
+      </a>
+    </div>
+
+    <div>
+      <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">PIPELINE</div>
+      <p class="text-verity-text-muted leading-relaxed">
+        Daily · 02:00 UTC<br />
+        cosign · SLSA L3 · CycloneDX
+      </p>
+      <p class="text-verity-text-muted leading-relaxed mt-3">
+        Generated {generated}
+      </p>
+    </div>
   </div>
 </footer>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -30,7 +30,7 @@ const generated = new Date(catalog.generatedAt).toLocaleDateString("en-US", {
     <div>
       <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">REGISTRY</div>
       <a
-        href="https://ghcr.io/verity-org"
+        href="https://github.com/orgs/verity-org/packages"
         class="block py-1 hover:text-verity-nucleus transition-colors"
       >
         ghcr.io/verity-org ↗

--- a/site/src/components/HeroSection.astro
+++ b/site/src/components/HeroSection.astro
@@ -12,143 +12,235 @@ const exampleImage =
   catalog.images?.find((img) => img.beforeVulns.total - img.afterVulns.total > 0) ??
   catalog.images?.[0];
 const exampleRef = exampleImage?.patchedRef ?? "ghcr.io/verity-org/prometheus/prometheus:v3.9.1";
+const pullCmd = `docker pull ${exampleRef}`;
+
+const pipelineSteps = [
+  { n: "01", t: "Discover" },
+  { n: "02", t: "Scan" },
+  { n: "03", t: "Patch", active: true },
+  { n: "04", t: "Sign" },
+  { n: "05", t: "Publish" },
+];
 ---
 
-<div class="mb-12">
-  <h1 class="text-4xl font-bold mb-6 tracking-[0.3em]">VERITY</h1>
+<section class="relative mb-16 -mt-8 pt-16 pb-8">
+  <div
+    class="absolute inset-x-0 top-0 h-[480px] pointer-events-none"
+    style="background: var(--grad-glow-radial);"
+  >
+  </div>
 
-  <div class="bg-verity-surface border-l-4 border-verity-nucleus rounded-r-lg p-6 mb-8">
-    <p class="text-verity-text-primary text-base leading-relaxed mb-3">
-      Container images ship with packages — OS and application-level — that accumulate CVEs daily.
-      Upstream maintainers patch on their own schedule — if at all. That leaves you choosing between
-      manually rebuilding every image or running known-vulnerable containers in production.
-    </p>
-    <p class="text-verity-nucleus text-base leading-relaxed font-medium">
-      Verity eliminates that trade-off. It continuously scans images, patches them in-place with <a
+  <div class="relative">
+    <div
+      class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mb-7"
+      aria-label="Tagline"
+    >
+      SELF-MAINTAINING REGISTRY · PATCHED DAILY · 02:00 UTC
+    </div>
+
+    <h1
+      class="text-4xl sm:text-5xl lg:text-[52px] leading-[1.15] tracking-[0.12em] text-verity-text uppercase font-normal mb-6"
+    >
+      CONTAINER IMAGES<br />
+      <span class="text-verity-nucleus" style="text-shadow: 0 0 24px rgba(0,240,204,0.25);"
+        >PATCHED IN-PLACE,</span
+      ><br />
+      SIGNED &amp; ATTESTED.
+    </h1>
+
+    <p class="text-[15px] leading-[1.7] text-verity-text max-w-[640px] mb-8">
+      Verity scans upstream container images for fixable CVEs, patches their OS packages with <a
         href="https://github.com/project-copacetic/copacetic"
-        class="underline decoration-verity-orbit hover:text-verity-teal-light transition-colors"
+        class="text-verity-nucleus hover:[text-shadow:0_0_8px_rgba(0,240,204,0.5)] transition-colors underline decoration-verity-orbit"
         >Copa</a
-      > (no Dockerfile rebuild), and publishes signed, attested, drop-in replacements.
+      > — no Dockerfile rebuild — and publishes signed, attested, drop-in replacements to <code
+        class="font-[var(--font-code)] bg-verity-surface border border-verity-border rounded-sm px-1.5 py-0.5 text-[13px] text-verity-nucleus"
+        >ghcr.io/verity-org</code
+      >.
     </p>
-  </div>
 
-  <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-10">
-    <div
-      class="bg-verity-surface border border-verity-border rounded-lg p-4 text-center hover:border-verity-orbit transition-colors"
-    >
-      <div class="text-2xl font-bold text-verity-text-primary">{totalImages}</div>
-      <div class="text-sm text-verity-text-secondary tracking-wider uppercase">Images</div>
+    <div class="flex flex-wrap gap-3 mb-10">
+      <a
+        href="#catalog"
+        class="inline-flex items-center text-xs tracking-[0.12em] uppercase px-5 py-3 rounded-md bg-verity-nucleus text-[#002820] shadow-[0_0_24px_rgba(0,240,204,0.25)] hover:bg-[#33FFD6] active:bg-verity-orbit active:shadow-none transition-all duration-[180ms]"
+      >
+        Browse Catalog →
+      </a>
+      <a
+        href="https://github.com/verity-org/verity"
+        class="inline-flex items-center text-xs tracking-[0.12em] uppercase px-5 py-3 rounded-md bg-transparent text-verity-text border border-verity-border-2 hover:border-verity-nucleus hover:text-verity-nucleus transition-colors duration-[180ms]"
+      >
+        View on GitHub
+      </a>
     </div>
-    <div
-      class="bg-verity-surface border border-verity-border rounded-lg p-4 text-center hover:border-verity-orbit transition-colors"
-    >
-      <div class="text-2xl font-bold text-verity-text-primary">{totalCategories}</div>
-      <div class="text-sm text-verity-text-secondary tracking-wider uppercase">Categories</div>
-    </div>
-    <div
-      class="bg-verity-surface border border-verity-border rounded-lg p-4 text-center hover:border-verity-orbit transition-colors"
-    >
-      <div class="text-lg font-bold text-verity-text-primary">amd64 + arm64</div>
-      <div class="text-sm text-verity-text-secondary tracking-wider uppercase">Platforms</div>
-    </div>
-    <div
-      class="bg-verity-surface border border-verity-nucleus rounded-lg p-4 text-center hover:border-verity-teal-light transition-colors"
-    >
-      <div class="text-2xl font-bold text-verity-nucleus">FIPS</div>
-      <div class="text-sm text-verity-nucleus tracking-wider uppercase opacity-80">Available</div>
-    </div>
-  </div>
 
-  <div class="grid md:grid-cols-2 gap-6 mb-4">
-    <div class="bg-verity-surface border border-verity-border rounded-lg p-5">
-      <h2 class="text-sm font-semibold text-verity-text-primary tracking-wider uppercase mb-4">
-        How it works
-      </h2>
-      <div class="space-y-3 text-sm">
-        <div class="flex items-start gap-3">
-          <span class="text-verity-nucleus font-bold shrink-0 w-5 text-right">1</span>
-          <div>
-            <span class="text-verity-text-primary font-medium">Discover</span>
-            <span class="text-verity-text-muted">
-              — images from Helm charts and copa-config.yaml</span
+    <div class="bg-black border border-verity-border rounded overflow-hidden max-w-[780px] mb-10">
+      <div
+        class="bg-verity-surface border-b border-verity-border px-3.5 py-2 flex items-center justify-between"
+      >
+        <span class="text-[10px] tracking-[0.12em] uppercase text-verity-text-muted">
+          $ pull a patched image
+        </span>
+        <CopyButton text={pullCmd} />
+      </div>
+      <pre
+        class="m-0 p-4 font-[var(--font-code)] text-[13px] text-verity-text-primary overflow-auto"><span class="text-verity-nucleus mr-2">$</span>{pullCmd}</pre>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-y-2">
+      {
+        pipelineSteps.map((step, i) => (
+          <>
+            <div
+              class:list={[
+                "border rounded px-4 py-3 min-w-[120px] text-center transition-all duration-[180ms]",
+                step.active
+                  ? "border-verity-nucleus bg-verity-surface shadow-[0_0_20px_rgba(0,240,204,0.25)]"
+                  : "border-verity-border-2 bg-verity-surface",
+              ]}
             >
-          </div>
-        </div>
-        <div class="flex items-start gap-3">
-          <span class="text-verity-nucleus font-bold shrink-0 w-5 text-right">2</span>
-          <div>
-            <span class="text-verity-text-primary font-medium">Scan</span>
-            <span class="text-verity-text-muted"> — Trivy detects known CVEs</span>
-          </div>
-        </div>
-        <div class="flex items-start gap-3">
-          <span class="text-verity-nucleus font-bold shrink-0 w-5 text-right">3</span>
-          <div>
-            <span class="text-verity-text-primary font-medium">Patch</span>
-            <span class="text-verity-text-muted"> — Copa fixes packages in-place (no rebuild)</span>
-          </div>
-        </div>
-        <div class="flex items-start gap-3">
-          <span class="text-verity-nucleus font-bold shrink-0 w-5 text-right">4</span>
-          <div>
-            <span class="text-verity-text-primary font-medium">Sign</span>
-            <span class="text-verity-text-muted"> — cosign + SLSA L3 + SBOM attestations</span>
-          </div>
-        </div>
-        <div class="flex items-start gap-3">
-          <span class="text-verity-nucleus font-bold shrink-0 w-5 text-right">5</span>
-          <div>
-            <span class="text-verity-text-primary font-medium">Publish</span>
-            <span class="text-verity-text-muted"> — pushed to </span>
-            <code class="text-verity-text-primary text-xs">ghcr.io/verity-org</code>
-          </div>
-        </div>
-        <div class="mt-4 pt-3 border-t border-verity-border text-xs text-verity-text-muted">
-          Runs daily at 02:00 UTC and on every config change.
-          <a
-            href="https://github.com/verity-org/verity"
-            class="text-verity-orbit hover:text-verity-nucleus transition-colors underline ml-1"
-            >Source</a
+              <span class="block text-[9px] tracking-[0.25em] text-verity-text-muted">
+                {step.n}
+              </span>
+              <span
+                class:list={[
+                  "block text-xs tracking-[0.12em] uppercase mt-1",
+                  step.active ? "text-verity-nucleus" : "text-verity-text",
+                ]}
+              >
+                {step.t}
+              </span>
+            </div>
+            {i < pipelineSteps.length - 1 && (
+              <span class="text-verity-nucleus px-2.5 text-base">→</span>
+            )}
+          </>
+        ))
+      }
+    </div>
+  </div>
+</section>
+
+<section class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-10">
+  <div
+    class="bg-verity-surface border border-verity-border rounded p-4 text-center hover:border-verity-border-2 hover:bg-verity-surface-2 transition-colors"
+  >
+    <div class="text-2xl text-verity-text">{totalImages}</div>
+    <div class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">Images</div>
+  </div>
+  <div
+    class="bg-verity-surface border border-verity-border rounded p-4 text-center hover:border-verity-border-2 hover:bg-verity-surface-2 transition-colors"
+  >
+    <div class="text-2xl text-verity-text">{totalCategories}</div>
+    <div class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">
+      Categories
+    </div>
+  </div>
+  <div
+    class="bg-verity-surface border border-verity-border rounded p-4 text-center hover:border-verity-border-2 hover:bg-verity-surface-2 transition-colors"
+  >
+    <div class="text-base text-verity-text tracking-[0.04em]">amd64 + arm64</div>
+    <div class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">Platforms</div>
+  </div>
+  <div
+    class="bg-[rgba(0,240,204,0.06)] border border-verity-nucleus rounded p-4 text-center hover:shadow-[0_0_20px_rgba(0,240,204,0.2)] transition-all"
+  >
+    <div class="text-2xl text-verity-nucleus">FIPS</div>
+    <div class="text-[10px] tracking-[0.25em] text-verity-nucleus uppercase mt-1 opacity-90">
+      Available
+    </div>
+  </div>
+</section>
+
+<section class="grid md:grid-cols-2 gap-4 mb-4">
+  <div class="bg-verity-surface border border-verity-border rounded p-5">
+    <h2 class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mb-4">
+      How it works
+    </h2>
+    <div class="space-y-3 text-sm">
+      <div class="flex items-start gap-3">
+        <span class="text-verity-nucleus shrink-0 w-5 text-right">1</span>
+        <div>
+          <span class="text-verity-text">Discover</span>
+          <span class="text-verity-text-muted">
+            — images from Helm charts and copa-config.yaml</span
           >
         </div>
       </div>
-    </div>
-
-    <div class="bg-verity-surface border border-verity-border rounded-lg p-5">
-      <h2 class="text-sm font-semibold text-verity-text-primary tracking-wider uppercase mb-4">
-        Use a patched image
-      </h2>
-      <p class="text-sm text-verity-text-muted mb-3">Replace your image reference. That's it.</p>
-      <div
-        class="bg-verity-void border border-verity-border rounded p-3 font-mono text-xs text-verity-text-primary overflow-x-auto mb-3"
-      >
-        <div class="text-verity-text-muted"># Pull a patched image</div>
-        <div>docker pull {exampleRef}</div>
+      <div class="flex items-start gap-3">
+        <span class="text-verity-nucleus shrink-0 w-5 text-right">2</span>
+        <div>
+          <span class="text-verity-text">Scan</span>
+          <span class="text-verity-text-muted"> — Trivy detects known CVEs</span>
+        </div>
       </div>
-      <div class="flex items-center gap-2">
-        <CopyButton text={`docker pull ${exampleRef}`} />
+      <div class="flex items-start gap-3">
+        <span class="text-verity-nucleus shrink-0 w-5 text-right">3</span>
+        <div>
+          <span class="text-verity-text">Patch</span>
+          <span class="text-verity-text-muted"> — Copa fixes packages in-place (no rebuild)</span>
+        </div>
       </div>
-      <div class="mt-4 pt-3 border-t border-verity-border flex items-center justify-between">
-        <span class="text-xs text-verity-text-muted"> Every image is signed and attested. </span>
+      <div class="flex items-start gap-3">
+        <span class="text-verity-nucleus shrink-0 w-5 text-right">4</span>
+        <div>
+          <span class="text-verity-text">Sign</span>
+          <span class="text-verity-text-muted"> — cosign + SLSA L3 + SBOM attestations</span>
+        </div>
+      </div>
+      <div class="flex items-start gap-3">
+        <span class="text-verity-nucleus shrink-0 w-5 text-right">5</span>
+        <div>
+          <span class="text-verity-text">Publish</span>
+          <span class="text-verity-text-muted"> — pushed to </span>
+          <code class="text-verity-text-primary text-xs">ghcr.io/verity-org</code>
+        </div>
+      </div>
+      <div class="mt-4 pt-3 border-t border-verity-border text-xs text-verity-text-muted">
+        Runs daily at 02:00 UTC and on every config change.
         <a
-          href={`${base}compliance/`}
-          class="text-xs text-verity-orbit hover:text-verity-nucleus transition-colors underline"
+          href="https://github.com/verity-org/verity"
+          class="text-verity-orbit hover:text-verity-nucleus transition-colors underline ml-1"
+          >Source</a
         >
-          Compliance details
-        </a>
       </div>
     </div>
   </div>
 
-  <div
-    class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 mt-6 text-xs text-verity-text-muted"
-  >
-    <span>{copaCount} Copa-patched upstream images</span>
-    <span class="text-verity-border">|</span>
-    <span>{integerCount} Wolfi-based hardened images</span>
-    <span class="text-verity-border">|</span>
-    <span>{chartCount} Helm wrapper {chartCount === 1 ? "chart" : "charts"}</span>
-    <span class="text-verity-border">|</span>
-    <span>cosign signed + SLSA L3 + CycloneDX SBOM</span>
+  <div class="bg-verity-surface border border-verity-border rounded p-5">
+    <h2 class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mb-4">
+      Use a patched image
+    </h2>
+    <p class="text-sm text-verity-text-muted mb-3">Replace your image reference. That's it.</p>
+    <div
+      class="bg-verity-void border border-verity-border rounded p-3 font-mono text-xs text-verity-text-primary overflow-x-auto mb-3"
+    >
+      <div class="text-verity-text-muted"># Pull a patched image</div>
+      <div>docker pull {exampleRef}</div>
+    </div>
+    <div class="flex items-center gap-2">
+      <CopyButton text={pullCmd} />
+    </div>
+    <div class="mt-4 pt-3 border-t border-verity-border flex items-center justify-between">
+      <span class="text-xs text-verity-text-muted"> Every image is signed and attested. </span>
+      <a
+        href={`${base}compliance/`}
+        class="text-xs text-verity-orbit hover:text-verity-nucleus transition-colors underline"
+      >
+        Compliance details
+      </a>
+    </div>
   </div>
+</section>
+
+<div
+  class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 mt-6 mb-8 text-xs text-verity-text-muted"
+>
+  <span>{copaCount} Copa-patched upstream images</span>
+  <span class="text-verity-border">|</span>
+  <span>{integerCount} Wolfi-based hardened images</span>
+  <span class="text-verity-border">|</span>
+  <span>{chartCount} Helm wrapper {chartCount === 1 ? "chart" : "charts"}</span>
+  <span class="text-verity-border">|</span>
+  <span>cosign signed + SLSA L3 + CycloneDX SBOM</span>
 </div>

--- a/site/src/components/HeroSection.astro
+++ b/site/src/components/HeroSection.astro
@@ -31,10 +31,7 @@ const pipelineSteps = [
   </div>
 
   <div class="relative">
-    <div
-      class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mb-7"
-      aria-label="Tagline"
-    >
+    <div class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mb-7">
       SELF-MAINTAINING REGISTRY · PATCHED DAILY · 02:00 UTC
     </div>
 

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -2,14 +2,14 @@
 const base = import.meta.env.BASE_URL;
 ---
 
-<nav class="bg-verity-surface border-b border-verity-border text-verity-text-primary">
-  <div class="max-w-6xl mx-auto px-4 py-3 flex items-center gap-4">
-    <a href={base} class="flex items-center gap-3 hover:opacity-80 transition-opacity group">
+<nav class="sticky top-0 z-40 bg-verity-void/80 border-b border-verity-border backdrop-blur-none">
+  <div class="max-w-[1120px] mx-auto px-6 py-3.5 flex items-center justify-between gap-6">
+    <a href={base} class="flex items-center gap-2.5 group">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 80 80"
-        width="32"
-        height="32"
+        width="28"
+        height="28"
         class="flex-shrink-0"
       >
         <defs>
@@ -17,13 +17,6 @@ const base = import.meta.env.BASE_URL;
             <stop offset="0%" stop-color="#00F0CC"></stop>
             <stop offset="100%" stop-color="#0099A8"></stop>
           </linearGradient>
-          <filter id="verity-nav-glow">
-            <feGaussianBlur stdDeviation="2" result="blur"></feGaussianBlur>
-            <feMerge
-              ><feMergeNode in="blur"></feMergeNode><feMergeNode in="SourceGraphic"
-              ></feMergeNode></feMerge
-            >
-          </filter>
         </defs>
         <ellipse
           cx="40"
@@ -32,8 +25,8 @@ const base = import.meta.env.BASE_URL;
           ry="9"
           fill="none"
           stroke="#00F0CC"
-          stroke-width="1"
-          stroke-opacity="0.5"></ellipse>
+          stroke-width="1.5"
+          stroke-opacity="0.55"></ellipse>
         <ellipse
           cx="40"
           cy="40"
@@ -41,8 +34,8 @@ const base = import.meta.env.BASE_URL;
           ry="9"
           fill="none"
           stroke="#0099A8"
-          stroke-width="1"
-          stroke-opacity="0.45"
+          stroke-width="1.5"
+          stroke-opacity="0.5"
           transform="rotate(60 40 40)"></ellipse>
         <ellipse
           cx="40"
@@ -51,42 +44,46 @@ const base = import.meta.env.BASE_URL;
           ry="9"
           fill="none"
           stroke="#00CCAA"
-          stroke-width="1"
-          stroke-opacity="0.4"
+          stroke-width="1.5"
+          stroke-opacity="0.45"
           transform="rotate(-60 40 40)"></ellipse>
-        <circle cx="66" cy="40" r="2.8" fill="#00F0CC" filter="url(#verity-nav-glow)"></circle>
-        <circle cx="53" cy="62.5" r="2.4" fill="#0099A8" filter="url(#verity-nav-glow)"></circle>
-        <circle cx="53" cy="17.5" r="2.4" fill="#00CCAA" filter="url(#verity-nav-glow)"></circle>
-        <circle
-          cx="40"
-          cy="40"
-          r="8"
-          fill="#060D12"
-          stroke="#00F0CC"
-          stroke-width="1.3"
-          filter="url(#verity-nav-glow)"></circle>
-        <circle cx="40" cy="40" r="4" fill="url(#verity-nav-teal)" filter="url(#verity-nav-glow)"
-        ></circle>
+        <circle cx="66" cy="40" r="3.5" fill="#00F0CC"></circle>
+        <circle cx="53" cy="62.5" r="3" fill="#0099A8"></circle>
+        <circle cx="53" cy="17.5" r="3" fill="#00CCAA"></circle>
+        <circle cx="40" cy="40" r="8" fill="#060D12" stroke="#00F0CC" stroke-width="1.5"></circle>
+        <circle cx="40" cy="40" r="4" fill="url(#verity-nav-teal)"></circle>
       </svg>
-      <div class="flex flex-col">
-        <span class="text-lg font-bold tracking-[0.4em] leading-none">VERITY</span>
-        <span class="text-[0.6rem] tracking-[0.25em] text-verity-text-secondary uppercase mt-0.5"
-          >Container Security</span
-        >
-      </div>
+      <span class="text-base tracking-[0.25em] text-verity-text leading-none">VERITY</span>
+      <span class="text-verity-border-2 mx-1">/</span>
+      <span class="text-[11px] tracking-[0.25em] text-verity-text-secondary uppercase leading-none"
+        >SUPPLY</span
+      >
     </a>
-    <div class="ml-auto flex items-center gap-4">
+
+    <div class="flex items-center gap-6">
+      <a
+        href={`${base}catalog/`}
+        class="text-xs tracking-[0.12em] uppercase text-verity-text-secondary hover:text-verity-nucleus hover:[text-shadow:0_0_8px_rgba(0,240,204,0.5)] transition-colors"
+      >
+        Catalog
+      </a>
       <a
         href={`${base}charts/`}
-        class="text-sm text-verity-text-muted hover:text-verity-nucleus transition-colors"
+        class="text-xs tracking-[0.12em] uppercase text-verity-text-secondary hover:text-verity-nucleus hover:[text-shadow:0_0_8px_rgba(0,240,204,0.5)] transition-colors"
       >
         Charts
       </a>
       <a
         href={`${base}compliance/`}
-        class="text-sm text-verity-text-muted hover:text-verity-nucleus transition-colors"
+        class="text-xs tracking-[0.12em] uppercase text-verity-text-secondary hover:text-verity-nucleus hover:[text-shadow:0_0_8px_rgba(0,240,204,0.5)] transition-colors"
       >
         Compliance
+      </a>
+      <a
+        href="https://github.com/verity-org/verity"
+        class="text-xs tracking-[0.12em] uppercase text-verity-text border border-verity-border-2 px-2.5 py-1.5 rounded-md hover:border-verity-nucleus hover:text-verity-nucleus transition-colors"
+      >
+        GitHub ↗
       </a>
     </div>
   </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -62,7 +62,7 @@ const charts = chartsCatalog.charts;
     )
   }
 
-  <section>
+  <section id="catalog">
     <div class="mb-6">
       <h2 class="text-xl font-semibold text-verity-text-primary tracking-wider mb-2">
         Image Catalog

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,20 +1,118 @@
 @import url("https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap");
 
 @import "tailwindcss";
 
+/* =========================================================
+   VERITY — Design tokens
+   Source: verity-design-system/project/colors_and_type.css
+   ========================================================= */
 @theme {
-  --color-verity-nucleus: #00d4b8;
+  /* Brand / atomic palette */
+  --color-verity-nucleus: #00f0cc;
+  --color-verity-nucleus-dim: #00d4b8;
   --color-verity-orbit: #0099a8;
   --color-verity-teal-light: #00ccaa;
   --color-verity-teal: #00d4b8;
   --color-verity-teal-dark: #0099a8;
-  --color-verity-void: #0b1419;
-  --color-verity-surface: #111b22;
-  --color-verity-border: #1f2b35;
+
+  /* Surfaces (dark is primary) */
+  --color-verity-void: #060d12;
+  --color-verity-void-2: #0b1419;
+  --color-verity-surface: #0a1720;
+  --color-verity-surface-2: #111b22;
+  --color-verity-border: #152230;
+  --color-verity-border-2: #1f2b35;
+
+  /* Text */
+  --color-verity-text: #e8edf2;
   --color-verity-text-primary: #c5d5dd;
   --color-verity-text-secondary: #7a8e9c;
   --color-verity-text-muted: #5a6e7c;
+  --color-verity-text-dim: #2e4a5a;
+  --color-verity-text-ghost: #2a3f50;
+
+  /* Light variant */
+  --color-verity-light-bg: #eef3f7;
+  --color-verity-light-card: #e0eef2;
+  --color-verity-light-border: #d0dce5;
+  --color-verity-light-ink: #0a1e2c;
+  --color-verity-light-ink-2: #6a8a9a;
+  --color-verity-light-teal: #008f7a;
+  --color-verity-light-teal-2: #006b7a;
+
+  /* Fonts */
   --font-mono: "Share Tech Mono", "Courier New", monospace;
+  --font-code: "JetBrains Mono", "SF Mono", "Share Tech Mono", monospace;
+}
+
+/* =========================================================
+   Non-color tokens (radii, spacing, tracking, motion, shadows).
+   Exposed as CSS vars so components can reference them directly.
+   ========================================================= */
+:root {
+  /* Radii — tight, terminal aesthetic */
+  --r-0: 0px;
+  --r-1: 2px;
+  --r-2: 3px;
+  --r-3: 4px;
+  --r-4: 6px;
+  --r-5: 18px;
+  --r-full: 999px;
+
+  /* Spacing scale */
+  --s-0: 0;
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 24px;
+  --s-6: 32px;
+  --s-7: 48px;
+  --s-8: 64px;
+  --s-9: 96px;
+
+  /* Letter-spacing — tracked-out mono is Verity's voice */
+  --ls-0: 0;
+  --ls-1: 0.04em;
+  --ls-2: 0.12em;
+  --ls-3: 0.25em;
+  --ls-4: 0.4em;
+
+  /* Elevation */
+  --shadow-glow-teal: 0 0 24px rgba(0, 240, 204, 0.25);
+  --shadow-glow-soft: 0 0 40px rgba(0, 240, 204, 0.12);
+  --shadow-card: 0 1px 0 rgba(255, 255, 255, 0.02), 0 8px 24px rgba(0, 0, 0, 0.5);
+
+  /* Motion */
+  --ease-out: cubic-bezier(0.2, 0.7, 0.2, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --dur-1: 120ms;
+  --dur-2: 180ms;
+  --dur-3: 280ms;
+
+  /* Severity — from site/src/lib/severity.ts */
+  --sev-critical: #f87171;
+  --sev-critical-bg: rgba(127, 29, 29, 0.4);
+  --sev-critical-bar: #dc2626;
+  --sev-high: #fb923c;
+  --sev-high-bg: rgba(67, 20, 7, 0.4);
+  --sev-high-bar: #ea580c;
+  --sev-medium: #facc15;
+  --sev-medium-bg: rgba(66, 32, 6, 0.4);
+  --sev-medium-bar: #ca8a04;
+  --sev-low: #4ade80;
+  --sev-low-bg: rgba(5, 46, 22, 0.4);
+  --sev-low-bar: #16a34a;
+
+  /* Signature gradients */
+  --grad-teal: linear-gradient(135deg, #00f0cc 0%, #0099a8 100%);
+  --grad-underline: linear-gradient(90deg, #00f0cc 0%, rgba(0, 240, 204, 0) 100%);
+  --grad-glow-radial: radial-gradient(
+    600px circle at 50% 0%,
+    rgba(0, 240, 204, 0.08),
+    transparent 60%
+  );
 }
 
 @layer base {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -91,9 +91,9 @@
   --dur-2: 180ms;
   --dur-3: 280ms;
 
-  /* Severity — from site/src/lib/severity.ts */
+  /* Severity — mirrors Tailwind classes in site/src/lib/severity.ts */
   --sev-critical: #f87171;
-  --sev-critical-bg: rgba(127, 29, 29, 0.4);
+  --sev-critical-bg: rgba(69, 10, 10, 0.4); /* red-950/40 */
   --sev-critical-bar: #dc2626;
   --sev-high: #fb923c;
   --sev-high-bg: rgba(67, 20, 7, 0.4);


### PR DESCRIPTION
## Summary

Bring the marketing site in line with the Verity Design System handoff bundle (terminal-on-void aesthetic, tracked-out mono, teal-on-void accent palette).

- **Tokens** — expand `global.css` Tailwind v4 `@theme` to the full palette (`nucleus` + `nucleus-dim`, `void`/`void-2`, `surface`/`surface-2`, `border`/`border-2`, full text ramp, light variant) and add CSS vars for radii, spacing, letter-spacing, motion, severity, and signature gradients. Pulls in JetBrains Mono for code blocks alongside Share Tech Mono.
- **Nav** — sticky `VERITY / SUPPLY` header with tracked-out mono, semi-transparent void backdrop, and a ghost `GitHub ↗` CTA.
- **Footer** — four-column terminal-style layout (brand / Registry / Docs / Pipeline) with generated-at line.
- **Hero** — eyebrow → accent headline → pull-command code card → 5-step pipeline strip (Discover → Scan → Patch → Sign → Publish). Live catalog stats and "How it works" panels preserved underneath.

## Test plan

- [x] `npm run build` succeeds (165 pages)
- [x] `npm run lint` clean (no new warnings)
- [ ] Visual check in browser: home page hero, nav sticky behavior, footer grid, hover/focus states on CTAs
- [ ] Verify catalog/charts/compliance pages still render with the updated token set
- [ ] Confirm teal intensity (`#00F0CC` nucleus) reads well across hero, cards, and links — design-system author flagged this as open for iteration

https://claude.ai/code/session_01LQiYGLqckGgRsfNVDBMejd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts the Verity Design System across the marketing site with new tokens, typography, and layouts. Restyles the nav, hero, and footer; keeps catalog and compliance views intact, and addresses review feedback.

- **New Features**
  - Tokens: Expanded Tailwind v4 `@theme` in `global.css` (void/surface/border, full text ramp, `nucleus`/`nucleus-dim`), plus radii, spacing, letter-spacing, motion, severity, and signature gradients; added `JetBrains Mono` for code.
  - Nav: Sticky "VERITY / SUPPLY" header with a semi-transparent backdrop, Catalog/Charts/Compliance links, and a GitHub CTA.
  - Hero: Eyebrow + accent headline, copyable `docker pull` for a live example, and a 5-step pipeline strip; live stats and “How it works” retained.
  - Footer: Four-column layout (Brand, Registry, Docs, Pipeline) with a generated-at line.

- **Bug Fixes**
  - Footer: internal links use `import.meta.env.BASE_URL`; REGISTRY links to the GitHub Packages org page while labeled “ghcr.io/verity-org”; generated date is formatted in UTC.
  - Hero accessibility: removed an unnecessary aria-label so the eyebrow text is read correctly.
  - Index: added `id="catalog"` so the “Browse Catalog” CTA scrolls to the catalog section.
  - Tokens: corrected `--sev-critical-bg` to `rgba(69,10,10,0.4)` to match severity colors.

<sup>Written for commit 48c0348be8281fcb3f10096e41cbb50b1d49cbfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

