### PR TITLE
docs: follow up on #240 review — fix-up terminology + script descriptions

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -5,12 +5,12 @@ and are shellcheck validated.
 
 ## Patching pipeline
 
-| Script              | Used by                                        | Purpose                                                       |
-| ------------------- | ---------------------------------------------- | ------------------------------------------------------------- |
-| `patch-image.sh`    | `patch-image.yaml`, `pr-test.yaml`             | Copa patch + crane fallback for one platform image            |
-| `scan-before.sh`    | `pr-test.yaml`                                 | Pre-patch Trivy scan                                          |
-| `verify-patched.sh` | `pr-test.yaml`                                 | Verify patched image vs. pre-patch CVE state                  |
-| `push-reports.sh`   | `patch-image.yaml`, `integer-build-image.yaml` | Push Trivy reports and preflight manifest to `reports` branch |
+| Script              | Used by                                        | Purpose                                                                                                                                        |
+| ------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `patch-image.sh`    | `patch-image.yaml`, `pr-test.yaml`             | Copa patch + crane fallback for one platform image                                                                                             |
+| `scan-before.sh`    | `pr-test.yaml`                                 | Pre-patch Trivy scan                                                                                                                           |
+| `verify-patched.sh` | `pr-test.yaml`                                 | Verify patched image vs. pre-patch CVE state                                                                                                   |
+| `push-reports.sh`   | `patch-image.yaml`, `integer-build-image.yaml` | Push JSON files (pre/post Copa scan reports, Integer build reports) to the `reports` branch via the Contents API (with retry)                  |
 
 ## Integer (Wolfi) build
 
@@ -19,11 +19,11 @@ and are shellcheck validated.
 | `melange-check.sh` | `pr-test.yaml` | Check whether an image type needs melange; emit build config |
 | `melange-build.sh` | `pr-test.yaml` | Resolve melange source and build a single-arch APK           |
 
-## Site build
+## Copa input lookup
 
-| Script                  | Used by        | Purpose                                          |
-| ----------------------- | -------------- | ------------------------------------------------ |
-| `read-catalog-entry.sh` | `pr-test.yaml` | Read a single catalog entry during site assembly |
+| Script                  | Used by        | Purpose                                                                                                           |
+| ----------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `read-catalog-entry.sh` | `pr-test.yaml` | Look up `image` (and optional `goVcsUrl` / `goVcsTagPrefix`) from `copa-config.yaml` for a given image name + tag |
 
 ## Issue-to-PR automation
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,8 +140,9 @@ per-image patch runs.
 ### `verity preflight update-manifest`
 
 Updates the preflight manifest on the `reports` branch. The manifest tracks
-upstream image digests and remaining fixable-vuln counts so the orchestrator can
-skip rebuilds that would produce identical output. Requires `GH_TOKEN` or
+upstream image digests and post-patch vulnerability counts (raw Trivy counts,
+including unfixable CVEs) so the orchestrator can skip rebuilds that would
+produce identical output. Requires `GH_TOKEN` or
 `GITHUB_TOKEN` in the environment.
 
 | Flag | Default | Description |
@@ -151,7 +152,7 @@ skip rebuilds that would produce identical output. Requires `GH_TOKEN` or
 | `--image` | *(required)* | Image name |
 | `--tag` | *(required)* | Image tag |
 | `--upstream-digest` | | Upstream image digest (`sha256:…`) |
-| `--patched-vulns` | `0` | Number of fixable vulnerabilities remaining after patching |
+| `--patched-vulns` | `0` | Count of vulnerabilities remaining after patching. The CLI flag's help text calls these "fixable", but the pipeline currently passes the raw Trivy count from `post.json` (no `--ignore-unfixed`), so the recorded value includes unfixable CVEs |
 
 ### `verity integer`
 
@@ -383,10 +384,12 @@ This keeps PR feedback fast while still exercising the real patch path. See
 ### Skip Detection (Preflight)
 
 `verity preflight` maintains a manifest on the `reports` branch that records
-each published image's upstream digest and remaining fixable-vuln count. When
-`verity discover --preflight` runs, images whose upstream digest hasn't changed
-AND whose fixable-vuln count is zero are skipped — avoiding unnecessary
-rebuilds, registry churn, and signing traffic.
+each published image's upstream digest and post-patch vulnerability count
+(raw Trivy count from `post.json` — includes unfixable CVEs, since the pipeline
+does not pass `--ignore-unfixed`). When `verity discover --preflight` runs,
+images whose upstream digest hasn't changed AND whose recorded vulnerability
+count is zero are skipped — avoiding unnecessary rebuilds, registry churn,
+and signing traffic.
 
 ## Site Architecture
 
@@ -409,8 +412,11 @@ Pages. `catalog.json` + `integer-catalog.json` drive every page.
 ### Daily Scans
 
 Cron triggers cascade across the night: Copa at 02:00 UTC, Integer at 03:00,
-chart-gen at 04:00, site build at 05:00. If new fixable vulnerabilities are
-found, images are patched and published automatically.
+chart-gen at 04:00, site build at 05:00. Whether each image actually publishes
+depends on the skip checks (see Skip Detection above) and on whether the
+post-patch Trivy vulnerability-ID set has changed since the previous
+published report on the `reports` branch — a change, including the appearance
+of a previously-unseen unfixable CVE, triggers a new push.
 
 ### Dependency Updates (Renovate)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,7 +152,7 @@ produce identical output. Requires `GH_TOKEN` or
 | `--image` | *(required)* | Image name |
 | `--tag` | *(required)* | Image tag |
 | `--upstream-digest` | | Upstream image digest (`sha256:…`) |
-| `--patched-vulns` | `0` | Count of vulnerabilities remaining after patching. The CLI flag's help text calls these "fixable", but the pipeline currently passes the raw Trivy count from `post.json` (no `--ignore-unfixed`), so the recorded value includes unfixable CVEs |
+| `--patched-vulns` | `0` | Count of vulnerabilities remaining after patching. The CLI flag's help text calls these "fixable". This CLI is not currently invoked by the workflows — today `patch-image.yaml` updates `preflight-manifest.json` inline via `gh api` + `jq`, writing the raw Trivy post-patch count from `post.json` (no `--ignore-unfixed`, so the value includes unfixable CVEs) — but the CLI exists as a programmatic alternative |
 
 ### `verity integer`
 
@@ -412,11 +412,17 @@ Pages. `catalog.json` + `integer-catalog.json` drive every page.
 ### Daily Scans
 
 Cron triggers cascade across the night: Copa at 02:00 UTC, Integer at 03:00,
-chart-gen at 04:00, site build at 05:00. Whether each image actually publishes
-depends on the skip checks (see Skip Detection above) and on whether the
+chart-gen at 04:00, site build at 05:00.
+
+For **Copa-patched images**, whether an image actually re-publishes on a given
+run depends on the skip checks (see Skip Detection above) plus whether the
 post-patch Trivy vulnerability-ID set has changed since the previous
 published report on the `reports` branch — a change, including the appearance
 of a previously-unseen unfixable CVE, triggers a new push.
+
+For **Integer (Wolfi) images**, the build runs on a schedule or when
+`images/<name>.yaml` changes; there is no vuln-ID-set delta comparison, so
+rebuilt images are published whenever the build succeeds.
 
 ### Dependency Updates (Renovate)
 


### PR DESCRIPTION
## Summary

Follow-up to #240. Six review threads landed on #240 after it was merged,
flagging remaining accuracy issues in ARCHITECTURE.md and
`.github/scripts/README.md`. This PR addresses them on `main`.

## Changes

### `ARCHITECTURE.md` — `fixable` terminology drift

The preflight manifest's `patched_vulns` field is populated from the raw
Trivy count in `post.json` (no `--ignore-unfixed`), so it includes unfixable
CVEs. The orchestrator's `--preflight` skip decision reads that same value.
The `verity preflight update-manifest --patched-vulns` flag help text still
says "fixable remaining", but the recorded value is the full count.

- Preflight-manifest description now says "post-patch vulnerability counts
  (raw Trivy counts, including unfixable CVEs)".
- `--patched-vulns` flag row now explicitly calls out the help-text drift
  and documents what's actually written.
- Skip Detection paragraph matches: "recorded vulnerability count is zero".
- Daily Scans paragraph reworded — publishing is gated on the post-patch
  vuln-ID-set changing (a new unfixable CVE can trigger a re-push), not on
  "new fixable vulnerabilities".

### `.github/scripts/README.md` — script descriptions

- `read-catalog-entry.sh` — was described as "Read a single catalog entry
  during site assembly" in the Site build section. The script actually
  looks up `image` + optional `goVcsUrl` / `goVcsTagPrefix` from
  `copa-config.yaml` for a given image name + tag (used in PR Copa patch
  tests). Moved to a new **Copa input lookup** section with the accurate
  description.
- `push-reports.sh` — was described as pushing "Trivy reports and preflight
  manifest". Actually it pushes arbitrary JSON report files via the Contents
  API (concurrent-safe with retry). The `preflight-manifest.json` update
  happens inline in `patch-image.yaml` / `integer-build-image.yaml`, not
  through this script. Updated accordingly.

## Verification

- `mise exec -- markdownlint ARCHITECTURE.md .github/scripts/README.md -c .markdownlint.json` → exit 0
- Diffs compared against actual workflow / script source, not assumptions
- No banned terms (`patch-matrix.yaml`, stale versions, etc.) introduced

Pure documentation follow-up — no code or workflow changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes accuracy issues in `ARCHITECTURE.md` and `.github/scripts/README.md` to match the pipeline. Clarifies preflight skip logic, CLI wiring, and how daily publishes work for Copa vs Integer.

- **Bug Fixes**
  - `ARCHITECTURE.md`: Document that the preflight manifest stores the raw post‑patch Trivy count (includes unfixable); update the `--patched-vulns` row to note help-text drift and that workflows update the manifest inline via `gh` + `jq` (CLI is optional); align Skip Detection wording; split Daily Scans into Copa gate (skip checks + vuln‑ID‑set delta) vs. Integer gate (schedule/source change, no delta compare).
  - `.github/scripts/README.md`: Clarify `push-reports.sh` pushes JSON reports to `reports` via the Contents API (with retry); preflight-manifest updates happen in workflows; move `read-catalog-entry.sh` to a new “Copa input lookup” section and describe its `copa-config.yaml` lookup.

<sup>Written for commit fd31096a7e87a3476730732127c98b13d6e4997c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

