### PR TITLE
feat(integer): Wolfi rebuilds for flux, cortex, temporal, external-secrets, kube-rbac-proxy, metallb, gitea, meilisearch

### DIFF
--- a/images/cortex.yaml
+++ b/images/cortex.yaml
@@ -1,0 +1,15 @@
+name: cortex
+description: "Cortex horizontally scalable Prometheus — Copa can't patch scratch-based official image; Wolfi rebuild"
+upstream:
+  package: cortex
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cortex"]
+    entrypoint: /usr/bin/cortex
+    paths:
+      - {path: /cortex, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "1": {}

--- a/images/external-secrets.yaml
+++ b/images/external-secrets.yaml
@@ -1,0 +1,13 @@
+name: external-secrets
+description: "External Secrets Operator — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: external-secrets-operator
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["external-secrets-operator"]
+    entrypoint: /usr/bin/external-secrets
+
+versions:
+  "0": {}

--- a/images/flux.yaml
+++ b/images/flux.yaml
@@ -1,0 +1,13 @@
+name: flux
+description: "Flux CD GitOps controller CLI — Copa can't patch scratch-based official image; Wolfi rebuild"
+upstream:
+  package: flux
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["flux"]
+    entrypoint: /usr/bin/flux
+
+versions:
+  "2": {}

--- a/images/gitea.yaml
+++ b/images/gitea.yaml
@@ -1,0 +1,15 @@
+name: gitea
+description: "Gitea self-hosted Git service — Wolfi rebuild targets upstream Alpine/Debian CVEs"
+upstream:
+  package: gitea
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["gitea"]
+    entrypoint: /usr/bin/gitea
+    paths:
+      - {path: /data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "1": {}

--- a/images/kube-rbac-proxy.yaml
+++ b/images/kube-rbac-proxy.yaml
@@ -1,0 +1,13 @@
+name: kube-rbac-proxy
+description: "Kubernetes RBAC authorization proxy — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: kube-rbac-proxy
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["kube-rbac-proxy"]
+    entrypoint: /usr/bin/kube-rbac-proxy
+
+versions:
+  "0": {}

--- a/images/meilisearch.yaml
+++ b/images/meilisearch.yaml
@@ -1,0 +1,15 @@
+name: meilisearch
+description: "Meilisearch search engine — Copa can't patch scratch-based official image; Wolfi rebuild"
+upstream:
+  package: meilisearch
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["meilisearch"]
+    entrypoint: /usr/bin/meilisearch
+    paths:
+      - {path: /meili_data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "1": {}

--- a/images/metallb-controller.yaml
+++ b/images/metallb-controller.yaml
@@ -1,0 +1,13 @@
+name: metallb-controller
+description: "MetalLB load-balancer controller — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: metallb-controller
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["metallb-controller"]
+    entrypoint: /usr/bin/metallb-controller
+
+versions:
+  "0": {}

--- a/images/metallb-speaker.yaml
+++ b/images/metallb-speaker.yaml
@@ -1,0 +1,13 @@
+name: metallb-speaker
+description: "MetalLB load-balancer speaker — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: metallb-speaker
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["metallb-speaker"]
+    entrypoint: /usr/bin/metallb-speaker
+
+versions:
+  "0": {}

--- a/images/temporal.yaml
+++ b/images/temporal.yaml
@@ -1,0 +1,13 @@
+name: temporal
+description: "Temporal durable execution server — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: temporal-server
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["temporal-server"]
+    entrypoint: /usr/bin/temporal-server
+
+versions:
+  "1": {}

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -340,6 +340,10 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "metrics-server", source: "integer" },
       { name: "velero", source: "integer" },
       { name: "sealed-secrets", source: "integer" },
+      { name: "external-secrets", source: "integer" },
+      { name: "kube-rbac-proxy", source: "integer" },
+      { name: "metallb-controller", source: "integer" },
+      { name: "metallb-speaker", source: "integer" },
     ],
   },
 
@@ -510,6 +514,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "jaeger", source: "integer" },
       { name: "tempo", source: "integer" },
       { name: "grafana-alloy", source: "integer" },
+      { name: "cortex", source: "integer" },
     ],
   },
 
@@ -572,6 +577,8 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "ghcr.io/renovatebot/renovate",
       },
       { name: "kaniko", source: "integer" },
+      { name: "flux", source: "integer" },
+      { name: "gitea", source: "integer" },
     ],
   },
 
@@ -732,6 +739,8 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "ghcr.io/kubeflow/spark-operator",
       },
       { name: "mlflow/mlflow", label: "mlflow", source: "copa", upstream: "ghcr.io/mlflow/mlflow" },
+      { name: "temporal", source: "integer" },
+      { name: "meilisearch", source: "integer" },
       {
         name: "tensorflow/serving",
         label: "tensorflow-serving",


### PR DESCRIPTION
## Summary

Adds 9 Wolfi-based Integer images for popular K8s ecosystem, GitOps, observability, and data tools. Each upstream official image is scratch- or distroless-based, so Copa cannot patch them — Wolfi rebuilds are the only path to zero-CVE coverage.

### Added (9 new Integer images)

**GitOps / Dev platform (2)**
| Image | Wolfi package | Binary |
|-------|--------------|--------|
| `flux` | `flux` | `/usr/bin/flux` |
| `gitea` | `gitea` | `/usr/bin/gitea` |

**Kubernetes ecosystem (4)**
| Image | Wolfi package | Binary |
|-------|--------------|--------|
| `external-secrets` | `external-secrets-operator` | `/usr/bin/external-secrets` |
| `kube-rbac-proxy` | `kube-rbac-proxy` | `/usr/bin/kube-rbac-proxy` |
| `metallb-controller` | `metallb-controller` | `/usr/bin/metallb-controller` |
| `metallb-speaker` | `metallb-speaker` | `/usr/bin/metallb-speaker` |

**Observability (1)**
| Image | Wolfi package | Binary |
|-------|--------------|--------|
| `cortex` | `cortex` | `/usr/bin/cortex` |

**Data & workflows (2)**
| Image | Wolfi package | Binary |
|-------|--------------|--------|
| `temporal` | `temporal-server` | `/usr/bin/temporal-server` |
| `meilisearch` | `meilisearch` | `/usr/bin/meilisearch` |

### Validation
- `./verity integer validate` → all 126 configs valid
- `./verity integer discover` → all 9 resolve versions + tags correctly
- Local Trivy preflight scan → **0 CRITICAL/HIGH CVEs** on all 9
- Binary paths verified against Wolfi APKINDEX contents

### Files
- 9 new YAMLs under `images/`
- `site/src/data/full-catalog.ts` — entries under kubernetes, monitoring, cicd, data categories

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nine Wolfi-based Integer images for key Kubernetes, GitOps, observability, and data tools. These rebuilds replace scratch/distroless upstreams so we can patch CVEs and ship zero‑CVE images.

- **New Features**
  - Added images: `flux`, `gitea`, `external-secrets`, `kube-rbac-proxy`, `metallb-controller`, `metallb-speaker`, `cortex`, `temporal`, `meilisearch`.
  - Catalog updated; configs validate and versions resolve; preflight scans show 0 critical/high CVEs.
  - Entrypoints set to `/usr/bin/*`; non-root data dirs created where needed (`gitea` `/data`, `meilisearch` `/meili_data`, `cortex` `/cortex`).

<sup>Written for commit c27de8fce250cb50c349f9f81fde2bdaf93b215d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

