### PR TITLE
feat(charts): add 6 chart deps + fix replacement substring-prefix bug

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,3 +19,27 @@ dependencies:
   - name: postgres-operator
     version: "1.15.1"
     repository: "https://opensource.zalando.com/postgres-operator/charts/postgres-operator"
+
+  - name: kyverno
+    version: "3.7.2"
+    repository: "oci://ghcr.io/kyverno/charts"
+
+  - name: argo-cd
+    version: "9.5.4"
+    repository: "https://argoproj.github.io/argo-helm"
+
+  - name: dex
+    version: "0.24.0"
+    repository: "https://charts.dexidp.io"
+
+  - name: metrics-server
+    version: "3.13.0"
+    repository: "https://kubernetes-sigs.github.io/metrics-server/"
+
+  - name: opensearch
+    version: "3.6.0"
+    repository: "https://opensearch-project.github.io/helm-charts"
+
+  - name: opensearch-dashboards
+    version: "3.6.0"
+    repository: "https://opensearch-project.github.io/helm-charts"

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -143,12 +143,21 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 		return imageRefs, nil
 	}
 
-	// Sort patterns for deterministic match order.
+	// Sort patterns longest-first so more-specific patterns win over their
+	// substring prefixes when matching. e.g. "kyverno/kyverno-cli" must be
+	// tried before "kyverno/kyverno" so that the cli image isn't greedily
+	// claimed by the bare-kyverno pattern's Contains check below.
+	// Ties broken alphabetically for deterministic order.
 	patterns := make([]string, 0, len(vc.Replacements))
 	for p := range vc.Replacements {
 		patterns = append(patterns, p)
 	}
-	sort.Strings(patterns)
+	sort.Slice(patterns, func(i, j int) bool {
+		if len(patterns[i]) != len(patterns[j]) {
+			return len(patterns[i]) > len(patterns[j])
+		}
+		return patterns[i] < patterns[j]
+	})
 
 	remaining := make([]string, 0, len(imageRefs))
 	var replacements []ImageMapping

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -143,10 +143,13 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 		return imageRefs, nil
 	}
 
-	// Sort patterns longest-first so more-specific patterns win over their
-	// substring prefixes when matching. e.g. "kyverno/kyverno-cli" must be
-	// tried before "kyverno/kyverno" so that the cli image isn't greedily
-	// claimed by the bare-kyverno pattern's Contains check below.
+	// Sort patterns longest-first so a more-specific pattern wins over a
+	// shorter pattern whose text is contained within it. The matcher below
+	// uses strings.Contains, so e.g. when both "kyverno/kyverno" and
+	// "kyverno/kyverno-cli" are configured, the cli pattern must be tried
+	// first or the bare "kyverno/kyverno" pattern would greedily claim the
+	// cli image (and the kyvernopre image too — which IS the desired
+	// behavior for kyvernopre, since it shares the kyverno binary).
 	// Ties broken alphabetically for deterministic order.
 	patterns := make([]string, 0, len(vc.Replacements))
 	for p := range vc.Replacements {

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -170,10 +170,10 @@ func TestApplyReplacementsLongestPatternWins(t *testing.T) {
 	_, replacements := applyReplacements(refs, vc, nil)
 
 	want := map[string]string{
-		"reg.kyverno.io/kyverno/kyverno":            "ghcr.io/verity-org/kyverno",
-		"reg.kyverno.io/kyverno/kyverno-cli":        "ghcr.io/verity-org/kyverno-cli",
-		"opensearchproject/opensearch":              "ghcr.io/verity-org/opensearch",
-		"opensearchproject/opensearch-dashboards":   "ghcr.io/verity-org/opensearch-dashboards",
+		"reg.kyverno.io/kyverno/kyverno":          "ghcr.io/verity-org/kyverno",
+		"reg.kyverno.io/kyverno/kyverno-cli":      "ghcr.io/verity-org/kyverno-cli",
+		"opensearchproject/opensearch":            "ghcr.io/verity-org/opensearch",
+		"opensearchproject/opensearch-dashboards": "ghcr.io/verity-org/opensearch-dashboards",
 	}
 	if len(replacements) != len(want) {
 		t.Fatalf("replacements = %d, want %d", len(replacements), len(want))

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -146,6 +146,51 @@ func TestApplyReplacementsNilConfig(t *testing.T) {
 	}
 }
 
+func TestApplyReplacementsLongestPatternWins(t *testing.T) {
+	// Regression test for substring-prefix collisions: a longer, more
+	// specific pattern must win over a shorter pattern that is a substring
+	// of the same image name. Lexicographic ordering would put the shorter
+	// "kyverno/kyverno" before "kyverno/kyverno-cli" and incorrectly claim
+	// the cli image; longest-first ordering fixes that.
+	refs := []string{
+		"reg.kyverno.io/kyverno/kyverno:v1.17.2",
+		"reg.kyverno.io/kyverno/kyverno-cli:v1.17.2",
+		"opensearchproject/opensearch:3.6.0",
+		"opensearchproject/opensearch-dashboards:3.6.0",
+	}
+	vc := &config.VerityConfig{
+		Replacements: map[string]config.Replacement{
+			"kyverno/kyverno":                         {Registry: "ghcr.io/verity-org", Image: "kyverno"},
+			"kyverno/kyverno-cli":                     {Registry: "ghcr.io/verity-org", Image: "kyverno-cli"},
+			"opensearchproject/opensearch":            {Registry: "ghcr.io/verity-org", Image: "opensearch"},
+			"opensearchproject/opensearch-dashboards": {Registry: "ghcr.io/verity-org", Image: "opensearch-dashboards"},
+		},
+	}
+
+	_, replacements := applyReplacements(refs, vc, nil)
+
+	want := map[string]string{
+		"reg.kyverno.io/kyverno/kyverno":            "ghcr.io/verity-org/kyverno",
+		"reg.kyverno.io/kyverno/kyverno-cli":        "ghcr.io/verity-org/kyverno-cli",
+		"opensearchproject/opensearch":              "ghcr.io/verity-org/opensearch",
+		"opensearchproject/opensearch-dashboards":   "ghcr.io/verity-org/opensearch-dashboards",
+	}
+	if len(replacements) != len(want) {
+		t.Fatalf("replacements = %d, want %d", len(replacements), len(want))
+	}
+	for _, r := range replacements {
+		got := r.PatchedRepo
+		expected, ok := want[r.OriginalRepo]
+		if !ok {
+			t.Errorf("unexpected OriginalRepo: %q", r.OriginalRepo)
+			continue
+		}
+		if got != expected {
+			t.Errorf("OriginalRepo=%q: got PatchedRepo=%q, want %q", r.OriginalRepo, got, expected)
+		}
+	}
+}
+
 func TestApplyReplacementsExcluded(t *testing.T) {
 	refs := []string{"quay.io/prometheus/pushgateway:v1.11.2"}
 	vc := &config.VerityConfig{

--- a/verity.yaml
+++ b/verity.yaml
@@ -27,3 +27,41 @@ replacements:
   "prometheus/pushgateway":
     registry: "ghcr.io/verity-org"
     image: "pushgateway"
+
+  # kyverno chart (3.7.2). Chart renders images under
+  # `reg.kyverno.io/kyverno/*` (Kyverno's pull-through mirror); repoPath
+  # strips the host so keys match `kyverno/<name>`. kyvernopre runs the
+  # same kyverno binary and maps to the same Integer image.
+  "kyverno/kyverno":
+    registry: "ghcr.io/verity-org"
+    image: "kyverno"
+  "kyverno/background-controller":
+    registry: "ghcr.io/verity-org"
+    image: "kyverno-background-controller"
+  "kyverno/reports-controller":
+    registry: "ghcr.io/verity-org"
+    image: "kyverno-reports-controller"
+  "kyverno/kyverno-cli":
+    registry: "ghcr.io/verity-org"
+    image: "kyverno-cli"
+
+  # argo-cd chart (9.5.4) → argocd controller; dex shared with dex chart.
+  "argoproj/argocd":
+    registry: "ghcr.io/verity-org"
+    image: "argocd"
+  "dexidp/dex":
+    registry: "ghcr.io/verity-org"
+    image: "dex"
+
+  # metrics-server chart (3.13.0).
+  "metrics-server/metrics-server":
+    registry: "ghcr.io/verity-org"
+    image: "metrics-server"
+
+  # opensearch + opensearch-dashboards charts (3.6.0).
+  "opensearchproject/opensearch":
+    registry: "ghcr.io/verity-org"
+    image: "opensearch"
+  "opensearchproject/opensearch-dashboards":
+    registry: "ghcr.io/verity-org"
+    image: "opensearch-dashboards"


### PR DESCRIPTION
## Summary

Adds 6 verified Helm chart dependencies to `Chart.yaml` and 9 image replacements to `verity.yaml`. Also includes a small bugfix to `applyReplacements()` so longer/more-specific patterns beat their substring prefixes — without it, `kyverno/kyverno` would greedily claim `kyverno/kyverno-cli` and `kyverno/kyvernopre` (and the same class of bug hit `opensearchproject/opensearch` vs `opensearchproject/opensearch-dashboards`).

All 6 chart additions ground-truth-verified via `helm pull` + `helm template` + `./verity chart-gen --dry-run` against live registries.

## Charts added

| Chart | Version | Repository | Mappings |
|---|---|---|---|
| kyverno | 3.7.2 | `oci://ghcr.io/kyverno/charts` | 5 (kyverno, kyvernopre→kyverno, background-controller, reports-controller, kyverno-cli) |
| argo-cd | 9.5.4 | `https://argoproj.github.io/argo-helm` | 2 (argocd, dex) |
| dex | 0.24.0 | `https://charts.dexidp.io` | 1 |
| metrics-server | 3.13.0 | `https://kubernetes-sigs.github.io/metrics-server/` | 1 |
| opensearch | 3.6.0 | `https://opensearch-project.github.io/helm-charts` | 1 |
| opensearch-dashboards | 3.6.0 | (same) | 1 |

**Total: 11 new replacements** across 6 charts.

## `applyReplacements` bugfix

Tiny but important. The old code sorted patterns alphabetically; combined with substring matching (`name == p || strings.Contains(name, p)`) and first-match-then-break, that meant a shorter pattern that was a *prefix* of a longer image name would silently steal the more specific pattern's match. Concrete failure observed in dry-run before the fix:

```
reg.kyverno.io/kyverno/kyverno-cli:v1.17.2 → ghcr.io/verity-org/kyverno   (WRONG; should be kyverno-cli)
opensearchproject/opensearch-dashboards:3.6.0 → ghcr.io/verity-org/opensearch  (WRONG)
```

After fix (`sort.Slice` longest-first, ties alphabetical):

```
reg.kyverno.io/kyverno/kyverno-cli:v1.17.2 → ghcr.io/verity-org/kyverno-cli      ✓
opensearchproject/opensearch-dashboards:3.6.0 → ghcr.io/verity-org/opensearch-dashboards  ✓
```

`TestApplyReplacementsLongestPatternWins` is the regression guard. Existing `TestApplyReplacements` still passes (its image refs only had 1 valid pattern each so order didn't matter, but verifies behavior preserved).

## Verification

```sh
go test ./...               # all green, including new regression test
go build -o verity .

./verity chart-gen \
  --charts-file Chart.yaml --verity-config verity.yaml \
  --target-registry ghcr.io/verity-org \
  --chart-registry oci://ghcr.io/verity-org/charts --dry-run
```

Output (all charts produce wrapper plans, no fatal errors):
```
prometheus@29.2.1            : 2 mappings
kyverno@3.7.2                : 5 mappings
argo-cd@9.5.4                : 2 mappings
dex@0.24.0                   : 1 mapping
metrics-server@3.13.0        : 1 mapping
opensearch@3.6.0             : 1 mapping
opensearch-dashboards@3.6.0  : 1 mapping
```

(Crane warnings present in dry-run because `crane` isn't in PATH locally and the patched tags don't exist yet — both expected; these resolve in CI after the first nightly patch run.)

## What was excluded (and why)

| Chart | Why excluded |
|---|---|
| tigera-operator | Chart emits only the operator image; calico data-plane is deployed by the operator at runtime via Installation CRD, invisible to `helm template`. |
| strimzi-kafka-operator | Same pattern — kafka/zookeeper images are CLI args / env vars to the operator, not `image:` fields. |
| bitnami/rabbitmq*, bitnami/* (any) | Bitnami deleted versioned tags from `docker.io/bitnami/*` on 2025-09-29; charts reference dead images. |
| cert-manager | Would collide with existing standalones in `copa-config.yaml` (controller, webhook, cainjector). |
| opentelemetry-collector | Hard-fails `helm template` without `--set image.repository=...`; chart-gen pipeline does not pass values. |
| cilium | Default render uses digest-pinned images (`tag@sha256:...`) — works but adds parsing complexity; defer. |
| traefik, nats | Single-segment image paths (`docker.io/traefik`, `nats:tag`) are too ambiguous for the current substring-matching `replacements:` key form. |

These are good follow-up PR candidates, but each needs a separate consideration before being a "sure bet."

## Files changed

- `Chart.yaml` — append 6 dependencies
- `verity.yaml` — append 9 replacement entries (with comments documenting the `reg.kyverno.io` host-stripping behavior and shared-image cases)
- `internal/chartgen/chartgen.go` — sort patterns longest-first
- `internal/chartgen/chartgen_test.go` — add regression test for substring-collision

## Notes for review

- Pre-existing orphan: `jimmidyson/configmap-reload` in verity.yaml. Prometheus 29.x no longer emits it. Left in place because dropping it is unrelated to this PR; flag for cleanup.
- `dexidp/dex` is shared between argo-cd and dex charts (different chart versions emit different dex tags). Both charts get the same Integer replacement repo, with version-appropriate tags preserved.
- kyverno's `kyvernopre` is the same kyverno binary in init mode; mapping it to the `kyverno` Integer image is correct (and what `Contains(kyverno/kyvernopre, kyverno/kyverno)` produces here).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 6 Helm chart dependencies and 9 image replacements, and fixes replacement matching to prefer longer patterns over shorter contained ones. Prevents incorrect rewrites like `kyverno/kyverno` capturing `kyverno/kyverno-cli` and `opensearchproject/opensearch` capturing `opensearchproject/opensearch-dashboards`.

- **New Features**
  - Added charts: `kyverno@3.7.2` (`oci://ghcr.io/kyverno/charts`), `argo-cd@9.5.4` (`https://argoproj.github.io/argo-helm`), `dex@0.24.0` (`https://charts.dexidp.io`), `metrics-server@3.13.0` (`https://kubernetes-sigs.github.io/metrics-server/`), `opensearch@3.6.0` and `opensearch-dashboards@3.6.0` (`https://opensearch-project.github.io/helm-charts`).
  - Added 9 replacements: `kyverno/kyverno`, `kyverno/background-controller`, `kyverno/reports-controller`, `kyverno/kyverno-cli`, `argoproj/argocd`, `dexidp/dex`, `metrics-server/metrics-server`, `opensearchproject/opensearch`, `opensearchproject/opensearch-dashboards`.
  - Verified via `helm template` and `./verity chart-gen --dry-run`.

- **Bug Fixes**
  - `applyReplacements`: sort patterns by length (desc), then name (asc) so specific matches win; added `TestApplyReplacementsLongestPatternWins`.
  - Clarified comments to reflect `strings.Contains` semantics; minor `gofumpt` formatting in tests.

<sup>Written for commit e3f1eb85307ddec687f41dc603284674f91146bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

