### PR TITLE
feat(integer): security suite — trivy-operator, kube-bench, openfga, spicedb + bespoke checkov

### DIFF
--- a/.github/scripts/melange-build.sh
+++ b/.github/scripts/melange-build.sh
@@ -9,6 +9,22 @@ mkdir -p melange-work
 
 if [ -n "${BESPOKE:-}" ]; then
   cp "packages/bespoke/${BESPOKE}" melange-work/build.yaml
+
+  # Bespoke builds may use Wolfi-specific pipelines (e.g. py/pip-build-install).
+  # Fetch the pipelines/ tree from the pinned wolfi_commit so they resolve.
+  commit=$(jq -r '.wolfi_commit' packages/upstream.lock.json)
+  if [ "$commit" != "null" ] && [ -n "$commit" ]; then
+    echo "Fetching wolfi pipelines/ at commit ${commit} for bespoke build"
+    tmp_wolfi=$(mktemp -d)
+    trap 'rm -rf "$tmp_wolfi"' EXIT
+    git -C "$tmp_wolfi" init --quiet
+    git -C "$tmp_wolfi" remote add origin "https://github.com/wolfi-dev/os.git"
+    git -C "$tmp_wolfi" sparse-checkout set --no-cone pipelines
+    git -C "$tmp_wolfi" fetch --quiet --depth 1 --filter=blob:none origin "$commit"
+    git -C "$tmp_wolfi" checkout --quiet FETCH_HEAD -- pipelines
+    rm -rf melange-work/pipelines
+    cp -r "$tmp_wolfi/pipelines" melange-work/pipelines
+  fi
 elif [ -n "${UPSTREAM:-}" ]; then
   commit=$(jq -r '.wolfi_commit' packages/upstream.lock.json)
   if [ "$commit" = "null" ] || [ -z "$commit" ]; then

--- a/.github/scripts/melange-build.sh
+++ b/.github/scripts/melange-build.sh
@@ -7,24 +7,47 @@ set -euo pipefail
 
 mkdir -p melange-work
 
+validate_filename() {
+  local label="$1" value="$2"
+
+  if [[ ! "$value" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "${label} contains unsafe characters: '${value}'" >&2
+    exit 1
+  fi
+
+  if [[ "$value" == *".."* ]]; then
+    echo "${label} must not contain path traversal sequences ('..'): '${value}'" >&2
+    exit 1
+  fi
+}
+
 if [ -n "${BESPOKE:-}" ]; then
+  validate_filename "BESPOKE" "$BESPOKE"
+  if [ ! -f "packages/bespoke/${BESPOKE}" ]; then
+    echo "Bespoke build file not found: packages/bespoke/${BESPOKE}" >&2
+    exit 1
+  fi
+
   cp "packages/bespoke/${BESPOKE}" melange-work/build.yaml
 
   # Bespoke builds may use Wolfi-specific pipelines (e.g. py/pip-build-install).
   # Fetch the pipelines/ tree from the pinned wolfi_commit so they resolve.
   commit=$(jq -r '.wolfi_commit' packages/upstream.lock.json)
-  if [ "$commit" != "null" ] && [ -n "$commit" ]; then
-    echo "Fetching wolfi pipelines/ at commit ${commit} for bespoke build"
-    tmp_wolfi=$(mktemp -d)
-    trap 'rm -rf "$tmp_wolfi"' EXIT
-    git -C "$tmp_wolfi" init --quiet
-    git -C "$tmp_wolfi" remote add origin "https://github.com/wolfi-dev/os.git"
-    git -C "$tmp_wolfi" sparse-checkout set --no-cone pipelines
-    git -C "$tmp_wolfi" fetch --quiet --depth 1 --filter=blob:none origin "$commit"
-    git -C "$tmp_wolfi" checkout --quiet FETCH_HEAD -- pipelines
-    rm -rf melange-work/pipelines
-    cp -r "$tmp_wolfi/pipelines" melange-work/pipelines
+  if [ "$commit" = "null" ] || [ -z "$commit" ]; then
+    echo "wolfi_commit missing or null in packages/upstream.lock.json" >&2
+    exit 1
   fi
+
+  echo "Fetching wolfi pipelines/ at commit ${commit} for bespoke build"
+  tmp_wolfi=$(mktemp -d)
+  trap 'rm -rf "$tmp_wolfi"' EXIT
+  git -C "$tmp_wolfi" init --quiet
+  git -C "$tmp_wolfi" remote add origin "https://github.com/wolfi-dev/os.git"
+  git -C "$tmp_wolfi" sparse-checkout set --no-cone pipelines
+  git -C "$tmp_wolfi" fetch --quiet --depth 1 --filter=blob:none origin "$commit"
+  git -C "$tmp_wolfi" checkout --quiet FETCH_HEAD -- pipelines
+  rm -rf melange-work/pipelines
+  cp -r "$tmp_wolfi/pipelines" melange-work/pipelines
 elif [ -n "${UPSTREAM:-}" ]; then
   commit=$(jq -r '.wolfi_commit' packages/upstream.lock.json)
   if [ "$commit" = "null" ] || [ -z "$commit" ]; then

--- a/images/checkov.yaml
+++ b/images/checkov.yaml
@@ -1,0 +1,16 @@
+name: checkov
+description: "Bridgecrew Checkov IaC scanner — Wolfi removed the package upstream; bespoke build from source"
+upstream:
+  package: checkov
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["checkov"]
+    entrypoint: /usr/bin/checkov
+    melange:
+      bespoke: "checkov.yaml"
+
+versions:
+  "3.2.524":
+    latest: true

--- a/images/kube-bench.yaml
+++ b/images/kube-bench.yaml
@@ -1,0 +1,13 @@
+name: kube-bench
+description: "Aqua kube-bench CIS Kubernetes benchmark scanner — Copa can't patch scratch-based official image; Wolfi rebuild"
+upstream:
+  package: kube-bench
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["kube-bench", "kube-bench-configs"]
+    entrypoint: /usr/bin/kube-bench
+
+versions:
+  "0": {}

--- a/images/openfga.yaml
+++ b/images/openfga.yaml
@@ -1,0 +1,13 @@
+name: openfga
+description: "OpenFGA fine-grained authorization server — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: openfga
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["openfga"]
+    entrypoint: /usr/bin/openfga
+
+versions:
+  "1": {}

--- a/images/spicedb.yaml
+++ b/images/spicedb.yaml
@@ -1,0 +1,13 @@
+name: spicedb
+description: "AuthZed SpiceDB authorization database — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: spicedb
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["spicedb"]
+    entrypoint: /usr/bin/spicedb
+
+versions:
+  "1": {}

--- a/images/trivy-operator.yaml
+++ b/images/trivy-operator.yaml
@@ -1,0 +1,13 @@
+name: trivy-operator
+description: "Aqua Trivy Operator for Kubernetes — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: trivy-operator
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["trivy-operator"]
+    entrypoint: /usr/bin/trivy-operator
+
+versions:
+  "0": {}

--- a/packages/bespoke/checkov.yaml
+++ b/packages/bespoke/checkov.yaml
@@ -1,0 +1,50 @@
+package:
+  name: checkov
+  version: "3.2.524"
+  epoch: 0
+  description: "Static code and composition analysis tool for Infrastructure-as-Code"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python-${{vars.python-version}}
+
+vars:
+  python-version: "3.12"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - ca-certificates-bundle
+      - glibc
+      - linux-headers
+      - posix-libc-utils
+      - py${{vars.python-version}}-pip
+      - py${{vars.python-version}}-pyyaml
+      - py${{vars.python-version}}-setuptools
+      - py${{vars.python-version}}-wheel
+      - python-${{vars.python-version}}
+      - wolfi-base
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/bridgecrewio/checkov
+      tag: ${{package.version}}
+      expected-commit: 68c02db9f1fb66ac561e7deb068be23413ace6bb
+
+  - uses: py/pip-build-install
+    with:
+      python: python${{vars.python-version}}
+
+  - uses: strip
+
+test:
+  pipeline:
+    - uses: test/tw/ldd-check
+    - uses: python/import
+      with:
+        python: python${{vars.python-version}}
+        import: checkov

--- a/scripts/melange_build_test.go
+++ b/scripts/melange_build_test.go
@@ -1,0 +1,78 @@
+package scripts_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func melangeBuildScriptPath(t *testing.T) string {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	return filepath.Join(filepath.Dir(currentFile), "..", ".github", "scripts", "melange-build.sh")
+}
+
+func writeTempFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func runMelangeBuild(t *testing.T, repoRoot string, env map[string]string) (string, error) {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "bash", melangeBuildScriptPath(t))
+	cmd.Dir = repoRoot
+	cmd.Env = os.Environ()
+	for key, value := range env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestMelangeBuildRejectsUnsafeBespokeValue(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	output, err := runMelangeBuild(t, repoRoot, map[string]string{
+		"BESPOKE": "../evil.yaml",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, output, "BESPOKE contains unsafe characters")
+}
+
+func TestMelangeBuildFailsWhenBespokeFileMissing(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTempFile(t, filepath.Join(repoRoot, "packages", "upstream.lock.json"), `{"wolfi_commit":"abc123"}`)
+
+	output, err := runMelangeBuild(t, repoRoot, map[string]string{
+		"BESPOKE": "custom.yaml",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, output, "Bespoke build file not found: packages/bespoke/custom.yaml")
+}
+
+func TestMelangeBuildFailsWhenBespokeWolfiCommitMissing(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTempFile(t, filepath.Join(repoRoot, "packages", "bespoke", "custom.yaml"), "package:\n  name: test\n")
+	writeTempFile(t, filepath.Join(repoRoot, "packages", "upstream.lock.json"), `{"wolfi_commit":null}`)
+
+	output, err := runMelangeBuild(t, repoRoot, map[string]string{
+		"BESPOKE": "custom.yaml",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, output, "wolfi_commit missing or null in packages/upstream.lock.json")
+}

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -650,6 +650,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "kube-bench", source: "integer" },
       { name: "openfga", source: "integer" },
       { name: "spicedb", source: "integer" },
+      { name: "checkov", source: "integer" },
     ],
   },
 

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -646,6 +646,10 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "dex", source: "integer" },
       { name: "falco", source: "integer" },
       { name: "oauth2-proxy", source: "integer" },
+      { name: "trivy-operator", source: "integer" },
+      { name: "kube-bench", source: "integer" },
+      { name: "openfga", source: "integer" },
+      { name: "spicedb", source: "integer" },
     ],
   },
 


### PR DESCRIPTION
## Summary

Adds 5 Wolfi-based Integer images for security scanning + authorization. Includes the **first bespoke melange build** for an image whose upstream Wolfi package was removed.

### Added (5 new Integer images) — `security` category

| Image | Source | Build mode | Binary |
|-------|--------|-----------|--------|
| `trivy-operator` | Wolfi `trivy-operator` | apko | `/usr/bin/trivy-operator` |
| `kube-bench` | Wolfi `kube-bench` + `kube-bench-configs` | apko | `/usr/bin/kube-bench` |
| `openfga` | Wolfi `openfga` | apko | `/usr/bin/openfga` |
| `spicedb` | Wolfi `spicedb` | apko | `/usr/bin/spicedb` |
| `checkov` | **Bespoke melange** (3.2.524) | melange + apko | `/usr/bin/checkov` |

### checkov: bespoke build

Wolfi removed `checkov.yaml` in [wolfi-dev/os#75030](https://github.com/wolfi-dev/os/commit/211bb973) (Dec 2025), but the official `bridgecrew/checkov` image still ships with unfixable CVEs. This is exactly what Verity exists for — when upstream is bad, we patch.

- `packages/bespoke/checkov.yaml` — fresh checkov 3.2.524 build from source ([bridgecrewio/checkov](https://github.com/bridgecrewio/checkov)), based on Wolfi's last working recipe.
- `images/checkov.yaml` — wires the bespoke build via `melange.bespoke`.
- `.github/scripts/melange-build.sh` — extended to fetch Wolfi's `pipelines/` tree for bespoke builds too (previously upstream-only). Required for `py/pip-build-install` and other shared pipelines.

### Investigated but dropped
- `semgrep` — Wolfi ships `osemgrep` and `semgrep-core` binaries but the user-facing `semgrep` CLI is the `py3-semgrep` Python wrapper. Multi-package image setup deferred for a focused PR.

### Validation
- `./verity integer validate` → all 135 configs valid
- **Full apko build + trivy image scan** locally for the 4 apko images → **0 CRITICAL/HIGH CVEs**
- Bespoke checkov: melange build runs in CI (couldn't reproduce locally without docker access)
- Binary paths verified against Wolfi APKINDEX contents

### Files
- 5 new YAMLs under `images/`
- `packages/bespoke/checkov.yaml` — bespoke melange recipe
- `.github/scripts/melange-build.sh` — extended for bespoke pipeline fetch
- `site/src/data/full-catalog.ts` — entries added under `security` category