### PR TITLE
ci(orchestrator): add 'preflight' input to workflow_dispatch

### DIFF
--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -21,6 +21,11 @@ on:
         description: "Image name to patch (empty = all)"
         required: false
         default: ""
+      preflight:
+        description: "Skip already-patched images (preflight manifest)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -193,9 +198,14 @@ jobs:
             --target-registry "${TARGET_REGISTRY}"
           )
 
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          # --preflight and --only are orthogonal: preflight controls whether to
+          # skip already-published images; --only controls which images are
+          # considered. They compose, so split them into independent blocks.
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event.inputs.preflight }}" = "true" ]; then
             DISCOVER_ARGS+=(--preflight --github-repo "${{ github.repository }}")
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$DISPATCH_IMAGE" ]; then
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$DISPATCH_IMAGE" ]; then
             # Validate dispatch input matches safe pattern
             if [[ ! "$DISPATCH_IMAGE" =~ ^[a-z0-9][a-z0-9./_-]*$ ]]; then
               echo "Invalid image name: ${DISPATCH_IMAGE}" >&2

--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -22,7 +22,7 @@ on:
         required: false
         default: ""
       preflight:
-        description: "Skip images that don't need work per the preflight manifest (unchanged upstream digest AND no remaining fixable vulns); may still rebuild when digests change or vulns remain"
+        description: "Skip images that don't need work per the preflight manifest (unchanged upstream digest AND zero remaining vulnerabilities in the previously-patched image); may still rebuild when digests change or any vulns are present"
         required: false
         type: boolean
         default: false
@@ -200,9 +200,9 @@ jobs:
 
           # --preflight and --only are orthogonal: --preflight uses the
           # manifest to skip images that don't need work (unchanged upstream
-          # digest AND no remaining fixable vulns); --only controls which
-          # images are considered. They compose, so split them into
-          # independent blocks.
+          # digest AND zero remaining vulns in the previously-patched
+          # image); --only controls which images are considered. They
+          # compose, so split them into independent blocks.
           if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event.inputs.preflight }}" = "true" ]; then
             DISCOVER_ARGS+=(--preflight --github-repo "${{ github.repository }}")
           fi

--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -22,7 +22,7 @@ on:
         required: false
         default: ""
       preflight:
-        description: "Skip already-patched images (preflight manifest)"
+        description: "Skip images that don't need work per the preflight manifest (unchanged upstream digest AND no remaining fixable vulns); may still rebuild when digests change or vulns remain"
         required: false
         type: boolean
         default: false
@@ -198,9 +198,11 @@ jobs:
             --target-registry "${TARGET_REGISTRY}"
           )
 
-          # --preflight and --only are orthogonal: preflight controls whether to
-          # skip already-published images; --only controls which images are
-          # considered. They compose, so split them into independent blocks.
+          # --preflight and --only are orthogonal: --preflight uses the
+          # manifest to skip images that don't need work (unchanged upstream
+          # digest AND no remaining fixable vulns); --only controls which
+          # images are considered. They compose, so split them into
+          # independent blocks.
           if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event.inputs.preflight }}" = "true" ]; then
             DISCOVER_ARGS+=(--preflight --github-repo "${{ github.repository }}")
           fi


### PR DESCRIPTION
## Summary

Adds a `preflight` boolean input to `Orchestrator`'s `workflow_dispatch` so manual runs can use the preflight manifest to skip images that don't need work — previously hardcoded to fire only on `schedule` events.

## Why

There's no way today to run a fast "only patch what's actually changed" pass on demand. A bulk `workflow_dispatch` rebuilds every image (hours of GHA compute) because the workflow has no opt-in for preflight mode. This blocks scenarios like "a new chart got added at noon, smoke-test it now" — you have to either wait for the 02:00 UTC schedule or burn the full rebuild budget.

## Change

```yaml
workflow_dispatch:
  inputs:
    image: ...
    preflight:           # NEW
      description: "Skip images that don't need work per the preflight manifest
        (unchanged upstream digest AND zero remaining vulnerabilities in the
        previously-patched image); may still rebuild when digests change or
        any vulns are present"
      required: false
      type: boolean
      default: false
```

```diff
+ # --preflight and --only are orthogonal: --preflight uses the manifest
+ # to skip images that don't need work (unchanged upstream digest AND
+ # zero remaining vulns in the previously-patched image); --only
+ # controls which images are considered. They compose, so split them
+ # into independent blocks.
  if [ "$event_name" = "schedule" ] || [ "$preflight" = "true" ]; then
    DISCOVER_ARGS+=(--preflight ...)
- elif [ "$event_name" = "workflow_dispatch" ] && [ -n "$DISPATCH_IMAGE" ]; then
+ fi
+
+ if [ "$event_name" = "workflow_dispatch" ] && [ -n "$DISPATCH_IMAGE" ]; then
    DISCOVER_ARGS+=(--only "$DISPATCH_IMAGE")
  ...
  fi
```

Default `false` preserves prior behaviour. Schedule path is unchanged. The two conditionals are independent so `preflight=true` and `image=<name>` compose: `gh workflow run "Orchestrator" -f preflight=true -f image=nginx` correctly runs preflight on a single image.

## Scope: Copa Orchestrator only

`Integer Orchestrator` is intentionally out of scope. `verity integer discover --preflight` is currently a no-op (see `cmd/integer_discover.go:100` — Integer images build from source, no upstream digest to compare). Exposing a `preflight` input there would be misleading. Real Integer preflight (e.g. melange config + Wolfi package version hashing) is a separate follow-up.

## Usage

```bash
# Skip images that don't need work, dispatch the rest:
gh workflow run "Orchestrator" --ref main -f preflight=true

# Preflight a single image:
gh workflow run "Orchestrator" --ref main -f preflight=true -f image=prometheus

# Existing behaviour unchanged:
gh workflow run "Orchestrator" --ref main                    # all images, no preflight
gh workflow run "Orchestrator" --ref main -f image=nginx     # just nginx, no preflight
```

## Verification

- `actionlint` clean
- `yamllint` clean
- All 11 CI checks pass
- The independence of the two conditionals is documented inline as a regression guard against re-collapsing them into an elif chain.

## Review feedback addressed

- **elif chain made flags mutually exclusive** (Copilot, cubic) — split into independent if blocks; flags now compose.
- **integer-orchestrator preflight is a no-op** (Copilot) — reverted those changes; PR scope reduced to Copa Orchestrator only.
- **Description claimed preflight just skips "already-patched" images** (Copilot, cubic) — corrected to describe the actual digest+vuln-based gate; verified against `internal/preflight/check.go` and `.github/workflows/patch-image.yaml:409` (trivy is invoked without `--ignore-unfixed`, so the gate counts all vulns, fixable or not).

## Known follow-up (out of scope)

`internal/preflight/check.go:69` reports the rebuild gate's reason as `"%d fixable vulns remain"` but the count includes unfixable vulns too — same misnomer in source. Fix in a separate PR.