### PR TITLE
feat(integer): Wolfi rebuilds for cassandra, neo4j, solr, postgres-operator (recover missed scope)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -105,15 +105,6 @@ images:
     goVcsUrl: "https://github.com/elastic/cloud-on-k8s"
     goVcsTagPrefix: "v"
 
-  - name: "zalando/postgres-operator"
-    image: "ghcr.io/zalando/postgres-operator"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/zalando/postgres-operator"
-
   # ============================================================================
   #  MESSAGING & STREAMING
   # ============================================================================

--- a/images/cassandra.yaml
+++ b/images/cassandra.yaml
@@ -1,0 +1,17 @@
+name: cassandra
+description: "Apache Cassandra distributed NoSQL database — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: cassandra-5.0
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cassandra-5.0", "openjdk-21-default-jvm"]
+    entrypoint: /usr/bin/cassandra
+    paths:
+      - {path: /var/lib/cassandra, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+      - {path: /var/log/cassandra, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "5.0":
+    latest: true

--- a/images/cassandra.yaml
+++ b/images/cassandra.yaml
@@ -7,11 +7,10 @@ types:
   default:
     base: wolfi-base
     packages: ["cassandra-5.0", "openjdk-21-default-jvm"]
-    entrypoint: /usr/bin/cassandra
+    entrypoint: /usr/bin/cassandra -f
     paths:
       - {path: /var/lib/cassandra, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /var/log/cassandra, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
-  "5.0":
-    latest: true
+  "5.0": {}

--- a/images/neo4j.yaml
+++ b/images/neo4j.yaml
@@ -1,0 +1,17 @@
+name: neo4j
+description: "Neo4j graph database — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: neo4j-2026.01
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["neo4j-2026.01"]
+    entrypoint: /usr/bin/neo4j
+    paths:
+      - {path: /data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+      - {path: /logs, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "2026.01":
+    latest: true

--- a/images/neo4j.yaml
+++ b/images/neo4j.yaml
@@ -7,11 +7,10 @@ types:
   default:
     base: wolfi-base
     packages: ["neo4j-2026.01"]
-    entrypoint: /usr/bin/neo4j
+    entrypoint: /usr/bin/neo4j console
     paths:
       - {path: /data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /logs, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
-  "2026.01":
-    latest: true
+  "2026.01": {}

--- a/images/postgres-operator.yaml
+++ b/images/postgres-operator.yaml
@@ -1,0 +1,13 @@
+name: postgres-operator
+description: "Zalando Postgres Operator — Wolfi rebuild replaces the Copa-patched upstream image with a from-source zero-CVE build"
+upstream:
+  package: postgres-operator
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["postgres-operator"]
+    entrypoint: /usr/bin/postgres-operator
+
+versions:
+  "1": {}

--- a/images/solr.yaml
+++ b/images/solr.yaml
@@ -7,7 +7,7 @@ types:
   default:
     base: wolfi-base
     packages: ["solr", "openjdk-21-default-jvm"]
-    entrypoint: /usr/share/java/solr/bin/solr
+    entrypoint: /usr/share/java/solr/bin/solr start -f
     paths:
       - {path: /var/solr, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 

--- a/images/solr.yaml
+++ b/images/solr.yaml
@@ -1,0 +1,15 @@
+name: solr
+description: "Apache Solr search platform — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: solr
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["solr", "openjdk-21-default-jvm"]
+    entrypoint: /usr/share/java/solr/bin/solr
+    paths:
+      - {path: /var/solr, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "9": {}

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -178,14 +178,12 @@ export const fullCatalog: FullCatalogCategory[] = [
         source: "copa",
         upstream: "mirror.gcr.io/elastic/eck-operator",
       },
-      {
-        name: "zalando/postgres-operator",
-        label: "postgres-operator",
-        source: "copa",
-        upstream: "ghcr.io/zalando/postgres-operator",
-      },
       { name: "minio", source: "integer" },
       { name: "minio-client", source: "integer" },
+      { name: "cassandra", source: "integer" },
+      { name: "neo4j", source: "integer" },
+      { name: "solr", source: "integer" },
+      { name: "postgres-operator", source: "integer" },
     ],
   },
 


### PR DESCRIPTION
## Summary

Adds 4 Wolfi-based Integer images for databases I previously dismissed. The miss was assuming Wolfi only had unversioned package names — Wolfi actually publishes major-versioned packages (`cassandra-5.0`, `neo4j-2026.01`, etc.) following the same convention as `coredns-1.14`.

### Added (4 new Integer images)

| Image | Wolfi package | Binary |
|-------|--------------|--------|
| `cassandra` | `cassandra-5.0` + `openjdk-21-default-jvm` | `/usr/bin/cassandra` |
| `neo4j` | `neo4j-2026.01` | `/usr/bin/neo4j` |
| `solr` | `solr` (9.8) + `openjdk-21-default-jvm` | `/usr/share/java/solr/bin/solr` |
| `postgres-operator` | `postgres-operator` (Zalando) | `/usr/bin/postgres-operator` |

### Removed
- Copa entry for `zalando/postgres-operator` — was carrying residual CVEs that Copa couldn't fix. The Wolfi rebuild eliminates them.

### Version selection notes
Picked the cleanest CVE-free versions via local Trivy scan:
- `cassandra-4.1` has 2 HIGH CVEs → using **5.0** (clean)
- `neo4j-2025.04` and `2025.05` have 4 HIGH CVEs each → using **2026.01** (clean)

### Validation
- `./verity integer validate` → all 134 configs valid
- **Full apko build + trivy image scan** for all 4 → **0 CRITICAL/HIGH CVEs**

### Files
- 4 new YAMLs under `images/`
- `copa-config.yaml` — `zalando/postgres-operator` entry removed
- `site/src/data/full-catalog.ts` — 4 new entries under `databases` category

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add four Wolfi-based Integer images for Cassandra, Neo4j, Solr, and Zalando Postgres Operator on `wolfi-base`, with foreground entrypoints and zero‑CVE builds. Replaces the Copa-tracked `zalando/postgres-operator` with a clean Wolfi rebuild.

- **New Features**
  - `cassandra` → packages: `cassandra-5.0`, `openjdk-21-default-jvm`; entrypoint: `/usr/bin/cassandra -f`.
  - `neo4j` → package: `neo4j-2026.01`; entrypoint: `/usr/bin/neo4j console`.
  - `solr` → packages: `solr` (9.x), `openjdk-21-default-jvm`; entrypoint: `/usr/share/java/solr/bin/solr start -f`.
  - `postgres-operator` → package: `postgres-operator`; entrypoint: `/usr/bin/postgres-operator`.
  - Catalog updated: add `cassandra`, `neo4j`, `solr`, and `postgres-operator` under databases.
  - Local Trivy and `./verity integer validate` pass with 0 HIGH/CRITICAL.

- **Bug Fixes**
  - Use foreground-mode entrypoints for the Java servers to prevent container exit.
  - Remove misleading `latest: true`; version ordering determines latest.

<sup>Written for commit c655c6997979f9476d6b720b55ab8f09d12173fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

