### PR TITLE
fix(preflight): drop misleading 'fixable vulns' wording from rebuild reason

### DIFF
--- a/internal/preflight/check.go
+++ b/internal/preflight/check.go
@@ -41,7 +41,12 @@ func extractTag(source string) string {
 //
 // Gate 1: If the image is not in the manifest → first time → needs work.
 // Gate 2: Fetch current upstream digest. If different from stored → needs work.
-// Gate 3: If digest unchanged but patched image still has vulns → needs work.
+// Gate 3: If digest unchanged but patched image still has any reported vulns
+//
+//	→ needs work. (PatchedVulns is populated from `trivy image` output
+//	without --ignore-unfixed, so it counts every reported vuln, fixable
+//	or not.)
+//
 // Otherwise: skip.
 func checkCopaImage(img *discovery.DiscoveredImage, manifest Manifest) CheckResult {
 	tag := extractTag(img.Source)
@@ -66,7 +71,7 @@ func checkCopaImage(img *discovery.DiscoveredImage, manifest Manifest) CheckResu
 	}
 
 	if entry.PatchedVulns > 0 {
-		return CheckResult{NeedsWork: true, Reason: fmt.Sprintf("%s: %d fixable vulns remain", key, entry.PatchedVulns)}
+		return CheckResult{NeedsWork: true, Reason: fmt.Sprintf("%s: %d vulns remain in patched image", key, entry.PatchedVulns)}
 	}
 
 	return CheckResult{NeedsWork: false, Reason: key + ": unchanged, 0 vulns — skipping"}

--- a/internal/preflight/check.go
+++ b/internal/preflight/check.go
@@ -69,11 +69,11 @@ func checkCopaImage(img *discovery.DiscoveredImage, manifest Manifest) CheckResu
 	}
 
 	if entry.PatchedVulns > 0 {
-		noun := "vulns"
+		noun, verb := "vulns", "remain"
 		if entry.PatchedVulns == 1 {
-			noun = "vuln"
+			noun, verb = "vuln", "remains"
 		}
-		return CheckResult{NeedsWork: true, Reason: fmt.Sprintf("%s: %d %s remain in patched image", key, entry.PatchedVulns, noun)}
+		return CheckResult{NeedsWork: true, Reason: fmt.Sprintf("%s: %d %s %s in patched image", key, entry.PatchedVulns, noun, verb)}
 	}
 
 	return CheckResult{NeedsWork: false, Reason: key + ": unchanged, 0 vulns — skipping"}

--- a/internal/preflight/check.go
+++ b/internal/preflight/check.go
@@ -41,13 +41,11 @@ func extractTag(source string) string {
 //
 // Gate 1: If the image is not in the manifest → first time → needs work.
 // Gate 2: Fetch current upstream digest. If different from stored → needs work.
-// Gate 3: If digest unchanged but patched image still has any reported vulns
-//
-//	→ needs work. (PatchedVulns is populated from `trivy image` output
-//	without --ignore-unfixed, so it counts every reported vuln, fixable
-//	or not.)
-//
+// Gate 3: If digest unchanged but patched image still has any reported vulns → needs work.
 // Otherwise: skip.
+//
+// PatchedVulns is populated from `trivy image` output without
+// --ignore-unfixed, so it counts every reported vuln, fixable or not.
 func checkCopaImage(img *discovery.DiscoveredImage, manifest Manifest) CheckResult {
 	tag := extractTag(img.Source)
 	if tag == "" {
@@ -71,7 +69,11 @@ func checkCopaImage(img *discovery.DiscoveredImage, manifest Manifest) CheckResu
 	}
 
 	if entry.PatchedVulns > 0 {
-		return CheckResult{NeedsWork: true, Reason: fmt.Sprintf("%s: %d vulns remain in patched image", key, entry.PatchedVulns)}
+		noun := "vulns"
+		if entry.PatchedVulns == 1 {
+			noun = "vuln"
+		}
+		return CheckResult{NeedsWork: true, Reason: fmt.Sprintf("%s: %d %s remain in patched image", key, entry.PatchedVulns, noun)}
 	}
 
 	return CheckResult{NeedsWork: false, Reason: key + ": unchanged, 0 vulns — skipping"}

--- a/internal/preflight/check_test.go
+++ b/internal/preflight/check_test.go
@@ -76,6 +76,27 @@ func TestCheckCopaImage_UnchangedWithVulns(t *testing.T) {
 	assert.Contains(t, result.Reason, "5 vulns remain in patched image")
 }
 
+func TestCheckCopaImage_SingleVulnUsesSingular(t *testing.T) {
+	manifest := Manifest{
+		"valkey/9.0.3": {UpstreamDigest: testDigestSame, PatchedVulns: 1},
+	}
+	img := discovery.DiscoveredImage{
+		Name:   "valkey",
+		Source: "mirror.gcr.io/valkey/valkey:9.0.3",
+	}
+
+	origFn := digestFn
+	digestFn = func(_ string) (string, error) { return testDigestSame, nil }
+	defer func() { digestFn = origFn }()
+
+	result := checkCopaImage(&img, manifest)
+	assert.True(t, result.NeedsWork)
+	assert.Contains(t, result.Reason, "1 vuln remain in patched image",
+		"single-vuln case must use singular 'vuln', not '1 vulns'")
+	assert.NotContains(t, result.Reason, "1 vulns",
+		"regression guard: prevent '1 vulns' grammatical error from returning")
+}
+
 func TestCheckCopaImage_UnchangedClean(t *testing.T) {
 	manifest := Manifest{
 		"nginx/1.29.3": {UpstreamDigest: testDigestSame, PatchedVulns: 0},

--- a/internal/preflight/check_test.go
+++ b/internal/preflight/check_test.go
@@ -73,7 +73,7 @@ func TestCheckCopaImage_UnchangedWithVulns(t *testing.T) {
 
 	result := checkCopaImage(&img, manifest)
 	assert.True(t, result.NeedsWork)
-	assert.Contains(t, result.Reason, "5 fixable vulns")
+	assert.Contains(t, result.Reason, "5 vulns remain in patched image")
 }
 
 func TestCheckCopaImage_UnchangedClean(t *testing.T) {

--- a/internal/preflight/check_test.go
+++ b/internal/preflight/check_test.go
@@ -91,10 +91,12 @@ func TestCheckCopaImage_SingleVulnUsesSingular(t *testing.T) {
 
 	result := checkCopaImage(&img, manifest)
 	assert.True(t, result.NeedsWork)
-	assert.Contains(t, result.Reason, "1 vuln remain in patched image",
-		"single-vuln case must use singular 'vuln', not '1 vulns'")
+	assert.Contains(t, result.Reason, "1 vuln remains in patched image",
+		"single-vuln case must use singular noun and matching singular verb ('1 vuln remains'), not '1 vuln remain' or '1 vulns'")
 	assert.NotContains(t, result.Reason, "1 vulns",
-		"regression guard: prevent '1 vulns' grammatical error from returning")
+		"regression guard: prevent plural noun returning for count==1")
+	assert.NotContains(t, result.Reason, "1 vuln remain ",
+		"regression guard: prevent singular noun + plural verb ('1 vuln remain') subject-verb agreement bug")
 }
 
 func TestCheckCopaImage_UnchangedClean(t *testing.T) {


### PR DESCRIPTION
## Summary

The preflight rebuild gate (`internal/preflight/check.go:69`) reports its decision as `"%d fixable vulns remain"` — but the count includes every reported vulnerability, fixable or not. Update the wording so the reason matches the actual gate.

## Why

`PatchedVulns` is populated by `.github/workflows/patch-image.yaml:494` from the output of `trivy image` (line 409). trivy is **not** invoked with `--ignore-unfixed`, so every reported vuln is counted. The gate `entry.PatchedVulns > 0` therefore rebuilds whenever any vuln is present — including ones Copa cannot fix.

The "fixable vulns" wording suggested otherwise. cubic flagged this when the same misnomer propagated into PR #249's workflow input description; that description was already corrected in #249, this commit fixes the upstream source.

## Change

```diff
- "%d fixable vulns remain"
+ "%d vulns remain in patched image"
```

Plus a clarifying godoc on `checkCopaImage` and the matching test assertion update.

## Verification

- `go test ./internal/preflight/...` — pass
- `golangci-lint run ./internal/preflight/...` — clean

## Regression guard

The godoc explicitly notes that `PatchedVulns` counts every reported vuln (not just fixable) — preventing the misnomer from being reintroduced by a future reader naturally assuming the simpler interpretation.

Refs: #249 (downstream description corrected by cubic).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the preflight rebuild reason to say "%d vulns remain in patched image" (uses singular "vuln" and "remains" when count is 1) since `PatchedVulns` counts all reported vulnerabilities, not just fixable ones. Clarified `checkCopaImage` docs and expanded tests with regression checks for both the singular noun and verb.

<sup>Written for commit ad43ac544fc16b0ee967c43fb87604a77b8d80d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

