### PR TITLE
feat(integer): add argo-workflows v4 + argo-rollouts + bespoke blackbox-exporter

### DIFF
--- a/images/argo-rollouts.yaml
+++ b/images/argo-rollouts.yaml
@@ -1,0 +1,13 @@
+name: argo-rollouts
+description: "Argo Rollouts progressive delivery controller — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: argo-rollouts
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["argo-rollouts"]
+    entrypoint: /usr/bin/rollouts-controller
+
+versions:
+  "1": {}

--- a/images/argo-workflows.yaml
+++ b/images/argo-workflows.yaml
@@ -1,0 +1,13 @@
+name: argo-workflows
+description: "Argo Workflows CLI — Copa can't patch scratch-based official image; Wolfi rebuild"
+upstream:
+  package: argo-workflows-4.0
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["argo-workflows-4.0"]
+    entrypoint: /usr/bin/argo
+
+versions:
+  "4.0": {}

--- a/images/blackbox-exporter.yaml
+++ b/images/blackbox-exporter.yaml
@@ -1,0 +1,16 @@
+name: blackbox-exporter
+description: "Prometheus Blackbox Exporter — Wolfi's apk lags upstream by ~3 versions (0.25 vs 0.28); bespoke build from source"
+upstream:
+  package: prometheus-blackbox-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["prometheus-blackbox-exporter"]
+    entrypoint: /usr/bin/blackbox_exporter
+    melange:
+      bespoke: "blackbox-exporter.yaml"
+
+versions:
+  "0.28.0":
+    latest: true

--- a/images/blackbox-exporter.yaml
+++ b/images/blackbox-exporter.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["prometheus-blackbox-exporter"]
     entrypoint: /usr/bin/blackbox_exporter
+    paths:
+      - {path: /etc/blackbox_exporter, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
     melange:
       bespoke: "blackbox-exporter.yaml"
 

--- a/packages/bespoke/blackbox-exporter.yaml
+++ b/packages/bespoke/blackbox-exporter.yaml
@@ -1,0 +1,41 @@
+package:
+  name: prometheus-blackbox-exporter
+  version: "0.28.0"
+  epoch: 0
+  description: "Prometheus exporter that allows blackbox probing of endpoints"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus/blackbox_exporter
+      tag: v${{package.version}}
+      expected-commit: 5a059bee8d8ffa4e75947c5055fb0abeefc582e6
+
+  - uses: go/build
+    with:
+      packages: .
+      output: blackbox_exporter
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=$(git rev-parse HEAD)
+        -X github.com/prometheus/common/version.Branch=v${{package.version}}
+
+test:
+  pipeline:
+    - runs: |
+        blackbox_exporter --version

--- a/packages/bespoke/blackbox-exporter.yaml
+++ b/packages/bespoke/blackbox-exporter.yaml
@@ -1,7 +1,10 @@
 package:
   name: prometheus-blackbox-exporter
   version: "0.28.0"
-  epoch: 0
+  # Epoch 99 ensures our bespoke (built with current Go toolchain) sorts above
+  # Wolfi's advisory fix versions (0.28.0-r1..-r4) that track stdlib CVE patches.
+  # When Wolfi catches up on its apk repo, we can drop the bespoke override.
+  epoch: 99
   description: "Prometheus exporter that allows blackbox probing of endpoints"
   copyright:
     - license: Apache-2.0

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -520,6 +520,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "tempo", source: "integer" },
       { name: "grafana-alloy", source: "integer" },
       { name: "cortex", source: "integer" },
+      { name: "blackbox-exporter", source: "integer" },
     ],
   },
 
@@ -587,6 +588,8 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "buildah", source: "integer" },
       { name: "podman", source: "integer" },
       { name: "pulumi", source: "integer" },
+      { name: "argo-workflows", source: "integer" },
+      { name: "argo-rollouts", source: "integer" },
     ],
   },
 


### PR DESCRIPTION
## Summary

Catch-up wave: 3 previously-deferred images now feasible. Includes a third bespoke melange build (after PR #248's checkov, PR #257's contour) for an image where Wolfi's published apk lags upstream by multiple versions.

### Added — apko via Wolfi APKINDEX (2)

| Image | Wolfi package | Binary | Original blocker |
|-------|--------------|--------|------------------|
| `argo-workflows` | `argo-workflows-4.0` | `/usr/bin/argo` | PR #245 dropped 3.7 (stale); Wolfi published 4.0 cleanly |
| `argo-rollouts` | `argo-rollouts` | `/usr/bin/rollouts-controller` | PR #245 dropped (transitive deps fixed) |

### Added — bespoke melange build (1)

| Image | Source | Reason |
|-------|--------|--------|
| `blackbox-exporter` | `packages/bespoke/blackbox-exporter.yaml` (v0.28.0) | Wolfi pkg pinned at `0.25.0-r11`; upstream is at `0.28.0` with 14 Go stdlib CVE fixes. PR #236 dropped this previously |

### Investigated but deferred for next bespoke wave
- `cluster-autoscaler-1.34` — Wolfi at r1, fixes need r3+ (8 CVEs). Bespoke from source planned for follow-up PR.
- `cert-manager-controller/cainjector/acmesolver/webhook-1.19` — Wolfi at r0, fixes need r1+ (4 CVEs each). Best done as a single multi-binary subpackaged bespoke (matching Wolfi's recipe structure).

### Validation
- `./verity integer validate` → all 145 configs valid
- **Full apko build + trivy image scan** for the 2 apko images (with fresh trivy DB) → **0 CRITICAL/HIGH CVEs**
- Bespoke `blackbox-exporter`: melange build runs in CI

### Files
- 3 new YAMLs under `images/`
- `packages/bespoke/blackbox-exporter.yaml` — bespoke melange recipe
- `site/src/data/full-catalog.ts` — entries added

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `argo-workflows` v4, `argo-rollouts`, and a bespoke `blackbox-exporter` to close a Wolfi catch-up gap. Uses Wolfi APKs where available and a melange build where Wolfi lags upstream.

- **New Features**
  - `argo-workflows` from Wolfi (`argo-workflows-4.0`), entrypoint `/usr/bin/argo`.
  - `argo-rollouts` from Wolfi (`argo-rollouts`), entrypoint `/usr/bin/rollouts-controller`.
  - Bespoke melange build for `prometheus-blackbox-exporter` v0.28.0 (Wolfi at 0.25.x); binary `/usr/bin/blackbox_exporter`. Set `epoch=99` to avoid advisory mismatches and add `/etc/blackbox_exporter` (non-root) for ConfigMap mounts.
  - Catalog updated; 145 configs validate; Trivy shows 0 High/Critical CVEs on the APK-based images; bespoke build runs in CI.

<sup>Written for commit 62dc7338324729659de7fb611be2f615a218b902. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

