### PR TITLE
feat(integer): cluster-autoscaler 1.35 + cert-manager 1.20 (Copa→Integer migration)

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -461,12 +461,15 @@ jobs:
           # Find added image names
           ADDED=$(comm -13 <(echo "$OLD_NAMES") <(echo "$NEW_NAMES") | paste -sd, || true)
 
-          # Find changed image entries (compare full YAML blocks)
+          # Find changed image entries (compare full data blocks).
+          # Use JSON output to ignore comment shifts: yq attributes leading
+          # comments to the next node, so removing an entry can make adjacent
+          # section headers re-attach to a sibling that didn't actually change.
           CHANGED_NAMES=""
           while IFS= read -r name; do
             [ -z "$name" ] && continue
-            old_block=$(git show "${BASE_SHA}":copa-config.yaml 2>/dev/null | yq ".images[] | select(.name == \"$name\")" 2>/dev/null || true)
-            new_block=$(yq ".images[] | select(.name == \"$name\")" copa-config.yaml)
+            old_block=$(git show "${BASE_SHA}":copa-config.yaml 2>/dev/null | yq -o=json ".images[] | select(.name == \"$name\")" 2>/dev/null || true)
+            new_block=$(yq -o=json ".images[] | select(.name == \"$name\")" copa-config.yaml)
             if [ "$old_block" != "$new_block" ]; then
               CHANGED_NAMES="${CHANGED_NAMES:+$CHANGED_NAMES,}$name"
             fi

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -144,14 +144,6 @@ images:
   #  KUBERNETES TOOLS
   # ============================================================================
 
-  - name: "kubernetes/autoscaler/cluster-autoscaler"
-    image: "ghcr.io/kubernetes/autoscaler/cluster-autoscaler"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-
   - name: "kubernetes-sigs/external-dns"
     image: "ghcr.io/kubernetes-sigs/external-dns"
     platforms: ["linux/amd64", "linux/arm64"]
@@ -444,38 +436,6 @@ images:
   # ============================================================================
   #  CERT MANAGEMENT
   # ============================================================================
-
-  # cert-manager-{controller,cainjector,acmesolver}: deferred Wolfi migration.
-  # Wolfi advisory DB references fix-versions (e.g. 1.19.4-r3+) for current
-  # grpc-go and net/url CVEs, but those apks aren't yet published. Tracking
-  # until upstream Wolfi catches up; cmctl already migrated since it lives in
-  # a separate repo and is unaffected.
-  - name: "jetstack/cert-manager-controller"
-    image: "quay.io/jetstack/cert-manager-controller"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/cert-manager/cert-manager"
-
-  - name: "jetstack/cert-manager-cainjector"
-    image: "quay.io/jetstack/cert-manager-cainjector"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/cert-manager/cert-manager"
-
-  - name: "jetstack/cert-manager-acmesolver"
-    image: "quay.io/jetstack/cert-manager-acmesolver"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/cert-manager/cert-manager"
 
   - name: "cert-manager/cert-manager-openshift-routes"
     image: "ghcr.io/cert-manager/cert-manager-openshift-routes"

--- a/images/cert-manager-acmesolver.yaml
+++ b/images/cert-manager-acmesolver.yaml
@@ -1,0 +1,13 @@
+name: cert-manager-acmesolver
+description: "cert-manager ACME HTTP-01 solver — Wolfi rebuild replaces Copa-patched upstream with zero-CVE base"
+upstream:
+  package: cert-manager-acmesolver-1.20
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cert-manager-acmesolver-1.20"]
+    entrypoint: /usr/bin/acmesolver
+
+versions:
+  "1.20": {}

--- a/images/cert-manager-cainjector.yaml
+++ b/images/cert-manager-cainjector.yaml
@@ -1,0 +1,13 @@
+name: cert-manager-cainjector
+description: "cert-manager CA injector — Wolfi rebuild replaces Copa-patched upstream with zero-CVE base"
+upstream:
+  package: cert-manager-cainjector-1.20
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cert-manager-cainjector-1.20"]
+    entrypoint: /usr/bin/cainjector
+
+versions:
+  "1.20": {}

--- a/images/cert-manager-controller.yaml
+++ b/images/cert-manager-controller.yaml
@@ -1,0 +1,13 @@
+name: cert-manager-controller
+description: "cert-manager controller — Wolfi rebuild replaces Copa-patched upstream with zero-CVE base"
+upstream:
+  package: cert-manager-controller-1.20
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cert-manager-controller-1.20"]
+    entrypoint: /usr/bin/controller
+
+versions:
+  "1.20": {}

--- a/images/cert-manager-webhook.yaml
+++ b/images/cert-manager-webhook.yaml
@@ -1,0 +1,13 @@
+name: cert-manager-webhook
+description: "cert-manager webhook — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: cert-manager-webhook-1.20
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cert-manager-webhook-1.20"]
+    entrypoint: /usr/bin/webhook
+
+versions:
+  "1.20": {}

--- a/images/cluster-autoscaler.yaml
+++ b/images/cluster-autoscaler.yaml
@@ -1,0 +1,13 @@
+name: cluster-autoscaler
+description: "Kubernetes Cluster Autoscaler — Wolfi rebuild replaces Copa-patched upstream with zero-CVE base"
+upstream:
+  package: cluster-autoscaler-1.35
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cluster-autoscaler-1.35"]
+    entrypoint: /usr/bin/cluster-autoscaler
+
+versions:
+  "1.35": {}

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -245,7 +245,8 @@ export const fullCatalog: FullCatalogCategory[] = [
       {
         name: "kubernetes/autoscaler/cluster-autoscaler",
         label: "cluster-autoscaler",
-        source: "copa",
+        source: "integer",
+        integerName: "cluster-autoscaler",
         upstream: "ghcr.io/kubernetes/autoscaler/cluster-autoscaler",
       },
       {
@@ -715,20 +716,30 @@ export const fullCatalog: FullCatalogCategory[] = [
       {
         name: "jetstack/cert-manager-controller",
         label: "cert-manager-controller",
-        source: "copa",
+        source: "integer",
+        integerName: "cert-manager-controller",
         upstream: "quay.io/jetstack/cert-manager-controller",
       },
       {
         name: "jetstack/cert-manager-cainjector",
         label: "cert-manager-cainjector",
-        source: "copa",
+        source: "integer",
+        integerName: "cert-manager-cainjector",
         upstream: "quay.io/jetstack/cert-manager-cainjector",
       },
       {
         name: "jetstack/cert-manager-acmesolver",
         label: "cert-manager-acmesolver",
-        source: "copa",
+        source: "integer",
+        integerName: "cert-manager-acmesolver",
         upstream: "quay.io/jetstack/cert-manager-acmesolver",
+      },
+      {
+        name: "jetstack/cert-manager-webhook",
+        label: "cert-manager-webhook",
+        source: "integer",
+        integerName: "cert-manager-webhook",
+        upstream: "quay.io/jetstack/cert-manager-webhook",
       },
       {
         name: "jetstack/cert-manager-cmctl",


### PR DESCRIPTION
## Summary

Completes the Copa→Integer migration that PR #251 started but had to defer due to Wolfi publish lag. Wolfi has now published the newer streams (1.20 for cert-manager, 1.35 for cluster-autoscaler) cleanly — the previously-stuck 1.19/1.34 fix-versions never landed in the apk repo, but the next stream up sidesteps that entirely.

### Migrated Copa → Integer (5 components, +1 net new)

| Image | Was | Now | Wolfi pkg |
|-------|-----|-----|-----------|
| `cluster-autoscaler` | Copa | Integer | `cluster-autoscaler-1.35` |
| `cert-manager-controller` | Copa | Integer | `cert-manager-controller-1.20` |
| `cert-manager-cainjector` | Copa | Integer | `cert-manager-cainjector-1.20` |
| `cert-manager-acmesolver` | Copa | Integer | `cert-manager-acmesolver-1.20` |
| `cert-manager-webhook` | (new) | Integer | `cert-manager-webhook-1.20` |

### Removed
- 4 Copa entries: `kubernetes/autoscaler/cluster-autoscaler`, `jetstack/cert-manager-{controller,cainjector,acmesolver}`

### Validation
- `./verity integer validate` → all 155 configs valid
- **Full apko build + trivy image scan** with fresh advisory DB → **0 CRITICAL/HIGH CVEs** on all 5

### Files
- 5 new YAMLs under `images/`
- `copa-config.yaml` — 4 Copa entries removed
- `site/src/data/full-catalog.ts` — entries flipped to integer + cert-manager-webhook added

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate cluster-autoscaler to 1.35 and cert-manager to 1.20 by switching from Copa to Integer Wolfi builds, and add the cert-manager webhook. Also fix CI to ignore comment-only diffs when detecting Copa image changes; all five images build and scan clean (0 critical/high CVEs).

- **Migration**
  - cluster-autoscaler → Integer `cluster-autoscaler-1.35`
  - cert-manager `{controller,cainjector,acmesolver}` → Integer `cert-manager-*-1.20`
  - Added `cert-manager-webhook` (`cert-manager-webhook-1.20`)
  - Removed 4 Copa entries from `copa-config.yaml`; updated catalog entries to Integer + webhook

- **Bug Fixes**
  - CI: use `yq -o=json` in detect-copa-changes to ignore comment shifts and prevent false-positive “changed” images

<sup>Written for commit d0c15d454e63970f65a5a57a2c8687e85e82217b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

