### PR TITLE
feat(integer): mega wave — 11 Wolfi rebuilds (security, identity, K8s ops, networking, tools)

### DIFF
--- a/images/argocd-image-updater.yaml
+++ b/images/argocd-image-updater.yaml
@@ -1,0 +1,13 @@
+name: argocd-image-updater
+description: "Argo CD Image Updater — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: argocd-image-updater
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["argocd-image-updater"]
+    entrypoint: /usr/bin/argocd-image-updater
+
+versions:
+  "0": {}

--- a/images/cert-manager-csi-driver.yaml
+++ b/images/cert-manager-csi-driver.yaml
@@ -1,0 +1,13 @@
+name: cert-manager-csi-driver
+description: "cert-manager CSI driver for delivering certificates as in-memory volumes — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: cert-manager-csi-driver
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cert-manager-csi-driver"]
+    entrypoint: /usr/bin/cert-manager-csi-driver
+
+versions:
+  "0": {}

--- a/images/cert-manager-istio-csr.yaml
+++ b/images/cert-manager-istio-csr.yaml
@@ -1,0 +1,13 @@
+name: cert-manager-istio-csr
+description: "cert-manager Istio CSR agent for issuing Istio certificates — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: cert-manager-istio-csr
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cert-manager-istio-csr"]
+    entrypoint: /usr/bin/cmd
+
+versions:
+  "0": {}

--- a/images/cloudflared.yaml
+++ b/images/cloudflared.yaml
@@ -1,0 +1,13 @@
+name: cloudflared
+description: "Cloudflare Tunnel daemon — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: cloudflared
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["cloudflared"]
+    entrypoint: /usr/bin/cloudflared
+
+versions:
+  "2025": {}

--- a/images/gomplate.yaml
+++ b/images/gomplate.yaml
@@ -1,0 +1,13 @@
+name: gomplate
+description: "Gomplate template renderer — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: gomplate
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["gomplate"]
+    entrypoint: /usr/bin/gomplate
+
+versions:
+  "4": {}

--- a/images/hubble.yaml
+++ b/images/hubble.yaml
@@ -1,0 +1,13 @@
+name: hubble
+description: "Cilium Hubble network observability CLI — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: hubble
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["hubble"]
+    entrypoint: /usr/bin/hubble
+
+versions:
+  "1": {}

--- a/images/hydra.yaml
+++ b/images/hydra.yaml
@@ -1,0 +1,13 @@
+name: hydra
+description: "Ory Hydra OAuth2 and OpenID Connect server — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: hydra
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["hydra"]
+    entrypoint: /usr/bin/hydra
+
+versions:
+  "2": {}

--- a/images/kratos.yaml
+++ b/images/kratos.yaml
@@ -1,0 +1,13 @@
+name: kratos
+description: "Ory Kratos identity and user management — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: kratos
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["kratos"]
+    entrypoint: /usr/bin/kratos
+
+versions:
+  "2": {}

--- a/images/nfs-subdir-external-provisioner.yaml
+++ b/images/nfs-subdir-external-provisioner.yaml
@@ -1,0 +1,13 @@
+name: nfs-subdir-external-provisioner
+description: "Kubernetes NFS subdir external provisioner — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: nfs-subdir-external-provisioner
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["nfs-subdir-external-provisioner"]
+    entrypoint: /usr/bin/nfs-subdir-external-provisioner
+
+versions:
+  "4": {}

--- a/images/rclone.yaml
+++ b/images/rclone.yaml
@@ -1,0 +1,13 @@
+name: rclone
+description: "rclone cloud storage sync — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: rclone
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["rclone"]
+    entrypoint: /usr/bin/rclone
+
+versions:
+  "1": {}

--- a/images/tetragon.yaml
+++ b/images/tetragon.yaml
@@ -1,0 +1,13 @@
+name: tetragon
+description: "Cilium Tetragon eBPF runtime security — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: tetragon
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["tetragon"]
+    entrypoint: /usr/bin/tetragon
+
+versions:
+  "1": {}

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -348,6 +348,8 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "k9s", source: "integer" },
       { name: "stern", source: "integer" },
       { name: "minio-operator", source: "integer" },
+      { name: "argocd-image-updater", source: "integer" },
+      { name: "nfs-subdir-external-provisioner", source: "integer" },
     ],
   },
 
@@ -438,6 +440,9 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "quay.io/calico/key-cert-provisioner",
       },
       { name: "contour", source: "integer" },
+      { name: "hubble", source: "integer" },
+      { name: "cert-manager-istio-csr", source: "integer" },
+      { name: "cloudflared", source: "integer" },
     ],
   },
 
@@ -591,6 +596,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "pulumi", source: "integer" },
       { name: "argo-workflows", source: "integer" },
       { name: "argo-rollouts", source: "integer" },
+      { name: "gomplate", source: "integer" },
     ],
   },
 
@@ -660,6 +666,9 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "spicedb", source: "integer" },
       { name: "checkov", source: "integer" },
       { name: "step-ca", source: "integer" },
+      { name: "tetragon", source: "integer" },
+      { name: "kratos", source: "integer" },
+      { name: "hydra", source: "integer" },
     ],
   },
 
@@ -748,6 +757,7 @@ export const fullCatalog: FullCatalogCategory[] = [
         integerName: "cert-manager-cmctl",
         upstream: "quay.io/jetstack/cert-manager-cmctl",
       },
+      { name: "cert-manager-csi-driver", source: "integer" },
       {
         name: "cert-manager/cert-manager-openshift-routes",
         label: "cert-manager-openshift-routes",
@@ -857,6 +867,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "crane", source: "integer", variants: ["default", "fips"] },
       { name: "grype", source: "integer" },
       { name: "coredns", source: "integer" },
+      { name: "rclone", source: "integer" },
     ],
   },
 ];


### PR DESCRIPTION
## Summary

Mega wave of 11 Wolfi-based Integer images covering security observability, identity, K8s operations, networking, and DevOps tools.

### Added (11 new Integer images)

**Security observability (1)** — `security` category
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `tetragon` | `tetragon` | `/usr/bin/tetragon` |

**Identity / Ory stack (2)** — `security` category
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `kratos` | `kratos` | `/usr/bin/kratos` |
| `hydra` | `hydra` | `/usr/bin/hydra` |

**K8s ecosystem (5)** — `kubernetes`, `mesh`, `certs` categories
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `argocd-image-updater` | `argocd-image-updater` | `/usr/bin/argocd-image-updater` |
| `cert-manager-csi-driver` | `cert-manager-csi-driver` | `/usr/bin/cert-manager-csi-driver` |
| `cert-manager-istio-csr` | `cert-manager-istio-csr` | `/usr/bin/cmd` |
| `nfs-subdir-external-provisioner` | `nfs-subdir-external-provisioner` | `/usr/bin/nfs-subdir-external-provisioner` |
| `hubble` | `hubble` | `/usr/bin/hubble` |

**Networking (1)** — `mesh` category
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `cloudflared` | `cloudflared` | `/usr/bin/cloudflared` |

**DevOps tools (2)** — `cicd` and `base` categories
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `gomplate` | `gomplate` | `/usr/bin/gomplate` |
| `rclone` | `rclone` | `/usr/bin/rclone` |

### Investigated but deferred
- `kubevela` (vela-core): Wolfi pkg pinned at `1.10.3-r2`; fixes need `1.10.4+`/`1.10.6+`/`1.10.7+` (12 CVEs, same publish-lag pattern). Will revisit when Wolfi catches up.
- `keycloak-config-cli`: ships as a JAR under `/usr/share/java/`, needs JDK runtime + custom `java -jar` entrypoint. Defer for a focused multi-pkg PR.

### Validation
- `./verity integer validate` → all 166 configs valid
- **Full apko build + trivy image scan** for all 11 (with fresh advisory DB) → **0 CRITICAL/HIGH CVEs**

### Files
- 11 new YAMLs under `images/`
- `site/src/data/full-catalog.ts` — entries added across kubernetes, mesh, cicd, security, certs, base categories

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 11 new Wolfi-based Integer images across security, identity, Kubernetes ops, networking, and DevOps tools. All run on `wolfi-base` and scanned clean (0 critical/high CVEs) via `apko` build and `trivy` image scan.

- **New Features**
  - Security observability: `tetragon`
  - Identity (Ory): `kratos`, `hydra`
  - Kubernetes ecosystem: `argocd-image-updater`, `cert-manager-csi-driver`, `cert-manager-istio-csr`, `nfs-subdir-external-provisioner`, `hubble`
  - Networking: `cloudflared`
  - DevOps tools: `gomplate`, `rclone`

<sup>Written for commit fccc08fc614a990fcd11fad69997e26926ad2d15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

