### PR TITLE
fix(chartgen): replacements: must beat --exclude-names (silent failure repro)

### DIFF
--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -3,6 +3,7 @@ package chartgen
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -67,14 +68,15 @@ func Run(cfg *Config) (*DryRunResult, error) {
 		}
 	}
 
-	// Loud summary so silent regressions (chart added to Chart.yaml but
-	// every image excluded → zero wrappers produced) are visible in CI.
+	// Loud summary so silent regressions (chart added to the configured
+	// charts file but every image excluded → zero wrappers produced) are
+	// visible in CI.
 	verb := "produced"
 	if cfg.DryRun {
 		verb = "would produce"
 	}
-	fmt.Fprintf(os.Stderr, "info: chart-gen summary: %d charts in Chart.yaml, %s %d wrappers, %d skipped (no patched mappings)\n",
-		len(charts), verb, len(result.Charts), skipped)
+	fmt.Fprintf(os.Stderr, "info: chart-gen summary: %d charts in %s, %s %d wrappers, %d skipped (no patched mappings)\n",
+		len(charts), filepath.Base(cfg.ChartsFile), verb, len(result.Charts), skipped)
 
 	return result, nil
 }
@@ -184,10 +186,11 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 		// Replacements are the authoritative signal — try them before
 		// considering --exclude-names. Otherwise a chart image whose
 		// basename collides with an Integer rebuild filename (the source
-		// of exclude-names) would be silently skipped before its explicit
-		// replacement entry could fire, leaving the chart with no
-		// wrapper at all. See PR #248-followup for the silent-failure
-		// case this prevents.
+		// of exclude-names, derived in CI from `images/*.yaml`) would be
+		// silently skipped before its explicit replacement entry could
+		// fire, leaving the chart with no wrapper at all (chart-gen would
+		// then warn "no patched image mappings" and skip the chart, but
+		// exit 0).
 		matched := false
 		for _, pattern := range patterns {
 			if name != pattern && !strings.Contains(name, pattern) {

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -54,6 +54,7 @@ func Run(cfg *Config) (*DryRunResult, error) {
 		Charts:        make([]ChartResult, 0, len(charts)),
 	}
 
+	skipped := 0
 	for _, chart := range charts {
 		chartResult, include, err := processChart(cfg, chart, vc)
 		if err != nil {
@@ -61,8 +62,19 @@ func Run(cfg *Config) (*DryRunResult, error) {
 		}
 		if include {
 			result.Charts = append(result.Charts, chartResult)
+		} else {
+			skipped++
 		}
 	}
+
+	// Loud summary so silent regressions (chart added to Chart.yaml but
+	// every image excluded → zero wrappers produced) are visible in CI.
+	verb := "produced"
+	if cfg.DryRun {
+		verb = "would produce"
+	}
+	fmt.Fprintf(os.Stderr, "info: chart-gen summary: %d charts in Chart.yaml, %s %d wrappers, %d skipped (no patched mappings)\n",
+		len(charts), verb, len(result.Charts), skipped)
 
 	return result, nil
 }
@@ -169,11 +181,13 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 		name := repoPath(imageRef)
 		sourceRepo, sourceTag := splitRef(imageRef)
 
-		if isExcluded(name, imageRef, excludeNames) {
-			fmt.Fprintf(os.Stderr, "warning: skipping excluded image %q (%s)\n", name, imageRef)
-			continue
-		}
-
+		// Replacements are the authoritative signal — try them before
+		// considering --exclude-names. Otherwise a chart image whose
+		// basename collides with an Integer rebuild filename (the source
+		// of exclude-names) would be silently skipped before its explicit
+		// replacement entry could fire, leaving the chart with no
+		// wrapper at all. See PR #248-followup for the silent-failure
+		// case this prevents.
 		matched := false
 		for _, pattern := range patterns {
 			if name != pattern && !strings.Contains(name, pattern) {
@@ -195,9 +209,20 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 			matched = true
 			break
 		}
-		if !matched {
-			remaining = append(remaining, imageRef)
+		if matched {
+			continue
 		}
+
+		// No replacement matched — now apply --exclude-names so that
+		// images backed by an Integer rebuild but lacking an explicit
+		// replacement entry don't get crane-looked-up against the Copa
+		// patched registry (where they don't exist).
+		if isExcluded(name, imageRef, excludeNames) {
+			fmt.Fprintf(os.Stderr, "warning: skipping excluded image %q (%s)\n", name, imageRef)
+			continue
+		}
+
+		remaining = append(remaining, imageRef)
 	}
 
 	return remaining, replacements

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -191,11 +191,14 @@ func TestApplyReplacementsLongestPatternWins(t *testing.T) {
 	}
 }
 
-func TestApplyReplacementsExcluded(t *testing.T) {
+func TestApplyReplacementsExcludedWithoutReplacement(t *testing.T) {
+	// An image present in --exclude-names but NOT covered by any
+	// replacement entry must be dropped (neither replaced nor passed
+	// through to crane lookup).
 	refs := []string{"quay.io/prometheus/pushgateway:v1.11.2"}
 	vc := &config.VerityConfig{
 		Replacements: map[string]config.Replacement{
-			"prometheus/pushgateway": {Registry: "ghcr.io/verity-org", Image: "pushgateway"},
+			"some-unrelated/image": {Registry: "ghcr.io/verity-org", Image: "other"},
 		},
 	}
 	exclude := map[string]struct{}{"pushgateway": {}}
@@ -205,6 +208,62 @@ func TestApplyReplacementsExcluded(t *testing.T) {
 		t.Errorf("remaining = %d, want 0 (excluded)", len(remaining))
 	}
 	if len(replacements) != 0 {
-		t.Errorf("replacements = %d, want 0 (excluded)", len(replacements))
+		t.Errorf("replacements = %d, want 0 (no replacement matches, excluded)", len(replacements))
+	}
+}
+
+func TestApplyReplacementsWinsOverExclude(t *testing.T) {
+	// Regression test for the silent-failure case where chart-gen
+	// produced zero wrappers for charts whose images had explicit
+	// replacements but whose basenames also collided with Integer
+	// rebuild filenames (the source of --exclude-names).
+	//
+	// Setup mirrors the real-world failure: an image whose basename
+	// matches an exclude entry AND has an explicit replacement entry.
+	// The replacement must win — otherwise the chart loses its mapping
+	// and gets skipped with "no patched image mappings".
+	refs := []string{
+		"opensearchproject/opensearch:3.6.0",
+		"registry.k8s.io/metrics-server/metrics-server:v0.8.0",
+		"reg.kyverno.io/kyverno/kyverno:v1.17.2",
+	}
+	vc := &config.VerityConfig{
+		Replacements: map[string]config.Replacement{
+			"opensearchproject/opensearch":  {Registry: "ghcr.io/verity-org", Image: "opensearch"},
+			"metrics-server/metrics-server": {Registry: "ghcr.io/verity-org", Image: "metrics-server"},
+			"kyverno/kyverno":               {Registry: "ghcr.io/verity-org", Image: "kyverno"},
+		},
+	}
+	// These exclude names match the basenames of the images above —
+	// derived in the workflow from `find images -name '*.yaml'`.
+	exclude := map[string]struct{}{
+		"opensearch":     {},
+		"metrics-server": {},
+		"kyverno":        {},
+	}
+
+	remaining, replacements := applyReplacements(refs, vc, exclude)
+
+	if len(remaining) != 0 {
+		t.Errorf("remaining = %d, want 0 (all should be replaced); remaining=%v", len(remaining), remaining)
+	}
+	if len(replacements) != 3 {
+		t.Fatalf("replacements = %d, want 3 (each image has an explicit replacement that must beat the exclude)", len(replacements))
+	}
+
+	want := map[string]string{
+		"opensearchproject/opensearch":                  "ghcr.io/verity-org/opensearch",
+		"registry.k8s.io/metrics-server/metrics-server": "ghcr.io/verity-org/metrics-server",
+		"reg.kyverno.io/kyverno/kyverno":                "ghcr.io/verity-org/kyverno",
+	}
+	for _, r := range replacements {
+		expected, ok := want[r.OriginalRepo]
+		if !ok {
+			t.Errorf("unexpected OriginalRepo: %q", r.OriginalRepo)
+			continue
+		}
+		if r.PatchedRepo != expected {
+			t.Errorf("OriginalRepo=%q: got PatchedRepo=%q, want %q (exclude must not block explicit replacement)", r.OriginalRepo, r.PatchedRepo, expected)
+		}
 	}
 }


### PR DESCRIPTION
## TL;DR

The chart-gen workflow [run on main after PR #246 merged](https://github.com/verity-org/verity/actions/runs/24938519884/job/73028174495) silently produced wrappers for only **4 of 9 charts**. 5 of the newly-added chart deps emitted no wrapper at all because `--exclude-names` short-circuited the `replacements:` map. Job exited 0, no failed step, no surface signal — pure silent failure.

This PR fixes the precedence and adds a summary log so this class of regression is visible.

## Symptom (from the silent run)

```
info: processing chart kyverno@3.7.2
info: replacing "kyvernopre"        with ghcr.io/verity-org/kyverno
warning: skipping excluded image "kyverno/kyverno"     (.../kyverno:v1.17.2)         ← lost
info: replacing "background-controller" with ghcr.io/verity-org/kyverno-background-controller
info: replacing "reports-controller" with ghcr.io/verity-org/kyverno-reports-controller
warning: skipping excluded image "kyverno/kyverno-cli" (.../kyverno-cli:v1.17.2)     ← lost
...
info: processing chart dex@0.24.0
warning: skipping excluded image "dexidp/dex"                                         ← lost
warning: no patched image mappings for chart dex@0.24.0; skipping                    ← chart skipped
... (same for metrics-server, opensearch, opensearch-dashboards)
```

Job conclusion: ✅ success. **5 charts produced zero wrappers.**

## Root cause

`applyReplacements()` in `internal/chartgen/chartgen.go` ran the exclude check **before** trying the replacement match:

```go
if isExcluded(name, imageRef, excludeNames) {     // ← exclude wins
    continue
}
matched := false
for _, pattern := range patterns { ... }          // ← never reached
```

The CI workflow step "Derive exclude names from Integer images" passes `--exclude-names` derived from `images/*.yaml` filenames (kyverno, kyverno-cli, dex, metrics-server, opensearch, opensearch-dashboards, ...). Every chart image whose basename matches one of those gets excluded **before** its `replacements:` entry can fire — even though the replacement entry was authored exactly to wire that image to the Integer build.

The pre-merge `chart-gen --dry-run` validation in PR #246 didn't reproduce this because I didn't pass `--exclude-names`. CI does.

## Fix

**1. Reorder `applyReplacements`** — try replacements first; fall through to `--exclude-names` only when nothing matched. Replacements are the authoritative signal (explicit "use this Integer image"); excludes are name-collision avoidance for the crane-lookup fallback (where Integer-only images don't exist).

**2. Loud summary log** at end of `Run()`:

```
info: chart-gen summary: 9 charts in Chart.yaml, produced 7 wrappers, 2 skipped (no patched mappings)
```

This makes "0 wrappers" visible at a glance instead of buried in 30+ lines of warnings.

**3. Regression tests** in `chartgen_test.go`:
- `TestApplyReplacementsExcludedWithoutReplacement` — replaces the old test; asserts excluded image with NO replacement still gets dropped (the legitimate exclude case).
- `TestApplyReplacementsWinsOverExclude` — new; reproduces the production failure mode with kyverno/metrics-server/opensearch image refs and asserts replacements still fire.

## Verification (local, against actual CI scenario)

```sh
EXCLUDE_NAMES=$(find images -maxdepth 1 -name '*.yaml' -printf '%f\n' | sed 's/\.yaml$//' | paste -sd,)

./verity chart-gen \
  --charts-file Chart.yaml --verity-config verity.yaml \
  --target-registry ghcr.io/verity-org \
  --chart-registry oci://ghcr.io/verity-org/charts \
  --exclude-names "$EXCLUDE_NAMES" --dry-run
```

| Chart | Before this PR | After this PR |
|---|---|---|
| prometheus            | 2 | 2 |
| kyverno               | 2 (3 lost) | **5** |
| argo-cd               | 1 (dex lost) | **2** |
| dex                   | 0 (skipped) | **1** |
| metrics-server        | 0 (skipped) | **1** |
| opensearch            | 0 (skipped) | **1** |
| opensearch-dashboards | 0 (skipped) | **1** |
| victoria-logs-single  | 0 (skipped — correct, no replacements) | 0 |
| postgres-operator     | 0 (skipped — correct, no replacements) | 0 |
| **Total wrappers**    | **4 / 9** | **7 / 9** |

`go test ./...`: green (5/5 chartgen tests).
`gofumpt -d`: clean.

## Why this design (replacements > excludes)

| User authored | Intent |
|---|---|
| `replacements: { "kyverno/kyverno": ghcr.io/verity-org/kyverno }` | "When chart emits kyverno, route to my Integer image." |
| `--exclude-names kyverno` (auto-derived) | "Don't crane-lookup `kyverno` against the Copa-patched registry — Integer publishes it independently." |

Both target the same images. The replacement is the explicit, authored signal — the exclude is automation. Explicit wins.

## Files

- `internal/chartgen/chartgen.go`        — reorder + summary log (29 lines)
- `internal/chartgen/chartgen_test.go`   — updated 1 test, added 1 regression test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a silent chart generation failure where `--exclude-names` blocked `replacements:`, causing missing wrappers. Reorders the logic and adds a CI-friendly summary that references the configured charts file name.

- **Bug Fixes**
  - Apply `replacements:` before `--exclude-names` in `applyReplacements()` so explicit mappings win and charts like kyverno, dex, metrics-server, and opensearch are not skipped.
  - Print an end-of-run summary: “chart-gen summary: N charts in <ChartsFile>, produced M wrappers, K skipped (no patched mappings)” and use `filepath.Base(cfg.ChartsFile)` so the message shows the actual file.
  - Add regression tests: `TestApplyReplacementsExcludedWithoutReplacement` and `TestApplyReplacementsWinsOverExclude`.

<sup>Written for commit b1db04a360d06207e0d36c8dca04280b6bbec931. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

