### PR TITLE
fix(verity.yaml): add postgres-operator → Integer replacement

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -66,6 +66,9 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "opensearch-dashboards"
 
+  # postgres-operator chart (1.15.1). Migrated Copa→Integer; this entry
+  # routes the chart's image to the existing images/postgres-operator.yaml
+  # rebuild.
   "zalando/postgres-operator":
     registry: "ghcr.io/verity-org"
     image: "postgres-operator"

--- a/verity.yaml
+++ b/verity.yaml
@@ -65,3 +65,7 @@ replacements:
   "opensearchproject/opensearch-dashboards":
     registry: "ghcr.io/verity-org"
     image: "opensearch-dashboards"
+
+  "zalando/postgres-operator":
+    registry: "ghcr.io/verity-org"
+    image: "postgres-operator"


### PR DESCRIPTION
## TL;DR

postgres-operator was migrated Copa→Integer (`images/postgres-operator.yaml` exists), but the matching `replacements:` entry was never added in `verity.yaml`. As a result, the postgres-operator wrapper chart hasn't been published since the migration. This PR wires the missing piece.

## What's broken

Looking at `main` right now:
```sh
$ ls images/postgres-operator.yaml      # ✓ Integer rebuild exists
$ grep postgres-operator copa-config.yaml   # (empty — removed in migration)
$ grep postgres-operator verity.yaml        # (empty — never added)
```

Result in CI logs:
```
warning: skipping excluded image "zalando/postgres-operator" (ghcr.io/zalando/postgres-operator:v1.15.1)
warning: no patched image mappings for chart postgres-operator@1.15.1; skipping
```

`oci://ghcr.io/verity-org/charts/postgres-operator` doesn't get pushed → users `helm install`-ing it get a 404.

## Fix

```yaml
# verity.yaml
"zalando/postgres-operator":
  registry: "ghcr.io/verity-org"
  image: "postgres-operator"
```

Routes the chart's image to the existing Integer rebuild — three lines, same pattern as kyverno/argo-cd/dex/metrics-server/opensearch added in #246.

## Dependency on #261

This fix only takes full effect after **#261** (the precedence fix for `applyReplacements`) merges. On current `main`, `--exclude-names` (derived from `images/*.yaml`) still wins over `replacements:`, so `zalando/postgres-operator` would still be excluded before this entry could fire. Local repro:

```
$ ./verity chart-gen --exclude-names "$(find images -name '*.yaml' -printf '%f\n' | sed 's/\.yaml$//' | paste -sd,)" --dry-run
warning: skipping excluded image "zalando/postgres-operator" ...
warning: no patched image mappings for chart postgres-operator@1.15.1; skipping
```

After #261 merges + this PR rebases on top of it, the same command produces:
```
info: replacing "ghcr.io/zalando/postgres-operator:v1.15.1" with Integer image ghcr.io/verity-org/postgres-operator:v1.15.1
info: chart-gen summary: 9 charts in Chart.yaml, would produce 9 wrappers, 0 skipped
```

(Verified locally on the #261 branch.)

## Merge order

1. Merge #261 first (precedence fix)
2. Rebase + merge this PR (will be a no-op rebase; just config)

## Files

- `verity.yaml` — 5 lines added (3 lines of replacement + blank line + comment-spaced)

No code change, no tests needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing replacement in `verity.yaml` to route `zalando/postgres-operator` to `ghcr.io/verity-org/postgres-operator`. This restores publishing of the `postgres-operator` wrapper chart.

- **Bug Fixes**
  - Added `replacements:` entry for `zalando/postgres-operator` → `ghcr.io/verity-org/postgres-operator`.
  - Added a chart context comment header for the `postgres-operator` block to match existing entries.

- **Migration**
  - Takes effect after PR #261 (replacement precedence). Merge #261 first, then this PR.

<sup>Written for commit 464ec4a7af02934976dd5a3826fbeded10d47def. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

