### PR TITLE
feat(chartgen): add --strict flag to fail when charts produce 0 wrappers

### DIFF
--- a/.github/workflows/chart-gen.yaml
+++ b/.github/workflows/chart-gen.yaml
@@ -77,4 +77,5 @@ jobs:
             --verity-config verity.yaml \
             --target-registry "${TARGET_REGISTRY}" \
             --chart-registry "${CHART_REGISTRY}" \
-            --exclude-names "${{ steps.exclude.outputs.names }}"
+            --exclude-names "${{ steps.exclude.outputs.names }}" \
+            --strict

--- a/cmd/chart_gen.go
+++ b/cmd/chart_gen.go
@@ -45,6 +45,10 @@ var ChartGenCommand = &cli.Command{
 			Name:  "dry-run",
 			Usage: "Output JSON plan without pushing charts",
 		},
+		&cli.BoolFlag{
+			Name:  "strict",
+			Usage: "Fail (exit non-zero) if any chart in the charts file produces zero patched image mappings — surfaces silent config gaps (e.g., chart added without a matching replacements: entry)",
+		},
 	},
 	Action: func(_ context.Context, cmd *cli.Command) error {
 		cfg := &chartgen.Config{
@@ -54,6 +58,7 @@ var ChartGenCommand = &cli.Command{
 			ChartRegistry:  cmd.String("chart-registry"),
 			ExcludeNames:   parseNameSet(cmd.String("exclude-names")),
 			DryRun:         cmd.Bool("dry-run"),
+			Strict:         cmd.Bool("strict"),
 		}
 
 		result, err := chartgen.Run(cfg)

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -19,6 +19,11 @@ type Config struct {
 	ChartRegistry  string
 	ExcludeNames   map[string]struct{}
 	DryRun         bool
+	// Strict treats "no patched image mappings" skips as a fatal error.
+	// Use it in CI to catch silent config gaps — e.g., a chart added to
+	// Chart.yaml whose images have an Integer rebuild but no matching
+	// replacements: entry, leaving the wrapper unpublished.
+	Strict bool
 }
 
 type ChartResult struct {
@@ -78,7 +83,23 @@ func Run(cfg *Config) (*DryRunResult, error) {
 	fmt.Fprintf(os.Stderr, "info: chart-gen summary: %d charts in %s, %s %d wrappers, %d skipped (no patched mappings)\n",
 		len(charts), filepath.Base(cfg.ChartsFile), verb, len(result.Charts), skipped)
 
+	if err := enforceStrict(cfg.Strict, len(charts), skipped, cfg.ChartsFile); err != nil {
+		return result, err
+	}
+
 	return result, nil
+}
+
+// enforceStrict returns an error when strict is true and any chart in the
+// charts file produced no patched image mappings. Extracted as a separate
+// function so the failure-mode logic is unit-testable without standing up
+// the full helm/crane machinery that Run() exercises.
+func enforceStrict(strict bool, total, skipped int, chartsFile string) error {
+	if !strict || skipped == 0 {
+		return nil
+	}
+	return fmt.Errorf("strict mode: %d of %d charts produced no patched image mappings (likely a chart added to %s without a matching replacements: entry in verity.yaml, or whose Integer rebuild lacks the wiring); re-run without --strict to allow, or fix the underlying config gap",
+		skipped, total, filepath.Base(chartsFile))
 }
 
 func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) (ChartResult, bool, error) {

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -3,6 +3,7 @@ package chartgen
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/verity-org/verity/internal/config"
@@ -89,6 +90,63 @@ func TestRunDryRunNoCharts(t *testing.T) {
 	}
 	if len(res.Charts) != 0 {
 		t.Fatalf("Run() charts length = %d, want 0", len(res.Charts))
+	}
+}
+
+func TestEnforceStrict(t *testing.T) {
+	cases := []struct {
+		name    string
+		strict  bool
+		total   int
+		skipped int
+		wantErr bool
+	}{
+		{name: "non-strict: 0 skipped is fine", strict: false, total: 5, skipped: 0, wantErr: false},
+		{name: "non-strict: skipped tolerated", strict: false, total: 5, skipped: 3, wantErr: false},
+		{name: "strict: 0 skipped is fine", strict: true, total: 5, skipped: 0, wantErr: false},
+		{name: "strict: 1 skipped fails", strict: true, total: 5, skipped: 1, wantErr: true},
+		{name: "strict: many skipped fails", strict: true, total: 5, skipped: 5, wantErr: true},
+		{name: "non-strict, no charts: fine", strict: false, total: 0, skipped: 0, wantErr: false},
+		{name: "strict, no charts: fine", strict: true, total: 0, skipped: 0, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := enforceStrict(tc.strict, tc.total, tc.skipped, "/tmp/Chart.yaml")
+			if (err != nil) != tc.wantErr {
+				t.Errorf("enforceStrict(strict=%v, total=%d, skipped=%d) err=%v, wantErr=%v",
+					tc.strict, tc.total, tc.skipped, err, tc.wantErr)
+			}
+			if tc.wantErr && err != nil {
+				if !strings.Contains(err.Error(), "strict mode") {
+					t.Errorf("error missing 'strict mode' prefix: %v", err)
+				}
+				if !strings.Contains(err.Error(), "Chart.yaml") {
+					t.Errorf("error should reference charts file basename: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRunDryRunStrictNoChartsPasses(t *testing.T) {
+	// With no charts loaded (empty Chart.yaml or missing file), strict
+	// mode should NOT fail — there's nothing to skip. Guards against
+	// over-eager error-on-empty.
+	tmpDir := t.TempDir()
+	res, err := Run(&Config{
+		ChartsFile:     filepath.Join(tmpDir, "does-not-exist.yaml"),
+		VerityConfig:   filepath.Join(tmpDir, "does-not-exist.yaml"),
+		TargetRegistry: "ghcr.io/verity-org",
+		ChartRegistry:  "oci://ghcr.io/verity-org/charts",
+		ExcludeNames:   map[string]struct{}{},
+		DryRun:         true,
+		Strict:         true,
+	})
+	if err != nil {
+		t.Fatalf("Run with strict=true and no charts: err=%v, want nil", err)
+	}
+	if res == nil || len(res.Charts) != 0 {
+		t.Fatalf("expected 0 charts in result, got %v", res)
 	}
 }
 


### PR DESCRIPTION
## TL;DR

Stacked on **#261**. Adds a `--strict` flag to `verity chart-gen` that converts the "no patched image mappings" soft warning into a hard error. Wires the chart-gen workflow to pass `--strict` so silent config gaps (chart in `Chart.yaml` without a matching `replacements:` entry) become loud CI failures.

Pairs with **#263** which fills the existing gap (postgres-operator). With both merged, the next chart-gen run produces all 9 wrappers cleanly. With this PR alone but #263 not merged, the next run would fail loudly — which is exactly the point.

## Motivation

PR #261 surfaced one silent failure. PR #263 caught a second instance immediately after. Both are the same class of bug: a chart in `Chart.yaml` whose images have no matching `replacements:` entry → chart-gen warns and continues → wrapper silently disappears from `oci://ghcr.io/verity-org/charts/`.

Without a CI gate, this bug recurs every time someone:
- adds a chart to `Chart.yaml` without remembering the replacement
- migrates an image Copa→Integer and forgets to add the replacement
- removes a `replacements:` entry that's still in use

`--strict` is the gate.

## Behavior

| Mode | Effect |
|---|---|
| `--strict` unset (default) | Existing behavior — soft warning, exit 0 |
| `--strict` set, all charts produce wrappers | Exit 0, identical output |
| `--strict` set, ≥1 chart produces 0 mappings | Exit 1 with descriptive error pointing at likely cause |

The error message is intentionally instructive:

```
error: strict mode: 1 of 9 charts produced no patched image mappings
(likely a chart added to Chart.yaml without a matching replacements:
entry in verity.yaml, or whose Integer rebuild lacks the wiring);
re-run without --strict to allow, or fix the underlying config gap
```

## Tests

- `TestEnforceStrict` — 7 sub-cases: { strict, non-strict } × { 0 skipped, ≥1 skipped, no charts }. Asserts error message contains `strict mode` and the charts file basename.
- `TestRunDryRunStrictNoChartsPasses` — integration test confirming `Run(Strict=true)` does NOT fail when 0 charts are loaded. Guards against the over-eager "error on empty" mistake.

`enforceStrict()` is extracted as a pure function to keep the failure-mode logic testable without spinning up helm/crane.

## Workflow change

```diff
       - name: Generate and push wrapper charts
         run: |
           ./verity chart-gen \
             --charts-file Chart.yaml \
             --verity-config verity.yaml \
             --target-registry "${TARGET_REGISTRY}" \
             --chart-registry "${CHART_REGISTRY}" \
-            --exclude-names "${{ steps.exclude.outputs.names }}"
+            --exclude-names "${{ steps.exclude.outputs.names }}" \
+            --strict
```

## Merge order (important)

1. **#261** must land first (chartgen replacement precedence — without this, `replacements:` entries don't fire, so even valid configs would trigger strict failures)
2. **#263** must land before/with this PR (postgres-operator replacement — without it, this PR would fail the next chart-gen run on `main`)
3. **This PR** — landing this without #263 would mean the first nightly run fails loudly with `1 of 9 charts produced no patched image mappings`. That's correct behavior for the gate, but would block other work.

If reviewers prefer, this PR can be rebased onto `main` after #261+#263 land — the diff stays the same (this branch is currently based on #261's branch for a clean review diff).

## Files

- `cmd/chart_gen.go` — register `--strict` flag, wire into `chartgen.Config`
- `internal/chartgen/chartgen.go` — `Strict` field on `Config`; `enforceStrict()` post-flight check
- `internal/chartgen/chartgen_test.go` — `TestEnforceStrict` (7 cases) + `TestRunDryRunStrictNoChartsPasses`
- `.github/workflows/chart-gen.yaml` — pass `--strict` to the daily run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `--strict` flag to `verity chart-gen` to fail builds when any chart produces zero patched image mappings. CI now runs chart-gen with `--strict` so missing `replacements:` entries fail fast instead of silently dropping wrappers.

- **New Features**
  - Added `--strict` (default off) that exits non-zero if any chart yields zero patched image mappings.
  - Updated workflow to pass `--strict` in the daily `chart-gen` job to gate on missing `replacements:` wiring.
  - Error message is descriptive and references the charts file; strict mode still passes when no charts are loaded.

<sup>Written for commit dabc31743599545745bdd5b1d212c4f619e1f904. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

