### PR TITLE
feat(chartgen): add --strict flag to fail when charts produce 0 wrappers

### DIFF
--- a/.github/workflows/chart-gen.yaml
+++ b/.github/workflows/chart-gen.yaml
@@ -77,4 +77,5 @@ jobs:
             --verity-config verity.yaml \
             --target-registry "${TARGET_REGISTRY}" \
             --chart-registry "${CHART_REGISTRY}" \
-            --exclude-names "${{ steps.exclude.outputs.names }}"
+            --exclude-names "${{ steps.exclude.outputs.names }}" \
+            --strict

--- a/cmd/chart_gen.go
+++ b/cmd/chart_gen.go
@@ -45,6 +45,10 @@ var ChartGenCommand = &cli.Command{
 			Name:  "dry-run",
 			Usage: "Output JSON plan without pushing charts",
 		},
+		&cli.BoolFlag{
+			Name:  "strict",
+			Usage: "Fail (exit non-zero) if any chart in the charts file produces zero patched image mappings — surfaces silent config gaps (e.g., chart added without a matching replacements: entry)",
+		},
 	},
 	Action: func(_ context.Context, cmd *cli.Command) error {
 		cfg := &chartgen.Config{
@@ -54,6 +58,7 @@ var ChartGenCommand = &cli.Command{
 			ChartRegistry:  cmd.String("chart-registry"),
 			ExcludeNames:   parseNameSet(cmd.String("exclude-names")),
 			DryRun:         cmd.Bool("dry-run"),
+			Strict:         cmd.Bool("strict"),
 		}
 
 		result, err := chartgen.Run(cfg)

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -19,6 +19,11 @@ type Config struct {
 	ChartRegistry  string
 	ExcludeNames   map[string]struct{}
 	DryRun         bool
+	// Strict treats "no patched image mappings" skips as a fatal error.
+	// Use it in CI to catch silent config gaps — e.g., a chart added to
+	// Chart.yaml whose images have an Integer rebuild but no matching
+	// replacements: entry, leaving the wrapper unpublished.
+	Strict bool
 }
 
 type ChartResult struct {
@@ -78,7 +83,23 @@ func Run(cfg *Config) (*DryRunResult, error) {
 	fmt.Fprintf(os.Stderr, "info: chart-gen summary: %d charts in %s, %s %d wrappers, %d skipped (no patched mappings)\n",
 		len(charts), filepath.Base(cfg.ChartsFile), verb, len(result.Charts), skipped)
 
+	if err := enforceStrict(cfg.Strict, len(charts), skipped, cfg.ChartsFile); err != nil {
+		return result, err
+	}
+
 	return result, nil
+}
+
+// enforceStrict returns an error when strict is true and any chart in the
+// charts file produced no patched image mappings. Extracted as a separate
+// function so the failure-mode logic is unit-testable without standing up
+// the full helm/crane machinery that Run() exercises.
+func enforceStrict(strict bool, total, skipped int, chartsFile string) error {
+	if !strict || skipped == 0 {
+		return nil
+	}
+	return fmt.Errorf("strict mode: %d of %d charts produced no patched image mappings (likely a chart added to %s without a matching replacements: entry in verity.yaml, or whose Integer rebuild lacks the wiring); re-run without --strict to allow, or fix the underlying config gap",
+		skipped, total, filepath.Base(chartsFile))
 }
 
 func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) (ChartResult, bool, error) {

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -3,6 +3,7 @@ package chartgen
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/verity-org/verity/internal/config"
@@ -89,6 +90,63 @@ func TestRunDryRunNoCharts(t *testing.T) {
 	}
 	if len(res.Charts) != 0 {
 		t.Fatalf("Run() charts length = %d, want 0", len(res.Charts))
+	}
+}
+
+func TestEnforceStrict(t *testing.T) {
+	cases := []struct {
+		name    string
+		strict  bool
+		total   int
+		skipped int
+		wantErr bool
+	}{
+		{name: "non-strict: 0 skipped is fine", strict: false, total: 5, skipped: 0, wantErr: false},
+		{name: "non-strict: skipped tolerated", strict: false, total: 5, skipped: 3, wantErr: false},
+		{name: "strict: 0 skipped is fine", strict: true, total: 5, skipped: 0, wantErr: false},
+		{name: "strict: 1 skipped fails", strict: true, total: 5, skipped: 1, wantErr: true},
+		{name: "strict: many skipped fails", strict: true, total: 5, skipped: 5, wantErr: true},
+		{name: "non-strict, no charts: fine", strict: false, total: 0, skipped: 0, wantErr: false},
+		{name: "strict, no charts: fine", strict: true, total: 0, skipped: 0, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := enforceStrict(tc.strict, tc.total, tc.skipped, "/tmp/Chart.yaml")
+			if (err != nil) != tc.wantErr {
+				t.Errorf("enforceStrict(strict=%v, total=%d, skipped=%d) err=%v, wantErr=%v",
+					tc.strict, tc.total, tc.skipped, err, tc.wantErr)
+			}
+			if tc.wantErr && err != nil {
+				if !strings.Contains(err.Error(), "strict mode") {
+					t.Errorf("error missing 'strict mode' prefix: %v", err)
+				}
+				if !strings.Contains(err.Error(), "Chart.yaml") {
+					t.Errorf("error should reference charts file basename: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRunDryRunStrictNoChartsPasses(t *testing.T) {
+	// With no charts loaded (empty Chart.yaml or missing file), strict
+	// mode should NOT fail — there's nothing to skip. Guards against
+	// over-eager error-on-empty.
+	tmpDir := t.TempDir()
+	res, err := Run(&Config{
+		ChartsFile:     filepath.Join(tmpDir, "does-not-exist.yaml"),
+		VerityConfig:   filepath.Join(tmpDir, "does-not-exist.yaml"),
+		TargetRegistry: "ghcr.io/verity-org",
+		ChartRegistry:  "oci://ghcr.io/verity-org/charts",
+		ExcludeNames:   map[string]struct{}{},
+		DryRun:         true,
+		Strict:         true,
+	})
+	if err != nil {
+		t.Fatalf("Run with strict=true and no charts: err=%v, want nil", err)
+	}
+	if res == nil || len(res.Charts) != 0 {
+		t.Fatalf("expected 0 charts in result, got %v", res)
 	}
 }
 


### PR DESCRIPTION
## TL;DR

Re-opened replacement for #264 (auto-closed when its base branch `fix/chartgen-replacement-precedence` was deleted after #261 merged). Adds a `--strict` flag to `verity chart-gen` that converts the "no patched image mappings" soft warning into a hard error. Wires the chart-gen workflow to pass `--strict` so silent config gaps become loud CI failures.

#261 (chartgen replacement precedence) is now merged. This PR pairs with #263 (postgres-operator entry) — once #263 lands, all 9 charts in `Chart.yaml` produce wrappers and the next nightly chart-gen run is fully clean.

## Behavior

| Mode | Effect |
|---|---|
| `--strict` unset (default) | Existing behavior — soft warning, exit 0 |
| `--strict` set, all charts produce wrappers | Exit 0, identical output |
| `--strict` set, ≥1 chart produces 0 mappings | Exit 1 with descriptive error |

The error message is intentionally instructive:

```
error: strict mode: 1 of 9 charts produced no patched image mappings
(likely a chart added to Chart.yaml without a matching replacements:
entry in verity.yaml, or whose Integer rebuild lacks the wiring);
re-run without --strict to allow, or fix the underlying config gap
```

## Tests

- `TestEnforceStrict` — 7 sub-cases: { strict, non-strict } × { 0 skipped, ≥1 skipped, no charts }. Asserts error message contains `strict mode` and the charts file basename.
- `TestRunDryRunStrictNoChartsPasses` — integration test confirming `Run(Strict=true)` does NOT fail when 0 charts are loaded.

`enforceStrict()` is extracted as a pure function so the failure-mode logic is unit-testable without standing up helm/crane.

## Workflow change

```diff
       - name: Generate and push wrapper charts
         run: |
           ./verity chart-gen \
             ...
-            --exclude-names "${{ steps.exclude.outputs.names }}"
+            --exclude-names "${{ steps.exclude.outputs.names }}" \
+            --strict
```

## Merge order

1. ✅ #261 — merged
2. **#263** — merge first/with this PR (postgres-operator config entry)
3. **This PR** — landing this without #263 means the next chart-gen run on main fails loudly with `1 of 9 charts produced no patched image mappings`. That's correct strict-mode behavior, but blocks other work, so land #263 first.

## Files

- `cmd/chart_gen.go` — register `--strict` flag
- `internal/chartgen/chartgen.go` — `Strict` field on `Config`; `enforceStrict()` post-flight check
- `internal/chartgen/chartgen_test.go` — `TestEnforceStrict` + `TestRunDryRunStrictNoChartsPasses`
- `.github/workflows/chart-gen.yaml` — pass `--strict` to the daily run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--strict` flag to `verity chart-gen` that fails the run if any chart produces zero patched image mappings, and updates the CI workflow to pass `--strict` so config gaps fail fast. Also prints a concise summary line to stderr to surface regressions.

- **New Features**
  - `--strict`: exit non-zero when any chart yields 0 mappings; default off; runs with 0 charts still pass.
  - CI: `.github/workflows/chart-gen.yaml` now passes `--strict`.
  - Logs: one-line summary with totals and the charts file name to stderr.

<sup>Written for commit 86dbea0a75b6727a77a479c39ebf51f665218213. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

