### PR TITLE
fix(chartgen): wrap strict-mode error with sentinel to satisfy err113 lint

### DIFF
--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -1,6 +1,7 @@
 package chartgen
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,12 @@ import (
 	"github.com/verity-org/verity/internal/config"
 	"github.com/verity-org/verity/internal/discovery"
 )
+
+// ErrStrictModeUnmappedCharts is returned by Run when --strict is set and at
+// least one chart in the configured charts file produced no patched image
+// mappings (i.e., chart-gen would otherwise have silently skipped it). The
+// usual root cause is a missing replacements: entry in verity.yaml.
+var ErrStrictModeUnmappedCharts = errors.New("strict mode: charts produced no patched image mappings")
 
 type Config struct {
 	ChartsFile     string
@@ -90,16 +97,17 @@ func Run(cfg *Config) (*DryRunResult, error) {
 	return result, nil
 }
 
-// enforceStrict returns an error when strict is true and any chart in the
-// charts file produced no patched image mappings. Extracted as a separate
-// function so the failure-mode logic is unit-testable without standing up
-// the full helm/crane machinery that Run() exercises.
+// enforceStrict returns an error wrapping ErrStrictModeUnmappedCharts when
+// strict is true and any chart in the charts file produced no patched image
+// mappings. Extracted as a separate function so the failure-mode logic is
+// unit-testable without standing up the full helm/crane machinery that
+// Run() exercises.
 func enforceStrict(strict bool, total, skipped int, chartsFile string) error {
 	if !strict || skipped == 0 {
 		return nil
 	}
-	return fmt.Errorf("strict mode: %d of %d charts produced no patched image mappings (likely a chart added to %s without a matching replacements: entry in verity.yaml, or whose Integer rebuild lacks the wiring); re-run without --strict to allow, or fix the underlying config gap",
-		skipped, total, filepath.Base(chartsFile))
+	return fmt.Errorf("%w: %d of %d charts skipped (likely a chart added to %s without a matching replacements: entry in verity.yaml, or whose Integer rebuild lacks the wiring); re-run without --strict to allow, or fix the underlying config gap",
+		ErrStrictModeUnmappedCharts, skipped, total, filepath.Base(chartsFile))
 }
 
 func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) (ChartResult, bool, error) {

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -2,6 +2,7 @@ package chartgen
 
 import (
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -117,8 +118,8 @@ func TestEnforceStrict(t *testing.T) {
 					tc.strict, tc.total, tc.skipped, err, tc.wantErr)
 			}
 			if tc.wantErr && err != nil {
-				if !strings.Contains(err.Error(), "strict mode") {
-					t.Errorf("error missing 'strict mode' prefix: %v", err)
+				if !errors.Is(err, ErrStrictModeUnmappedCharts) {
+					t.Errorf("error should wrap ErrStrictModeUnmappedCharts: %v", err)
 				}
 				if !strings.Contains(err.Error(), "Chart.yaml") {
 					t.Errorf("error should reference charts file basename: %v", err)


### PR DESCRIPTION
## TL;DR

CI Go Lint failure on main after PR #265 merged. The `err113` linter (in `.golangci.yml`) requires `errors.Is`-friendly sentinel errors instead of dynamic `fmt.Errorf` messages. This PR defines `ErrStrictModeUnmappedCharts` and wraps it with `%w` in the existing message.

I should have caught this in PR #265 — my local `golangci-lint` differs from CI (local has unknown `modernize` linter and bails). Filed for follow-up: align local lint config or run via mise (which the CI uses).

## Diff

```go
+ var ErrStrictModeUnmappedCharts = errors.New("strict mode: charts produced no patched image mappings")

  func enforceStrict(strict bool, total, skipped int, chartsFile string) error {
      if !strict || skipped == 0 {
          return nil
      }
-     return fmt.Errorf("strict mode: %d of %d charts produced no patched image mappings (likely a chart added to %s without a matching replacements: entry in verity.yaml, or whose Integer rebuild lacks the wiring); re-run without --strict to allow, or fix the underlying config gap",
-         skipped, total, filepath.Base(chartsFile))
+     return fmt.Errorf("%w: %d of %d charts skipped (likely a chart added to %s without a matching replacements: entry in verity.yaml, or whose Integer rebuild lacks the wiring); re-run without --strict to allow, or fix the underlying config gap",
+         ErrStrictModeUnmappedCharts, skipped, total, filepath.Base(chartsFile))
  }
```

Test assertion changed from string-match to `errors.Is` — that's the proper API contract callers should use.

## Verification

- `go test ./internal/chartgen/` — green (TestEnforceStrict 7/7, TestRunDryRunStrictNoChartsPasses)
- `gofumpt -d internal/chartgen/` — clean
- `go build ./...` — clean

Once merged, the daily chart-gen workflow runs cleanly with `--strict` (postgres-operator now has its replacement entry from #263, so all 9 charts produce wrappers in CI where crane is available).

Note: my local repro showed victoria-logs-single skipping under `--strict`, but only because `crane` isn't in my local PATH. In CI, crane is available and victoria-logs-single produces a wrapper via the Copa-fallback path (verified by the dispatched run on PR #261's branch which produced 8 wrappers including victoria-logs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `golangci-lint` err113 by introducing a sentinel strict-mode error and wrapping it so callers can use `errors.Is`. Lint and tests now pass; error messaging remains the same.

- **Bug Fixes**
  - Added `ErrStrictModeUnmappedCharts` sentinel.
  - Wrapped the strict-mode error via `fmt.Errorf("%w", ...)`; message still includes counts and the charts file basename.
  - Updated tests to assert `errors.Is(err, ErrStrictModeUnmappedCharts)` instead of string matching.

<sup>Written for commit 0006c6eb57bb591ce9161968048e1e8dada9a525. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

