### PR TITLE
feat(integer): linkerd + qdrant + weaviate + otelcol-contrib + kind + tflint + kubescape (7 images)

### DIFF
--- a/images/kind.yaml
+++ b/images/kind.yaml
@@ -1,0 +1,13 @@
+name: kind
+description: "kind — Kubernetes in Docker for testing — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: kind
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["kind"]
+    entrypoint: /usr/bin/kind
+
+versions:
+  "0": {}

--- a/images/kubescape.yaml
+++ b/images/kubescape.yaml
@@ -1,0 +1,13 @@
+name: kubescape
+description: "Kubescape Kubernetes security posture scanner — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: kubescape
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["kubescape"]
+    entrypoint: /usr/bin/kubescape
+
+versions:
+  "3": {}

--- a/images/linkerd.yaml
+++ b/images/linkerd.yaml
@@ -1,0 +1,13 @@
+name: linkerd
+description: "Linkerd service mesh CLI — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: linkerd2-cli
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["linkerd2-cli"]
+    entrypoint: /usr/bin/linkerd
+
+versions:
+  "25": {}

--- a/images/opentelemetry-collector-contrib.yaml
+++ b/images/opentelemetry-collector-contrib.yaml
@@ -1,0 +1,15 @@
+name: opentelemetry-collector-contrib
+description: "OpenTelemetry Collector contrib distribution (all receivers/exporters/processors) — Copa can't patch distroless-based official image; Wolfi rebuild"
+upstream:
+  package: opentelemetry-collector-contrib
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["opentelemetry-collector-contrib"]
+    entrypoint: /usr/bin/otelcol-contrib
+    paths:
+      - {path: /etc/otelcol-contrib, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "0": {}

--- a/images/qdrant.yaml
+++ b/images/qdrant.yaml
@@ -1,0 +1,15 @@
+name: qdrant
+description: "Qdrant vector database — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: qdrant
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["qdrant"]
+    entrypoint: /usr/bin/qdrant
+    paths:
+      - {path: /qdrant/storage, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "1": {}

--- a/images/qdrant.yaml
+++ b/images/qdrant.yaml
@@ -10,6 +10,7 @@ types:
     entrypoint: /usr/bin/qdrant
     paths:
       - {path: /qdrant/storage, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+      - {path: /qdrant/snapshots, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
   "1": {}

--- a/images/tflint.yaml
+++ b/images/tflint.yaml
@@ -1,0 +1,13 @@
+name: tflint
+description: "TFLint Terraform/OpenTofu linter — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: tflint
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["tflint"]
+    entrypoint: /usr/bin/tflint
+
+versions:
+  "0": {}

--- a/images/weaviate.yaml
+++ b/images/weaviate.yaml
@@ -1,0 +1,15 @@
+name: weaviate
+description: "Weaviate vector database — Wolfi rebuild for zero-CVE base"
+upstream:
+  package: weaviate
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["weaviate"]
+    entrypoint: /usr/bin/weaviate
+    paths:
+      - {path: /var/lib/weaviate, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+
+versions:
+  "1": {}

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -350,6 +350,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "minio-operator", source: "integer" },
       { name: "argocd-image-updater", source: "integer" },
       { name: "nfs-subdir-external-provisioner", source: "integer" },
+      { name: "kind", source: "integer" },
     ],
   },
 
@@ -443,6 +444,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "hubble", source: "integer" },
       { name: "cert-manager-istio-csr", source: "integer" },
       { name: "cloudflared", source: "integer" },
+      { name: "linkerd", source: "integer" },
     ],
   },
 
@@ -522,6 +524,7 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "quay.io/victoriametrics/victoria-logs",
       },
       { name: "opentelemetry-collector", source: "integer" },
+      { name: "opentelemetry-collector-contrib", source: "integer" },
       { name: "jaeger", source: "integer" },
       { name: "tempo", source: "integer" },
       { name: "grafana-alloy", source: "integer" },
@@ -597,6 +600,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "argo-workflows", source: "integer" },
       { name: "argo-rollouts", source: "integer" },
       { name: "gomplate", source: "integer" },
+      { name: "tflint", source: "integer" },
     ],
   },
 
@@ -669,6 +673,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "tetragon", source: "integer" },
       { name: "kratos", source: "integer" },
       { name: "hydra", source: "integer" },
+      { name: "kubescape", source: "integer" },
     ],
   },
 
@@ -781,6 +786,8 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "mlflow/mlflow", label: "mlflow", source: "copa", upstream: "ghcr.io/mlflow/mlflow" },
       { name: "temporal", source: "integer" },
       { name: "meilisearch", source: "integer" },
+      { name: "qdrant", source: "integer" },
+      { name: "weaviate", source: "integer" },
       {
         name: "tensorflow/serving",
         label: "tensorflow-serving",


### PR DESCRIPTION
## Summary

7 new Wolfi-based Integer images covering service mesh, vector databases, observability, and dev tools.

### Added

**Service mesh (1)** — `mesh` category
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `linkerd` | `linkerd2-cli` | `/usr/bin/linkerd` |

**Vector databases (2)** — `data` category
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `qdrant` | `qdrant` | `/usr/bin/qdrant` |
| `weaviate` | `weaviate` | `/usr/bin/weaviate` |

**Observability (1)** — `monitoring` category
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `opentelemetry-collector-contrib` | `opentelemetry-collector-contrib` | `/usr/bin/otelcol-contrib` |

**Dev tools (3)** — `kubernetes`, `cicd`, `security` categories
| Image | Wolfi pkg | Binary |
|-------|-----------|--------|
| `kind` | `kind` | `/usr/bin/kind` |
| `tflint` | `tflint` | `/usr/bin/tflint` |
| `kubescape` | `kubescape` | `/usr/bin/kubescape` |

### Notes
- `linkerd2` is a meta-package (no `/usr/bin/`); shipping `linkerd2-cli` as the user-facing `linkerd` image. Other linkerd subpackages (controller, proxy, policy-controller, metrics-api) deferred for a linkerd-control-plane PR if there's demand.

### Validation
- `./verity integer validate` → all 173 configs valid
- **Full apko build + trivy image scan** (with fresh advisory DB) → **0 CRITICAL/HIGH CVEs** on all 7

### Files
- 7 new YAMLs under `images/`
- `site/src/data/full-catalog.ts` — entries added across kubernetes, mesh, monitoring, data, cicd, security

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds seven Wolfi-based images for mesh, vector databases, observability, and dev tools, and registers them in the catalog. All images scan with zero critical/high CVEs, and `qdrant` now supports nonroot snapshot creation.

- **New Features**
  - Images: `linkerd` (CLI via `linkerd2-cli`), `qdrant`, `weaviate`, `opentelemetry-collector-contrib`, `kind`, `tflint`, `kubescape`

- **Bug Fixes**
  - `qdrant`: add `/qdrant/snapshots` path (uid/gid 65532) to enable snapshot create/recover when running as nonroot

<sup>Written for commit d8f59bfbe205795f436e7c6936eeb98cd7f0e063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

