### PR TITLE
feat(doctor): add 'verity doctor' subcommand + drop orphan replacement

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/verity-org/verity/internal/doctor"
+)
+
+// DoctorCommand lints Verity's configuration cross-references — currently
+// the orphan-replacements check, with more checks to follow. Useful as a
+// pre-merge gate (e.g. local dev or CI) to catch silent config drift before
+// it produces broken wrapper charts.
+var DoctorCommand = &cli.Command{
+	Name:  "doctor",
+	Usage: "Lint Verity configuration files for known silent-failure patterns",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "charts-file",
+			Usage: "Helm Chart.yaml whose dependencies: provides chart specs",
+			Value: "Chart.yaml",
+		},
+		&cli.StringFlag{
+			Name:  "verity-config",
+			Usage: "Path to verity.yaml (replacements + overrides)",
+			Value: "verity.yaml",
+		},
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "Emit issues as JSON instead of human text (useful for CI parsing)",
+		},
+		&cli.BoolFlag{
+			Name:  "fail-on-warning",
+			Usage: "Exit non-zero when any warning is reported (default: only errors fail)",
+		},
+	},
+	Action: func(_ context.Context, c *cli.Command) error {
+		issues, err := doctor.Run(doctor.Config{
+			ChartsFile:   c.String("charts-file"),
+			VerityConfig: c.String("verity-config"),
+		})
+		if err != nil {
+			return fmt.Errorf("verity doctor: %w", err)
+		}
+
+		if c.Bool("json") {
+			out, jerr := json.MarshalIndent(issues, "", "  ")
+			if jerr != nil {
+				return fmt.Errorf("marshal doctor output: %w", jerr)
+			}
+			fmt.Fprintln(os.Stdout, string(out))
+		} else {
+			fmt.Fprint(os.Stdout, doctor.FormatText(issues))
+		}
+
+		if doctor.HasErrors(issues) {
+			return cli.Exit("verity doctor: errors reported", 1)
+		}
+		if c.Bool("fail-on-warning") && len(issues) > 0 {
+			return cli.Exit("verity doctor: warnings reported and --fail-on-warning is set", 1)
+		}
+		return nil
+	},
+}

--- a/internal/chartgen/mapping.go
+++ b/internal/chartgen/mapping.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/verity-org/verity/internal/imageref"
 )
 
 // ImageMapping represents the mapping from an original image to its patched replacement.
@@ -83,25 +85,12 @@ func isExcluded(name, imageRef string, excludeNames map[string]struct{}) bool {
 	return false
 }
 
+// repoPath returns the registry-stripped, tag/digest-stripped portion of
+// an image ref. Thin wrapper over imageref.RepoPath so chartgen, doctor,
+// and any future consumer share one implementation — divergence here would
+// silently mask the very class of failures doctor exists to surface.
 func repoPath(ref string) string {
-	if idx := strings.Index(ref, "@"); idx != -1 {
-		ref = ref[:idx]
-	}
-
-	lastSlash := strings.LastIndex(ref, "/")
-	if lastColon := strings.LastIndex(ref, ":"); lastColon > lastSlash {
-		ref = ref[:lastColon]
-	}
-
-	parts := strings.Split(ref, "/")
-	if len(parts) >= 2 {
-		first := parts[0]
-		if strings.ContainsAny(first, ".:") || first == "localhost" {
-			return strings.Join(parts[1:], "/")
-		}
-	}
-
-	return ref
+	return imageref.RepoPath(ref)
 }
 
 func nameBasename(ref string) string {
@@ -119,17 +108,9 @@ func nameBasename(ref string) string {
 }
 
 // splitRef splits an image reference into its name and tag components.
-// Digest suffixes (@sha256:...) are stripped before extracting the tag.
+// Thin wrapper over imageref.SplitRef.
 func splitRef(ref string) (name, tag string) {
-	// Strip digest — we want the tag, not the digest hash.
-	if idx := strings.Index(ref, "@"); idx != -1 {
-		ref = ref[:idx]
-	}
-	lastSlash := strings.LastIndex(ref, "/")
-	if lastColon := strings.LastIndex(ref, ":"); lastColon > lastSlash {
-		return ref[:lastColon], ref[lastColon+1:]
-	}
-	return ref, ""
+	return imageref.SplitRef(ref)
 }
 
 // runCommand executes a CLI command with a timeout and returns stdout.

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -78,12 +78,15 @@ func Run(cfg Config) ([]Issue, error) {
 		return nil, fmt.Errorf("load verity config %s: %w", cfg.VerityConfig, err)
 	}
 
-	issues := make([]Issue, 0)
-
 	orphans, err := CheckOrphanReplacements(charts, vc, cfg.VerityConfig, cfg.ChartsFile, discovery.ExtractChartImages)
 	if err != nil {
 		return nil, fmt.Errorf("orphan-replacements check: %w", err)
 	}
+
+	// Pre-allocated to len(orphans) so the slice header is non-nil even
+	// when there are zero issues; downstream JSON output then renders as
+	// [] instead of null.
+	issues := make([]Issue, 0, len(orphans))
 	issues = append(issues, orphans...)
 
 	sort.Slice(issues, func(i, j int) bool {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,198 @@
+// Package doctor lints Verity's configuration cross-references — Chart.yaml,
+// verity.yaml, copa-config.yaml, and the images/ Integer rebuilds — to catch
+// silent failure modes (orphan replacements, charts with no patched
+// mappings, dangling Integer rebuilds, etc.) before they reach production.
+//
+// Each check is a small function that returns Issues. Run aggregates and
+// formats them. Today the package ships a single check
+// (CheckOrphanReplacements); future PRs add more.
+package doctor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/verity-org/verity/internal/config"
+	"github.com/verity-org/verity/internal/discovery"
+)
+
+// Severity classifies a doctor finding. error fails the run; warning is
+// informational.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Issue is a single linter finding.
+type Issue struct {
+	Check    string   `json:"check"`
+	Severity Severity `json:"severity"`
+	Path     string   `json:"path,omitempty"`
+	Message  string   `json:"message"`
+	Hint     string   `json:"hint,omitempty"`
+}
+
+// Config controls a doctor run. Paths default to the repo-root file names
+// when empty.
+type Config struct {
+	ChartsFile   string
+	VerityConfig string
+}
+
+// Run executes all checks and returns the aggregated findings sorted by
+// (check, severity, message) for stable output.
+func Run(cfg Config) ([]Issue, error) {
+	if cfg.ChartsFile == "" {
+		cfg.ChartsFile = "Chart.yaml"
+	}
+	if cfg.VerityConfig == "" {
+		cfg.VerityConfig = "verity.yaml"
+	}
+
+	charts, err := discovery.LoadChartsFile(cfg.ChartsFile)
+	if err != nil {
+		return nil, fmt.Errorf("load charts file %s: %w", cfg.ChartsFile, err)
+	}
+
+	vc, err := discovery.LoadVerityConfig(cfg.VerityConfig)
+	if err != nil {
+		return nil, fmt.Errorf("load verity config %s: %w", cfg.VerityConfig, err)
+	}
+
+	var issues []Issue
+
+	orphans, err := CheckOrphanReplacements(charts, vc, cfg.VerityConfig)
+	if err != nil {
+		return nil, fmt.Errorf("orphan-replacements check: %w", err)
+	}
+	issues = append(issues, orphans...)
+
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].Check != issues[j].Check {
+			return issues[i].Check < issues[j].Check
+		}
+		if issues[i].Severity != issues[j].Severity {
+			return issues[i].Severity < issues[j].Severity
+		}
+		return issues[i].Message < issues[j].Message
+	})
+
+	return issues, nil
+}
+
+// CheckOrphanReplacements finds entries in vc.Replacements that match no
+// image rendered by any chart in charts. An orphan is a stale config entry
+// — once it was wiring a real chart image to an Integer rebuild, but the
+// chart upgraded or the image moved and the entry was never cleaned up.
+//
+// This check shells out to `helm template` (via discovery.ExtractChartImages)
+// once per chart, so it requires helm in PATH and network access to chart
+// repositories. In CI the existing chart-gen workflow already exercises that
+// path; running doctor in the same job is cheap.
+func CheckOrphanReplacements(charts []config.ChartSpec, vc *config.VerityConfig, verityConfigPath string) ([]Issue, error) {
+	if vc == nil || len(vc.Replacements) == 0 {
+		return nil, nil
+	}
+
+	matchedPatterns := make(map[string]bool, len(vc.Replacements))
+	for pattern := range vc.Replacements {
+		matchedPatterns[pattern] = false
+	}
+
+	for _, chart := range charts {
+		refs, err := discovery.ExtractChartImages(chart, vc.Overrides)
+		if err != nil {
+			return nil, fmt.Errorf("extract images for chart %s@%s: %w", chart.Name, chart.Version, err)
+		}
+		for _, ref := range refs {
+			name := repoPath(ref)
+			for pattern := range vc.Replacements {
+				if name == pattern || strings.Contains(name, pattern) {
+					matchedPatterns[pattern] = true
+				}
+			}
+		}
+	}
+
+	var issues []Issue
+	for pattern, matched := range matchedPatterns {
+		if matched {
+			continue
+		}
+		repl := vc.Replacements[pattern]
+		issues = append(issues, Issue{
+			Check:    "orphan-replacements",
+			Severity: SeverityWarning,
+			Path:     verityConfigPath,
+			Message:  fmt.Sprintf("replacements: entry %q (→ %s/%s) matches no image rendered by any chart in Chart.yaml", pattern, repl.Registry, repl.Image),
+			Hint:     "remove the entry from verity.yaml, or confirm whether the original chart removed/renamed the image",
+		})
+	}
+	return issues, nil
+}
+
+// repoPath strips the registry host (if it has a dot/colon, signaling a
+// hostname rather than a Docker Hub library namespace) and any tag/digest,
+// leaving just the path used for replacements: matching. Mirrors the
+// matcher in internal/chartgen so doctor reasons about images the same way
+// chart-gen does.
+func repoPath(ref string) string {
+	if idx := strings.Index(ref, "@"); idx != -1 {
+		ref = ref[:idx]
+	}
+	lastSlash := strings.LastIndex(ref, "/")
+	if lastColon := strings.LastIndex(ref, ":"); lastColon > lastSlash {
+		ref = ref[:lastColon]
+	}
+	parts := strings.Split(ref, "/")
+	if len(parts) >= 2 {
+		first := parts[0]
+		if strings.ContainsAny(first, ".:") || first == "localhost" {
+			return strings.Join(parts[1:], "/")
+		}
+	}
+	return ref
+}
+
+// FormatText renders issues as a human-readable report. Empty input yields
+// a single "all checks passed" line.
+func FormatText(issues []Issue) string {
+	if len(issues) == 0 {
+		return "verity doctor: all checks passed.\n"
+	}
+	var b strings.Builder
+	for _, iss := range issues {
+		fmt.Fprintf(&b, "[%s] %s: %s\n", iss.Severity, iss.Check, iss.Message)
+		if iss.Path != "" {
+			fmt.Fprintf(&b, "  in: %s\n", iss.Path)
+		}
+		if iss.Hint != "" {
+			fmt.Fprintf(&b, "  hint: %s\n", iss.Hint)
+		}
+	}
+	errs := 0
+	warns := 0
+	for _, iss := range issues {
+		switch iss.Severity {
+		case SeverityError:
+			errs++
+		case SeverityWarning:
+			warns++
+		}
+	}
+	fmt.Fprintf(&b, "verity doctor: %d issues (%d errors, %d warnings)\n", len(issues), errs, warns)
+	return b.String()
+}
+
+// HasErrors reports whether any issue has Severity error.
+func HasErrors(issues []Issue) bool {
+	for _, iss := range issues {
+		if iss.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,24 +1,23 @@
-// Package doctor lints Verity's configuration cross-references — Chart.yaml,
-// verity.yaml, copa-config.yaml, and the images/ Integer rebuilds — to catch
-// silent failure modes (orphan replacements, charts with no patched
-// mappings, dangling Integer rebuilds, etc.) before they reach production.
-//
-// Each check is a small function that returns Issues. Run aggregates and
-// formats them. Today the package ships a single check
-// (CheckOrphanReplacements); future PRs add more.
+// Package doctor lints Verity's configuration cross-references for known
+// silent-failure patterns. Today it ships one check
+// (CheckOrphanReplacements); the package is structured so additional checks
+// can be added incrementally as separate Check* functions.
 package doctor
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/verity-org/verity/internal/config"
 	"github.com/verity-org/verity/internal/discovery"
+	"github.com/verity-org/verity/internal/imageref"
 )
 
 // Severity classifies a doctor finding. error fails the run; warning is
-// informational.
+// informational unless --fail-on-warning is set by the caller.
 type Severity string
 
 const (
@@ -35,21 +34,38 @@ type Issue struct {
 	Hint     string   `json:"hint,omitempty"`
 }
 
-// Config controls a doctor run. Paths default to the repo-root file names
-// when empty.
+// Config controls a doctor run. Empty paths default to the repo-root file
+// names; a missing file is an error rather than a silent no-op (otherwise a
+// typoed --charts-file would report every replacement as orphan).
 type Config struct {
 	ChartsFile   string
 	VerityConfig string
 }
 
+// ErrChartsFileMissing is returned by Run when the configured charts file
+// does not exist. Callers can errors.Is-check it to distinguish "config
+// gone" from a check that produced findings.
+var ErrChartsFileMissing = errors.New("charts file does not exist")
+
+// ChartImagesFunc renders a chart and returns the image references it
+// emits. Production code passes discovery.ExtractChartImages; tests pass a
+// stub so CheckOrphanReplacements can be exercised without helm + network.
+type ChartImagesFunc func(chart config.ChartSpec, overrides map[string]config.Override) ([]string, error)
+
 // Run executes all checks and returns the aggregated findings sorted by
-// (check, severity, message) for stable output.
+// (check, severity, message) for stable output. The returned slice is never
+// nil — Run returns []Issue{} when no findings are produced so JSON
+// callers see an array, not null.
 func Run(cfg Config) ([]Issue, error) {
 	if cfg.ChartsFile == "" {
 		cfg.ChartsFile = "Chart.yaml"
 	}
 	if cfg.VerityConfig == "" {
 		cfg.VerityConfig = "verity.yaml"
+	}
+
+	if _, err := os.Stat(cfg.ChartsFile); errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("%w: %s", ErrChartsFileMissing, cfg.ChartsFile)
 	}
 
 	charts, err := discovery.LoadChartsFile(cfg.ChartsFile)
@@ -62,9 +78,9 @@ func Run(cfg Config) ([]Issue, error) {
 		return nil, fmt.Errorf("load verity config %s: %w", cfg.VerityConfig, err)
 	}
 
-	var issues []Issue
+	issues := make([]Issue, 0)
 
-	orphans, err := CheckOrphanReplacements(charts, vc, cfg.VerityConfig)
+	orphans, err := CheckOrphanReplacements(charts, vc, cfg.VerityConfig, cfg.ChartsFile, discovery.ExtractChartImages)
 	if err != nil {
 		return nil, fmt.Errorf("orphan-replacements check: %w", err)
 	}
@@ -79,47 +95,60 @@ func Run(cfg Config) ([]Issue, error) {
 		}
 		return issues[i].Message < issues[j].Message
 	})
-
 	return issues, nil
 }
 
 // CheckOrphanReplacements finds entries in vc.Replacements that match no
 // image rendered by any chart in charts. An orphan is a stale config entry
-// — once it was wiring a real chart image to an Integer rebuild, but the
-// chart upgraded or the image moved and the entry was never cleaned up.
+// — once it wired a real chart image to an Integer rebuild, but the chart
+// upgraded or the image moved and the entry was never cleaned up.
 //
-// This check shells out to `helm template` (via discovery.ExtractChartImages)
-// once per chart, so it requires helm in PATH and network access to chart
-// repositories. In CI the existing chart-gen workflow already exercises that
-// path; running doctor in the same job is cheap.
-func CheckOrphanReplacements(charts []config.ChartSpec, vc *config.VerityConfig, verityConfigPath string) ([]Issue, error) {
+// The chartImages parameter abstracts the helm-shelling step so production
+// code passes discovery.ExtractChartImages while tests pass a stub. This
+// lets the same function be exercised by fast unit tests without requiring
+// helm + network.
+//
+// Match semantics intentionally mirror chartgen.applyReplacements (Contains
+// after RepoPath) so this check reasons about images the same way the
+// runtime matcher does. Note: chartgen also sorts patterns longest-first
+// for first-match selection, which can mean a shorter pattern technically
+// matches an image but a longer one is selected at runtime. For the orphan
+// check, "matches anywhere" is the right semantic — the pattern still has
+// a downstream consumer if any image's name contains it, even if a more
+// specific pattern claims that image first at runtime.
+func CheckOrphanReplacements(
+	charts []config.ChartSpec,
+	vc *config.VerityConfig,
+	verityConfigPath, chartsFilePath string,
+	chartImages ChartImagesFunc,
+) ([]Issue, error) {
 	if vc == nil || len(vc.Replacements) == 0 {
 		return nil, nil
 	}
 
-	matchedPatterns := make(map[string]bool, len(vc.Replacements))
+	matched := make(map[string]bool, len(vc.Replacements))
 	for pattern := range vc.Replacements {
-		matchedPatterns[pattern] = false
+		matched[pattern] = false
 	}
 
 	for _, chart := range charts {
-		refs, err := discovery.ExtractChartImages(chart, vc.Overrides)
+		refs, err := chartImages(chart, vc.Overrides)
 		if err != nil {
 			return nil, fmt.Errorf("extract images for chart %s@%s: %w", chart.Name, chart.Version, err)
 		}
 		for _, ref := range refs {
-			name := repoPath(ref)
+			name := imageref.RepoPath(ref)
 			for pattern := range vc.Replacements {
 				if name == pattern || strings.Contains(name, pattern) {
-					matchedPatterns[pattern] = true
+					matched[pattern] = true
 				}
 			}
 		}
 	}
 
-	var issues []Issue
-	for pattern, matched := range matchedPatterns {
-		if matched {
+	issues := make([]Issue, 0, len(matched))
+	for pattern, ok := range matched {
+		if ok {
 			continue
 		}
 		repl := vc.Replacements[pattern]
@@ -127,34 +156,11 @@ func CheckOrphanReplacements(charts []config.ChartSpec, vc *config.VerityConfig,
 			Check:    "orphan-replacements",
 			Severity: SeverityWarning,
 			Path:     verityConfigPath,
-			Message:  fmt.Sprintf("replacements: entry %q (→ %s/%s) matches no image rendered by any chart in Chart.yaml", pattern, repl.Registry, repl.Image),
-			Hint:     "remove the entry from verity.yaml, or confirm whether the original chart removed/renamed the image",
+			Message:  fmt.Sprintf("replacements: entry %q (→ %s/%s) matches no image rendered by any chart in %s", pattern, repl.Registry, repl.Image, chartsFilePath),
+			Hint:     fmt.Sprintf("remove the entry from %s, or confirm whether the original chart removed/renamed the image", verityConfigPath),
 		})
 	}
 	return issues, nil
-}
-
-// repoPath strips the registry host (if it has a dot/colon, signaling a
-// hostname rather than a Docker Hub library namespace) and any tag/digest,
-// leaving just the path used for replacements: matching. Mirrors the
-// matcher in internal/chartgen so doctor reasons about images the same way
-// chart-gen does.
-func repoPath(ref string) string {
-	if idx := strings.Index(ref, "@"); idx != -1 {
-		ref = ref[:idx]
-	}
-	lastSlash := strings.LastIndex(ref, "/")
-	if lastColon := strings.LastIndex(ref, ":"); lastColon > lastSlash {
-		ref = ref[:lastColon]
-	}
-	parts := strings.Split(ref, "/")
-	if len(parts) >= 2 {
-		first := parts[0]
-		if strings.ContainsAny(first, ".:") || first == "localhost" {
-			return strings.Join(parts[1:], "/")
-		}
-	}
-	return ref
 }
 
 // FormatText renders issues as a human-readable report. Empty input yields
@@ -164,6 +170,7 @@ func FormatText(issues []Issue) string {
 		return "verity doctor: all checks passed.\n"
 	}
 	var b strings.Builder
+	errs, warns := 0, 0
 	for _, iss := range issues {
 		fmt.Fprintf(&b, "[%s] %s: %s\n", iss.Severity, iss.Check, iss.Message)
 		if iss.Path != "" {
@@ -172,10 +179,6 @@ func FormatText(issues []Issue) string {
 		if iss.Hint != "" {
 			fmt.Fprintf(&b, "  hint: %s\n", iss.Hint)
 		}
-	}
-	errs := 0
-	warns := 0
-	for _, iss := range issues {
 		switch iss.Severity {
 		case SeverityError:
 			errs++

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,38 +1,34 @@
 package doctor
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/verity-org/verity/internal/config"
 )
 
-func TestRepoPath(t *testing.T) {
-	cases := []struct {
-		ref  string
-		want string
-	}{
-		{"quay.io/prometheus/prometheus:v3.11.2", "prometheus/prometheus"},
-		{"ghcr.io/dexidp/dex:v2.45.1", "dexidp/dex"},
-		{"reg.kyverno.io/kyverno/kyverno-cli:v1.17.2", "kyverno/kyverno-cli"},
-		{"opensearchproject/opensearch:3.6.0", "opensearchproject/opensearch"},
-		{"nats:2.12.6-alpine", "nats"},
-		{"docker.io/library/nginx:1.29.5", "library/nginx"},
-		{"quay.io/cilium/cilium:v1.19.3@sha256:abc", "cilium/cilium"},
-	}
-	for _, c := range cases {
-		got := repoPath(c.ref)
-		if got != c.want {
-			t.Errorf("repoPath(%q) = %q, want %q", c.ref, got, c.want)
-		}
+// fakeExtractor returns canned image lists keyed by chart name. Callers
+// supply the map; chart specs that aren't in the map render no images.
+func fakeExtractor(byChart map[string][]string) ChartImagesFunc {
+	return func(chart config.ChartSpec, _ map[string]config.Override) ([]string, error) {
+		return byChart[chart.Name], nil
 	}
 }
 
 func TestCheckOrphanReplacements_AllMatched(t *testing.T) {
-	// Every replacement matches at least one rendered image — no orphans.
+	charts := []config.ChartSpec{
+		{Name: "prometheus", Version: "29.2.1"},
+		{Name: "argo-cd", Version: "9.5.4"},
+	}
 	chartImages := map[string][]string{
-		"prometheus": {"quay.io/prometheus/pushgateway:v1.11.2", "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0"},
-		"argo-cd":    {"quay.io/argoproj/argocd:v3.3.8", "ghcr.io/dexidp/dex:v2.45.1"},
+		"prometheus": {
+			"quay.io/prometheus/pushgateway:v1.11.2",
+			"registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0",
+		},
+		"argo-cd": {"quay.io/argoproj/argocd:v3.3.8", "ghcr.io/dexidp/dex:v2.45.1"},
 	}
 	vc := &config.VerityConfig{
 		Replacements: map[string]config.Replacement{
@@ -42,14 +38,18 @@ func TestCheckOrphanReplacements_AllMatched(t *testing.T) {
 			"dexidp/dex":                            {Registry: "ghcr.io/verity-org", Image: "dex"},
 		},
 	}
-	issues := runOrphanCheckWithFakeRender(t, chartImages, vc)
+
+	issues, err := CheckOrphanReplacements(charts, vc, "verity.yaml", "Chart.yaml", fakeExtractor(chartImages))
+	if err != nil {
+		t.Fatalf("CheckOrphanReplacements err = %v", err)
+	}
 	if len(issues) != 0 {
 		t.Errorf("want 0 orphans, got %d: %+v", len(issues), issues)
 	}
 }
 
 func TestCheckOrphanReplacements_OneOrphan(t *testing.T) {
-	// jimmidyson/configmap-reload doesn't appear in any rendered image.
+	charts := []config.ChartSpec{{Name: "prometheus", Version: "29.2.1"}}
 	chartImages := map[string][]string{
 		"prometheus": {"quay.io/prometheus/pushgateway:v1.11.2"},
 	}
@@ -59,25 +59,34 @@ func TestCheckOrphanReplacements_OneOrphan(t *testing.T) {
 			"jimmidyson/configmap-reload": {Registry: "ghcr.io/verity-org", Image: "configmap-reload"},
 		},
 	}
-	issues := runOrphanCheckWithFakeRender(t, chartImages, vc)
+
+	issues, err := CheckOrphanReplacements(charts, vc, "verity.yaml", "Chart.yaml", fakeExtractor(chartImages))
+	if err != nil {
+		t.Fatalf("CheckOrphanReplacements err = %v", err)
+	}
 	if len(issues) != 1 {
 		t.Fatalf("want 1 orphan, got %d: %+v", len(issues), issues)
 	}
-	if !strings.Contains(issues[0].Message, "jimmidyson/configmap-reload") {
-		t.Errorf("orphan should reference jimmidyson/configmap-reload pattern, got: %s", issues[0].Message)
+	got := issues[0]
+	if got.Check != "orphan-replacements" {
+		t.Errorf("check = %q, want orphan-replacements", got.Check)
 	}
-	if issues[0].Check != "orphan-replacements" {
-		t.Errorf("check name = %q, want orphan-replacements", issues[0].Check)
+	if got.Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", got.Severity)
 	}
-	if issues[0].Severity != SeverityWarning {
-		t.Errorf("severity = %q, want warning", issues[0].Severity)
+	if !strings.Contains(got.Message, "jimmidyson/configmap-reload") {
+		t.Errorf("message should reference orphan pattern: %s", got.Message)
+	}
+	if !strings.Contains(got.Message, "Chart.yaml") {
+		t.Errorf("message should reference chartsFilePath: %s", got.Message)
+	}
+	if !strings.Contains(got.Hint, "verity.yaml") {
+		t.Errorf("hint should reference verityConfigPath: %s", got.Hint)
 	}
 }
 
 func TestCheckOrphanReplacements_SubstringMatchesCount(t *testing.T) {
-	// Substring matches (Contains semantics) keep an entry alive — same
-	// rule chartgen.applyReplacements uses. e.g., "kyverno/kyverno"
-	// matches "kyverno/kyverno-cli" via Contains, so it's not an orphan.
+	charts := []config.ChartSpec{{Name: "kyverno", Version: "3.7.2"}}
 	chartImages := map[string][]string{
 		"kyverno": {"reg.kyverno.io/kyverno/kyverno-cli:v1.17.2"},
 	}
@@ -86,19 +95,78 @@ func TestCheckOrphanReplacements_SubstringMatchesCount(t *testing.T) {
 			"kyverno/kyverno": {Registry: "ghcr.io/verity-org", Image: "kyverno"},
 		},
 	}
-	issues := runOrphanCheckWithFakeRender(t, chartImages, vc)
+	issues, err := CheckOrphanReplacements(charts, vc, "verity.yaml", "Chart.yaml", fakeExtractor(chartImages))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
 	if len(issues) != 0 {
 		t.Errorf("substring match should keep replacement alive, got orphans: %+v", issues)
 	}
 }
 
 func TestCheckOrphanReplacements_NilConfig(t *testing.T) {
-	issues, err := CheckOrphanReplacements(nil, nil, "verity.yaml")
+	issues, err := CheckOrphanReplacements(nil, nil, "verity.yaml", "Chart.yaml", fakeExtractor(nil))
 	if err != nil {
 		t.Fatalf("nil vc should be a no-op, got err=%v", err)
 	}
 	if len(issues) != 0 {
 		t.Errorf("want 0 issues for nil vc, got %d", len(issues))
+	}
+}
+
+func TestCheckOrphanReplacements_ExtractorError(t *testing.T) {
+	charts := []config.ChartSpec{{Name: "broken", Version: "0.0.0"}}
+	vc := &config.VerityConfig{
+		Replacements: map[string]config.Replacement{"x": {Registry: "r", Image: "i"}},
+	}
+	wantErr := errors.New("boom")
+	failingExtractor := func(_ config.ChartSpec, _ map[string]config.Override) ([]string, error) {
+		return nil, wantErr
+	}
+	_, err := CheckOrphanReplacements(charts, vc, "verity.yaml", "Chart.yaml", failingExtractor)
+	if err == nil {
+		t.Fatal("expected error to surface from extractor")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error chain should include extractor error, got: %v", err)
+	}
+}
+
+func TestRun_MissingChartsFile(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := Run(Config{
+		ChartsFile:   filepath.Join(tmp, "no-such.yaml"),
+		VerityConfig: filepath.Join(tmp, "no-such-verity.yaml"),
+	})
+	if err == nil {
+		t.Fatal("expected ErrChartsFileMissing for nonexistent file")
+	}
+	if !errors.Is(err, ErrChartsFileMissing) {
+		t.Errorf("error should wrap ErrChartsFileMissing, got: %v", err)
+	}
+}
+
+func TestRun_NeverNilSlice(t *testing.T) {
+	// JSON callers expect an array, not null. Verify the empty-result
+	// path returns a non-nil slice even though it's empty.
+	tmp := t.TempDir()
+	chartsPath := filepath.Join(tmp, "Chart.yaml")
+	verityPath := filepath.Join(tmp, "verity.yaml")
+	if err := os.WriteFile(chartsPath, []byte("apiVersion: v2\nname: test\nversion: 0.0.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(verityPath, []byte("replacements: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	issues, err := Run(Config{ChartsFile: chartsPath, VerityConfig: verityPath})
+	if err != nil {
+		t.Fatalf("Run err = %v", err)
+	}
+	if issues == nil {
+		t.Error("Run should return non-nil empty slice, got nil")
+	}
+	if len(issues) != 0 {
+		t.Errorf("want 0 issues for empty config, got %d", len(issues))
 	}
 }
 
@@ -110,12 +178,14 @@ func TestFormatText_Empty(t *testing.T) {
 
 func TestFormatText_Counts(t *testing.T) {
 	issues := []Issue{
-		{Check: "x", Severity: SeverityError, Message: "boom"},
+		{Check: "x", Severity: SeverityError, Message: "boom", Path: "a.yaml", Hint: "fix it"},
 		{Check: "x", Severity: SeverityWarning, Message: "tsk"},
 	}
 	out := FormatText(issues)
-	if !strings.Contains(out, "1 errors, 1 warnings") {
-		t.Errorf("FormatText should include error+warning counts, got %q", out)
+	for _, want := range []string{"1 errors, 1 warnings", "boom", "tsk", "fix it", "a.yaml"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("FormatText missing %q in output: %q", want, out)
+		}
 	}
 }
 
@@ -129,41 +199,4 @@ func TestHasErrors(t *testing.T) {
 	if !HasErrors([]Issue{{Severity: SeverityWarning}, {Severity: SeverityError}}) {
 		t.Error("at least one error should make HasErrors true")
 	}
-}
-
-// runOrphanCheckWithFakeRender bypasses helm by computing matches the same
-// way CheckOrphanReplacements does, but with caller-supplied image lists.
-// Keeps the package's logic exercised without standing up helm + network.
-func runOrphanCheckWithFakeRender(t *testing.T, chartImages map[string][]string, vc *config.VerityConfig) []Issue {
-	t.Helper()
-	matched := make(map[string]bool, len(vc.Replacements))
-	for p := range vc.Replacements {
-		matched[p] = false
-	}
-	for _, refs := range chartImages {
-		for _, ref := range refs {
-			name := repoPath(ref)
-			for pattern := range vc.Replacements {
-				if name == pattern || strings.Contains(name, pattern) {
-					matched[pattern] = true
-				}
-			}
-		}
-	}
-	var issues []Issue
-	for pattern, ok := range matched {
-		if ok {
-			continue
-		}
-		repl := vc.Replacements[pattern]
-		issues = append(issues, Issue{
-			Check:    "orphan-replacements",
-			Severity: SeverityWarning,
-			Path:     "verity.yaml",
-			Message: "replacements: entry \"" + pattern + "\" (→ " + repl.Registry + "/" + repl.Image +
-				") matches no image rendered by any chart in Chart.yaml",
-			Hint: "remove the entry from verity.yaml, or confirm whether the original chart removed/renamed the image",
-		})
-	}
-	return issues
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,169 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/verity-org/verity/internal/config"
+)
+
+func TestRepoPath(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want string
+	}{
+		{"quay.io/prometheus/prometheus:v3.11.2", "prometheus/prometheus"},
+		{"ghcr.io/dexidp/dex:v2.45.1", "dexidp/dex"},
+		{"reg.kyverno.io/kyverno/kyverno-cli:v1.17.2", "kyverno/kyverno-cli"},
+		{"opensearchproject/opensearch:3.6.0", "opensearchproject/opensearch"},
+		{"nats:2.12.6-alpine", "nats"},
+		{"docker.io/library/nginx:1.29.5", "library/nginx"},
+		{"quay.io/cilium/cilium:v1.19.3@sha256:abc", "cilium/cilium"},
+	}
+	for _, c := range cases {
+		got := repoPath(c.ref)
+		if got != c.want {
+			t.Errorf("repoPath(%q) = %q, want %q", c.ref, got, c.want)
+		}
+	}
+}
+
+func TestCheckOrphanReplacements_AllMatched(t *testing.T) {
+	// Every replacement matches at least one rendered image — no orphans.
+	chartImages := map[string][]string{
+		"prometheus": {"quay.io/prometheus/pushgateway:v1.11.2", "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0"},
+		"argo-cd":    {"quay.io/argoproj/argocd:v3.3.8", "ghcr.io/dexidp/dex:v2.45.1"},
+	}
+	vc := &config.VerityConfig{
+		Replacements: map[string]config.Replacement{
+			"prometheus/pushgateway":                {Registry: "ghcr.io/verity-org", Image: "pushgateway"},
+			"kube-state-metrics/kube-state-metrics": {Registry: "ghcr.io/verity-org", Image: "kube-state-metrics"},
+			"argoproj/argocd":                       {Registry: "ghcr.io/verity-org", Image: "argocd"},
+			"dexidp/dex":                            {Registry: "ghcr.io/verity-org", Image: "dex"},
+		},
+	}
+	issues := runOrphanCheckWithFakeRender(t, chartImages, vc)
+	if len(issues) != 0 {
+		t.Errorf("want 0 orphans, got %d: %+v", len(issues), issues)
+	}
+}
+
+func TestCheckOrphanReplacements_OneOrphan(t *testing.T) {
+	// jimmidyson/configmap-reload doesn't appear in any rendered image.
+	chartImages := map[string][]string{
+		"prometheus": {"quay.io/prometheus/pushgateway:v1.11.2"},
+	}
+	vc := &config.VerityConfig{
+		Replacements: map[string]config.Replacement{
+			"prometheus/pushgateway":      {Registry: "ghcr.io/verity-org", Image: "pushgateway"},
+			"jimmidyson/configmap-reload": {Registry: "ghcr.io/verity-org", Image: "configmap-reload"},
+		},
+	}
+	issues := runOrphanCheckWithFakeRender(t, chartImages, vc)
+	if len(issues) != 1 {
+		t.Fatalf("want 1 orphan, got %d: %+v", len(issues), issues)
+	}
+	if !strings.Contains(issues[0].Message, "jimmidyson/configmap-reload") {
+		t.Errorf("orphan should reference jimmidyson/configmap-reload pattern, got: %s", issues[0].Message)
+	}
+	if issues[0].Check != "orphan-replacements" {
+		t.Errorf("check name = %q, want orphan-replacements", issues[0].Check)
+	}
+	if issues[0].Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", issues[0].Severity)
+	}
+}
+
+func TestCheckOrphanReplacements_SubstringMatchesCount(t *testing.T) {
+	// Substring matches (Contains semantics) keep an entry alive — same
+	// rule chartgen.applyReplacements uses. e.g., "kyverno/kyverno"
+	// matches "kyverno/kyverno-cli" via Contains, so it's not an orphan.
+	chartImages := map[string][]string{
+		"kyverno": {"reg.kyverno.io/kyverno/kyverno-cli:v1.17.2"},
+	}
+	vc := &config.VerityConfig{
+		Replacements: map[string]config.Replacement{
+			"kyverno/kyverno": {Registry: "ghcr.io/verity-org", Image: "kyverno"},
+		},
+	}
+	issues := runOrphanCheckWithFakeRender(t, chartImages, vc)
+	if len(issues) != 0 {
+		t.Errorf("substring match should keep replacement alive, got orphans: %+v", issues)
+	}
+}
+
+func TestCheckOrphanReplacements_NilConfig(t *testing.T) {
+	issues, err := CheckOrphanReplacements(nil, nil, "verity.yaml")
+	if err != nil {
+		t.Fatalf("nil vc should be a no-op, got err=%v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("want 0 issues for nil vc, got %d", len(issues))
+	}
+}
+
+func TestFormatText_Empty(t *testing.T) {
+	if got := FormatText(nil); !strings.Contains(got, "all checks passed") {
+		t.Errorf("empty issues should report all-passed, got %q", got)
+	}
+}
+
+func TestFormatText_Counts(t *testing.T) {
+	issues := []Issue{
+		{Check: "x", Severity: SeverityError, Message: "boom"},
+		{Check: "x", Severity: SeverityWarning, Message: "tsk"},
+	}
+	out := FormatText(issues)
+	if !strings.Contains(out, "1 errors, 1 warnings") {
+		t.Errorf("FormatText should include error+warning counts, got %q", out)
+	}
+}
+
+func TestHasErrors(t *testing.T) {
+	if HasErrors(nil) {
+		t.Error("HasErrors(nil) should be false")
+	}
+	if HasErrors([]Issue{{Severity: SeverityWarning}}) {
+		t.Error("warning-only issues should not count as errors")
+	}
+	if !HasErrors([]Issue{{Severity: SeverityWarning}, {Severity: SeverityError}}) {
+		t.Error("at least one error should make HasErrors true")
+	}
+}
+
+// runOrphanCheckWithFakeRender bypasses helm by computing matches the same
+// way CheckOrphanReplacements does, but with caller-supplied image lists.
+// Keeps the package's logic exercised without standing up helm + network.
+func runOrphanCheckWithFakeRender(t *testing.T, chartImages map[string][]string, vc *config.VerityConfig) []Issue {
+	t.Helper()
+	matched := make(map[string]bool, len(vc.Replacements))
+	for p := range vc.Replacements {
+		matched[p] = false
+	}
+	for _, refs := range chartImages {
+		for _, ref := range refs {
+			name := repoPath(ref)
+			for pattern := range vc.Replacements {
+				if name == pattern || strings.Contains(name, pattern) {
+					matched[pattern] = true
+				}
+			}
+		}
+	}
+	var issues []Issue
+	for pattern, ok := range matched {
+		if ok {
+			continue
+		}
+		repl := vc.Replacements[pattern]
+		issues = append(issues, Issue{
+			Check:    "orphan-replacements",
+			Severity: SeverityWarning,
+			Path:     "verity.yaml",
+			Message: "replacements: entry \"" + pattern + "\" (→ " + repl.Registry + "/" + repl.Image +
+				") matches no image rendered by any chart in Chart.yaml",
+			Hint: "remove the entry from verity.yaml, or confirm whether the original chart removed/renamed the image",
+		})
+	}
+	return issues
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -114,20 +114,21 @@ func TestCheckOrphanReplacements_NilConfig(t *testing.T) {
 	}
 }
 
+var errBoom = errors.New("boom")
+
 func TestCheckOrphanReplacements_ExtractorError(t *testing.T) {
 	charts := []config.ChartSpec{{Name: "broken", Version: "0.0.0"}}
 	vc := &config.VerityConfig{
 		Replacements: map[string]config.Replacement{"x": {Registry: "r", Image: "i"}},
 	}
-	wantErr := errors.New("boom")
 	failingExtractor := func(_ config.ChartSpec, _ map[string]config.Override) ([]string, error) {
-		return nil, wantErr
+		return nil, errBoom
 	}
 	_, err := CheckOrphanReplacements(charts, vc, "verity.yaml", "Chart.yaml", failingExtractor)
 	if err == nil {
 		t.Fatal("expected error to surface from extractor")
 	}
-	if !errors.Is(err, wantErr) {
+	if !errors.Is(err, errBoom) {
 		t.Errorf("error chain should include extractor error, got: %v", err)
 	}
 }

--- a/internal/imageref/imageref.go
+++ b/internal/imageref/imageref.go
@@ -1,0 +1,50 @@
+// Package imageref parses container image references for Verity tooling:
+// strips registry hosts, tags, and digests so callers can match image refs
+// by repository path. Shared by internal/chartgen and internal/doctor to
+// ensure they reason about images identically — a divergence between the
+// chart-gen runtime matcher and the doctor lint would silently hide the
+// exact silent failures doctor exists to surface.
+package imageref
+
+import "strings"
+
+// RepoPath returns the registry-stripped, tag/digest-stripped portion of a
+// container image reference. e.g.,
+//
+//	ghcr.io/dexidp/dex:v2.45.1            → dexidp/dex
+//	quay.io/cilium/cilium:v1.19.3@sha256:… → cilium/cilium
+//	docker.io/library/nginx:1.29.5        → library/nginx
+//	nats:2.12.6-alpine                    → nats
+//
+// A "registry" is detected as the first path segment that contains a dot
+// or colon, or that is literally "localhost".
+func RepoPath(ref string) string {
+	if idx := strings.Index(ref, "@"); idx != -1 {
+		ref = ref[:idx]
+	}
+	lastSlash := strings.LastIndex(ref, "/")
+	if lastColon := strings.LastIndex(ref, ":"); lastColon > lastSlash {
+		ref = ref[:lastColon]
+	}
+	parts := strings.Split(ref, "/")
+	if len(parts) >= 2 {
+		first := parts[0]
+		if strings.ContainsAny(first, ".:") || first == "localhost" {
+			return strings.Join(parts[1:], "/")
+		}
+	}
+	return ref
+}
+
+// SplitRef splits an image reference into (repo, tag). Digests are stripped
+// before splitting.
+func SplitRef(ref string) (repo, tag string) {
+	if idx := strings.Index(ref, "@"); idx != -1 {
+		ref = ref[:idx]
+	}
+	lastSlash := strings.LastIndex(ref, "/")
+	if lastColon := strings.LastIndex(ref, ":"); lastColon > lastSlash {
+		return ref[:lastColon], ref[lastColon+1:]
+	}
+	return ref, ""
+}

--- a/internal/imageref/imageref_test.go
+++ b/internal/imageref/imageref_test.go
@@ -1,0 +1,43 @@
+package imageref
+
+import "testing"
+
+func TestRepoPath(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want string
+	}{
+		{"quay.io/prometheus/prometheus:v3.11.2", "prometheus/prometheus"},
+		{"ghcr.io/dexidp/dex:v2.45.1", "dexidp/dex"},
+		{"reg.kyverno.io/kyverno/kyverno-cli:v1.17.2", "kyverno/kyverno-cli"},
+		{"opensearchproject/opensearch:3.6.0", "opensearchproject/opensearch"},
+		{"nats:2.12.6-alpine", "nats"},
+		{"docker.io/library/nginx:1.29.5", "library/nginx"},
+		{"quay.io/cilium/cilium:v1.19.3@sha256:abc", "cilium/cilium"},
+		{"localhost:5000/foo/bar:1", "foo/bar"},
+		{"plain", "plain"},
+	}
+	for _, c := range cases {
+		if got := RepoPath(c.ref); got != c.want {
+			t.Errorf("RepoPath(%q) = %q, want %q", c.ref, got, c.want)
+		}
+	}
+}
+
+func TestSplitRef(t *testing.T) {
+	cases := []struct {
+		ref      string
+		wantRepo string
+		wantTag  string
+	}{
+		{"quay.io/prometheus/prometheus:v3.11.2", "quay.io/prometheus/prometheus", "v3.11.2"},
+		{"foo/bar", "foo/bar", ""},
+		{"foo/bar:tag@sha256:abc", "foo/bar", "tag"},
+	}
+	for _, c := range cases {
+		gotRepo, gotTag := SplitRef(c.ref)
+		if gotRepo != c.wantRepo || gotTag != c.wantTag {
+			t.Errorf("SplitRef(%q) = (%q, %q), want (%q, %q)", c.ref, gotRepo, gotTag, c.wantRepo, c.wantTag)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 			cmd.PreflightCommand,
 			cmd.ChartGenCommand,
 			cmd.PatchCommand,
+			cmd.DoctorCommand,
 		},
 		Version: "2.0.0",
 	}

--- a/verity.yaml
+++ b/verity.yaml
@@ -18,9 +18,6 @@ overrides:
 # an override pointing to the replacement image instead of looking for
 # a Copa-patched version.
 replacements:
-  "jimmidyson/configmap-reload":
-    registry: "ghcr.io/verity-org"
-    image: "configmap-reload"
   "kube-state-metrics/kube-state-metrics":
     registry: "ghcr.io/verity-org"
     image: "kube-state-metrics"


### PR DESCRIPTION
## TL;DR

Adds `verity doctor` — a lint-style command for Verity's configuration cross-references. Ships with one check (`orphan-replacements`); designed so future PRs can drop in more checks incrementally.

Same PR also drops the existing orphan (`jimmidyson/configmap-reload`) that the new check would flag. After merge, `verity doctor` returns `all checks passed`.

## Why

The recent silent-failure stack (#261/#263/#265) caught two instances of charts losing their wrappers because `verity.yaml` was out of sync with `Chart.yaml`. Adding `--strict` to chart-gen (via #265) now fails CI loudly. `verity doctor` is the **fast pre-flight** equivalent — runs in seconds, returns structured issues, and is the natural surface to add more lint checks (orphan copa-config entries, charts without mappings, dangling Integer rebuilds, etc.) without bolting them onto chart-gen.

## What's in the box

```sh
$ ./verity doctor --help
NAME:
   verity doctor - Lint Verity configuration files for known silent-failure patterns

OPTIONS:
   --charts-file string    Helm Chart.yaml whose dependencies: provides chart specs (default: "Chart.yaml")
   --verity-config string  Path to verity.yaml (replacements + overrides) (default: "verity.yaml")
   --json                  Emit issues as JSON instead of human text (useful for CI parsing)
   --fail-on-warning       Exit non-zero when any warning is reported (default: only errors fail)
```

### `orphan-replacements` (the one check)

For each entry in `verity.yaml replacements:`, runs `helm template` against every chart in `Chart.yaml` and checks whether the entry's key matches at least one rendered image (using the same Contains semantics as `chartgen.applyReplacements`). Entries that match nothing are reported as warnings.

Demo against current `main` (with the orphan re-added for show):

```
$ ./verity doctor
[warning] orphan-replacements: replacements: entry "jimmidyson/configmap-reload" (→ ghcr.io/verity-org/configmap-reload) matches no image rendered by any chart in Chart.yaml
  in: verity.yaml
  hint: remove the entry from verity.yaml, or confirm whether the original chart removed/renamed the image
verity doctor: 1 issues (0 errors, 1 warnings)
```

After this PR's `verity.yaml` cleanup:

```
$ ./verity doctor
verity doctor: all checks passed.
```

## Tests

`internal/doctor/doctor_test.go` — 8 sub-cases:

- `TestRepoPath` — table covering registry-host stripping, digest stripping, single-segment names, Docker library namespaces.
- `TestCheckOrphanReplacements_AllMatched` — no orphans when every replacement has a chart match.
- `TestCheckOrphanReplacements_OneOrphan` — detects `jimmidyson/configmap-reload` when prometheus emits only `pushgateway`.
- `TestCheckOrphanReplacements_SubstringMatchesCount` — `kyverno/kyverno` pattern stays alive when only `kyverno/kyverno-cli` is rendered (Contains semantics, mirrors chartgen).
- `TestCheckOrphanReplacements_NilConfig` — no panic on missing config.
- `TestFormatText_Empty` / `TestFormatText_Counts` — output formatting.
- `TestHasErrors` — exit-code logic.

The helm-shelling integration path is exercised by the existing chart-gen tests (which use the same `discovery.ExtractChartImages`); doctor's logic is tested with caller-supplied image lists to keep tests fast and offline.

## Files

- `cmd/doctor.go` — new CLI command (urfave/cli/v3, matches existing patterns)
- `internal/doctor/doctor.go` — package + `CheckOrphanReplacements`
- `internal/doctor/doctor_test.go` — 8 test cases
- `main.go` — register `cmd.DoctorCommand` in the root command list
- `verity.yaml` — drop the `jimmidyson/configmap-reload` orphan (3 lines)

## Follow-ups (not in this PR)

- Wire `verity doctor --fail-on-warning` into the chart-gen workflow as a fast pre-flight (would catch new orphans before the slow chart-gen run).
- Add more checks: orphan copa-config entries, charts in Chart.yaml without any mapping, Integer images at `images/<x>.yaml` with no consumer in `Chart.yaml` or `copa-config.yaml`, override entries pointing at non-existent value paths, etc.

Each of those is a 50-line PR adding one function in `internal/doctor/`. The framework is now in place.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `verity doctor`, a fast linter for Verity config to catch silent drift, and removes the stale `jimmidyson/configmap-reload` replacement. Use it in CI as a quick preflight before chart-gen.

- **New Features**
  - New `verity doctor` subcommand to lint cross-references between `Chart.yaml` and `verity.yaml`; flags: `--charts-file`, `--verity-config`, `--json`, `--fail-on-warning`.
  - Text or JSON output; errors exit non-zero; warnings fail only with `--fail-on-warning`.
  - `orphan-replacements`: templates charts and warns when a `replacements` key matches no rendered image (exact or substring), via `discovery.ExtractChartImages`.

- **Refactors**
  - Added `internal/imageref` for consistent image parsing; `chartgen` and `doctor` now share it.
  - `CheckOrphanReplacements` accepts an injectable extractor; added unit tests and lint fixes (preallocated issue slice to keep JSON as `[]`, promoted test error var per err113).
  - `Run` errors on missing `--charts-file`; messages include configured paths; JSON output is always an array.

<sup>Written for commit 6fd1b7621da721a38a804d3aa99042ca0a8a4e1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

