### PR TITLE
feat(charts): add rabbitmq-cluster-operator (CloudPirates)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -43,3 +43,7 @@ dependencies:
   - name: opensearch-dashboards
     version: "3.6.0"
     repository: "https://opensearch-project.github.io/helm-charts"
+
+  - name: rabbitmq-cluster-operator
+    version: "0.2.3"
+    repository: "oci://registry-1.docker.io/cloudpirates"


### PR DESCRIPTION
## TL;DR

Adds the rabbitmq cluster-operator chart to Chart.yaml — completes the RabbitMQ story we opened in #246. After merge, `oci://ghcr.io/verity-org/charts/rabbitmq-cluster-operator` will start publishing nightly with patched images.

## Why CloudPirates over Bitnami / KlickTipp / upstream

Investigated four sources before picking:

| Source | Verdict |
|---|---|
| **Bitnami** `rabbitmq-cluster-operator` 4.4.34 | ❌ Default images return HTTP 404 since the Sept-2025 `docker.io/bitnami/*` lockdown. Chart appVersion is 2.16.1 (4 minors behind upstream 2.20.1). |
| **Upstream `rabbitmq/cluster-operator`** | ❌ No Helm chart in the repo — releases ship only raw YAML manifests (`cluster-operator.yml`, `cluster-operator-ghcr-io.yml`). `kubectl apply` model only. |
| **KlickTipp** v0.3.2 (appVersion 2.20.1) | 🟡 Viable but renders `ghcr.io/rabbitmq/cluster-operator` — doesn't line up with the existing `copa-config.yaml rabbitmqoperator/*` entries; would need new copa-config entries or replacements. |
| **CloudPirates** v0.2.3 (appVersion 2.19.1) | ✅ Renders `docker.io/rabbitmqoperator/{cluster-operator,messaging-topology-operator}` — exact match to existing `copa-config.yaml` standalone entries (lines 129 and 141). No new wiring needed. |

## How it integrates

CloudPirates renders 2 images:

```
docker.io/rabbitmqoperator/cluster-operator:2.19.1
docker.io/rabbitmqoperator/messaging-topology-operator:1.18.3
```

After `repoPath()` strips `docker.io/`, both become `rabbitmqoperator/<name>` which are already in `copa-config.yaml` with `goVcsUrl` wiring. `chart-gen`'s `BuildImageMappings` does `crane ls ghcr.io/verity-org/rabbitmqoperator/cluster-operator`, finds the source tag, and produces a mapping. No `replacements:` entry needed. No new `images/<x>.yaml` Integer rebuild needed.

Verified live (HTTP 200) for both upstream source paths and Verity's mirrors.

## Verification

```sh
$ ./verity doctor
verity doctor: all checks passed.

$ ./verity chart-gen --strict --dry-run \
    --charts-file Chart.yaml --verity-config verity.yaml \
    --target-registry ghcr.io/verity-org \
    --chart-registry oci://ghcr.io/verity-org/charts \
    --exclude-names "$(find images -name '*.yaml' -printf '%f\n' | sed 's/\.yaml$//' | paste -sd,)"

info: processing chart rabbitmq-cluster-operator@0.2.3
info: chart-gen summary: 10 charts in Chart.yaml, would produce 10 wrappers, 0 skipped
exit: 0
```

Per-chart mappings:
```
prometheus@29.2.1               : 4
victoria-logs-single@0.12.0     : 1
postgres-operator@1.15.1        : 1
kyverno@3.7.2                   : 5
argo-cd@9.5.4                   : 3
dex@0.24.0                      : 1
metrics-server@3.13.0           : 1
opensearch@3.6.0                : 1
opensearch-dashboards@3.6.0     : 1
rabbitmq-cluster-operator@0.2.3 : 2  ← NEW
```

## Caveat

CloudPirates' appVersion (2.19.1) trails upstream's latest (2.20.1) by one minor. Renovate will pick up CloudPirates 0.2.x bumps automatically. If we want to be on 2.20.1 sooner, switching to KlickTipp is the alternative — would require adding two new `copa-config.yaml` entries with `name: "rabbitmq/{cluster-operator,messaging-topology-operator}"` mirroring the chart's `ghcr.io/rabbitmq/*` paths, OR adding `replacements:` redirecting them. Happy to do that as a follow-up if maintainers prefer.

## Files

- `Chart.yaml` — append 1 dependency (4 lines)

No code, no tests, no other config files. Pure config addition that lights up via existing infrastructure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `rabbitmq-cluster-operator` Helm chart (v0.2.3) from `oci://registry-1.docker.io/cloudpirates` to `Chart.yaml`, enabling nightly publishes at `oci://ghcr.io/verity-org/charts/rabbitmq-cluster-operator`. Uses `rabbitmqoperator/*` images that already match `copa-config.yaml`, so no replacements or extra wiring needed.

<sup>Written for commit c4a51bd1a335fd0013581e64043c1d9bae408922. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

