### PR TITLE
feat(discovery): find operator data-plane images in env vars and ConfigMaps

### DIFF
--- a/internal/discovery/charts.go
+++ b/internal/discovery/charts.go
@@ -132,9 +132,11 @@ func walkNode(node any, seen map[string]struct{}, result *[]string) {
 		if args, ok := v["args"].([]any); ok {
 			collectArgImages(args, seen, result)
 		}
-		if kind, _ := v["kind"].(string); kind == "ConfigMap" {
-			if data, ok := v["data"].(map[string]any); ok {
-				collectConfigMapImages(data, seen, result)
+		if rawKind, ok := v["kind"]; ok {
+			if kind, ok := rawKind.(string); ok && kind == "ConfigMap" {
+				if data, ok := v["data"].(map[string]any); ok {
+					collectConfigMapImages(data, seen, result)
+				}
 			}
 		}
 		for _, val := range v {
@@ -154,9 +156,21 @@ func collectEnvImages(env []any, seen map[string]struct{}, result *[]string) {
 			continue
 		}
 
-		name, _ := entry["name"].(string)
-		value, _ := entry["value"].(string)
-		if !isImageEnvName(name) {
+		rawName, ok := entry["name"]
+		if !ok {
+			continue
+		}
+		name, ok := rawName.(string)
+		if !ok || !isImageEnvName(name) {
+			continue
+		}
+
+		rawValue, ok := entry["value"]
+		if !ok {
+			continue
+		}
+		value, ok := rawValue.(string)
+		if !ok {
 			continue
 		}
 
@@ -186,7 +200,7 @@ func collectArgImages(args []any, seen map[string]struct{}, result *[]string) {
 			continue
 		}
 
-		for _, piece := range strings.Fields(arg) {
+		for piece := range strings.FieldsSeq(arg) {
 			candidate := piece
 			if idx := strings.LastIndex(candidate, "="); idx >= 0 {
 				candidate = candidate[idx+1:]
@@ -214,7 +228,7 @@ func isImageEnvName(name string) bool {
 
 func extractImageValues(value string) []string {
 	var images []string
-	for _, line := range strings.Split(value, "\n") {
+	for line := range strings.SplitSeq(value, "\n") {
 		candidate := strings.TrimSpace(line)
 		if candidate == "" {
 			continue

--- a/internal/discovery/charts.go
+++ b/internal/discovery/charts.go
@@ -125,6 +125,14 @@ func walkNode(node any, seen map[string]struct{}, result *[]string) {
 		if env, ok := v["env"].([]any); ok {
 			collectEnvImages(env, seen, result)
 		}
+		if args, ok := v["args"].([]any); ok {
+			collectArgImages(args, seen, result)
+		}
+		if kind, _ := v["kind"].(string); kind == "ConfigMap" {
+			if data, ok := v["data"].(map[string]any); ok {
+				collectConfigMapImages(data, seen, result)
+			}
+		}
 		for _, val := range v {
 			walkNode(val, seen, result)
 		}
@@ -144,11 +152,45 @@ func collectEnvImages(env []any, seen map[string]struct{}, result *[]string) {
 
 		name, _ := entry["name"].(string)
 		value, _ := entry["value"].(string)
-		if !isImageEnvName(name) || !looksLikeImageRef(value) {
+		if !isImageEnvName(name) {
 			continue
 		}
 
-		addImage(value, seen, result)
+		for _, image := range extractImageValues(value) {
+			addImage(image, seen, result)
+		}
+	}
+}
+
+func collectConfigMapImages(data map[string]any, seen map[string]struct{}, result *[]string) {
+	for key, raw := range data {
+		value, ok := raw.(string)
+		if !ok || !isImageEnvName(key) {
+			continue
+		}
+
+		for _, image := range extractImageValues(value) {
+			addImage(image, seen, result)
+		}
+	}
+}
+
+func collectArgImages(args []any, seen map[string]struct{}, result *[]string) {
+	for _, item := range args {
+		arg, ok := item.(string)
+		if !ok {
+			continue
+		}
+
+		for _, piece := range strings.Fields(arg) {
+			candidate := piece
+			if idx := strings.LastIndex(candidate, "="); idx >= 0 {
+				candidate = candidate[idx+1:]
+			}
+			for _, image := range extractImageValues(candidate) {
+				addImage(image, seen, result)
+			}
+		}
 	}
 }
 
@@ -166,8 +208,25 @@ func isImageEnvName(name string) bool {
 	return strings.Contains(upper, "_IMAGE") || upper == "STRIMZI_DEFAULT_MAVEN_BUILDER"
 }
 
+func extractImageValues(value string) []string {
+	var images []string
+	for _, line := range strings.Split(value, "\n") {
+		candidate := strings.TrimSpace(line)
+		if candidate == "" {
+			continue
+		}
+		if idx := strings.Index(candidate, "="); idx >= 0 {
+			candidate = strings.TrimSpace(candidate[idx+1:])
+		}
+		if looksLikeImageRef(candidate) {
+			images = append(images, candidate)
+		}
+	}
+	return images
+}
+
 func looksLikeImageRef(value string) bool {
-	if strings.Contains(value, " ") {
+	if strings.TrimSpace(value) == "" || strings.ContainsAny(value, " \t\r\n") {
 		return false
 	}
 

--- a/internal/discovery/charts.go
+++ b/internal/discovery/charts.go
@@ -119,11 +119,11 @@ func walkNode(node any, seen map[string]struct{}, result *[]string) {
 	case map[string]any:
 		if img, ok := v["image"]; ok {
 			if imgStr, ok := img.(string); ok && imgStr != "" {
-				if _, exists := seen[imgStr]; !exists {
-					seen[imgStr] = struct{}{}
-					*result = append(*result, imgStr)
-				}
+				addImage(imgStr, seen, result)
 			}
+		}
+		if env, ok := v["env"].([]any); ok {
+			collectEnvImages(env, seen, result)
 		}
 		for _, val := range v {
 			walkNode(val, seen, result)
@@ -133,6 +133,46 @@ func walkNode(node any, seen map[string]struct{}, result *[]string) {
 			walkNode(item, seen, result)
 		}
 	}
+}
+
+func collectEnvImages(env []any, seen map[string]struct{}, result *[]string) {
+	for _, item := range env {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := entry["name"].(string)
+		value, _ := entry["value"].(string)
+		if !isImageEnvName(name) || !looksLikeImageRef(value) {
+			continue
+		}
+
+		addImage(value, seen, result)
+	}
+}
+
+func addImage(image string, seen map[string]struct{}, result *[]string) {
+	if _, exists := seen[image]; exists {
+		return
+	}
+
+	seen[image] = struct{}{}
+	*result = append(*result, image)
+}
+
+func isImageEnvName(name string) bool {
+	upper := strings.ToUpper(name)
+	return strings.Contains(upper, "_IMAGE") || upper == "STRIMZI_DEFAULT_MAVEN_BUILDER"
+}
+
+func looksLikeImageRef(value string) bool {
+	if strings.Contains(value, " ") {
+		return false
+	}
+
+	name, tag := splitRef(value)
+	return name != "" && strings.Contains(name, "/") && tag != ""
 }
 
 // applyOverride substitutes a tag variant in an image reference using the overrides map.

--- a/internal/discovery/charts.go
+++ b/internal/discovery/charts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -21,6 +22,9 @@ var (
 	ErrInvalidChartName    = errors.New("chart name must not start with '-'")
 	ErrInvalidChartVersion = errors.New("chart version must not start with '-'")
 	ErrInvalidChartRepo    = errors.New("chart repository must start with oci://, https://, or http://")
+	imageTagPattern        = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	imageDigestPattern     = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+	imageNamePattern       = regexp.MustCompile(`^[A-Za-z0-9._:-]+(?:/[A-Za-z0-9._-]+)+$`)
 )
 
 // ExtractChartImages runs helm template for a chart and returns all unique image references found.
@@ -229,9 +233,37 @@ func looksLikeImageRef(value string) bool {
 	if strings.TrimSpace(value) == "" || strings.ContainsAny(value, " \t\r\n") {
 		return false
 	}
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		return false
+	}
 
-	name, tag := splitRef(value)
-	return name != "" && strings.Contains(name, "/") && tag != ""
+	base := value
+	if at := strings.Index(base, "@"); at >= 0 {
+		digest := base[at+1:]
+		if !imageDigestPattern.MatchString(digest) {
+			return false
+		}
+		base = base[:at]
+	}
+
+	lastColon := strings.LastIndex(base, ":")
+	if lastColon < 0 {
+		return false
+	}
+
+	name := base[:lastColon]
+	tag := base[lastColon+1:]
+	if !imageTagPattern.MatchString(tag) {
+		return false
+	}
+	if strings.HasPrefix(name, "/") || !strings.Contains(name, "/") {
+		return false
+	}
+	if !imageNamePattern.MatchString(name) {
+		return false
+	}
+
+	return true
 }
 
 // applyOverride substitutes a tag variant in an image reference using the overrides map.

--- a/internal/discovery/charts_test.go
+++ b/internal/discovery/charts_test.go
@@ -361,4 +361,55 @@ spec:
 			}
 		}
 	})
+
+	t.Run("ignores URL, path, and version-like false positives", func(t *testing.T) {
+		yaml := []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: false-positives
+spec:
+  template:
+    spec:
+      containers:
+      - name: operator
+        image: ghcr.io/verity-org/operator:v0.1.0
+        args:
+        - --default-image=https://example.com/foo:bar
+        env:
+        - name: FAKE_URL_IMAGE
+          value: https://example.com/foo:bar
+        - name: FAKE_PATH_IMAGE
+          value: /some/path:1.2.3
+        - name: FAKE_VERSION_IMAGE
+          value: 1.2.3-beta
+        - name: FAKE_BINARY_IMAGE
+          value: kubectl-1.34.3
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: false-positive-config
+data:
+  ROOK_CSI_FAKE_URL_IMAGE: https://example.com/foo:bar
+  ROOK_CSI_FAKE_PATH_IMAGE: /some/path:1.2.3
+  ROOK_CSI_FAKE_VERSION_IMAGE: 1.2.3-beta
+  ROOK_CSI_FAKE_BINARY_IMAGE: kubectl-1.34.3
+`)
+
+		got, err := extractImagesFromManifests(yaml)
+		if err != nil {
+			t.Fatalf("extractImagesFromManifests() error = %v", err)
+		}
+
+		want := []string{"ghcr.io/verity-org/operator:v0.1.0"}
+		if len(got) != len(want) {
+			t.Fatalf("extractImagesFromManifests() returned %d images, want %d: %v", len(got), len(want), got)
+		}
+		for i, image := range want {
+			if got[i] != image {
+				t.Fatalf("extractImagesFromManifests()[%d] = %q, want %q (all images: %v)", i, got[i], image, got)
+			}
+		}
+	})
 }

--- a/internal/discovery/charts_test.go
+++ b/internal/discovery/charts_test.go
@@ -198,7 +198,8 @@ func TestSplitRef(t *testing.T) {
 }
 
 func TestExtractImagesFromManifests(t *testing.T) {
-	yaml := []byte(`
+	t.Run("deduplicates image fields across manifests", func(t *testing.T) {
+		yaml := []byte(`
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -226,24 +227,51 @@ spec:
         image: quay.io/prometheus/prometheus:v3.2.1
 `)
 
-	got, err := extractImagesFromManifests(yaml)
-	if err != nil {
-		t.Fatalf("extractImagesFromManifests() error = %v", err)
-	}
-
-	// Should have 3 unique images (deduplication of the repeated prometheus ref)
-	if len(got) != 3 {
-		t.Errorf("extractImagesFromManifests() returned %d images, want 3: %v", len(got), got)
-	}
-
-	wantImages := map[string]bool{
-		"quay.io/prometheus/prometheus:v3.2.1":        true,
-		"ghcr.io/jimmidyson/configmap-reload:v0.14.0": true,
-		"quay.io/prometheus/alertmanager:v0.28.1":     true,
-	}
-	for _, img := range got {
-		if !wantImages[img] {
-			t.Errorf("unexpected image: %q", img)
+		got, err := extractImagesFromManifests(yaml)
+		if err != nil {
+			t.Fatalf("extractImagesFromManifests() error = %v", err)
 		}
-	}
+
+		if len(got) != 3 {
+			t.Errorf("extractImagesFromManifests() returned %d images, want 3: %v", len(got), got)
+		}
+
+		wantImages := map[string]bool{
+			"quay.io/prometheus/prometheus:v3.2.1":        true,
+			"ghcr.io/jimmidyson/configmap-reload:v0.14.0": true,
+			"quay.io/prometheus/alertmanager:v0.28.1":     true,
+		}
+		for _, img := range got {
+			if !wantImages[img] {
+				t.Errorf("unexpected image: %q", img)
+			}
+		}
+	})
+
+	t.Run("keeps existing image key discovery", func(t *testing.T) {
+		yaml := []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tiny
+spec:
+  template:
+    spec:
+      containers:
+      - name: tiny
+        image: ghcr.io/verity-org/tiny:v1.2.3
+`)
+
+		got, err := extractImagesFromManifests(yaml)
+		if err != nil {
+			t.Fatalf("extractImagesFromManifests() error = %v", err)
+		}
+
+		if len(got) != 1 {
+			t.Fatalf("extractImagesFromManifests() returned %d images, want 1: %v", len(got), got)
+		}
+		if got[0] != "ghcr.io/verity-org/tiny:v1.2.3" {
+			t.Fatalf("extractImagesFromManifests() = %v, want ghcr.io/verity-org/tiny:v1.2.3", got)
+		}
+	})
 }

--- a/internal/discovery/charts_test.go
+++ b/internal/discovery/charts_test.go
@@ -313,4 +313,52 @@ spec:
 			}
 		}
 	})
+
+	t.Run("discovers configmap image values from operator charts", func(t *testing.T) {
+		got, err := extractImagesFromManifests(readDiscoveryFixture(t, "rook-ceph-operator-configmap.yaml"))
+		if err != nil {
+			t.Fatalf("extractImagesFromManifests() error = %v", err)
+		}
+
+		wantImages := []string{
+			"quay.io/cephcsi/cephcsi:v3.16.2",
+			"registry.k8s.io/sig-storage/csi-provisioner:v6.1.1",
+			"registry.k8s.io/sig-storage/csi-attacher:v4.11.0",
+			"quay.io/csiaddons/k8s-sidecar:v0.14.0",
+		}
+
+		gotSet := make(map[string]struct{}, len(got))
+		for _, image := range got {
+			gotSet[image] = struct{}{}
+		}
+
+		for _, want := range wantImages {
+			if _, ok := gotSet[want]; !ok {
+				t.Fatalf("extractImagesFromManifests() missing ConfigMap image %q in %v", want, got)
+			}
+		}
+	})
+
+	t.Run("splits multiline image maps into distinct refs", func(t *testing.T) {
+		got, err := extractImagesFromManifests(readDiscoveryFixture(t, "strimzi-kafka-operator-env.yaml"))
+		if err != nil {
+			t.Fatalf("extractImagesFromManifests() error = %v", err)
+		}
+
+		wantImages := []string{
+			"quay.io/strimzi/kafka:0.51.0-kafka-4.1.0",
+			"quay.io/strimzi/kafka:0.51.0-kafka-4.2.0",
+		}
+
+		gotSet := make(map[string]struct{}, len(got))
+		for _, image := range got {
+			gotSet[image] = struct{}{}
+		}
+
+		for _, want := range wantImages {
+			if _, ok := gotSet[want]; !ok {
+				t.Fatalf("extractImagesFromManifests() missing multiline image %q in %v", want, got)
+			}
+		}
+	})
 }

--- a/internal/discovery/charts_test.go
+++ b/internal/discovery/charts_test.go
@@ -2,10 +2,23 @@ package discovery
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/verity-org/verity/internal/config"
 )
+
+func readDiscoveryFixture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	path := filepath.Join("testdata", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", path, err)
+	}
+	return data
+}
 
 func TestApplyOverride(t *testing.T) {
 	overrides := map[string]config.Override{
@@ -272,6 +285,32 @@ spec:
 		}
 		if got[0] != "ghcr.io/verity-org/tiny:v1.2.3" {
 			t.Fatalf("extractImagesFromManifests() = %v, want ghcr.io/verity-org/tiny:v1.2.3", got)
+		}
+	})
+
+	t.Run("discovers env var images from operator deployments", func(t *testing.T) {
+		got, err := extractImagesFromManifests(readDiscoveryFixture(t, "strimzi-kafka-operator-env.yaml"))
+		if err != nil {
+			t.Fatalf("extractImagesFromManifests() error = %v", err)
+		}
+
+		wantImages := []string{
+			"quay.io/strimzi/kafka:0.51.0-kafka-4.2.0",
+			"quay.io/strimzi/kafka-bridge:0.33.1",
+			"quay.io/strimzi/kaniko-executor:0.51.0",
+			"quay.io/strimzi/buildah:0.51.0",
+			"quay.io/strimzi/maven-builder:0.51.0",
+		}
+
+		gotSet := make(map[string]struct{}, len(got))
+		for _, image := range got {
+			gotSet[image] = struct{}{}
+		}
+
+		for _, want := range wantImages {
+			if _, ok := gotSet[want]; !ok {
+				t.Fatalf("extractImagesFromManifests() missing env-var image %q in %v", want, got)
+			}
 		}
 	})
 }

--- a/internal/discovery/testdata/rook-ceph-operator-configmap.yaml
+++ b/internal/discovery/testdata/rook-ceph-operator-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-ceph-operator-config
+data:
+  CSI_RBD_FSGROUPPOLICY: "File"
+  CSI_CEPHFS_FSGROUPPOLICY: "File"
+  CSI_NFS_FSGROUPPOLICY: "File"
+  ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.16.2"
+  ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0"
+  ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v6.1.1"
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0"
+  ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v4.11.0"
+  ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"
+  ROOK_CSI_IMAGE_PULL_POLICY: "IfNotPresent"
+  CSI_ENABLE_CSIADDONS: "false"
+  ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.14.0"

--- a/internal/discovery/testdata/strimzi-kafka-operator-env.yaml
+++ b/internal/discovery/testdata/strimzi-kafka-operator-env.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-cluster-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: strimzi-cluster-operator
+          image: quay.io/strimzi/operator:0.51.0
+          env:
+            - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+              value: quay.io/strimzi/kafka:0.51.0-kafka-4.2.0
+            - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+              value: quay.io/strimzi/kafka:0.51.0-kafka-4.2.0
+            - name: STRIMZI_KAFKA_IMAGES
+              value: |
+                4.1.0=quay.io/strimzi/kafka:0.51.0-kafka-4.1.0
+                4.1.1=quay.io/strimzi/kafka:0.51.0-kafka-4.1.1
+                4.2.0=quay.io/strimzi/kafka:0.51.0-kafka-4.2.0
+            - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+              value: quay.io/strimzi/operator:0.51.0
+            - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+              value: quay.io/strimzi/operator:0.51.0
+            - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+              value: quay.io/strimzi/operator:0.51.0
+            - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
+              value: quay.io/strimzi/kafka-bridge:0.33.1
+            - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
+              value: quay.io/strimzi/kaniko-executor:0.51.0
+            - name: STRIMZI_DEFAULT_BUILDAH_IMAGE
+              value: quay.io/strimzi/buildah:0.51.0
+            - name: STRIMZI_DEFAULT_MAVEN_BUILDER
+              value: quay.io/strimzi/maven-builder:0.51.0


### PR DESCRIPTION
## Summary
- extend `internal/discovery/charts.go::walkNode` so chart-gen still finds classic `image:` keys while also harvesting operator data-plane image defaults hidden in env vars, ConfigMap data, multiline `version=image` blocks, and image-bearing container args
- add sanitized real-world fixtures from `helm template` output for `strimzi-kafka-operator` and `rook-ceph`, plus regression/false-positive coverage around image-key behavior and validator filtering
- tighten non-image parsing with an explicit image-ref validator so URLs, paths, and version strings are rejected while registry/tag shaped refs still pass

## Motivation
Operator charts like Strimzi and Rook-Ceph hide patchable data-plane images outside plain `image:` keys, which makes `verity chart-gen` miss them today. This unlocks discovery for that operator-only class without changing wrapper generation yet.

## Design notes
- fixture rationale and rollout context are documented in `.sisyphus/plans/operator-data-plane-discovery.md`
- env/ConfigMap discovery only adds refs when the key name looks image-related and the value passes the new validator
- multiline values are split into distinct refs by taking the right-hand side of `version=image` lines

## Test plan
- `go test ./... -coverprofile=/tmp/verity-phase1-cover.out`
- `go build ./...`
- `gofumpt -d .`
- `mise x golangci-lint@2 -- golangci-lint run --timeout=5m ./...`
- verified total Go coverage remains `81.0%`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands `internal/discovery` to find operator data‑plane images hidden in env vars, ConfigMaps, multiline mappings, and container args, not just `image:` keys. This enables discovery for charts like Strimzi and Rook while filtering common false positives.

- **New Features**
  - Extend chart walker to parse images from `env` (keys matching `*_IMAGE` and `STRIMZI_DEFAULT_MAVEN_BUILDER`), `ConfigMap.data`, container `args`, and multiline `version=image` blocks.
  - Add strict image-ref validator (tag/digest/name shape) to reject URLs, filesystem paths, and plain version strings.
  - Preserve existing `image:` key discovery and de-dup behavior.
  - Add real fixtures and tests for `strimzi-kafka-operator` and `rook-ceph`, plus false-positive guards.

<sup>Written for commit e5de8ff28b27f36eb732b8ab54b7da6e17345edc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

