### PR TITLE
feat(chartgen): support chartImageOverrides for operator data-plane images

### DIFF
--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -148,6 +148,10 @@ func buildValuesTree(chartName string, overrides []ValueOverride) map[string]any
 			}
 
 			if i == len(parts)-1 {
+				if override.Value != "" {
+					current[part] = override.Value
+					break
+				}
 				current[part] = map[string]any{
 					"repository": override.Repository,
 					"tag":        override.Tag,

--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -139,7 +139,7 @@ func buildValuesTree(chartName string, overrides []ValueOverride) map[string]any
 	root[chartName] = chartRoot
 
 	for _, override := range overrides {
-		parts := strings.Split(override.Path, ".")
+		parts := splitOverridePath(override.Path)
 		current := chartRoot
 
 		for i, part := range parts {
@@ -177,4 +177,63 @@ func buildValuesTree(chartName string, overrides []ValueOverride) map[string]any
 	}
 
 	return root
+}
+
+func splitOverridePath(path string) []string {
+	if path == "" {
+		return nil
+	}
+
+	parts := make([]string, 0, strings.Count(path, ".")+1)
+	var current strings.Builder
+	inBracket := false
+	var quote byte
+
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		parts = append(parts, current.String())
+		current.Reset()
+	}
+
+	for i := 0; i < len(path); i++ {
+		ch := path[i]
+		if inBracket {
+			if quote != 0 {
+				if ch == quote {
+					quote = 0
+					continue
+				}
+				current.WriteByte(ch)
+				continue
+			}
+
+			switch ch {
+			case '\'', '"':
+				quote = ch
+			case ']':
+				inBracket = false
+				flush()
+			case ' ':
+				continue
+			default:
+				current.WriteByte(ch)
+			}
+			continue
+		}
+
+		switch ch {
+		case '.':
+			flush()
+		case '[':
+			flush()
+			inBracket = true
+		default:
+			current.WriteByte(ch)
+		}
+	}
+
+	flush()
+	return parts
 }

--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -197,7 +197,7 @@ func splitOverridePath(path string) []string {
 		current.Reset()
 	}
 
-	for i := 0; i < len(path); i++ {
+	for i := range len(path) {
 		ch := path[i]
 		if inBracket {
 			if quote != 0 {

--- a/internal/chartgen/chart_test.go
+++ b/internal/chartgen/chart_test.go
@@ -173,6 +173,51 @@ func TestBuildWrapperChartValues(t *testing.T) {
 	}
 }
 
+func TestBuildWrapperChartValues_ChartImageOverrideSingleSource(t *testing.T) {
+	original := config.ChartSpec{Name: "strimzi-kafka-operator", Version: "0.51.0", Repository: "oci://repo/charts"}
+	vc := &config.VerityConfig{
+		ChartImageOverrides: map[string][]config.ChartImageOverride{
+			"strimzi-kafka-operator": {
+				{
+					Source: "STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE",
+					Path:   "kafka.image",
+				},
+			},
+		},
+	}
+
+	overrides, err := buildChartImageOverrides(original.Name, []ImageMapping{{
+		Source:      "STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE",
+		PatchedRepo: "ghcr.io/verity-org/kafka",
+		PatchedTag:  "patched-tag",
+	}}, vc)
+	if err != nil {
+		t.Fatalf("buildChartImageOverrides() error = %v", err)
+	}
+
+	chart, err := BuildWrapperChart(original, overrides)
+	if err != nil {
+		t.Fatalf("BuildWrapperChart() error = %v", err)
+	}
+
+	var values map[string]any
+	if err := yaml.Unmarshal(chart.ValuesYAML, &values); err != nil {
+		t.Fatalf("yaml.Unmarshal(ValuesYAML) error = %v", err)
+	}
+
+	root, ok := values["strimzi-kafka-operator"].(map[string]any)
+	if !ok {
+		t.Fatalf("chart root missing or invalid: %#v", values["strimzi-kafka-operator"])
+	}
+	kafka, ok := root["kafka"].(map[string]any)
+	if !ok {
+		t.Fatalf("kafka node missing or invalid: %#v", root["kafka"])
+	}
+	if kafka["image"] != "ghcr.io/verity-org/kafka:patched-tag" {
+		t.Fatalf("kafka.image = %#v, want patched image string", kafka["image"])
+	}
+}
+
 func TestBuildWrapperChartEmptyOverrides(t *testing.T) {
 	original := config.ChartSpec{Name: "prometheus", Version: "28.9.1", Repository: "oci://repo/charts"}
 

--- a/internal/chartgen/chart_test.go
+++ b/internal/chartgen/chart_test.go
@@ -218,6 +218,70 @@ func TestBuildWrapperChartValues_ChartImageOverrideSingleSource(t *testing.T) {
 	}
 }
 
+func TestBuildWrapperChartValues_ChartImageOverrideCSV(t *testing.T) {
+	original := config.ChartSpec{Name: "strimzi-kafka-operator", Version: "0.51.0", Repository: "oci://repo/charts"}
+	vc := &config.VerityConfig{
+		ChartImageOverrides: map[string][]config.ChartImageOverride{
+			"strimzi-kafka-operator": {
+				{
+					Source: "STRIMZI_KAFKA_IMAGES",
+					Type:   "csv",
+					Path:   "kafka.versions[\"{version}\"]",
+				},
+			},
+		},
+	}
+
+	overrides, err := buildChartImageOverrides(original.Name, []ImageMapping{
+		{
+			Source:       "STRIMZI_KAFKA_IMAGES",
+			OriginalRepo: "quay.io/strimzi/kafka",
+			OriginalTag:  "0.51.0-kafka-4.1.0",
+			PatchedRepo:  "ghcr.io/verity-org/kafka",
+			PatchedTag:   "patched-4.1.0",
+		},
+		{
+			Source:       "STRIMZI_KAFKA_IMAGES",
+			OriginalRepo: "quay.io/strimzi/kafka",
+			OriginalTag:  "0.51.0-kafka-4.2.0",
+			PatchedRepo:  "ghcr.io/verity-org/kafka",
+			PatchedTag:   "patched-4.2.0",
+		},
+	}, vc)
+	if err != nil {
+		t.Fatalf("buildChartImageOverrides() error = %v", err)
+	}
+
+	chart, err := BuildWrapperChart(original, overrides)
+	if err != nil {
+		t.Fatalf("BuildWrapperChart() error = %v", err)
+	}
+
+	var values map[string]any
+	if err := yaml.Unmarshal(chart.ValuesYAML, &values); err != nil {
+		t.Fatalf("yaml.Unmarshal(ValuesYAML) error = %v", err)
+	}
+
+	root, ok := values["strimzi-kafka-operator"].(map[string]any)
+	if !ok {
+		t.Fatalf("chart root missing or invalid: %#v", values["strimzi-kafka-operator"])
+	}
+	kafka, ok := root["kafka"].(map[string]any)
+	if !ok {
+		t.Fatalf("kafka node missing or invalid: %#v", root["kafka"])
+	}
+	versions, ok := kafka["versions"].(map[string]any)
+	if !ok {
+		t.Fatalf("versions node missing or invalid: %#v", kafka["versions"])
+	}
+	if versions["4.1.0"] != "ghcr.io/verity-org/kafka:patched-4.1.0" {
+		t.Fatalf("versions[4.1.0] = %#v, want patched 4.1.0 image", versions["4.1.0"])
+	}
+	if versions["4.2.0"] != "ghcr.io/verity-org/kafka:patched-4.2.0" {
+		t.Fatalf("versions[4.2.0] = %#v, want patched 4.2.0 image", versions["4.2.0"])
+	}
+}
+
 func TestBuildWrapperChartEmptyOverrides(t *testing.T) {
 	original := config.ChartSpec{Name: "prometheus", Version: "28.9.1", Repository: "oci://repo/charts"}
 

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -18,7 +18,11 @@ import (
 // least one chart in the configured charts file produced no patched image
 // mappings (i.e., chart-gen would otherwise have silently skipped it). The
 // usual root cause is a missing replacements: entry in verity.yaml.
-var ErrStrictModeUnmappedCharts = errors.New("strict mode: charts produced no patched image mappings")
+var (
+	ErrStrictModeUnmappedCharts          = errors.New("strict mode: charts produced no patched image mappings")
+	ErrChartImageOverrideVersion         = errors.New("chartImageOverrides: derive version")
+	ErrUnsupportedChartImageOverrideType = errors.New("chartImageOverrides: unsupported type")
+)
 
 var chartImageOverrideVersionPattern = regexp.MustCompile(`v?\d+\.\d+\.\d+`)
 
@@ -258,7 +262,7 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 		// images backed by an Integer rebuild but lacking an explicit
 		// replacement entry don't get crane-looked-up against the Copa
 		// patched registry (where they don't exist).
-		if isExcluded(name, imageRef, excludeNames) {
+		if isExcluded(name, excludeNames) {
 			fmt.Fprintf(os.Stderr, "warning: skipping excluded image %q (%s)\n", name, imageRef)
 			continue
 		}
@@ -280,7 +284,8 @@ func buildChartImageOverrides(chartName string, mappings []ImageMapping, vc *con
 	}
 
 	result := make([]ValueOverride, 0, len(chartOverrides))
-	for _, mapping := range mappings {
+	for i := range mappings {
+		mapping := &mappings[i]
 		for _, override := range chartOverrides {
 			if mapping.Source != override.Source {
 				continue
@@ -297,11 +302,11 @@ func buildChartImageOverrides(chartName string, mappings []ImageMapping, vc *con
 			case "csv":
 				version, ok := chartImageOverrideVersion(mapping)
 				if !ok {
-					return nil, fmt.Errorf("derive version for chartImageOverrides source %q", override.Source)
+					return nil, fmt.Errorf("%w: source %q", ErrChartImageOverrideVersion, override.Source)
 				}
 				path = strings.ReplaceAll(path, "{version}", version)
 			default:
-				return nil, fmt.Errorf("unsupported chartImageOverrides type %q for source %q", override.Type, override.Source)
+				return nil, fmt.Errorf("%w: %q for source %q", ErrUnsupportedChartImageOverrideType, override.Type, override.Source)
 			}
 
 			result = append(result, ValueOverride{
@@ -314,14 +319,14 @@ func buildChartImageOverrides(chartName string, mappings []ImageMapping, vc *con
 	return result, nil
 }
 
-func patchedImageRef(mapping ImageMapping) string {
+func patchedImageRef(mapping *ImageMapping) string {
 	if mapping.PatchedTag == "" {
 		return mapping.PatchedRepo
 	}
 	return mapping.PatchedRepo + ":" + mapping.PatchedTag
 }
 
-func chartImageOverrideVersion(mapping ImageMapping) (string, bool) {
+func chartImageOverrideVersion(mapping *ImageMapping) (string, bool) {
 	haystacks := []string{mapping.OriginalTag, mapping.OriginalRepo + ":" + mapping.OriginalTag}
 	for _, haystack := range haystacks {
 		matches := chartImageOverrideVersionPattern.FindAllString(haystack, -1)

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -143,6 +143,12 @@ func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) 
 		return ChartResult{}, false, fmt.Errorf("resolve value paths for %s: %w", chart.Name, err)
 	}
 
+	chartImageOverrides, err := buildChartImageOverrides(chart.Name, allMappings, vc)
+	if err != nil {
+		return ChartResult{}, false, fmt.Errorf("build chart image overrides for %s: %w", chart.Name, err)
+	}
+	valueOverrides = append(valueOverrides, chartImageOverrides...)
+
 	wrapper, err := BuildWrapperChart(chart, valueOverrides)
 	if err != nil {
 		return ChartResult{}, false, fmt.Errorf("build wrapper chart for %s: %w", chart.Name, err)
@@ -258,4 +264,46 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 	}
 
 	return remaining, replacements
+}
+
+func buildChartImageOverrides(chartName string, mappings []ImageMapping, vc *config.VerityConfig) ([]ValueOverride, error) {
+	if vc == nil {
+		return nil, nil
+	}
+
+	chartOverrides := vc.ChartImageOverrides[chartName]
+	if len(chartOverrides) == 0 {
+		return nil, nil
+	}
+
+	result := make([]ValueOverride, 0, len(chartOverrides))
+	for _, mapping := range mappings {
+		for _, override := range chartOverrides {
+			if mapping.Source != override.Source {
+				continue
+			}
+
+			overrideType := override.Type
+			if overrideType == "" {
+				overrideType = "single"
+			}
+			if overrideType != "single" {
+				return nil, fmt.Errorf("unsupported chartImageOverrides type %q for source %q", override.Type, override.Source)
+			}
+
+			result = append(result, ValueOverride{
+				Path:  override.Path,
+				Value: patchedImageRef(mapping),
+			})
+		}
+	}
+
+	return result, nil
+}
+
+func patchedImageRef(mapping ImageMapping) string {
+	if mapping.PatchedTag == "" {
+		return mapping.PatchedRepo
+	}
+	return mapping.PatchedRepo + ":" + mapping.PatchedTag
 }

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -18,6 +19,8 @@ import (
 // mappings (i.e., chart-gen would otherwise have silently skipped it). The
 // usual root cause is a missing replacements: entry in verity.yaml.
 var ErrStrictModeUnmappedCharts = errors.New("strict mode: charts produced no patched image mappings")
+
+var chartImageOverrideVersionPattern = regexp.MustCompile(`v?\d+\.\d+\.\d+`)
 
 type Config struct {
 	ChartsFile     string
@@ -287,12 +290,22 @@ func buildChartImageOverrides(chartName string, mappings []ImageMapping, vc *con
 			if overrideType == "" {
 				overrideType = "single"
 			}
-			if overrideType != "single" {
+
+			path := override.Path
+			switch overrideType {
+			case "single":
+			case "csv":
+				version, ok := chartImageOverrideVersion(mapping)
+				if !ok {
+					return nil, fmt.Errorf("derive version for chartImageOverrides source %q", override.Source)
+				}
+				path = strings.ReplaceAll(path, "{version}", version)
+			default:
 				return nil, fmt.Errorf("unsupported chartImageOverrides type %q for source %q", override.Type, override.Source)
 			}
 
 			result = append(result, ValueOverride{
-				Path:  override.Path,
+				Path:  path,
 				Value: patchedImageRef(mapping),
 			})
 		}
@@ -306,4 +319,15 @@ func patchedImageRef(mapping ImageMapping) string {
 		return mapping.PatchedRepo
 	}
 	return mapping.PatchedRepo + ":" + mapping.PatchedTag
+}
+
+func chartImageOverrideVersion(mapping ImageMapping) (string, bool) {
+	haystacks := []string{mapping.OriginalTag, mapping.OriginalRepo + ":" + mapping.OriginalTag}
+	for _, haystack := range haystacks {
+		matches := chartImageOverrideVersionPattern.FindAllString(haystack, -1)
+		if len(matches) > 0 {
+			return matches[len(matches)-1], true
+		}
+	}
+	return "", false
 }

--- a/internal/chartgen/mapping.go
+++ b/internal/chartgen/mapping.go
@@ -17,6 +17,7 @@ import (
 type ImageMapping struct {
 	OriginalRepo string `json:"originalRepo"`
 	OriginalTag  string `json:"originalTag"`
+	Source       string `json:"source,omitempty"`
 	PatchedRepo  string `json:"patchedRepo"`
 	PatchedTag   string `json:"patchedTag"`
 }

--- a/internal/chartgen/mapping.go
+++ b/internal/chartgen/mapping.go
@@ -32,7 +32,7 @@ func BuildImageMappings(imageRefs []string, targetRegistry string, excludeNames 
 		sourceRepo, sourceTag := splitRef(imageRef)
 		name := repoPath(imageRef)
 
-		if isExcluded(name, imageRef, excludeNames) {
+		if isExcluded(name, excludeNames) {
 			fmt.Fprintf(os.Stderr, "warning: skipping excluded image %q (%s)\n", name, imageRef)
 			continue
 		}
@@ -70,7 +70,7 @@ func BuildImageMappings(imageRefs []string, targetRegistry string, excludeNames 
 }
 
 // isExcluded checks whether a chart-discovered image should be skipped.
-func isExcluded(name, imageRef string, excludeNames map[string]struct{}) bool {
+func isExcluded(name string, excludeNames map[string]struct{}) bool {
 	if len(excludeNames) == 0 {
 		return false
 	}

--- a/internal/chartgen/mapping_test.go
+++ b/internal/chartgen/mapping_test.go
@@ -209,7 +209,7 @@ func TestIsExcluded(t *testing.T) {
 			if tc.name == "nil exclude set" {
 				exc = nil
 			}
-			got := isExcluded(tc.imgName, tc.imageRef, exc)
+			got := isExcluded(tc.imgName, exc)
 			if got != tc.want {
 				t.Errorf("isExcluded(%q, %q) = %v, want %v", tc.imgName, tc.imageRef, got, tc.want)
 			}

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -17,6 +17,7 @@ type ValueOverride struct {
 	Path       string `json:"path"`
 	Repository string `json:"repository"`
 	Tag        string `json:"tag"`
+	Value      string `json:"value,omitempty"`
 }
 
 type repoTagPair struct {

--- a/internal/config/testdata/verity-chart-image-overrides.yaml
+++ b/internal/config/testdata/verity-chart-image-overrides.yaml
@@ -1,0 +1,12 @@
+chartImageOverrides:
+  strimzi-kafka-operator:
+    - source: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+      path: kafka.image
+    - source: STRIMZI_KAFKA_IMAGES
+      type: csv
+      path: kafka.versions["{version}"]
+  rook-ceph:
+    - source: ROOK_CSI_CEPH_IMAGE
+      path: csi.cephcsi.repository
+    - source: ROOK_CSI_PROVISIONER_IMAGE
+      path: csi.provisionerImage

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -26,7 +26,21 @@ type CopaConfig struct {
 type VerityConfig struct {
 	Overrides         map[string]Override    `yaml:"overrides,omitempty"`
 	Replacements      map[string]Replacement `yaml:"replacements,omitempty"`
+	ChartImageOverrides map[string][]ChartImageOverride `yaml:"chartImageOverrides,omitempty"`
 	UnpatchableImages []string               `yaml:"unpatchableImages,omitempty"`
+}
+
+// ChartImageOverride maps an operator-discovered image source to a wrapper
+// chart values path override.
+type ChartImageOverride struct {
+	// Source is either an env-var name like STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+	// or a ConfigMap data key like ROOK_CSI_CEPH_IMAGE.
+	Source string `yaml:"source"`
+	// Type is "single" (default) or "csv" (multi-line version=image rows).
+	Type string `yaml:"type,omitempty"`
+	// Path is the wrapper-chart values.yaml path to override.
+	// For csv rows, use {version} as a substitution placeholder.
+	Path string `yaml:"path"`
 }
 
 // Replacement maps a chart-discovered image to a Verity Integer (Wolfi) image.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -24,10 +24,10 @@ type CopaConfig struct {
 // the rebuild stub at images/<name>.yaml and let --exclude-names handle
 // the chart-discovery skip.
 type VerityConfig struct {
-	Overrides         map[string]Override    `yaml:"overrides,omitempty"`
-	Replacements      map[string]Replacement `yaml:"replacements,omitempty"`
+	Overrides           map[string]Override             `yaml:"overrides,omitempty"`
+	Replacements        map[string]Replacement          `yaml:"replacements,omitempty"`
 	ChartImageOverrides map[string][]ChartImageOverride `yaml:"chartImageOverrides,omitempty"`
-	UnpatchableImages []string               `yaml:"unpatchableImages,omitempty"`
+	UnpatchableImages   []string                        `yaml:"unpatchableImages,omitempty"`
 }
 
 // ChartImageOverride maps an operator-discovered image source to a wrapper

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestVerityConfigChartImageOverridesYAML(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "verity-chart-image-overrides.yaml"))
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+
+	var cfg VerityConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	if len(cfg.ChartImageOverrides) != 2 {
+		t.Fatalf("len(ChartImageOverrides) = %d, want 2", len(cfg.ChartImageOverrides))
+	}
+
+	strimzi := cfg.ChartImageOverrides["strimzi-kafka-operator"]
+	if len(strimzi) != 2 {
+		t.Fatalf("len(strimzi overrides) = %d, want 2", len(strimzi))
+	}
+	if strimzi[0].Source != "STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE" || strimzi[0].Path != "kafka.image" || strimzi[0].Type != "" {
+		t.Fatalf("strimzi[0] = %+v, want source/path with default type", strimzi[0])
+	}
+	if strimzi[1].Source != "STRIMZI_KAFKA_IMAGES" || strimzi[1].Type != "csv" || strimzi[1].Path != "kafka.versions[\"{version}\"]" {
+		t.Fatalf("strimzi[1] = %+v, want csv override", strimzi[1])
+	}
+
+	rook := cfg.ChartImageOverrides["rook-ceph"]
+	if len(rook) != 2 {
+		t.Fatalf("len(rook overrides) = %d, want 2", len(rook))
+	}
+	if rook[0].Source != "ROOK_CSI_CEPH_IMAGE" || rook[0].Path != "csi.cephcsi.repository" {
+		t.Fatalf("rook[0] = %+v, want ceph CSI override", rook[0])
+	}
+	if rook[1].Source != "ROOK_CSI_PROVISIONER_IMAGE" || rook[1].Path != "csi.provisionerImage" {
+		t.Fatalf("rook[1] = %+v, want provisioner override", rook[1])
+	}
+}

--- a/internal/discovery/discover.go
+++ b/internal/discovery/discover.go
@@ -171,7 +171,8 @@ func LoadConfig(path string) (*config.CopaConfig, error) {
 	return &cfg, nil
 }
 
-// LoadVerityConfig reads verity-specific configuration from verity.yaml.
+// LoadVerityConfig reads verity-specific configuration from verity.yaml,
+// including overrides, replacements, chartImageOverrides, and unpatchableImages.
 // Returns an empty config (not an error) if the file does not exist.
 func LoadVerityConfig(path string) (*config.VerityConfig, error) {
 	data, err := os.ReadFile(path)

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -378,6 +378,39 @@ overrides:
 	}
 }
 
+func TestLoadVerityConfig_ChartImageOverrides(t *testing.T) {
+	yaml := `
+chartImageOverrides:
+  strimzi-kafka-operator:
+    - source: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+      path: kafka.image
+    - source: STRIMZI_KAFKA_IMAGES
+      type: csv
+      path: kafka.versions["{version}"]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "verity.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vc, err := LoadVerityConfig(path)
+	if err != nil {
+		t.Fatalf("LoadVerityConfig() error = %v", err)
+	}
+
+	overrides := vc.ChartImageOverrides["strimzi-kafka-operator"]
+	if len(overrides) != 2 {
+		t.Fatalf("len(strimzi overrides) = %d, want 2", len(overrides))
+	}
+	if overrides[0].Source != "STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE" || overrides[0].Path != "kafka.image" {
+		t.Fatalf("overrides[0] = %+v, want single-source override", overrides[0])
+	}
+	if overrides[1].Source != "STRIMZI_KAFKA_IMAGES" || overrides[1].Type != "csv" || overrides[1].Path != "kafka.versions[\"{version}\"]" {
+		t.Fatalf("overrides[1] = %+v, want csv override", overrides[1])
+	}
+}
+
 func TestLoadVerityConfig_Missing(t *testing.T) {
 	vc, err := LoadVerityConfig("/nonexistent/verity.yaml")
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `chartImageOverrides:` config support so wrapper charts can override operator data-plane image values by discovered source key
- extend chartgen with source-aware image mappings plus single-source and csv/path-template wrapper value generation
- cover config loading, source-field plumbing, single-source overrides, and csv version substitution with unit tests

## Design
- `internal/config/types.go` adds `ChartImageOverride` plus `VerityConfig.ChartImageOverrides`
- `internal/discovery/LoadVerityConfig` now carries the new config through loader tests
- `internal/chartgen` adds source-aware override generation and bracket-aware wrapper values paths for keys like `kafka.versions[\"4.1.0\"]`

## Evidence
- local: `go build ./...`
- local: `go test ./...`
- local: `go test ./... -coverprofile=coverage.out` → total coverage `81.1%`
- local: `$(go env GOPATH)/bin/golangci-lint run`
- rebase: `git rebase origin/main` completed cleanly with no conflicts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `chartImageOverrides` so wrapper charts can override operator data‑plane image values by discovered source (single or CSV). Extends `chartgen` to generate correct wrapper values, including bracket-aware paths like `kafka.versions["4.1.0"]`.

- **New Features**
  - New `chartImageOverrides` in `verity.yaml` maps chart names to per-source overrides; types: `single` (default) and `csv` (use `{version}` in `path`).
  - `internal/chartgen`: carries `Source` on `ImageMapping`, builds value overrides for patched image refs, and parses dot/bracket paths via `splitOverridePath`.
  - `ValueOverride` gains `Value` to set direct string values (e.g., `repo:tag`) in wrapper values.
  - Version extraction for `csv` overrides with a semver regex; errors on unsupported types or missing version.
  - `internal/discovery/LoadVerityConfig` loads `chartImageOverrides`; tests added across `internal/{config,chartgen,discovery}`.
  - Minor cleanup: simplify `isExcluded` signature.

- **Migration**
  - Define per-chart overrides under `chartImageOverrides` in `verity.yaml`. For CSV-like sources, include `{version}` in the `path`.
  - Use bracketed paths for keyed entries, e.g., `kafka.versions["{version}"]` or `kafka.versions["4.1.0"]`.

<sup>Written for commit 02541dc1e059ed4ffff1db6f416f64d8632ec17d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

