### PR TITLE
feat(charts): add 7 wave-1 free-win charts (cert-manager, ingress-nginx, external-dns, consul, valkey, etcd, velero)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -47,3 +47,31 @@ dependencies:
   - name: rabbitmq-cluster-operator
     version: "0.2.3"
     repository: "oci://registry-1.docker.io/cloudpirates"
+
+  - name: cert-manager
+    version: "1.20.2"
+    repository: "https://charts.jetstack.io"
+
+  - name: ingress-nginx
+    version: "4.15.1"
+    repository: "https://kubernetes.github.io/ingress-nginx"
+
+  - name: external-dns
+    version: "1.20.0"
+    repository: "https://kubernetes-sigs.github.io/external-dns/"
+
+  - name: consul
+    version: "1.9.6"
+    repository: "https://helm.releases.hashicorp.com"
+
+  - name: valkey
+    version: "0.20.0"
+    repository: "oci://registry-1.docker.io/cloudpirates"
+
+  - name: etcd
+    version: "0.7.0"
+    repository: "oci://registry-1.docker.io/cloudpirates"
+
+  - name: velero
+    version: "12.0.0"
+    repository: "https://vmware-tanzu.github.io/helm-charts"

--- a/test/chart-integration/values/cert-manager.yaml
+++ b/test/chart-integration/values/cert-manager.yaml
@@ -1,0 +1,2 @@
+startupapicheck:
+  enabled: false

--- a/verity.yaml
+++ b/verity.yaml
@@ -81,6 +81,49 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "postgres-operator"
 
+  # cert-manager chart (1.20.2). Jetstack chart image refs keep the upstream
+  # quay.io/jetstack path and v-prefixed tag; Verity publishes the rebuilds at
+  # flattened ghcr.io/verity-org/<name> repos with non-v tags.
+  "jetstack/cert-manager-controller":
+    registry: "ghcr.io/verity-org"
+    image: "cert-manager-controller"
+    tag: "1.20.2"
+  "jetstack/cert-manager-cainjector":
+    registry: "ghcr.io/verity-org"
+    image: "cert-manager-cainjector"
+    tag: "1.20.2"
+  "jetstack/cert-manager-webhook":
+    registry: "ghcr.io/verity-org"
+    image: "cert-manager-webhook"
+    tag: "1.20.2"
+
+  # ingress-nginx chart (4.15.1) + external-dns chart (1.20.0). Existing
+  # Copa-patched repos preserve the standalone source naming used in
+  # copa-config.yaml rather than the charts' rendered repo paths.
+  "ingress-nginx/controller":
+    registry: "ghcr.io/verity-org"
+    image: "kubernetes/ingress-nginx/controller"
+  "ingress-nginx/kube-webhook-certgen":
+    registry: "ghcr.io/verity-org"
+    image: "kubernetes/ingress-nginx/kube-webhook-certgen"
+  "external-dns/external-dns":
+    registry: "ghcr.io/verity-org"
+    image: "kubernetes-sigs/external-dns"
+
+  # Integer-backed free wins.
+  "valkey/valkey":
+    registry: "ghcr.io/verity-org"
+    image: "valkey"
+    tag: "9.0"
+  "etcd-development/etcd":
+    registry: "ghcr.io/verity-org"
+    image: "etcd"
+    tag: "3.6.10"
+  "velero/velero":
+    registry: "ghcr.io/verity-org"
+    image: "velero"
+    tag: "1.18.0"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement


### PR DESCRIPTION
## TL;DR

Adds 7 charts whose images already have copa-config standalone entries or Integer rebuilds. No new copa-config or Integer build needed — wrappers light up via existing infrastructure.

| Chart | Version | Repo | Replaces | New mappings |
|---|---|---|---|---|
| cert-manager | 1.20.2 | jetstack | already in copa-config (controller, webhook, cainjector) | 3 (Integer-replacement entries) |
| ingress-nginx | 4.15.1 | kubernetes.github.io | existing Copa standalones | 2 |
| external-dns | 1.20.0 | kubernetes-sigs | existing Copa | 1 |
| consul | 1.9.6 | hashicorp | existing Copa (consul) | 0 (crane-fallback) |
| valkey | 0.20.0 | cloudpirates | `images/valkey.yaml` | 1 |
| etcd | 0.7.0 | cloudpirates | `images/etcd.yaml` | 1 |
| velero | 12.0.0 | vmware-tanzu | `images/velero.yaml` | 1 |

## Verification

```
./verity doctor                                  # all checks passed
./verity chart-gen --strict --dry-run ...        # 17 charts in Chart.yaml, 17 wrappers, 0 skipped
go build ./... && go test ./...                  # clean
gofumpt -d .                                     # clean
```

Per-chart mapping count after merge (10 prior + 7 new = 17 total):
- prometheus: 4
- victoria-logs-single: 1
- postgres-operator: 1
- kyverno: 5
- argo-cd: 3
- dex: 1
- metrics-server: 1
- opensearch: 1
- opensearch-dashboards: 1
- rabbitmq-cluster-operator: 2
- **cert-manager: 4** (replacements for 3 + crane-fallback for startupapicheck)
- **ingress-nginx: 2**
- **external-dns: 1**
- **consul: 2** (crane-fallback)
- **valkey: 1**
- **etcd: 1**
- **velero: 1**

## What's NOT in this PR

**nats** dropped. Chart emits `nats:2.12.6-alpine` but Integer rebuild publishes `2.12.6` (no `-alpine` variant). With `--strict`, the tag mismatch makes chart-gen skip the chart. Two paths to add it later:
1. Add an `overrides:` entry stripping `-alpine` (needs the empty-`to:` chartgen fix)
2. Add an `images/nats.yaml` build that emits `-alpine` tags

Tracked as a Wave 2+ item.

## Background

This is **Wave 1** of the chart-mirror expansion plan in `.sisyphus/plans/chart-mirror-expansion-50.md` (50 candidates ranked from ArtifactHub data). "Wave 1" = the easiest 8 (now 7) — every chart has existing copa-config alignment, so the wrapper just lights up. Subsequent waves add observability, GitOps, databases, mesh, etc.

This PR also pairs with #275 (Phase 1 walker) and #276 (Phase 2 chartImageOverrides) which together unlock operator-only charts (strimzi, rook, minio) for future waves.

## Background context

Originally launched as a delegated subagent task that timed out at 30 min idle after completing ~80% of the work. Took the worktree's Chart.yaml + verity.yaml additions, restored Go files to current main (Phase 1 + Phase 2 had landed during the agent's run), trimmed nats due to tag mismatch, verified locally, pushed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 7 wave-1 charts wired to existing copa-config/Integer images, so wrappers work without new builds. Expands chart coverage to 17 mappings and includes a small cert-manager test tweak for CI.

- **New Features**
  - Charts added: cert-manager 1.20.2; ingress-nginx 4.15.1; external-dns 1.20.0; consul 1.9.6; valkey 0.20.0; etcd 0.7.0; velero 12.0.0.
  - Image replacements in `verity.yaml` for `jetstack/cert-manager-{controller,webhook,cainjector}`, `ingress-nginx/{controller,kube-webhook-certgen}`, `external-dns/external-dns`, `valkey/valkey`, `etcd-development/etcd`, `velero/velero`.
  - Test: disable cert-manager `startupapicheck` in integration values.

<sup>Written for commit c7a5cdfa8fbc25d4e9d1597f9ae174ef88df8941. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

