### PR TITLE
feat(charts): add MinIO operator wrapper chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -75,3 +75,10 @@ dependencies:
   - name: velero
     version: "12.0.0"
     repository: "https://vmware-tanzu.github.io/helm-charts"
+
+  # MinIO's current operator chart package is named `operator` in the
+  # https://operator.min.io repo. It templates only the operator deployment;
+  # tenant data-plane images live in the separate tenant chart / CRD specs.
+  - name: operator
+    version: "7.1.1"
+    repository: "https://operator.min.io"

--- a/verity.yaml
+++ b/verity.yaml
@@ -124,6 +124,14 @@ replacements:
     image: "velero"
     tag: "1.18.0"
 
+  # MinIO operator chart (package name: operator, version 7.1.1). The chart
+  # renders only the operator deployment; route it to the existing Wolfi
+  # rebuild whose published tags omit the upstream v-prefix.
+  "minio/operator":
+    registry: "ghcr.io/verity-org"
+    image: "minio-operator"
+    tag: "7.1.1"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement


### PR DESCRIPTION
## Summary
- add the MinIO Operator Helm dependency from `https://operator.min.io` (chart package name `operator`) and route `quay.io/minio/operator:v7.1.1` to the existing `ghcr.io/verity-org/minio-operator:7.1.1` Wolfi rebuild via `replacements:`
- verify the latest MinIO operator chart only templates the operator deployment; tenant/data-plane images are not rendered by this chart and therefore do not require `chartImageOverrides` for wrapper generation
- investigate the requested Strimzi and rook-ceph charts with real `helm template` output and drop them from this PR because the current Phase 2 config model cannot wire their rendered env/ConfigMap image refs cleanly: Strimzi derives images from `registry/repository/name/tagPrefix` maps instead of plain string values, and rook-ceph has no matching Verity repos yet for its operator/CSI images

## Discovery notes
### MinIO operator (`operator` 7.1.1)
- rendered image: `quay.io/minio/operator:v7.1.1`
- rendered env review: operator-only (`OPERATOR_STS_ENABLED=on`); no tenant image env/configmap refs are emitted by this chart
- values path used by wrapper: `operator.image`

### Investigated but intentionally excluded
#### Strimzi (`strimzi-kafka-operator` 0.51.0)
- rendered operator env refs include `STRIMZI_DEFAULT_*`, `STRIMZI_KAFKA_IMAGES`, `STRIMZI_KAFKA_CONNECT_IMAGES`, and `STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES`
- chart templates those refs from structured values like `kafka.image.{registry,repository,name,tagPrefix}` rather than string-valued paths, so the current `chartImageOverrides` schema cannot express a clean wrapper override for them

#### Rook (`rook-ceph` v1.19.4)
- rendered operator ConfigMap includes `ROOK_CSI_CEPH_IMAGE`, `ROOK_CSI_PROVISIONER_IMAGE`, `ROOK_CSI_REGISTRAR_IMAGE`, `ROOK_CSI_RESIZER_IMAGE`, `ROOK_CSI_SNAPSHOTTER_IMAGE`, `ROOK_CSIADDONS_IMAGE`, and `ROOK_CSI_ATTACHER_IMAGE`
- `chart-gen --strict --dry-run` skips the chart because `ghcr.io/verity-org/rook/ceph`, `ghcr.io/verity-org/cephcsi/cephcsi`, and the required `sig-storage/*` / `csiaddons/*` repos do not exist yet

## Verification
- `go build ./...`
- `go test ./...`
- `gofumpt -d .` → clean
- `golangci-lint run` → 0 issues
- `./verity doctor` → `verity doctor: all checks passed.`
- `./verity chart-gen --strict --dry-run ...` → `info: chart-gen summary: 18 charts in Chart.yaml, would produce 18 wrappers, 0 skipped (no patched mappings)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a wrapper chart for the MinIO Operator and routes its image to our Wolfi rebuild. Strimzi and Rook-Ceph were investigated but are out of scope for now due to config limitations and missing repos.

- **New Features**
  - Add `operator` chart `7.1.1` from `https://operator.min.io`.
  - Map `minio/operator` to `ghcr.io/verity-org/minio-operator:7.1.1` via `replacements`.
  - Chart renders only the operator deployment; no tenant image overrides needed.

<sup>Written for commit 4bd8ddfd2795481a08fb673519660da9321cccf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

