### PR TITLE
feat(charts): add grafana observability charts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -82,3 +82,19 @@ dependencies:
   - name: operator
     version: "7.1.1"
     repository: "https://operator.min.io"
+
+  - name: loki
+    version: "7.0.0"
+    repository: "https://grafana.github.io/helm-charts"
+
+  - name: grafana
+    version: "10.5.15"
+    repository: "https://grafana.github.io/helm-charts"
+
+  - name: mimir-distributed
+    version: "6.0.6"
+    repository: "https://grafana.github.io/helm-charts"
+
+  - name: tempo-distributed
+    version: "1.61.3"
+    repository: "https://grafana.github.io/helm-charts"

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -103,7 +103,7 @@ var DiscoverCommand = &cli.Command{
 			}
 		}
 
-		images, err := discovery.Discover(cfg, cmd.String("target-registry"), overrides, excludeNames, unpatchable)
+		images, err := discovery.DiscoverWithChartValues(cfg, cmd.String("target-registry"), overrides, vc.ChartValues, excludeNames, unpatchable)
 		if err != nil {
 			return fmt.Errorf("failed to discover images: %w", err)
 		}

--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,7 +25,7 @@ type WrapperChart struct {
 
 // BuildWrapperChart creates a wrapper Helm chart that depends on the original
 // chart and overrides image values with patched references.
-func BuildWrapperChart(original config.ChartSpec, overrides []ValueOverride) (*WrapperChart, error) {
+func BuildWrapperChart(original config.ChartSpec, chartValues map[string]any, overrides []ValueOverride) (*WrapperChart, error) {
 	if original.Name == "" {
 		return nil, ErrEmptyChartName
 	}
@@ -58,7 +59,7 @@ func BuildWrapperChart(original config.ChartSpec, overrides []ValueOverride) (*W
 		return nil, fmt.Errorf("marshal Chart.yaml: %w", err)
 	}
 
-	valuesTree := buildValuesTree(original.Name, overrides)
+	valuesTree := buildValuesTree(original.Name, chartValues, overrides)
 	valuesYAML, err := yaml.Marshal(valuesTree)
 	if err != nil {
 		return nil, fmt.Errorf("marshal values.yaml: %w", err)
@@ -129,8 +130,8 @@ func PushChart(tgzPath, registry string) error {
 
 // buildValuesTree converts flat dotted-path overrides to a nested map scoped
 // under the chart name (Helm dependency override convention).
-func buildValuesTree(chartName string, overrides []ValueOverride) map[string]any {
-	if len(overrides) == 0 {
+func buildValuesTree(chartName string, chartValues map[string]any, overrides []ValueOverride) map[string]any {
+	if len(chartValues) == 0 && len(overrides) == 0 {
 		return map[string]any{}
 	}
 
@@ -138,45 +139,58 @@ func buildValuesTree(chartName string, overrides []ValueOverride) map[string]any
 	chartRoot := make(map[string]any)
 	root[chartName] = chartRoot
 
+	keys := make([]string, 0, len(chartValues))
+	for key := range chartValues {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		setScalarValue(chartRoot, key, chartValues[key])
+	}
+
 	for _, override := range overrides {
-		parts := splitOverridePath(override.Path)
-		current := chartRoot
-
-		for i, part := range parts {
-			if part == "" {
-				continue
-			}
-
-			if i == len(parts)-1 {
-				if override.Value != "" {
-					current[part] = override.Value
-					break
-				}
-				current[part] = map[string]any{
-					"repository": override.Repository,
-					"tag":        override.Tag,
-				}
-				break
-			}
-
-			next, ok := current[part]
-			if !ok {
-				nextMap := make(map[string]any)
-				current[part] = nextMap
-				current = nextMap
-				continue
-			}
-
-			nextMap, ok := next.(map[string]any)
-			if !ok {
-				nextMap = make(map[string]any)
-				current[part] = nextMap
-			}
-			current = nextMap
+		if override.Value != "" {
+			setScalarValue(chartRoot, override.Path, override.Value)
+			continue
 		}
+		setScalarValue(chartRoot, override.Path, map[string]any{
+			"repository": override.Repository,
+			"tag":        override.Tag,
+		})
 	}
 
 	return root
+}
+
+func setScalarValue(root map[string]any, path string, value any) {
+	parts := splitOverridePath(path)
+	current := root
+
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		if i == len(parts)-1 {
+			current[part] = value
+			return
+		}
+
+		next, ok := current[part]
+		if !ok {
+			nextMap := make(map[string]any)
+			current[part] = nextMap
+			current = nextMap
+			continue
+		}
+
+		nextMap, ok := next.(map[string]any)
+		if !ok {
+			nextMap = make(map[string]any)
+			current[part] = nextMap
+		}
+		current = nextMap
+	}
 }
 
 func splitOverridePath(path string) []string {

--- a/internal/chartgen/chart_test.go
+++ b/internal/chartgen/chart_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/verity-org/verity/internal/config"
 )
 
+const testPromRepo = "ghcr.io/verity-org/prom"
+
 func TestBuildWrapperChart(t *testing.T) {
 	original := config.ChartSpec{
 		Name:       "prometheus",
@@ -81,7 +83,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 			chartValues: nil,
 			overrides: []ValueOverride{{
 				Path:       "image",
-				Repository: "ghcr.io/verity-org/prom",
+				Repository: testPromRepo,
 				Tag:        "v3",
 			}},
 			assert: func(t *testing.T, values map[string]any) {
@@ -93,7 +95,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				if !ok {
 					t.Fatalf("prometheus.image missing or invalid: %#v", prom["image"])
 				}
-				if image["repository"] != "ghcr.io/verity-org/prom" || image["tag"] != "v3" {
+				if image["repository"] != testPromRepo || image["tag"] != "v3" {
 					t.Fatalf("prometheus.image = %#v, want repository/tag override", image)
 				}
 			},
@@ -128,7 +130,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 			name:        "multiple overrides",
 			chartValues: nil,
 			overrides: []ValueOverride{
-				{Path: "image", Repository: "ghcr.io/verity-org/prom", Tag: "v3"},
+				{Path: "image", Repository: testPromRepo, Tag: "v3"},
 				{Path: "server.image", Repository: "ghcr.io/verity-org/prometheus", Tag: "v3.2.1"},
 			},
 			assert: func(t *testing.T, values map[string]any) {
@@ -148,7 +150,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				if !ok {
 					t.Fatal("server.image missing")
 				}
-				if img["repository"] != "ghcr.io/verity-org/prom" || img["tag"] != "v3" {
+				if img["repository"] != testPromRepo || img["tag"] != "v3" {
 					t.Fatalf("prometheus.image = %#v, want override", img)
 				}
 				if serverImg["repository"] != "ghcr.io/verity-org/prometheus" || serverImg["tag"] != "v3.2.1" {
@@ -164,7 +166,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 			},
 			overrides: []ValueOverride{{
 				Path:       "image",
-				Repository: "ghcr.io/verity-org/prom",
+				Repository: testPromRepo,
 				Tag:        "v3",
 			}},
 			assert: func(t *testing.T, values map[string]any) {
@@ -184,7 +186,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				if !ok {
 					t.Fatal("image missing")
 				}
-				if image["repository"] != "ghcr.io/verity-org/prom" || image["tag"] != "v3" {
+				if image["repository"] != testPromRepo || image["tag"] != "v3" {
 					t.Fatalf("prometheus.image = %#v, want override", image)
 				}
 			},
@@ -353,13 +355,13 @@ func TestBuildValuesTree(t *testing.T) {
 			name: "single path",
 			overrides: []ValueOverride{{
 				Path:       "image",
-				Repository: "ghcr.io/verity-org/prom",
+				Repository: testPromRepo,
 				Tag:        "v3",
 			}},
 			want: map[string]any{
 				"prometheus": map[string]any{
 					"image": map[string]any{
-						"repository": "ghcr.io/verity-org/prom",
+						"repository": testPromRepo,
 						"tag":        "v3",
 					},
 				},

--- a/internal/chartgen/chart_test.go
+++ b/internal/chartgen/chart_test.go
@@ -16,7 +16,7 @@ func TestBuildWrapperChart(t *testing.T) {
 		Repository: "oci://ghcr.io/prometheus-community/charts",
 	}
 
-	chart, err := BuildWrapperChart(original, nil)
+	chart, err := BuildWrapperChart(original, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildWrapperChart() error = %v", err)
 	}
@@ -71,12 +71,14 @@ func TestBuildWrapperChart(t *testing.T) {
 
 func TestBuildWrapperChartValues(t *testing.T) {
 	tests := []struct {
-		name      string
-		overrides []ValueOverride
-		assert    func(t *testing.T, values map[string]any)
+		name        string
+		chartValues map[string]any
+		overrides   []ValueOverride
+		assert      func(t *testing.T, values map[string]any)
 	}{
 		{
-			name: "single image override",
+			name:        "single image override",
+			chartValues: nil,
 			overrides: []ValueOverride{{
 				Path:       "image",
 				Repository: "ghcr.io/verity-org/prom",
@@ -97,7 +99,8 @@ func TestBuildWrapperChartValues(t *testing.T) {
 			},
 		},
 		{
-			name: "nested path",
+			name:        "nested path",
+			chartValues: nil,
 			overrides: []ValueOverride{{
 				Path:       "server.image",
 				Repository: "ghcr.io/verity-org/prometheus",
@@ -122,7 +125,8 @@ func TestBuildWrapperChartValues(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple overrides",
+			name:        "multiple overrides",
+			chartValues: nil,
 			overrides: []ValueOverride{
 				{Path: "image", Repository: "ghcr.io/verity-org/prom", Tag: "v3"},
 				{Path: "server.image", Repository: "ghcr.io/verity-org/prometheus", Tag: "v3.2.1"},
@@ -152,13 +156,46 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "chart values merged before image overrides",
+			chartValues: map[string]any{
+				"testFramework.enabled": false,
+				"grafana.enabled":       false,
+			},
+			overrides: []ValueOverride{{
+				Path:       "image",
+				Repository: "ghcr.io/verity-org/prom",
+				Tag:        "v3",
+			}},
+			assert: func(t *testing.T, values map[string]any) {
+				prom, ok := values["prometheus"].(map[string]any)
+				if !ok {
+					t.Fatal("prometheus root missing")
+				}
+				testFramework, ok := prom["testFramework"].(map[string]any)
+				if !ok || !reflect.DeepEqual(testFramework["enabled"], false) {
+					t.Fatalf("testFramework.enabled = %#v, want false", prom["testFramework"])
+				}
+				grafana, ok := prom["grafana"].(map[string]any)
+				if !ok || !reflect.DeepEqual(grafana["enabled"], false) {
+					t.Fatalf("grafana.enabled = %#v, want false", prom["grafana"])
+				}
+				image, ok := prom["image"].(map[string]any)
+				if !ok {
+					t.Fatal("image missing")
+				}
+				if image["repository"] != "ghcr.io/verity-org/prom" || image["tag"] != "v3" {
+					t.Fatalf("prometheus.image = %#v, want override", image)
+				}
+			},
+		},
 	}
 
 	original := config.ChartSpec{Name: "prometheus", Version: "28.9.1", Repository: "oci://repo/charts"}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			chart, err := BuildWrapperChart(original, tt.overrides)
+			chart, err := BuildWrapperChart(original, tt.chartValues, tt.overrides)
 			if err != nil {
 				t.Fatalf("BuildWrapperChart() error = %v", err)
 			}
@@ -195,7 +232,7 @@ func TestBuildWrapperChartValues_ChartImageOverrideSingleSource(t *testing.T) {
 		t.Fatalf("buildChartImageOverrides() error = %v", err)
 	}
 
-	chart, err := BuildWrapperChart(original, overrides)
+	chart, err := BuildWrapperChart(original, nil, overrides)
 	if err != nil {
 		t.Fatalf("BuildWrapperChart() error = %v", err)
 	}
@@ -252,7 +289,7 @@ func TestBuildWrapperChartValues_ChartImageOverrideCSV(t *testing.T) {
 		t.Fatalf("buildChartImageOverrides() error = %v", err)
 	}
 
-	chart, err := BuildWrapperChart(original, overrides)
+	chart, err := BuildWrapperChart(original, nil, overrides)
 	if err != nil {
 		t.Fatalf("BuildWrapperChart() error = %v", err)
 	}
@@ -285,7 +322,7 @@ func TestBuildWrapperChartValues_ChartImageOverrideCSV(t *testing.T) {
 func TestBuildWrapperChartEmptyOverrides(t *testing.T) {
 	original := config.ChartSpec{Name: "prometheus", Version: "28.9.1", Repository: "oci://repo/charts"}
 
-	chart, err := BuildWrapperChart(original, []ValueOverride{})
+	chart, err := BuildWrapperChart(original, nil, []ValueOverride{})
 	if err != nil {
 		t.Fatalf("BuildWrapperChart() error = %v", err)
 	}
@@ -300,7 +337,7 @@ func TestBuildWrapperChartEmptyOverrides(t *testing.T) {
 }
 
 func TestBuildWrapperChartEmptyName(t *testing.T) {
-	_, err := BuildWrapperChart(config.ChartSpec{Version: "1.0.0", Repository: "oci://repo/charts"}, nil)
+	_, err := BuildWrapperChart(config.ChartSpec{Version: "1.0.0", Repository: "oci://repo/charts"}, nil, nil)
 	if err == nil {
 		t.Fatal("BuildWrapperChart() error = nil, want non-nil")
 	}
@@ -369,7 +406,7 @@ func TestBuildValuesTree(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildValuesTree("prometheus", tt.overrides)
+			got := buildValuesTree("prometheus", nil, tt.overrides)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("buildValuesTree() = %#v, want %#v", got, tt.want)
 			}

--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -120,7 +120,7 @@ func enforceStrict(strict bool, total, skipped int, chartsFile string) error {
 func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) (ChartResult, bool, error) {
 	fmt.Fprintf(os.Stderr, "info: processing chart %s@%s\n", chart.Name, chart.Version)
 
-	imageRefs, err := discovery.ExtractChartImages(chart, vc.Overrides)
+	imageRefs, err := discovery.ExtractChartImagesWithValues(chart, vc.Overrides, vc.ChartValues[chart.Name])
 	if err != nil {
 		return ChartResult{}, false, fmt.Errorf("extract images for chart %s: %w", chart.Name, err)
 	}
@@ -156,7 +156,7 @@ func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) 
 	}
 	valueOverrides = append(valueOverrides, chartImageOverrides...)
 
-	wrapper, err := BuildWrapperChart(chart, valueOverrides)
+	wrapper, err := BuildWrapperChart(chart, vc.ChartValues[chart.Name], valueOverrides)
 	if err != nil {
 		return ChartResult{}, false, fmt.Errorf("build wrapper chart for %s: %w", chart.Name, err)
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -24,20 +24,19 @@ type CopaConfig struct {
 // the rebuild stub at images/<name>.yaml and let --exclude-names handle
 // the chart-discovery skip.
 type VerityConfig struct {
-	Overrides           map[string]Override             `yaml:"overrides,omitempty"`
-	ChartValues         map[string]map[string]any       `yaml:"chartValues,omitempty"`
+	Overrides map[string]Override `yaml:"overrides,omitempty"`
+
+	// ChartValues injects per-chart scalar values into both helm template
+	// extraction and generated wrapper-chart values.yaml. Keys are
+	// dot-delimited Helm values paths (e.g. "grafana.enabled",
+	// "loki.useTestSchema"). Values must be scalar YAML types that Helm's
+	// --set / --set-string can represent (string, bool, int, float).
+	ChartValues map[string]map[string]any `yaml:"chartValues,omitempty"`
+
 	Replacements        map[string]Replacement          `yaml:"replacements,omitempty"`
 	ChartImageOverrides map[string][]ChartImageOverride `yaml:"chartImageOverrides,omitempty"`
 	UnpatchableImages   []string                        `yaml:"unpatchableImages,omitempty"`
 }
-
-// ChartValues injects per-chart scalar values into both helm template
-// extraction and generated wrapper-chart values.yaml.
-//
-// Keys are dot-delimited Helm values paths (for example
-// "grafana.enabled" or "testFramework.enabled"). Values must be scalar YAML
-// types that Helm's --set / --set-string can represent (string, bool, int,
-// float).
 
 // ChartImageOverride maps an operator-discovered image source to a wrapper
 // chart values path override.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -25,10 +25,19 @@ type CopaConfig struct {
 // the chart-discovery skip.
 type VerityConfig struct {
 	Overrides           map[string]Override             `yaml:"overrides,omitempty"`
+	ChartValues         map[string]map[string]any       `yaml:"chartValues,omitempty"`
 	Replacements        map[string]Replacement          `yaml:"replacements,omitempty"`
 	ChartImageOverrides map[string][]ChartImageOverride `yaml:"chartImageOverrides,omitempty"`
 	UnpatchableImages   []string                        `yaml:"unpatchableImages,omitempty"`
 }
+
+// ChartValues injects per-chart scalar values into both helm template
+// extraction and generated wrapper-chart values.yaml.
+//
+// Keys are dot-delimited Helm values paths (for example
+// "grafana.enabled" or "testFramework.enabled"). Values must be scalar YAML
+// types that Helm's --set / --set-string can represent (string, bool, int,
+// float).
 
 // ChartImageOverride maps an operator-discovered image source to a wrapper
 // chart values path override.

--- a/internal/discovery/charts.go
+++ b/internal/discovery/charts.go
@@ -19,15 +19,39 @@ import (
 	"github.com/verity-org/verity/internal/config"
 )
 
-// Sentinel errors for chart spec validation.
+// Sentinel errors for chart spec validation and chart-value coercion.
 var (
 	ErrInvalidChartName    = errors.New("chart name must not start with '-'")
 	ErrInvalidChartVersion = errors.New("chart version must not start with '-'")
 	ErrInvalidChartRepo    = errors.New("chart repository must start with oci://, https://, or http://")
-	imageTagPattern        = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
-	imageDigestPattern     = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
-	imageNamePattern       = regexp.MustCompile(`^[A-Za-z0-9._:-]+(?:/[A-Za-z0-9._-]+)+$`)
+
+	// ErrChartValueUnsupportedFloat is wrapped when a chartValues entry
+	// resolves to NaN or +/-Inf, which cannot be represented as a Helm
+	// --set value.
+	ErrChartValueUnsupportedFloat = errors.New("unsupported non-finite float in chart value")
+
+	// ErrChartValueNil is wrapped when a chartValues entry resolves to
+	// the YAML null literal — Helm's --set has no scalar representation
+	// for nil, so the user must either drop the key or pass an empty
+	// string.
+	ErrChartValueNil = errors.New("chart value is nil")
+
+	// ErrChartValueUnsupportedType is wrapped when a chartValues entry
+	// is a complex type (slice/map/struct) instead of one of the scalar
+	// types Helm's --set / --set-string accept.
+	ErrChartValueUnsupportedType = errors.New("chart value type is unsupported (use scalar string/bool/number)")
+
+	imageTagPattern    = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	imageDigestPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+	imageNamePattern   = regexp.MustCompile(`^[A-Za-z0-9._:-]+(?:/[A-Za-z0-9._-]+)+$`)
 )
+
+// helmSetFlag is the helm CLI flag for non-string scalar values.
+const helmSetFlag = "--set"
+
+// helmSetStringFlag is the helm CLI flag for string values, avoiding the
+// type coercion that --set applies (e.g. "false" parsed as bool).
+const helmSetStringFlag = "--set-string"
 
 // ExtractChartImages runs helm template for a chart and returns all unique image references found.
 // Overrides are applied to substitute tag variants (e.g., distroless-libc → debian).
@@ -74,21 +98,21 @@ func ExtractChartImagesWithValues(chart config.ChartSpec, overrides map[string]c
 // helmTemplateArgs builds the helm template argument list for a chart spec.
 
 func helmTemplateArgs(chart config.ChartSpec, chartValues map[string]any) ([]string, error) {
-	var args []string
+	args := make([]string, 0, 7+2*len(chartValues))
 	if strings.HasPrefix(chart.Repository, "oci://") {
 		// OCI registry: helm template <name> <oci-repo>/<name> --version <ver>
-		args = []string{
+		args = append(args,
 			"template", chart.Name,
-			chart.Repository + "/" + chart.Name,
+			chart.Repository+"/"+chart.Name,
 			"--version", chart.Version,
-		}
+		)
 	} else {
 		// HTTP repository: helm template <name> <name> --repo <url> --version <ver>
-		args = []string{
+		args = append(args,
 			"template", chart.Name, chart.Name,
 			"--repo", chart.Repository,
 			"--version", chart.Version,
-		}
+		)
 	}
 
 	setArgs, err := helmSetArgs(chartValues)
@@ -121,28 +145,43 @@ func helmSetArgs(chartValues map[string]any) ([]string, error) {
 	return args, nil
 }
 
+// escapeHelmSetValue escapes characters that Helm's --set / --set-string
+// strvals parser treats as structural separators. Specifically: backslash
+// (so it doesn't confuse later replacements), comma (separates list items),
+// and equals (separates key from value at the top level).
+func escapeHelmSetValue(v string) string {
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, ",", `\,`)
+	v = strings.ReplaceAll(v, "=", `\=`)
+	return v
+}
+
 func helmSetPair(path string, value any) (flag, encoded string, err error) {
 	switch v := value.(type) {
 	case string:
-		return "--set-string", v, nil
+		return helmSetStringFlag, escapeHelmSetValue(v), nil
 	case bool:
-		return "--set", strconv.FormatBool(v), nil
+		return helmSetFlag, strconv.FormatBool(v), nil
 	case int:
-		return "--set", strconv.Itoa(v), nil
+		return helmSetFlag, strconv.Itoa(v), nil
 	case int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64:
-		return "--set", fmt.Sprintf("%v", v), nil
+		return helmSetFlag, fmt.Sprintf("%v", v), nil
 	case float32:
-		return "--set", strconv.FormatFloat(float64(v), 'f', -1, 32), nil
+		f := float64(v)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return "", "", fmt.Errorf("%w: %q=%v", ErrChartValueUnsupportedFloat, path, v)
+		}
+		return helmSetFlag, strconv.FormatFloat(f, 'f', -1, 32), nil
 	case float64:
 		if math.IsNaN(v) || math.IsInf(v, 0) {
-			return "", "", fmt.Errorf("chart value %q: unsupported float %v", path, v)
+			return "", "", fmt.Errorf("%w: %q=%v", ErrChartValueUnsupportedFloat, path, v)
 		}
-		return "--set", strconv.FormatFloat(v, 'f', -1, 64), nil
+		return helmSetFlag, strconv.FormatFloat(v, 'f', -1, 64), nil
 	case nil:
-		return "", "", fmt.Errorf("chart value %q: nil is unsupported", path)
+		return "", "", fmt.Errorf("%w: %q", ErrChartValueNil, path)
 	default:
-		return "", "", fmt.Errorf("chart value %q: unsupported type %T (use scalar string/bool/number)", path, value)
+		return "", "", fmt.Errorf("%w: %q has type %T", ErrChartValueUnsupportedType, path, value)
 	}
 }
 

--- a/internal/discovery/charts.go
+++ b/internal/discovery/charts.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os/exec"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,11 +32,21 @@ var (
 // ExtractChartImages runs helm template for a chart and returns all unique image references found.
 // Overrides are applied to substitute tag variants (e.g., distroless-libc → debian).
 func ExtractChartImages(chart config.ChartSpec, overrides map[string]config.Override) ([]string, error) {
+	return ExtractChartImagesWithValues(chart, overrides, nil)
+}
+
+// ExtractChartImagesWithValues runs helm template for a chart using optional
+// scalar value overrides and returns all unique image references found.
+// Overrides are applied to substitute tag variants (e.g., distroless-libc → debian).
+func ExtractChartImagesWithValues(chart config.ChartSpec, overrides map[string]config.Override, chartValues map[string]any) ([]string, error) {
 	if err := ValidateChartSpec(chart); err != nil {
 		return nil, err
 	}
 
-	args := helmTemplateArgs(chart)
+	args, err := helmTemplateArgs(chart, chartValues)
+	if err != nil {
+		return nil, fmt.Errorf("build helm template args for %s: %w", chart.Name, err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "helm", args...)
@@ -60,20 +72,77 @@ func ExtractChartImages(chart config.ChartSpec, overrides map[string]config.Over
 }
 
 // helmTemplateArgs builds the helm template argument list for a chart spec.
-func helmTemplateArgs(chart config.ChartSpec) []string {
+
+func helmTemplateArgs(chart config.ChartSpec, chartValues map[string]any) ([]string, error) {
+	var args []string
 	if strings.HasPrefix(chart.Repository, "oci://") {
 		// OCI registry: helm template <name> <oci-repo>/<name> --version <ver>
-		return []string{
+		args = []string{
 			"template", chart.Name,
 			chart.Repository + "/" + chart.Name,
 			"--version", chart.Version,
 		}
+	} else {
+		// HTTP repository: helm template <name> <name> --repo <url> --version <ver>
+		args = []string{
+			"template", chart.Name, chart.Name,
+			"--repo", chart.Repository,
+			"--version", chart.Version,
+		}
 	}
-	// HTTP repository: helm template <name> <name> --repo <url> --version <ver>
-	return []string{
-		"template", chart.Name, chart.Name,
-		"--repo", chart.Repository,
-		"--version", chart.Version,
+
+	setArgs, err := helmSetArgs(chartValues)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, setArgs...)
+	return args, nil
+}
+
+func helmSetArgs(chartValues map[string]any) ([]string, error) {
+	if len(chartValues) == 0 {
+		return nil, nil
+	}
+
+	keys := make([]string, 0, len(chartValues))
+	for key := range chartValues {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	args := make([]string, 0, len(keys)*2)
+	for _, key := range keys {
+		flag, encoded, err := helmSetPair(key, chartValues[key])
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, flag, key+"="+encoded)
+	}
+	return args, nil
+}
+
+func helmSetPair(path string, value any) (flag, encoded string, err error) {
+	switch v := value.(type) {
+	case string:
+		return "--set-string", v, nil
+	case bool:
+		return "--set", strconv.FormatBool(v), nil
+	case int:
+		return "--set", strconv.Itoa(v), nil
+	case int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return "--set", fmt.Sprintf("%v", v), nil
+	case float32:
+		return "--set", strconv.FormatFloat(float64(v), 'f', -1, 32), nil
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return "", "", fmt.Errorf("chart value %q: unsupported float %v", path, v)
+		}
+		return "--set", strconv.FormatFloat(v, 'f', -1, 64), nil
+	case nil:
+		return "", "", fmt.Errorf("chart value %q: nil is unsupported", path)
+	default:
+		return "", "", fmt.Errorf("chart value %q: unsupported type %T (use scalar string/bool/number)", path, value)
 	}
 }
 

--- a/internal/discovery/charts_test.go
+++ b/internal/discovery/charts_test.go
@@ -2,8 +2,10 @@ package discovery
 
 import (
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/verity-org/verity/internal/config"
@@ -415,4 +417,136 @@ data:
 			}
 		}
 	})
+}
+
+func TestHelmSetArgs(t *testing.T) {
+	cases := []struct {
+		name        string
+		chartValues map[string]any
+		want        []string
+		wantErr     error
+	}{
+		{
+			name:        "nil values yields nil args",
+			chartValues: nil,
+			want:        nil,
+		},
+		{
+			name: "string scalar uses --set-string with no escaping",
+			chartValues: map[string]any{
+				"name": "verity",
+			},
+			want: []string{"--set-string", "name=verity"},
+		},
+		{
+			name: "string scalar escapes commas, equals, and backslashes",
+			chartValues: map[string]any{
+				"name": `a,b=c\d`,
+			},
+			want: []string{"--set-string", `name=a\,b\=c\\d`},
+		},
+		{
+			name: "bool scalar uses --set",
+			chartValues: map[string]any{
+				"enabled": false,
+			},
+			want: []string{"--set", "enabled=false"},
+		},
+		{
+			name: "int scalar uses --set",
+			chartValues: map[string]any{
+				"replicas": 3,
+			},
+			want: []string{"--set", "replicas=3"},
+		},
+		{
+			name: "int64 scalar uses --set",
+			chartValues: map[string]any{
+				"replicas": int64(7),
+			},
+			want: []string{"--set", "replicas=7"},
+		},
+		{
+			name: "float64 scalar uses --set",
+			chartValues: map[string]any{
+				"resources.cpu": 1.5,
+			},
+			want: []string{"--set", "resources.cpu=1.5"},
+		},
+		{
+			name: "float64 NaN rejected",
+			chartValues: map[string]any{
+				"x": math.NaN(),
+			},
+			wantErr: ErrChartValueUnsupportedFloat,
+		},
+		{
+			name: "float64 +Inf rejected",
+			chartValues: map[string]any{
+				"x": math.Inf(1),
+			},
+			wantErr: ErrChartValueUnsupportedFloat,
+		},
+		{
+			name: "float32 NaN rejected (cubic review parity with float64)",
+			chartValues: map[string]any{
+				"x": float32(math.NaN()),
+			},
+			wantErr: ErrChartValueUnsupportedFloat,
+		},
+		{
+			name: "float32 -Inf rejected",
+			chartValues: map[string]any{
+				"x": float32(math.Inf(-1)),
+			},
+			wantErr: ErrChartValueUnsupportedFloat,
+		},
+		{
+			name: "nil value rejected",
+			chartValues: map[string]any{
+				"x": nil,
+			},
+			wantErr: ErrChartValueNil,
+		},
+		{
+			name: "map value rejected",
+			chartValues: map[string]any{
+				"x": map[string]any{"y": 1},
+			},
+			wantErr: ErrChartValueUnsupportedType,
+		},
+		{
+			name: "deterministic key ordering",
+			chartValues: map[string]any{
+				"b": "two",
+				"a": "one",
+				"c": "three",
+			},
+			want: []string{
+				"--set-string", "a=one",
+				"--set-string", "b=two",
+				"--set-string", "c=three",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := helmSetArgs(tc.chartValues)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("helmSetArgs() error = nil, want %v", tc.wantErr)
+				}
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("helmSetArgs() error = %v, want chain to include %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("helmSetArgs() unexpected error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("helmSetArgs() = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }

--- a/internal/discovery/charts_test.go
+++ b/internal/discovery/charts_test.go
@@ -93,7 +93,10 @@ func TestHelmTemplateArgs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := helmTemplateArgs(tc.chart)
+			got, err := helmTemplateArgs(tc.chart, nil)
+			if err != nil {
+				t.Fatalf("helmTemplateArgs() error = %v", err)
+			}
 			if len(got) != len(tc.want) {
 				t.Fatalf("helmTemplateArgs() = %v, want %v", got, tc.want)
 			}

--- a/internal/discovery/discover.go
+++ b/internal/discovery/discover.go
@@ -42,6 +42,21 @@ type DiscoveredImage struct {
 // unpatchable is checked first; an image listed in both sets is skipped
 // with the unpatchable log line.
 func Discover(cfg *config.CopaConfig, targetRegistry string, overrides map[string]config.Override, excludeNames, unpatchable map[string]struct{}) ([]DiscoveredImage, error) {
+	return DiscoverWithChartValues(cfg, targetRegistry, overrides, nil, excludeNames, unpatchable)
+}
+
+// DiscoverWithChartValues is Discover with per-chart Helm values applied
+// during chart-image extraction. chartValues maps chart names to their
+// scalar value overrides (matching VerityConfig.ChartValues). Same logging
+// + skip-attribution semantics as Discover; pass nil for chartValues to
+// preserve original behavior.
+func DiscoverWithChartValues(
+	cfg *config.CopaConfig,
+	targetRegistry string,
+	overrides map[string]config.Override,
+	chartValues map[string]map[string]any,
+	excludeNames, unpatchable map[string]struct{},
+) ([]DiscoveredImage, error) {
 	registry := targetRegistry
 	if registry == "" {
 		registry = cfg.Target.Registry
@@ -70,7 +85,7 @@ func Discover(cfg *config.CopaConfig, targetRegistry string, overrides map[strin
 	}
 
 	for _, chartSpec := range cfg.Charts {
-		imgs, err := discoverChartImages(chartSpec, overrides, registry)
+		imgs, err := discoverChartImages(chartSpec, overrides, chartValues[chartSpec.Name], registry)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to discover images from chart %q: %v\n", chartSpec.Name, err)
 			continue
@@ -235,8 +250,8 @@ func discoverStandaloneImage(spec *config.ImageSpec, registry string) ([]Discove
 	return result, nil
 }
 
-func discoverChartImages(chart config.ChartSpec, overrides map[string]config.Override, registry string) ([]DiscoveredImage, error) {
-	images, err := ExtractChartImages(chart, overrides)
+func discoverChartImages(chart config.ChartSpec, overrides map[string]config.Override, chartValues map[string]any, registry string) ([]DiscoveredImage, error) {
+	images, err := ExtractChartImagesWithValues(chart, overrides, chartValues)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -411,6 +411,37 @@ chartImageOverrides:
 	}
 }
 
+func TestLoadVerityConfig_ChartValues(t *testing.T) {
+	yaml := `
+chartValues:
+  loki:
+    loki.useTestSchema: true
+    gateway.enabled: false
+    loki.storage.bucketNames.chunks: chunks
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "verity.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vc, err := LoadVerityConfig(path)
+	if err != nil {
+		t.Fatalf("LoadVerityConfig() error = %v", err)
+	}
+
+	values := vc.ChartValues["loki"]
+	if got, ok := values["loki.useTestSchema"].(bool); !ok || !got {
+		t.Fatalf("loki.useTestSchema = %#v, want true", values["loki.useTestSchema"])
+	}
+	if got, ok := values["gateway.enabled"].(bool); !ok || got {
+		t.Fatalf("gateway.enabled = %#v, want false", values["gateway.enabled"])
+	}
+	if got, ok := values["loki.storage.bucketNames.chunks"].(string); !ok || got != "chunks" {
+		t.Fatalf("loki.storage.bucketNames.chunks = %#v, want chunks", values["loki.storage.bucketNames.chunks"])
+	}
+}
+
 func TestLoadVerityConfig_Missing(t *testing.T) {
 	vc, err := LoadVerityConfig("/nonexistent/verity.yaml")
 	if err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -48,8 +48,10 @@ type Config struct {
 var ErrChartsFileMissing = errors.New("charts file does not exist")
 
 // ChartImagesFunc renders a chart and returns the image references it
-// emits. Production code passes discovery.ExtractChartImages; tests pass a
-// stub so CheckOrphanReplacements can be exercised without helm + network.
+// emits. Production code wraps discovery.ExtractChartImagesWithValues so
+// per-chart verity.yaml chartValues are applied during render (matching
+// what verity discover and chart-gen see); tests pass a stub so
+// CheckOrphanReplacements can be exercised without helm + network.
 type ChartImagesFunc func(chart config.ChartSpec, overrides map[string]config.Override) ([]string, error)
 
 // Run executes all checks and returns the aggregated findings sorted by
@@ -110,9 +112,10 @@ func Run(cfg Config) ([]Issue, error) {
 // upgraded or the image moved and the entry was never cleaned up.
 //
 // The chartImages parameter abstracts the helm-shelling step so production
-// code passes discovery.ExtractChartImages while tests pass a stub. This
-// lets the same function be exercised by fast unit tests without requiring
-// helm + network.
+// code wraps discovery.ExtractChartImagesWithValues (with verity.yaml's
+// per-chart chartValues applied) while tests pass a stub. This lets the
+// same function be exercised by fast unit tests without requiring helm +
+// network.
 //
 // Match semantics intentionally mirror chartgen.applyReplacements (Contains
 // after RepoPath) so this check reasons about images the same way the

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -78,7 +78,10 @@ func Run(cfg Config) ([]Issue, error) {
 		return nil, fmt.Errorf("load verity config %s: %w", cfg.VerityConfig, err)
 	}
 
-	orphans, err := CheckOrphanReplacements(charts, vc, cfg.VerityConfig, cfg.ChartsFile, discovery.ExtractChartImages)
+	chartImages := func(chart config.ChartSpec, overrides map[string]config.Override) ([]string, error) {
+		return discovery.ExtractChartImagesWithValues(chart, overrides, vc.ChartValues[chart.Name])
+	}
+	orphans, err := CheckOrphanReplacements(charts, vc, cfg.VerityConfig, cfg.ChartsFile, chartImages)
 	if err != nil {
 		return nil, fmt.Errorf("orphan-replacements check: %w", err)
 	}

--- a/verity.yaml
+++ b/verity.yaml
@@ -12,6 +12,41 @@ overrides:
     to: "debian"
     valuePath: "image"  # explicit hint for chart-gen value path resolution
 
+# Per-chart values injected both during helm template image discovery and into
+# generated wrapper-chart values.yaml defaults.
+chartValues:
+  # grafana chart 10.5.15 otherwise renders a bats test pod. Disable it so the
+  # wrapper only needs to route the primary Grafana workload image.
+  grafana:
+    testFramework.enabled: false
+
+  # loki 7.0.0 requires explicit test schema + bucket names to render, and its
+  # default gateway/caches add unpatchable auxiliary images. Keep a minimal
+  # runtime: Loki + already-Copa-backed kiwigrid sidecar.
+  loki:
+    loki.storage.bucketNames.admin: admin
+    loki.storage.bucketNames.chunks: chunks
+    loki.storage.bucketNames.ruler: ruler
+    loki.useTestSchema: true
+    test.enabled: false
+    lokiCanary.enabled: false
+    gateway.enabled: false
+    chunksCache.enabled: false
+    resultsCache.enabled: false
+
+  # mimir-distributed 6.0.6 can render as a single-image runtime if we turn off
+  # optional bundled infra components (MinIO, Kafka, nginx gateway, rollout-operator).
+  mimir-distributed:
+    gateway.enabled: false
+    kafka.enabled: false
+    minio.enabled: false
+    rollout_operator.enabled: false
+
+  # tempo-distributed 1.61.3 defaults to a separate Memcached statefulset; the
+  # minimal CI-friendly wrapper just runs the Tempo microservices themselves.
+  tempo-distributed:
+    memcached.enabled: false
+
 # Image replacements for chart-gen.
 # Maps upstream image path patterns to Verity Integer (Wolfi) images.
 # When chart-gen discovers a chart image matching the key, it generates
@@ -21,9 +56,36 @@ replacements:
   "kube-state-metrics/kube-state-metrics":
     registry: "ghcr.io/verity-org"
     image: "kube-state-metrics"
+    tag: "2.18.0"
   "prometheus/pushgateway":
     registry: "ghcr.io/verity-org"
     image: "pushgateway"
+
+  # Observability wave 2.
+  "prometheus/alertmanager":
+    registry: "ghcr.io/verity-org"
+    image: "alertmanager"
+    tag: "0"
+  "prometheus/prometheus":
+    registry: "ghcr.io/verity-org"
+    image: "prometheus"
+    tag: "3.11.2"
+  "grafana/grafana":
+    registry: "ghcr.io/verity-org"
+    image: "grafana"
+    tag: "12.3"
+  "grafana/loki":
+    registry: "ghcr.io/verity-org"
+    image: "loki"
+    tag: "3.6"
+  "grafana/mimir":
+    registry: "ghcr.io/verity-org"
+    image: "mimir"
+    tag: "3.0"
+  "grafana/tempo":
+    registry: "ghcr.io/verity-org"
+    image: "tempo"
+    tag: "2"
 
   # kyverno chart (3.7.2). Chart renders images under
   # `reg.kyverno.io/kyverno/*` (Kyverno's pull-through mirror); repoPath

--- a/verity.yaml
+++ b/verity.yaml
@@ -61,15 +61,11 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "pushgateway"
 
-  # Observability wave 2.
-  "prometheus/alertmanager":
-    registry: "ghcr.io/verity-org"
-    image: "alertmanager"
-    tag: "0"
-  "prometheus/prometheus":
-    registry: "ghcr.io/verity-org"
-    image: "prometheus"
-    tag: "3.11.2"
+  # Observability wave 2. The prometheus chart was dropped from this PR
+  # (kube-prometheus-stack rendered images for jkroepke/kube-webhook-certgen
+  # and prometheus-operator/prometheus-operator without Verity coverage), so
+  # we add no replacements for prometheus/prometheus or prometheus/alertmanager
+  # here — the existing prometheus chart's wrapper falls through to crane.
   "grafana/grafana":
     registry: "ghcr.io/verity-org"
     image: "grafana"


### PR DESCRIPTION
## Summary
- add grafana, loki, mimir-distributed, and tempo-distributed to `Chart.yaml` with pinned versions plus the replacement/chartValues wiring they need in `verity.yaml`
- teach discovery, chart-gen, and doctor to honor per-chart scalar Helm values so charts that need minimal render-time overrides can still generate clean wrapper defaults
- leave `kube-prometheus-stack` out of this wave because its current render still depends on unresolved `prometheus-operator` and `jkroepke/kube-webhook-certgen` replacement gaps

## Verification
- `gofumpt -d .`
- `go build ./...`
- `go test ./...`
- `./verity doctor --charts-file Chart.yaml --verity-config verity.yaml`
- prior strict dry-run artifact: `./verity chart-gen --strict --dry-run --charts-file Chart.yaml --verity-config verity.yaml --target-registry ghcr.io/verity-org --chart-registry oci://ghcr.io/verity-org/charts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Grafana observability charts and per‑chart scalar Helm values applied across discover, chart-gen, and doctor with safe `--set/--set-string` encoding and stricter validation. Excludes `kube-prometheus-stack` until replacements for `prometheus-operator` and `jkroepke/kube-webhook-certgen` are in place.

- **New Features**
  - Added charts with pinned versions: `grafana@10.5.15`, `loki@7.0.0`, `mimir-distributed@6.0.6`, `tempo-distributed@1.61.3`.
  - Introduced `chartValues` in `verity.yaml`; used during `helm template` and merged into wrapper defaults before image overrides, disabling tests/gateways/caches and optional components.
  - `verity discover` and doctor now apply `chartValues` during chart-image extraction via `DiscoverWithChartValues`; builds deterministic `--set/--set-string` args, escapes strvals separators, and rejects unsupported scalars (NaN/Inf/nil) and non-scalar types.
  - Updated `replacements` with pinned tags for `grafana`, `loki`, `mimir`, and `tempo`; dropped speculative pins for `prometheus` and `alertmanager`.

<sup>Written for commit 1784697873da4951bc043c48903d64ca15c54e58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

