### PR TITLE
feat(charts): add Jenkins and Argo Rollouts wave-3 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -46,7 +46,7 @@ dependencies:
 
   - name: rabbitmq-cluster-operator
     version: "0.2.3"
-    repository: "oci://registry-1.docker.io/cloudpirates"
+    repository: "oci://ghcr.io/cloudpirates-io/helm-charts"
 
   - name: cert-manager
     version: "1.20.2"
@@ -66,11 +66,11 @@ dependencies:
 
   - name: valkey
     version: "0.20.0"
-    repository: "oci://registry-1.docker.io/cloudpirates"
+    repository: "oci://ghcr.io/cloudpirates-io/helm-charts"
 
   - name: etcd
     version: "0.7.0"
-    repository: "oci://registry-1.docker.io/cloudpirates"
+    repository: "oci://ghcr.io/cloudpirates-io/helm-charts"
 
   - name: velero
     version: "12.0.0"
@@ -98,3 +98,11 @@ dependencies:
   - name: tempo-distributed
     version: "1.61.3"
     repository: "https://grafana.github.io/helm-charts"
+
+  - name: argo-rollouts
+    version: "2.40.9"
+    repository: "https://argoproj.github.io/argo-helm"
+
+  - name: jenkins
+    version: "5.9.18"
+    repository: "https://charts.jenkins.io"

--- a/verity.yaml
+++ b/verity.yaml
@@ -47,6 +47,13 @@ chartValues:
   tempo-distributed:
     memcached.enabled: false
 
+  # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
+  # default inbound agent image. Keep the wrapper focused on the controller and
+  # the existing kiwigrid sidecar image.
+  jenkins:
+    controller.testEnabled: false
+    agent.enabled: false
+
 # Image replacements for chart-gen.
 # Maps upstream image path patterns to Verity Integer (Wolfi) images.
 # When chart-gen discovers a chart image matching the key, it generates
@@ -115,6 +122,10 @@ replacements:
   "argoproj/argocd":
     registry: "ghcr.io/verity-org"
     image: "argocd"
+  "argoproj/argo-rollouts":
+    registry: "ghcr.io/verity-org"
+    image: "argo-rollouts"
+    tag: "1"
   "dexidp/dex":
     registry: "ghcr.io/verity-org"
     image: "dex"
@@ -189,6 +200,12 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "minio-operator"
     tag: "7.1.1"
+
+  # jenkins 5.9.18.
+  "jenkins/jenkins":
+    registry: "ghcr.io/verity-org"
+    image: "jenkins"
+    tag: "2.555.1"
 
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this


### PR DESCRIPTION
## Summary
- add `chartValues` support to chart discovery/wrapper generation so Chart.yaml deps can carry required render-time `--set` values
- add `argo-rollouts` and `jenkins` wrapper-chart dependencies plus Integer replacements, and switch existing CloudPirates OCI deps to GHCR to avoid Docker Hub rate limits in local verification
- drop `argo-workflows`, `flux2`, and `tekton-pipeline` from this wave after pull/template verification because the current Verity image inventory cannot map them cleanly without substantial new image work

## Chart decisions
- **argo-rollouts 2.40.9**: kept; default render is clean; mapped `quay.io/argoproj/argo-rollouts:v1.9.0` to `ghcr.io/verity-org/argo-rollouts:1.9.0`
- **jenkins 5.9.18**: kept with `chartValues` (`controller.testEnabled=false`, `agent.enabled=false`) to drop the unpatched Helm test `bats/bats` image and default `jenkins/inbound-agent`; mapped controller to `ghcr.io/verity-org/jenkins:2.555.1` and reuse existing patched `kiwigrid/k8s-sidecar:2.6.0`
- **argo-workflows 1.0.13**: dropped; even after pruning the CRD kubectl job, chart still needs `workflow-controller:v4.0.5` and current Verity inventory only exposes `argo-workflow-controller` tags in the 3.7 line
- **flux2 2.18.3**: dropped; default render emits 7 Flux controller images and current Verity inventory in this branch does not contain matching rebuild/replacement wiring for those controller repos
- **tekton-pipeline 1.9.2 (cdfoundation repo)**: dropped; repo templates four digest-pinned Tekton pipeline component images and current Verity inventory lacks corresponding published replacements

## Verification
- `go build ./...`
- `go test ./...`
- `gofumpt -d .`
- `mise x golangci-lint@2 -- golangci-lint run --timeout=5m ./...`
- `./verity doctor` → `verity doctor: all checks passed.`
- `PATH=$PATH:/tmp/verity-wave3/bin ./verity chart-gen --strict --dry-run ...` → `20 charts in Chart.yaml, would produce 20 wrappers, 0 skipped`

## Notes
- main on current `origin/main` had 18 chart dependencies before this branch; after this PR it produces 20 wrappers locally, not 27

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `chartValues` support to Helm wrapper generation and introduces wave‑3 wrappers for `argo-rollouts` and `jenkins`. Also moves CloudPirates charts to `ghcr.io` and adds image replacements to keep local verification green.

- **New Features**
  - Parse `ChartSpec.ChartValues` from `Chart.yaml` and merge into wrapper `values.yaml`.
  - Pass a temp values file to `helm template` when `chartValues` exist.
  - Preserve user values by deep‑cloning maps/slices before merging overrides.
  - Tests cover `chartValues` merging and `helm template` arg construction.

- **Dependencies**
  - Add `argo-rollouts@2.40.9` and `jenkins@5.9.18`; for `jenkins`, set `controller.testEnabled=false` and `agent.enabled=false`.
  - Move CloudPirates charts to `oci://ghcr.io/cloudpirates-io/helm-charts`.
  - Image replacements: `argoproj/argo-rollouts -> ghcr.io/verity-org/argo-rollouts:1`, `jenkins/jenkins -> ghcr.io/verity-org/jenkins:2.555.1`.
  - Defer `argo-workflows`, `flux2`, and `tekton-pipeline` due to missing image inventory.

<sup>Written for commit 6db254b861ec4f7d2c8a0db67ccea22fab748b8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

