### PR TITLE
feat(charts): add traefik and grafana alloy wave-4 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -106,3 +106,11 @@ dependencies:
   - name: jenkins
     version: "5.9.18"
     repository: "https://charts.jenkins.io"
+
+  - name: traefik
+    version: "39.0.8"
+    repository: "https://traefik.github.io/charts"
+
+  - name: alloy
+    version: "1.8.0"
+    repository: "https://grafana.github.io/helm-charts"

--- a/verity.yaml
+++ b/verity.yaml
@@ -207,6 +207,19 @@ replacements:
     image: "jenkins"
     tag: "2.555.1"
 
+  # Wave 4 charts (mesh + observability).
+  # traefik 39.0.8 → traefik 3.6.x; rebuild publishes major.minor tag.
+  # Image is `docker.io/traefik` (root-level, no namespace).
+  "traefik":
+    registry: "ghcr.io/verity-org"
+    image: "traefik"
+    tag: "3.6"
+  # grafana/alloy 1.8.0 → alloy v1.16.x; prometheus-config-reloader falls through.
+  "grafana/alloy":
+    registry: "ghcr.io/verity-org"
+    image: "grafana-alloy"
+    tag: "1"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement


### PR DESCRIPTION
## Summary

Adds 2 well-covered charts to the wrapper-chart pipeline:

- **traefik 39.0.8** → routes `docker.io/traefik` to `images/traefik.yaml` Wolfi rebuild (`3.6` major.minor track)
- **grafana/alloy 1.8.0** → routes `docker.io/grafana/alloy` to `images/grafana-alloy.yaml` Wolfi rebuild (`1` major track); `prometheus-config-reloader` falls through to crane

## Scope decision

Initially scoped wave-4 to databases (cnpg, mariadb, mongo, harbor, dragonfly, clickhouse) per the original chart-mirror-expansion plan, but rebuild coverage is poor:

- **cnpg/cloudnative-pg** — no \`images/cloudnative-pg.yaml\` rebuild for the operator binary
- **mariadb-operator** — only data-plane mariadb rebuild exists; the operator binary itself has no rebuild
- **harbor** — 8 chart images (core, db, jobservice, portal, registryctl, redis-photon, registry-photon, trivy-adapter), 0 with rebuilds
- **mongodb (bitnami)** — Bitnami chart licensing concerns + only renders test pod image at default values
- **dragonfly-operator** — chart not officially published
- **altinity-clickhouse-operator** — operator + metrics-exporter + bitnami/kubectl, no matching rebuilds

Pivoted to clean single-image charts where the existing Integer rebuilds match the chart's primary image.

**vault** and **falco** were also evaluated but dropped — their charts emit auxiliary binaries (\`vault-k8s\`, \`falcoctl\`, \`falco-driver-loader\`) that get substring-matched to the main rebuild via chart-gen's \`strings.Contains\` matching, which would route to an image that does not contain those binaries. Will revisit when separate rebuilds exist or when the matching logic supports per-image opt-out.

## Verification

- \`verity doctor\`: all checks passed (no orphan replacements, no duplicate keys)
- \`chart-gen --strict --dry-run\`: 26 charts in Chart.yaml, would produce 26 wrappers, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds wrapper charts for `traefik` and `grafana/alloy` to the wave-4 mesh/observability set. Routes upstream images to Verity Wolfi rebuilds for consistent, tracked tags.

- **New Features**
  - Added Helm deps: `traefik` 39.0.8 (https://traefik.github.io/charts) and `alloy` 1.8.0 (https://grafana.github.io/helm-charts).
  - Added image replacements in `verity.yaml`: `docker.io/traefik` → `ghcr.io/verity-org/traefik:3.6`, `docker.io/grafana/alloy` → `ghcr.io/verity-org/grafana-alloy:1`; `prometheus-config-reloader` stays upstream.

<sup>Written for commit ab6c92321f2adc0b64008e27b946dc74c6a72b17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

