### PR TITLE
feat(charts): add openbao and airflow wave-5 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -114,3 +114,11 @@ dependencies:
   - name: alloy
     version: "1.8.0"
     repository: "https://grafana.github.io/helm-charts"
+
+  - name: openbao
+    version: "0.27.2"
+    repository: "https://openbao.github.io/openbao-helm"
+
+  - name: airflow
+    version: "1.21.0"
+    repository: "https://airflow.apache.org"

--- a/verity.yaml
+++ b/verity.yaml
@@ -220,6 +220,20 @@ replacements:
     image: "grafana-alloy"
     tag: "1"
 
+  # Wave 5 charts (secrets, AI/ML).
+  # openbao 0.27.2 → openbao v2.5.x; chart's hashicorp/vault-k8s injector
+  # falls through to crane (no rebuild for vault-k8s).
+  "openbao/openbao":
+    registry: "ghcr.io/verity-org"
+    image: "openbao"
+    tag: "2"
+  # apache-airflow 1.21.0 → airflow v3.2.x; bitnamilegacy/postgresql,
+  # statsd-exporter, and root-level redis fall through to crane.
+  "apache/airflow":
+    registry: "ghcr.io/verity-org"
+    image: "airflow"
+    tag: "3"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement


### PR DESCRIPTION
## Summary

Adds 2 well-covered charts to the wrapper-chart pipeline:

- **openbao 0.27.2** → \`quay.io/openbao/openbao:2.5.3\` routed to \`images/openbao.yaml\` Wolfi rebuild (\`2\` major track). The chart's \`hashicorp/vault-k8s\` injector falls through to crane (no rebuild for vault-k8s).
- **apache-airflow 1.21.0** → \`apache/airflow:3.2.0\` routed to \`images/airflow.yaml\` Wolfi rebuild (\`3\` major track). Auxiliary images (\`bitnamilegacy/postgresql\`, \`statsd-exporter\`, root-level \`redis\`) fall through to crane.

## Scope decision

Wave 5 was originally scoped to mesh+ingress (traefik, linkerd, kong, contour, aws-lb-controller). Findings:

- **traefik** — already shipped in #283 (Wave 4)
- **linkerd-control-plane** — chart's controller/proxy/policy-controller images (\`cr.l5d.io/linkerd/*\`) don't map to \`images/linkerd.yaml\` (which is the \`linkerd2-cli\` Wolfi rebuild — a different binary)
- **kong** — no Integer rebuild
- **contour (bitnami)** — \`images/contour.yaml\` is at v1.33.4 but chart deploys v1.32.1; \`images/envoy.yaml\` is at v1.37 but chart deploys v1.34.5. Forcing newer-than-chart versions is risky.
- **aws-load-balancer-controller** — \`images/aws-load-balancer-controller.yaml\` is pinned to major v2 but the chart deploys v3.2.2

Pivoted to candidates from later waves where the rebuild track and chart appVersion align cleanly. \`openbao\` and \`apache/airflow\` both meet the criteria.

Other candidates evaluated and dropped:
- **nats** — chart's root-level \`nats:2.12.6\` would substring-match a \`nats\` replacement key, but \`natsio/nats-box\` and \`natsio/nats-server-config-reloader\` (separate binaries) would also match → wrong substitution
- **jaeger** — \`images/jaeger.yaml\` is for \`jaeger-all-in-one\` (v1 architecture); chart deploys jaeger v2 with different binaries
- **mlflow** — \`images/mlflow.yaml\` at v2 but chart's \`burakince/mlflow:3.7.0\` at v3
- **opentelemetry-collector** — chart has empty default \`image.repository\`, requires \`chartValues:\` to render

## Verification

- \`verity doctor\`: all checks passed (no orphan replacements, no duplicate keys)
- \`chart-gen --strict --dry-run\`: 28 charts in Chart.yaml, would produce 28 wrappers, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds wave‑5 wrappers for `openbao` and `airflow`, mapping their main images to `ghcr.io/verity-org` Wolfi rebuilds while non‑rebuilt sidecars fall back to crane. Updates `Chart.yaml` and `verity.yaml` to wire the new charts and replacements.

- New Features
  - `openbao` 0.27.2 (app v2.5.x): route `quay.io/openbao/openbao` → `ghcr.io/verity-org/openbao:2`; `hashicorp/vault-k8s` injector falls through to crane.
  - `airflow` 1.21.0 (app v3.2.x): route `apache/airflow` → `ghcr.io/verity-org/airflow:3`; `bitnamilegacy/postgresql`, `statsd-exporter`, and root-level `redis` fall through to crane.

<sup>Written for commit 0fe1b85459f62a9e116a1a8114549d699cf6aa1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

