### PR TITLE
feat(charts): add gitea and crossplane wave-6 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -122,3 +122,11 @@ dependencies:
   - name: airflow
     version: "1.21.0"
     repository: "https://airflow.apache.org"
+
+  - name: gitea
+    version: "12.5.3"
+    repository: "https://dl.gitea.com/charts/"
+
+  - name: crossplane
+    version: "2.2.1"
+    repository: "https://charts.crossplane.io/stable"

--- a/verity.yaml
+++ b/verity.yaml
@@ -234,6 +234,19 @@ replacements:
     image: "airflow"
     tag: "3"
 
+  # Wave 6 charts (developer tooling).
+  # gitea 12.5.3 → gitea v1.25.x; chart's busybox helper falls through (excluded).
+  # Image is `docker.gitea.com/gitea` (root-level path under custom registry).
+  "gitea":
+    registry: "ghcr.io/verity-org"
+    image: "gitea"
+    tag: "1"
+  # crossplane 2.2.1 → crossplane v2.2.x; single image.
+  "crossplane/crossplane":
+    registry: "ghcr.io/verity-org"
+    image: "crossplane"
+    tag: "2"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement


### PR DESCRIPTION
## Summary

Adds 2 well-covered charts to the wrapper-chart pipeline:

- **gitea 12.5.3** → \`docker.gitea.com/gitea:1.25.5-rootless\` routed to \`images/gitea.yaml\` Wolfi rebuild (\`1\` major track). Chart's \`busybox\` helper falls through (excluded).
- **crossplane 2.2.1** → \`xpkg.crossplane.io/crossplane/crossplane:v2.2.1\` routed to \`images/crossplane.yaml\` Wolfi rebuild (\`2\` major track). Single image chart.

## Other candidates evaluated

- **temporal 1.1.1** — chart requires database driver config to render templates; would need \`chartValues:\` schema setup
- **karpenter 1.12.0** — \`images/karpenter.yaml\` rebuild publishes only \`1.11\` and \`1.11.1\` tags; chart deploys \`v1.12.0\`
- **keycloak 25.2.0** — Bitnami chart (license concerns)

## Verification

- \`verity doctor\`: all checks passed
- \`chart-gen --strict --dry-run\`: 30 charts in Chart.yaml, would produce 30 wrappers, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds wave-6 wrappers for `gitea` 12.5.3 and `crossplane` 2.2.1 to expand the wrapper-chart pipeline. Images are remapped to Wolfi rebuilds in `ghcr.io/verity-org` with major tag tracks.

- **New Features**
  - Add `gitea` chart `12.5.3`; map `docker.gitea.com/gitea:1.25.x` to `ghcr.io/verity-org/gitea:1`; exclude the chart `busybox` helper.
  - Add `crossplane` chart `2.2.1`; map `xpkg.crossplane.io/crossplane/crossplane:v2.2.1` to `ghcr.io/verity-org/crossplane:2`; single-image chart.

<sup>Written for commit 855a4ef15930c7070b8e24bf5c1db8c03d358d8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

