### PR TITLE
feat(charts): add meilisearch, weaviate, atlantis wave-8 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -146,3 +146,15 @@ dependencies:
   - name: victoria-metrics-single
     version: "0.35.0"
     repository: "https://victoriametrics.github.io/helm-charts/"
+
+  - name: meilisearch
+    version: "0.32.0"
+    repository: "https://meilisearch.github.io/meilisearch-kubernetes"
+
+  - name: weaviate
+    version: "17.8.0"
+    repository: "https://weaviate.github.io/weaviate-helm"
+
+  - name: atlantis
+    version: "6.3.0"
+    repository: "https://runatlantis.github.io/helm-charts"

--- a/verity.yaml
+++ b/verity.yaml
@@ -270,6 +270,23 @@ replacements:
     image: "victoriametrics"
     tag: "1"
 
+  # Wave 8 charts (search, AI, automation).
+  # meilisearch 0.32.0 → meilisearch v1.42.x; chart's busybox helper falls through.
+  "getmeili/meilisearch":
+    registry: "ghcr.io/verity-org"
+    image: "meilisearch"
+    tag: "1"
+  # weaviate 17.8.0 → weaviate v1.37.x; chart's alpine test image falls through.
+  "semitechnologies/weaviate":
+    registry: "ghcr.io/verity-org"
+    image: "weaviate"
+    tag: "1"
+  # atlantis 6.3.0 → atlantis v0.42.x; chart's bats helm-test image falls through.
+  "runatlantis/atlantis":
+    registry: "ghcr.io/verity-org"
+    image: "atlantis"
+    tag: "0"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement


### PR DESCRIPTION
## Summary

Adds 3 single-image charts to the wrapper-chart pipeline (search, AI, automation):

- **meilisearch 0.32.0** → \`getmeili/meilisearch:v1.42.1\` routed to \`images/meilisearch.yaml\` Wolfi rebuild (\`1\` major track). Chart's \`busybox\` helper falls through to crane.
- **weaviate 17.8.0** → \`cr.weaviate.io/semitechnologies/weaviate:1.37.0\` routed to \`images/weaviate.yaml\` Wolfi rebuild (\`1\` major track). Chart's \`alpine:latest\` test image falls through.
- **atlantis 6.3.0** → \`ghcr.io/runatlantis/atlantis:v0.42.0\` routed to \`images/atlantis.yaml\` Wolfi rebuild (\`0\` major track). Chart's \`bats:1.9.0\` helm-test image falls through.

## Other candidate evaluated

- **teleport-cluster 18.7.5** — \`images/teleport.yaml\` is pinned to v18.6 and the rebuild's \`18\` tag tracks 18.6.x; chart deploys 18.7.5 (forcing a downgrade is risky)

## Verification

- \`verity doctor\`: all checks passed
- \`chart-gen --strict --dry-run\`: 37 charts in Chart.yaml, would produce 37 wrappers, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `meilisearch`, `weaviate`, and `atlantis` charts to the wrapper-chart pipeline for Wave 8 (search, AI, automation). Validation passed; chart-gen strict dry-run would produce 37 wrappers with 0 skipped.

- New Features
  - `meilisearch` 0.32.0 → `ghcr.io/verity-org/meilisearch:1` (rebuild of `getmeili/meilisearch` v1.42.x). Chart `busybox` helper falls through.
  - `weaviate` 17.8.0 → `ghcr.io/verity-org/weaviate:1` (rebuild of `semitechnologies/weaviate` v1.37.x). Chart `alpine` test image falls through.
  - `atlantis` 6.3.0 → `ghcr.io/verity-org/atlantis:0` (rebuild of `runatlantis/atlantis` v0.42.x). Chart `bats` helm-test image falls through.

<sup>Written for commit 6b42c9d66d65765e598263502435ff5525941e26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

