### PR TITLE
feat(charts): add vault, falco, nats, contour wave-9 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -170,3 +170,7 @@ dependencies:
   - name: nats
     version: "2.12.6"
     repository: "https://nats-io.github.io/k8s/helm/charts/"
+
+  - name: contour
+    version: "0.5.0"
+    repository: "https://projectcontour.github.io/helm-charts/"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -158,3 +158,15 @@ dependencies:
   - name: atlantis
     version: "6.3.0"
     repository: "https://runatlantis.github.io/helm-charts"
+
+  - name: vault
+    version: "0.32.0"
+    repository: "https://helm.releases.hashicorp.com"
+
+  - name: falco
+    version: "8.0.2"
+    repository: "https://falcosecurity.github.io/charts"
+
+  - name: nats
+    version: "2.12.6"
+    repository: "https://nats-io.github.io/k8s/helm/charts/"

--- a/verity.yaml
+++ b/verity.yaml
@@ -287,6 +287,51 @@ replacements:
     image: "atlantis"
     tag: "0"
 
+  # Wave 9 charts (auxiliary-binary self-maps for prefix-collision safety).
+  # These charts emit a primary image plus auxiliary images that share a
+  # prefix with the primary key. Without the self-map entries, chart-gen's
+  # strings.Contains matcher would route auxiliary images to the primary
+  # rebuild (which lacks the auxiliary binary). Longest-pattern-first sort
+  # guarantees the more-specific self-map wins.
+
+  # vault 0.32.0 → hashicorp/vault server binary on Wolfi rebuild.
+  # The vault-k8s auth injector is a separate binary; self-map keeps the
+  # chart's docker.io/hashicorp/vault-k8s reference unchanged.
+  "hashicorp/vault-k8s":
+    registry: "docker.io"
+    image: "hashicorp/vault-k8s"
+  "hashicorp/vault":
+    registry: "ghcr.io/verity-org"
+    image: "vault"
+    tag: "1"
+
+  # falco 8.0.2 → falco daemon (/usr/bin/falco) on Wolfi rebuild.
+  # falcoctl and falco-driver-loader are separate binaries; self-map them.
+  "falcosecurity/falcoctl":
+    registry: "docker.io"
+    image: "falcosecurity/falcoctl"
+  "falcosecurity/falco-driver-loader":
+    registry: "docker.io"
+    image: "falcosecurity/falco-driver-loader"
+  "falcosecurity/falco":
+    registry: "ghcr.io/verity-org"
+    image: "falco"
+    tag: "0"
+
+  # nats 2.12.6 → nats-server (root-level docker.io/nats path) on Wolfi
+  # rebuild. nats-box (CLI) and nats-server-config-reloader are separate
+  # binaries under the natsio/ namespace; self-map them.
+  "natsio/nats-server-config-reloader":
+    registry: "docker.io"
+    image: "natsio/nats-server-config-reloader"
+  "natsio/nats-box":
+    registry: "docker.io"
+    image: "natsio/nats-box"
+  "nats":
+    registry: "ghcr.io/verity-org"
+    image: "nats"
+    tag: "2"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement

--- a/verity.yaml
+++ b/verity.yaml
@@ -332,6 +332,19 @@ replacements:
     image: "nats"
     tag: "2"
 
+  # contour 0.5.0 (official Project Contour chart, NOT Bitnami) →
+  # ghcr.io/projectcontour/contour:v1.33.4 routed to images/contour.yaml.
+  # The chart also deploys envoyproxy/envoy:v1.35.10 → images/envoy.yaml
+  # rebuild (major.minor track 1.35).
+  "projectcontour/contour":
+    registry: "ghcr.io/verity-org"
+    image: "contour"
+    tag: "1.33.4"
+  "envoyproxy/envoy":
+    registry: "ghcr.io/verity-org"
+    image: "envoy"
+    tag: "1.35"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement


### PR DESCRIPTION
## Summary

Unblocks 4 charts previously thought blocked, using two new techniques:

### Self-map pattern (vault, falco, nats)

Chart-gen's \`applyReplacements\` uses \`strings.Contains\` with longest-pattern-first sort. Without intervention, a primary key like \`hashicorp/vault\` would substring-match \`hashicorp/vault-k8s\` (a separate auth-injector binary) and route it to the vault-server image, breaking the chart at runtime.

The fix: add a more-specific replacement that maps the auxiliary image to itself — registry: \`docker.io\`, image: \`hashicorp/vault-k8s\`, no tag override. The longest-pattern-first sort guarantees the auxiliary key is tried first and wins. The wrapper chart's values explicitly set \`docker.io/hashicorp/vault-k8s:<original-tag>\`, which is functionally identical to leaving the chart's default unchanged.

- **vault 0.32.0** → \`hashicorp/vault\` server on \`images/vault.yaml\` Wolfi rebuild (\`1\` major track). \`hashicorp/vault-k8s\` self-maps.
- **falco 8.0.2** → \`falcosecurity/falco\` daemon on \`images/falco.yaml\` Wolfi rebuild (\`0\` major track). \`falcoctl\` and \`falco-driver-loader\` self-map.
- **nats 2.12.6** → \`nats\` server (root-level docker.io/nats path) on \`images/nats.yaml\` Wolfi rebuild (\`2\` major track). \`natsio/nats-box\` and \`natsio/nats-server-config-reloader\` self-map.

### Alternative chart source (contour)

The Bitnami contour chart 21.1.4 deploys contour v1.32.1 + envoy v1.34.5, but our \`images/contour.yaml\` rebuild is at v1.33.4. Switching to the official Project Contour chart 0.5.0 deploys contour v1.33.4 + envoy v1.35.10 — both match our rebuilds.

- **contour 0.5.0** → \`projectcontour/contour:v1.33.4\` and \`envoyproxy/envoy:v1.35.10\` routed to \`images/contour.yaml\` and \`images/envoy.yaml\` Wolfi rebuilds.

## Verification

- \`verity doctor\`: all checks passed
- \`chart-gen --strict --dry-run\`: 41 charts in Chart.yaml, would produce 41 wrappers, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)