### PR TITLE
fix(orchestrator): unblock Dispatch Patches on workflow_dispatch (#256)

### DIFF
--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -241,7 +241,10 @@ jobs:
     name: Dispatch Patches
     needs: discover
     runs-on: ubuntu-24.04
-    if: needs.discover.outputs.count != '0'
+    # GHA propagates skipped state from transitive `needs:` ancestors into
+    # this job's implicit success() check; `detect` is push-only so workflow_dispatch
+    # runs need always()+!failure()+!cancelled() to escape the skip. See PR #203 (#256).
+    if: always() && !failure() && !cancelled() && needs.discover.outputs.count != '0'
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -242,8 +242,9 @@ jobs:
     needs: discover
     runs-on: ubuntu-24.04
     # GHA propagates skipped state from transitive `needs:` ancestors into
-    # this job's implicit success() check; `detect` is push-only so workflow_dispatch
-    # runs need always()+!failure()+!cancelled() to escape the skip. See PR #203 (#256).
+    # this job's implicit success() check; `detect` is push-only so schedule
+    # and workflow_dispatch runs need always()+!failure()+!cancelled() to
+    # escape the skip. See PR #203 (#256).
     if: always() && !failure() && !cancelled() && needs.discover.outputs.count != '0'
 
     steps:


### PR DESCRIPTION
## Problem

The orchestrator workflow's `Dispatch Patches` job is silently **skipped** on every `workflow_dispatch` (and `schedule`) trigger, even when `Discover Images` succeeded with a non-zero `count` output. Reproduced on run [`24934762268`](https://github.com/verity-org/verity/actions/runs/24934762268) — `Discover` succeeded with 66 image+tag combos, `Dispatch` showed `skipped 0s`. This means manual dispatcher runs and the nightly cron silently no-op'd the most important step in the pipeline.

The dispatch job's previous condition was:
```yaml
if: needs.discover.outputs.count != '0'
```
which looks correct in isolation but fails because of how GHA evaluates job-level `if:`.

## Solution

Replace the condition with an explicit transitive-skip-tolerant guard:

```yaml
if: always() && !failure() && !cancelled() && needs.discover.outputs.count != '0'
```

**Why all four functions?** GitHub Actions applies an implicit `success()` default to every job-level `if:` — and `success()` is evaluated against the **transitive** `needs:` ancestor set, not just direct parents (confirmed by the GH Actions team in [actions/runner#2356](https://github.com/actions/runner/issues/2356) and [#1540](https://github.com/actions/runner/issues/1540)).

Job graph:
- `prepare` (success) → `detect` (skipped — push-only) → `discover` (success, count=66) → `dispatch`

Even though `dispatch` only directly `needs: discover`, the implicit `success()` check pulls in `detect` (a transitive ancestor) and treats it as not-success because it was skipped. `always()` neutralizes the implicit `success()`; `!cancelled()` and `!failure()` keep the job from running on terminal-bad states.

This is **exactly** the same fix [PR #203](https://github.com/verity-org/verity/pull/203) ([`616a4fad1`](https://github.com/verity-org/verity/commit/616a4fad1)) shipped to the sister workflow `integer-orchestrator.yaml:149` 22 days ago. The pattern works there; copy-pasting it here is the cheapest, lowest-risk fix and keeps the two orchestrators consistent.

A 3-line comment now documents the GHA quirk so future maintainers don't 'simplify' the seemingly-redundant guard.

## Testing

- `make lint-workflows` (actionlint) — clean.
- `yamllint -c .yamllint.yml .github/workflows/orchestrator.yaml` — clean.
- The fix can be functionally verified post-merge by triggering a `workflow_dispatch` of `Orchestrator` with `preflight=true`: `Dispatch Patches` must run instead of skipping. The sister workflow has been running this same pattern successfully on every nightly cron since 2026-04-05 (precedent for behavior).

## Breaking Changes

None. The fix is strictly additive (the new guard is a superset of the old condition for `workflow_dispatch` runs and behaves identically on `push` runs where `detect` actually runs).

Closes #256.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the `Dispatch Patches` job on `workflow_dispatch` and scheduled runs by bypassing GHA’s transitive skip behavior. Manual and nightly runs now dispatch when `Discover Images` finds work.

- **Bug Fixes**
  - In `.github/workflows/orchestrator.yaml`, changed job `if:` to `always() && !failure() && !cancelled() && needs.discover.outputs.count != '0'` to avoid implicit `success()` on skipped transitive `needs`.
  - Added a comment documenting the GHA quirk and linking to PR #203 and this fix; behavior on `push` runs is unchanged.

<sup>Written for commit 357d18334945c19255e391195fb9b039efa578d7. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

