### PR TITLE
feat(charts): add aws-lb-controller, cert-manager-csi, descheduler, blackbox-exporter wave-10 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -174,3 +174,19 @@ dependencies:
   - name: contour
     version: "0.5.0"
     repository: "https://projectcontour.github.io/helm-charts/"
+
+  - name: aws-load-balancer-controller
+    version: "1.17.1"
+    repository: "https://aws.github.io/eks-charts"
+
+  - name: cert-manager-csi-driver
+    version: "v0.14.0"
+    repository: "https://charts.jetstack.io"
+
+  - name: descheduler
+    version: "0.35.1"
+    repository: "https://kubernetes-sigs.github.io/descheduler/"
+
+  - name: prometheus-blackbox-exporter
+    version: "11.9.1"
+    repository: "https://prometheus-community.github.io/helm-charts"

--- a/verity.yaml
+++ b/verity.yaml
@@ -47,6 +47,11 @@ chartValues:
   tempo-distributed:
     memcached.enabled: false
 
+  # aws-load-balancer-controller requires a clusterName to render templates.
+  # The wrapper chart consumers MUST override this to their actual cluster name.
+  aws-load-balancer-controller:
+    clusterName: verity-placeholder
+
   # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
   # default inbound agent image. Keep the wrapper focused on the controller and
   # the existing kiwigrid sidecar image.
@@ -344,6 +349,31 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "envoy"
     tag: "1.35"
+
+  # Wave 10 charts (single-image controllers + CSI driver + exporter).
+  # aws-load-balancer-controller chart 1.17.1 (app v2.17.1) → controller binary
+  # on Wolfi rebuild (v2 major track). Older chart line maintained for v2 users.
+  "eks/aws-load-balancer-controller":
+    registry: "ghcr.io/verity-org"
+    image: "aws-load-balancer-controller"
+    tag: "2"
+  # cert-manager-csi-driver v0.14.0 (app v0.14.0) → exact tag match.
+  # csi-node-driver-registrar and livenessprobe are different binaries under
+  # quay.io/jetstack and have no rebuilds; they fall through to crane.
+  "jetstack/cert-manager-csi-driver":
+    registry: "ghcr.io/verity-org"
+    image: "cert-manager-csi-driver"
+    tag: "0.14"
+  # descheduler 0.35.1 (app 0.35.1) → exact tag match; single image.
+  "descheduler/descheduler":
+    registry: "ghcr.io/verity-org"
+    image: "descheduler"
+    tag: "0.35"
+  # prometheus-blackbox-exporter 11.9.1 (app v0.28.0) → single image.
+  "prometheus/blackbox-exporter":
+    registry: "ghcr.io/verity-org"
+    image: "blackbox-exporter"
+    tag: "0.28.0"
 
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this


### PR DESCRIPTION
## Summary

Adds 4 single-image charts to the wrapper-chart pipeline:

- **aws-load-balancer-controller chart 1.17.1** (older v1.x chart line maintained for v2 controller users) → \`public.ecr.aws/eks/aws-load-balancer-controller:v2.17.1\` routed to \`images/aws-load-balancer-controller.yaml\` Wolfi rebuild (\`2\` major track). Adds \`chartValues:\` entry setting \`clusterName: verity-placeholder\` so the chart's required validation passes during chart-gen helm template extraction.
- **cert-manager-csi-driver v0.14.0** → \`quay.io/jetstack/cert-manager-csi-driver:v0.14.0\` routed to \`images/cert-manager-csi-driver.yaml\` Wolfi rebuild (exact tag match \`0.14\`). The chart's auxiliary \`csi-node-driver-registrar\` and \`livenessprobe\` images don't share a path prefix with the main key and fall through to crane.
- **descheduler 0.35.1** → \`registry.k8s.io/descheduler/descheduler:v0.35.1\` routed to \`images/descheduler.yaml\` Wolfi rebuild (\`0.35\` major.minor track).
- **prometheus-blackbox-exporter 11.9.1** → \`quay.io/prometheus/blackbox-exporter:v0.28.0\` routed to \`images/blackbox-exporter.yaml\` Wolfi rebuild (exact tag match \`0.28.0\`).

## Important: aws-load-balancer-controller clusterName

The \`chartValues.aws-load-balancer-controller.clusterName: verity-placeholder\` is a placeholder required for chart-gen's helm template extraction to succeed. **Wrapper chart consumers MUST override this** with their actual EKS cluster name when installing. Documented inline in verity.yaml.

## Verification

- \`verity doctor\`: all checks passed
- \`chart-gen --strict --dry-run\`: 45 charts in Chart.yaml, would produce 45 wrappers, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds wave-10 wrapper charts for `aws-load-balancer-controller`, `cert-manager-csi-driver`, `descheduler`, and `prometheus-blackbox-exporter`. Routes images to `ghcr.io/verity-org` rebuilds and sets a required value for template rendering.

- **New Features**
  - `aws-load-balancer-controller` 1.17.1 → `aws-load-balancer-controller:2` (app v2.17.1).
  - `cert-manager-csi-driver` v0.14.0 → `cert-manager-csi-driver:0.14`; registrar and livenessprobe stay upstream.
  - `descheduler` 0.35.1 → `descheduler:0.35`.
  - `prometheus-blackbox-exporter` 11.9.1 → `blackbox-exporter:0.28.0`.

- **Migration**
  - Set `chartValues.aws-load-balancer-controller.clusterName` to your EKS cluster name. Default is `verity-placeholder`.

<sup>Written for commit 433953775d36961109c66d8383dc75b91f3279ca. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/291?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

