### PR TITLE
feat(charts): add cilium, oauth2-proxy, influxdb2, nginx-prometheus-exporter, fluent-bit wave-11 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -190,3 +190,23 @@ dependencies:
   - name: prometheus-blackbox-exporter
     version: "11.9.1"
     repository: "https://prometheus-community.github.io/helm-charts"
+
+  - name: cilium
+    version: "1.19.3"
+    repository: "https://helm.cilium.io"
+
+  - name: oauth2-proxy
+    version: "10.4.3"
+    repository: "https://oauth2-proxy.github.io/manifests"
+
+  - name: influxdb2
+    version: "2.1.2"
+    repository: "https://helm.influxdata.com"
+
+  - name: prometheus-nginx-exporter
+    version: "1.21.1"
+    repository: "https://prometheus-community.github.io/helm-charts"
+
+  - name: fluent-bit
+    version: "0.56.0"
+    repository: "https://fluent.github.io/helm-charts"

--- a/verity.yaml
+++ b/verity.yaml
@@ -375,6 +375,43 @@ replacements:
     image: "blackbox-exporter"
     tag: "0.28.0"
 
+  # Wave 11 charts (networking + observability + auth).
+  # cilium 1.19.3 → cilium/cilium agent on Wolfi rebuild (1.19 major.minor).
+  # cilium/cilium-envoy is a fork of envoy with Cilium-specific binaries — NOT
+  # interchangeable with our envoy rebuild; self-map keeps it as upstream.
+  # cilium/operator-generic doesn't share path prefix with cilium/cilium so
+  # falls through to crane naturally.
+  "cilium/cilium-envoy":
+    registry: "quay.io"
+    image: "cilium/cilium-envoy"
+  "cilium/cilium":
+    registry: "ghcr.io/verity-org"
+    image: "cilium"
+    tag: "1.19"
+  # oauth2-proxy 10.4.3 (app v7.15.2) → exact tag match.
+  "oauth2-proxy/oauth2-proxy":
+    registry: "ghcr.io/verity-org"
+    image: "oauth2-proxy"
+    tag: "7.15.2"
+  # influxdb2 2.1.2 (app 2.7.4) → influxdb v2.7 rebuild track.
+  # Image is `docker.io/influxdb` (root-level, no namespace).
+  "influxdb":
+    registry: "ghcr.io/verity-org"
+    image: "influxdb"
+    tag: "2.7"
+  # prometheus-nginx-exporter 1.21.1 (app 1.5.1) → exact tag match.
+  "nginx/nginx-prometheus-exporter":
+    registry: "ghcr.io/verity-org"
+    image: "nginx-prometheus-exporter"
+    tag: "1.5.1"
+  # fluent-bit 0.56.0 (app 4.2.3) → fluent-bit v4.2 rebuild track.
+  # Newer charts deploy v5.x but rebuild is still at v4.2; this older chart
+  # version aligns with the rebuild track.
+  "fluent/fluent-bit":
+    registry: "ghcr.io/verity-org"
+    image: "fluent-bit"
+    tag: "4.2"
+
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this
 # list for images that have NO Wolfi/Integer rebuild AND no replacement


### PR DESCRIPTION
## Summary

Adds 5 charts to the wrapper-chart pipeline (networking + auth + observability):

- **cilium 1.19.3** → \`cilium/cilium:v1.19.3\` routed to \`images/cilium.yaml\` Wolfi rebuild (\`1.19\` major.minor track). Auxiliary images:
  - \`cilium/cilium-envoy\` is a Cilium-specific envoy fork (NOT interchangeable with our envoy rebuild) → self-map keeps the upstream quay.io reference
  - \`cilium/operator-generic\` doesn't share path prefix with \`cilium/cilium\` and falls through to crane naturally
- **oauth2-proxy 10.4.3** → \`oauth2-proxy/oauth2-proxy:v7.15.2\` routed to \`images/oauth2-proxy.yaml\` (exact tag match)
- **influxdb2 2.1.2** → root-level \`influxdb:2.7.4-alpine\` routed to \`images/influxdb.yaml\` Wolfi rebuild (\`2.7\` track)
- **prometheus-nginx-exporter 1.21.1** → \`nginx/nginx-prometheus-exporter:1.5.1\` routed to \`images/nginx-prometheus-exporter.yaml\` (exact tag match)
- **fluent-bit 0.56.0** (older chart line — newer 0.57.x deploys v5.x which lacks rebuild coverage) → \`cr.fluentbit.io/fluent/fluent-bit:4.2.3\` routed to \`images/fluent-bit.yaml\` Wolfi rebuild (\`4.2\` track)

## Verification

- \`verity doctor\`: all checks passed
- \`chart-gen --strict --dry-run\`: 46 charts in Chart.yaml, would produce 46 wrappers, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds wave-11 Helm chart wrappers for `cilium`, `oauth2-proxy`, `influxdb2`, `prometheus-nginx-exporter`, and `fluent-bit`. Routes images to `ghcr.io/verity-org` Wolfi rebuilds where available and keeps `cilium/cilium-envoy` on upstream.

- **New Features**
  - cilium 1.19.3 — `cilium/cilium` → `ghcr.io/verity-org/cilium:1.19`; keep `quay.io/cilium/cilium-envoy`; `cilium/operator-generic` passthrough.
  - oauth2-proxy 10.4.3 — `oauth2-proxy/oauth2-proxy:v7.15.2` → `ghcr.io/verity-org/oauth2-proxy:7.15.2`.
  - influxdb2 2.1.2 — `influxdb:2.7.4-alpine` → `ghcr.io/verity-org/influxdb:2.7`.
  - prometheus-nginx-exporter 1.21.1 — `nginx/nginx-prometheus-exporter:1.5.1` → `ghcr.io/verity-org/nginx-prometheus-exporter:1.5.1`.
  - fluent-bit 0.56.0 — `cr.fluentbit.io/fluent/fluent-bit:4.2.3` → `ghcr.io/verity-org/fluent-bit:4.2`.

<sup>Written for commit 8b32d8cdbe46dfc51101399ea122f7070b40d138. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/292?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

