### PR TITLE
feat(chartgen): walk subchart values for image override descent

### DIFF
--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -145,7 +145,13 @@ func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) 
 		return ChartResult{}, false, fmt.Errorf("get chart values for %s: %w", chart.Name, err)
 	}
 
-	valueOverrides, err := ResolveValuePaths(valuesYAML, allMappings, vc.Overrides)
+	subchartValues, err := GetSubchartValues(chart)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not load subchart values for %s@%s: %v\n", chart.Name, chart.Version, err)
+		subchartValues = nil
+	}
+
+	valueOverrides, err := ResolveValuePathsWithSubcharts(valuesYAML, subchartValues, allMappings, vc.Overrides)
 	if err != nil {
 		return ChartResult{}, false, fmt.Errorf("resolve value paths for %s: %w", chart.Name, err)
 	}

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -164,6 +165,25 @@ func GetSubchartValues(chart config.ChartSpec) (map[string][]byte, error) {
 	}
 	defer os.RemoveAll(tmpDir)
 
+	if err := writeSubchartDependencyChart(tmpDir, chart); err != nil {
+		return nil, err
+	}
+
+	if _, err := runCommand(context.Background(), 5*time.Minute, "helm", "dependency", "build", tmpDir); err != nil {
+		return nil, fmt.Errorf("helm dependency build for %s: %w", chart.Name, err)
+	}
+
+	subchartValues := make(map[string][]byte)
+	chartsDir := filepath.Join(tmpDir, "charts")
+	parentExtractDir := filepath.Join(tmpDir, "parent-chart")
+	if err := collectNestedSubchartValues(chartsDir, parentExtractDir, subchartValues); err != nil {
+		return nil, err
+	}
+
+	return subchartValues, nil
+}
+
+func writeSubchartDependencyChart(tmpDir string, chart config.ChartSpec) error {
 	chartYAML, err := yaml.Marshal(map[string]any{
 		"apiVersion": "v2",
 		"name":       "verity-subchart-values",
@@ -175,23 +195,18 @@ func GetSubchartValues(chart config.ChartSpec) (map[string][]byte, error) {
 		}},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal temp Chart.yaml: %w", err)
+		return fmt.Errorf("marshal temp Chart.yaml: %w", err)
 	}
 	if err := os.WriteFile(filepath.Join(tmpDir, "Chart.yaml"), chartYAML, 0o644); err != nil {
-		return nil, fmt.Errorf("write temp Chart.yaml: %w", err)
+		return fmt.Errorf("write temp Chart.yaml: %w", err)
 	}
+	return nil
+}
 
-	if _, err := runCommand(context.Background(), 5*time.Minute, "helm", "dependency", "build", tmpDir); err != nil {
-		return nil, fmt.Errorf("helm dependency build for %s: %w", chart.Name, err)
-	}
-
-	subchartValues := make(map[string][]byte)
-	chartsDir := filepath.Join(tmpDir, "charts")
-	parentExtractDir := filepath.Join(tmpDir, "parent-chart")
-
+func collectNestedSubchartValues(chartsDir, parentExtractDir string, subchartValues map[string][]byte) error {
 	archives, err := enumerateSubchartArchives(chartsDir)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	for _, archive := range archives {
 		chartName, err := extractTarball(archive, parentExtractDir)
@@ -199,31 +214,35 @@ func GetSubchartValues(chart config.ChartSpec) (map[string][]byte, error) {
 			fmt.Fprintf(os.Stderr, "warning: skipping unreadable parent chart archive %s: %v\n", filepath.Base(archive), err)
 			continue
 		}
-		if chartName == "" {
-			continue
-		}
-		if err := collectSubchartValues(filepath.Join(parentExtractDir, chartName, "charts"), subchartValues); err != nil {
-			return nil, err
+		if err := collectParentSubcharts(filepath.Join(parentExtractDir, chartName), subchartValues); err != nil {
+			return err
 		}
 	}
 
 	entries, err := os.ReadDir(chartsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return subchartValues, nil
+			return nil
 		}
-		return nil, fmt.Errorf("read charts directory: %w", err)
+		return fmt.Errorf("read charts directory: %w", err)
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		if err := collectSubchartValues(filepath.Join(chartsDir, entry.Name(), "charts"), subchartValues); err != nil {
-			return nil, err
+		if err := collectParentSubcharts(filepath.Join(chartsDir, entry.Name()), subchartValues); err != nil {
+			return err
 		}
 	}
 
-	return subchartValues, nil
+	return nil
+}
+
+func collectParentSubcharts(parentChartDir string, subchartValues map[string][]byte) error {
+	if filepath.Base(parentChartDir) == "" {
+		return nil
+	}
+	return collectSubchartValues(filepath.Join(parentChartDir, "charts"), subchartValues)
 }
 
 func enumerateSubchartArchives(chartsDir string) ([]string, error) {
@@ -291,6 +310,51 @@ func collectSubchartValues(chartsDir string, subchartValues map[string][]byte) e
 }
 
 func extractTarball(tgzPath, destDir string) (string, error) {
+	return visitTarballEntries(tgzPath, func(header *tar.Header, name string, tarReader io.Reader) error {
+		targetPath := filepath.Join(destDir, filepath.FromSlash(name))
+		switch header.Typeflag {
+		case tar.TypeDir:
+			return os.MkdirAll(targetPath, 0o755)
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return fmt.Errorf("create parent directory for %s: %w", targetPath, err)
+			}
+			fileMode := os.FileMode(header.Mode)
+			if fileMode == 0 {
+				fileMode = 0o644
+			}
+			content, err := io.ReadAll(tarReader)
+			if err != nil {
+				return fmt.Errorf("read file %s from %s: %w", name, filepath.Base(tgzPath), err)
+			}
+			if err := os.WriteFile(targetPath, content, fileMode); err != nil {
+				return fmt.Errorf("write extracted file %s: %w", targetPath, err)
+			}
+		}
+		return nil
+	})
+}
+
+// extractValuesFromTarball reads a Helm chart tarball and returns the chart
+// name together with the raw values.yaml bytes when present.
+func extractValuesFromTarball(tgzPath string) (valuesYAML []byte, chartName string, err error) {
+	chartName, err = visitTarballEntries(tgzPath, func(_ *tar.Header, name string, tarReader io.Reader) error {
+		parts := strings.Split(name, "/")
+		if len(parts) == 2 && parts[1] == "values.yaml" {
+			valuesYAML, err = io.ReadAll(tarReader)
+			if err != nil {
+				return fmt.Errorf("read values.yaml from %s: %w", filepath.Base(tgzPath), err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return valuesYAML, chartName, nil
+}
+
+func visitTarballEntries(tgzPath string, visit func(header *tar.Header, name string, tarReader io.Reader) error) (string, error) {
 	file, err := os.Open(tgzPath)
 	if err != nil {
 		return "", fmt.Errorf("open tarball %s: %w", filepath.Base(tgzPath), err)
@@ -307,7 +371,7 @@ func extractTarball(tgzPath, destDir string) (string, error) {
 	chartName := ""
 	for {
 		header, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return chartName, nil
 		}
 		if err != nil {
@@ -318,68 +382,6 @@ func extractTarball(tgzPath, destDir string) (string, error) {
 		if name == "" {
 			continue
 		}
-		parts := strings.Split(name, "/")
-		if len(parts) == 0 || parts[0] == "" {
-			continue
-		}
-		if chartName == "" {
-			chartName = parts[0]
-		}
-
-		targetPath := filepath.Join(destDir, filepath.FromSlash(name))
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(targetPath, 0o755); err != nil {
-				return "", fmt.Errorf("create directory %s: %w", targetPath, err)
-			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
-				return "", fmt.Errorf("create parent directory for %s: %w", targetPath, err)
-			}
-			fileMode := os.FileMode(header.Mode)
-			if fileMode == 0 {
-				fileMode = 0o644
-			}
-			content, err := io.ReadAll(tarReader)
-			if err != nil {
-				return "", fmt.Errorf("read file %s from %s: %w", name, filepath.Base(tgzPath), err)
-			}
-			if err := os.WriteFile(targetPath, content, fileMode); err != nil {
-				return "", fmt.Errorf("write extracted file %s: %w", targetPath, err)
-			}
-		}
-	}
-}
-
-// extractValuesFromTarball reads a Helm chart tarball and returns the chart
-// name together with the raw values.yaml bytes when present.
-func extractValuesFromTarball(tgzPath string) (valuesYAML []byte, chartName string, err error) {
-	file, err := os.Open(tgzPath)
-	if err != nil {
-		return nil, "", fmt.Errorf("open tarball %s: %w", filepath.Base(tgzPath), err)
-	}
-	defer file.Close()
-
-	gzReader, err := gzip.NewReader(file)
-	if err != nil {
-		return nil, "", fmt.Errorf("open gzip stream for %s: %w", filepath.Base(tgzPath), err)
-	}
-	defer gzReader.Close()
-
-	tarReader := tar.NewReader(gzReader)
-	for {
-		header, err := tarReader.Next()
-		if err == io.EOF {
-			return valuesYAML, chartName, nil
-		}
-		if err != nil {
-			return nil, "", fmt.Errorf("read tarball %s: %w", filepath.Base(tgzPath), err)
-		}
-
-		name := strings.TrimPrefix(header.Name, "./")
-		if name == "" {
-			continue
-		}
 
 		parts := strings.Split(name, "/")
 		if len(parts) == 0 || parts[0] == "" {
@@ -389,11 +391,8 @@ func extractValuesFromTarball(tgzPath string) (valuesYAML []byte, chartName stri
 			chartName = parts[0]
 		}
 
-		if len(parts) == 2 && parts[1] == "values.yaml" {
-			valuesYAML, err = io.ReadAll(tarReader)
-			if err != nil {
-				return nil, "", fmt.Errorf("read values.yaml from %s: %w", filepath.Base(tgzPath), err)
-			}
+		if err := visit(header, name, tarReader); err != nil {
+			return "", err
 		}
 	}
 }

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -42,7 +42,7 @@ func ResolveValuePaths(valuesYAML []byte, mappings []ImageMapping, overrides map
 func ResolveValuePathsWithSubcharts(valuesYAML []byte, subchartValues map[string][]byte, mappings []ImageMapping, overrides map[string]config.Override) ([]ValueOverride, error) {
 	pairs, err := collectValuePairs(valuesYAML, "")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("collect parent chart values: %w", err)
 	}
 
 	subchartNames := make([]string, 0, len(subchartValues))
@@ -53,7 +53,7 @@ func ResolveValuePathsWithSubcharts(valuesYAML []byte, subchartValues map[string
 	for _, name := range subchartNames {
 		subchartPairs, err := collectValuePairs(subchartValues[name], name)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("collect subchart values for %q: %w", name, err)
 		}
 		pairs = append(pairs, subchartPairs...)
 	}

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -1,8 +1,13 @@
 package chartgen
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -113,6 +118,53 @@ func GetChartValues(chart config.ChartSpec) ([]byte, error) {
 	}
 
 	return []byte(out), nil
+}
+
+// extractValuesFromTarball reads a Helm chart tarball and returns the chart
+// name together with the raw values.yaml bytes when present.
+func extractValuesFromTarball(tgzPath string) (valuesYAML []byte, chartName string, err error) {
+	file, err := os.Open(tgzPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("open tarball %s: %w", filepath.Base(tgzPath), err)
+	}
+	defer file.Close()
+
+	gzReader, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, "", fmt.Errorf("open gzip stream for %s: %w", filepath.Base(tgzPath), err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			return valuesYAML, chartName, nil
+		}
+		if err != nil {
+			return nil, "", fmt.Errorf("read tarball %s: %w", filepath.Base(tgzPath), err)
+		}
+
+		name := strings.TrimPrefix(header.Name, "./")
+		if name == "" {
+			continue
+		}
+
+		parts := strings.Split(name, "/")
+		if len(parts) == 0 || parts[0] == "" {
+			continue
+		}
+		if chartName == "" {
+			chartName = parts[0]
+		}
+
+		if len(parts) == 2 && parts[1] == "values.yaml" {
+			valuesYAML, err = io.ReadAll(tarReader)
+			if err != nil {
+				return nil, "", fmt.Errorf("read values.yaml from %s: %w", filepath.Base(tgzPath), err)
+			}
+		}
+	}
 }
 
 func walkValues(prefix string, node map[string]any, pairs *[]repoTagPair) {

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -332,7 +332,10 @@ func collectSubchartValues(chartsDir string, subchartValues map[string][]byte) e
 	return nil
 }
 
-var ErrUnsafeTarballEntry = errors.New("unsafe tarball entry path")
+var (
+	ErrUnsafeTarballEntry = errors.New("unsafe tarball entry path")
+	ErrEmptyTarball       = errors.New("tarball contains no chart entries")
+)
 
 func safeExtractPath(destDir, name string) (string, error) {
 	cleaned := filepath.Clean(filepath.FromSlash(name))
@@ -357,27 +360,56 @@ func extractTarball(tgzPath, destDir string) (string, error) {
 		if err != nil {
 			return err
 		}
+		rel, err := filepath.Rel(destDir, targetPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("%w: %q escapes %q", ErrUnsafeTarballEntry, name, destDir)
+		}
 		switch header.Typeflag {
 		case tar.TypeDir:
-			return os.MkdirAll(targetPath, 0o755)
+			return extractTarballDirEntry(destDir, targetPath, name)
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
-				return fmt.Errorf("create parent directory for %s: %w", targetPath, err)
-			}
-			fileMode := os.FileMode(header.Mode)
-			if fileMode == 0 {
-				fileMode = 0o644
-			}
-			content, err := io.ReadAll(tarReader)
-			if err != nil {
-				return fmt.Errorf("read file %s from %s: %w", name, filepath.Base(tgzPath), err)
-			}
-			if err := os.WriteFile(targetPath, content, fileMode); err != nil {
-				return fmt.Errorf("write extracted file %s: %w", targetPath, err)
-			}
+			return extractTarballRegularEntry(tgzPath, destDir, targetPath, name, header, tarReader)
 		}
 		return nil
 	})
+}
+
+func extractTarballDirEntry(destDir, targetPath, name string) error {
+	rel, err := filepath.Rel(destDir, targetPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %q escapes %q", ErrUnsafeTarballEntry, name, destDir)
+	}
+	return os.MkdirAll(targetPath, 0o755)
+}
+
+func extractTarballRegularEntry(tgzPath, destDir, targetPath, name string, header *tar.Header, tarReader io.Reader) error {
+	rel, err := filepath.Rel(destDir, targetPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %q escapes %q", ErrUnsafeTarballEntry, name, destDir)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return fmt.Errorf("create parent directory for %s: %w", targetPath, err)
+	}
+	fileMode := os.FileMode(header.Mode) & 0o777
+	if fileMode == 0 {
+		fileMode = 0o644
+	}
+	rel, err = filepath.Rel(destDir, targetPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %q escapes %q", ErrUnsafeTarballEntry, name, destDir)
+	}
+	out, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileMode)
+	if err != nil {
+		return fmt.Errorf("open extracted file %s: %w", targetPath, err)
+	}
+	if _, err := io.Copy(out, tarReader); err != nil {
+		out.Close()
+		return fmt.Errorf("copy file %s from %s: %w", name, filepath.Base(tgzPath), err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close extracted file %s: %w", targetPath, err)
+	}
+	return nil
 }
 
 // extractValuesFromTarball reads a Helm chart tarball and returns the chart
@@ -442,6 +474,9 @@ func visitTarballEntries(tgzPath string, visit func(header *tar.Header, name str
 	for {
 		header, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {
+			if chartName == "" {
+				return "", fmt.Errorf("%w: %s", ErrEmptyTarball, filepath.Base(tgzPath))
+			}
 			return chartName, nil
 		}
 		if err != nil {

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -35,11 +35,35 @@ type repoTagPair struct {
 }
 
 func ResolveValuePaths(valuesYAML []byte, mappings []ImageMapping, overrides map[string]config.Override) ([]ValueOverride, error) {
-	values := make(map[string]any)
-	if err := yaml.Unmarshal(valuesYAML, &values); err != nil {
-		return nil, fmt.Errorf("unmarshal values YAML: %w", err)
+	return ResolveValuePathsWithSubcharts(valuesYAML, nil, mappings, overrides)
+}
+
+func ResolveValuePathsWithSubcharts(valuesYAML []byte, subchartValues map[string][]byte, mappings []ImageMapping, overrides map[string]config.Override) ([]ValueOverride, error) {
+	pairs, err := collectValuePairs(valuesYAML, "")
+	if err != nil {
+		return nil, err
 	}
 
+	subchartNames := make([]string, 0, len(subchartValues))
+	for name := range subchartValues {
+		subchartNames = append(subchartNames, name)
+	}
+	sort.Strings(subchartNames)
+	for _, name := range subchartNames {
+		subchartPairs, err := collectValuePairs(subchartValues[name], name)
+		if err != nil {
+			return nil, err
+		}
+		pairs = append(pairs, subchartPairs...)
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].Path < pairs[j].Path
+	})
+
+	return resolveValuePathPairs(pairs, mappings, overrides), nil
+}
+
+func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrides map[string]config.Override) []ValueOverride {
 	result := make([]ValueOverride, 0, len(mappings))
 	matched := make([]bool, len(mappings))
 
@@ -69,12 +93,6 @@ func ResolveValuePaths(valuesYAML []byte, mappings []ImageMapping, overrides map
 		}
 	}
 
-	var pairs []repoTagPair
-	walkValues("", values, &pairs)
-	sort.Slice(pairs, func(i, j int) bool {
-		return pairs[i].Path < pairs[j].Path
-	})
-
 	for _, pair := range pairs {
 		if !pair.HasTag {
 			continue
@@ -96,7 +114,20 @@ func ResolveValuePaths(valuesYAML []byte, mappings []ImageMapping, overrides map
 		}
 	}
 
-	return result, nil
+	return result
+}
+
+func collectValuePairs(valuesYAML []byte, prefix string) ([]repoTagPair, error) {
+	values := make(map[string]any)
+	if len(valuesYAML) > 0 {
+		if err := yaml.Unmarshal(valuesYAML, &values); err != nil {
+			return nil, fmt.Errorf("unmarshal values YAML: %w", err)
+		}
+	}
+
+	pairs := make([]repoTagPair, 0)
+	walkValues(prefix, values, &pairs)
+	return pairs, nil
 }
 
 func GetChartValues(chart config.ChartSpec) ([]byte, error) {
@@ -154,23 +185,26 @@ func GetSubchartValues(chart config.ChartSpec) (map[string][]byte, error) {
 		return nil, fmt.Errorf("helm dependency build for %s: %w", chart.Name, err)
 	}
 
-	chartsDir := filepath.Join(tmpDir, "charts")
 	subchartValues := make(map[string][]byte)
+	chartsDir := filepath.Join(tmpDir, "charts")
+	parentExtractDir := filepath.Join(tmpDir, "parent-chart")
 
 	archives, err := enumerateSubchartArchives(chartsDir)
 	if err != nil {
 		return nil, err
 	}
 	for _, archive := range archives {
-		valuesYAML, chartName, err := extractValuesFromTarball(archive)
+		chartName, err := extractTarball(archive, parentExtractDir)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: skipping unreadable subchart archive %s: %v\n", filepath.Base(archive), err)
+			fmt.Fprintf(os.Stderr, "warning: skipping unreadable parent chart archive %s: %v\n", filepath.Base(archive), err)
 			continue
 		}
-		if chartName == "" || len(valuesYAML) == 0 {
+		if chartName == "" {
 			continue
 		}
-		subchartValues[chartName] = valuesYAML
+		if err := collectSubchartValues(filepath.Join(parentExtractDir, chartName, "charts"), subchartValues); err != nil {
+			return nil, err
+		}
 	}
 
 	entries, err := os.ReadDir(chartsDir)
@@ -184,17 +218,9 @@ func GetSubchartValues(chart config.ChartSpec) (map[string][]byte, error) {
 		if !entry.IsDir() {
 			continue
 		}
-
-		valuesPath := filepath.Join(chartsDir, entry.Name(), "values.yaml")
-		valuesYAML, err := os.ReadFile(valuesPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			fmt.Fprintf(os.Stderr, "warning: skipping unreadable subchart values %s: %v\n", valuesPath, err)
-			continue
+		if err := collectSubchartValues(filepath.Join(chartsDir, entry.Name(), "charts"), subchartValues); err != nil {
+			return nil, err
 		}
-		subchartValues[entry.Name()] = valuesYAML
 	}
 
 	return subchartValues, nil
@@ -218,6 +244,111 @@ func enumerateSubchartArchives(chartsDir string) ([]string, error) {
 	}
 	sort.Strings(archives)
 	return archives, nil
+}
+
+func collectSubchartValues(chartsDir string, subchartValues map[string][]byte) error {
+	archives, err := enumerateSubchartArchives(chartsDir)
+	if err != nil {
+		return err
+	}
+	for _, archive := range archives {
+		valuesYAML, chartName, err := extractValuesFromTarball(archive)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping unreadable subchart archive %s: %v\n", filepath.Base(archive), err)
+			continue
+		}
+		if chartName == "" || len(valuesYAML) == 0 {
+			continue
+		}
+		subchartValues[chartName] = valuesYAML
+	}
+
+	entries, err := os.ReadDir(chartsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read charts directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		valuesPath := filepath.Join(chartsDir, entry.Name(), "values.yaml")
+		valuesYAML, err := os.ReadFile(valuesPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "warning: skipping unreadable subchart values %s: %v\n", valuesPath, err)
+			continue
+		}
+		subchartValues[entry.Name()] = valuesYAML
+	}
+
+	return nil
+}
+
+func extractTarball(tgzPath, destDir string) (string, error) {
+	file, err := os.Open(tgzPath)
+	if err != nil {
+		return "", fmt.Errorf("open tarball %s: %w", filepath.Base(tgzPath), err)
+	}
+	defer file.Close()
+
+	gzReader, err := gzip.NewReader(file)
+	if err != nil {
+		return "", fmt.Errorf("open gzip stream for %s: %w", filepath.Base(tgzPath), err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+	chartName := ""
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			return chartName, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("read tarball %s: %w", filepath.Base(tgzPath), err)
+		}
+
+		name := strings.TrimPrefix(header.Name, "./")
+		if name == "" {
+			continue
+		}
+		parts := strings.Split(name, "/")
+		if len(parts) == 0 || parts[0] == "" {
+			continue
+		}
+		if chartName == "" {
+			chartName = parts[0]
+		}
+
+		targetPath := filepath.Join(destDir, filepath.FromSlash(name))
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+				return "", fmt.Errorf("create directory %s: %w", targetPath, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return "", fmt.Errorf("create parent directory for %s: %w", targetPath, err)
+			}
+			fileMode := os.FileMode(header.Mode)
+			if fileMode == 0 {
+				fileMode = 0o644
+			}
+			content, err := io.ReadAll(tarReader)
+			if err != nil {
+				return "", fmt.Errorf("read file %s from %s: %w", name, filepath.Base(tgzPath), err)
+			}
+			if err := os.WriteFile(targetPath, content, fileMode); err != nil {
+				return "", fmt.Errorf("write extracted file %s: %w", targetPath, err)
+			}
+		}
+	}
 }
 
 // extractValuesFromTarball reads a Helm chart tarball and returns the chart

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -74,6 +74,13 @@ func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrid
 	}
 	sort.Strings(overrideKeys)
 
+	pathHasRegistry := make(map[string]bool, len(pairs))
+	for _, p := range pairs {
+		if p.HasRegistry {
+			pathHasRegistry[p.Path] = true
+		}
+	}
+
 	for i, m := range mappings {
 		for _, key := range overrideKeys {
 			override := overrides[key]
@@ -81,12 +88,11 @@ func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrid
 				continue
 			}
 			if matchesRepo(m.OriginalRepo, key) {
-				clearRegistry := valuePathHasRegistry(values, override.ValuePath)
 				result = append(result, ValueOverride{
 					Path:          override.ValuePath,
 					Repository:    m.PatchedRepo,
 					Tag:           m.PatchedTag,
-					ClearRegistry: clearRegistry,
+					ClearRegistry: pathHasRegistry[override.ValuePath],
 				})
 				matched[i] = true
 				break
@@ -441,32 +447,4 @@ func matchesRepo(imageRepo, candidate string) bool {
 		return true
 	}
 	return false
-}
-
-func valuePathHasRegistry(values map[string]any, path string) bool {
-	parts := splitOverridePath(path)
-	if len(parts) == 0 {
-		return false
-	}
-
-	var current any = values
-	for _, part := range parts {
-		node, ok := current.(map[string]any)
-		if !ok {
-			return false
-		}
-
-		current, ok = node[part]
-		if !ok {
-			return false
-		}
-	}
-
-	node, ok := current.(map[string]any)
-	if !ok {
-		return false
-	}
-
-	registry, ok := node["registry"].(string)
-	return ok && registry != ""
 }

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -245,10 +245,22 @@ func collectNestedSubchartValues(chartsDir, parentExtractDir string, subchartVal
 }
 
 func collectParentSubcharts(parentChartDir string, subchartValues map[string][]byte) error {
-	if filepath.Base(parentChartDir) == "" {
+	if parentChartDir == "" {
 		return nil
 	}
 	return collectSubchartValues(filepath.Join(parentChartDir, "charts"), subchartValues)
+}
+
+func subchartKeyFromArchive(archive string) string {
+	base := strings.TrimSuffix(filepath.Base(archive), ".tgz")
+	idx := strings.LastIndex(base, "-")
+	if idx > 0 && idx < len(base)-1 {
+		first := base[idx+1]
+		if first >= '0' && first <= '9' {
+			return base[:idx]
+		}
+	}
+	return base
 }
 
 func enumerateSubchartArchives(chartsDir string) ([]string, error) {
@@ -277,15 +289,15 @@ func collectSubchartValues(chartsDir string, subchartValues map[string][]byte) e
 		return err
 	}
 	for _, archive := range archives {
-		valuesYAML, chartName, err := extractValuesFromTarball(archive)
+		valuesYAML, _, err := extractValuesFromTarball(archive)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping unreadable subchart archive %s: %v\n", filepath.Base(archive), err)
 			continue
 		}
-		if chartName == "" || len(valuesYAML) == 0 {
+		if len(valuesYAML) == 0 {
 			continue
 		}
-		subchartValues[chartName] = valuesYAML
+		subchartValues[subchartKeyFromArchive(archive)] = valuesYAML
 	}
 
 	entries, err := os.ReadDir(chartsDir)
@@ -315,9 +327,31 @@ func collectSubchartValues(chartsDir string, subchartValues map[string][]byte) e
 	return nil
 }
 
+var ErrUnsafeTarballEntry = errors.New("unsafe tarball entry path")
+
+func safeExtractPath(destDir, name string) (string, error) {
+	cleaned := filepath.Clean(filepath.FromSlash(name))
+	if cleaned == "." || cleaned == ".." || filepath.IsAbs(cleaned) || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q", ErrUnsafeTarballEntry, name)
+	}
+	target := filepath.Join(destDir, cleaned)
+	rel, err := filepath.Rel(destDir, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q escapes %q", ErrUnsafeTarballEntry, name, destDir)
+	}
+	return target, nil
+}
+
 func extractTarball(tgzPath, destDir string) (string, error) {
 	return visitTarballEntries(tgzPath, func(header *tar.Header, name string, tarReader io.Reader) error {
-		targetPath := filepath.Join(destDir, filepath.FromSlash(name))
+		switch header.Typeflag {
+		case tar.TypeSymlink, tar.TypeLink:
+			return nil
+		}
+		targetPath, err := safeExtractPath(destDir, name)
+		if err != nil {
+			return err
+		}
 		switch header.Typeflag {
 		case tar.TypeDir:
 			return os.MkdirAll(targetPath, 0o755)
@@ -416,19 +450,24 @@ func walkValues(prefix string, node map[string]any, pairs *[]repoTagPair) {
 		}
 
 		repo, hasRepo := child["repository"].(string)
-		if hasRepo && repo != "" {
-			_, hasTag := child["tag"]
-			registry, hasRegistry := child["registry"].(string)
-			if registry == "" {
-				hasRegistry = false
-			}
+		registry, registrySibling := child["registry"].(string)
+		hasRegistry := registrySibling && registry != ""
 
+		switch {
+		case hasRepo && repo != "":
+			_, hasTag := child["tag"]
 			*pairs = append(*pairs, repoTagPair{
 				Path:        path,
 				Repo:        repo,
 				HasTag:      hasTag,
 				Registry:    registry,
 				HasRegistry: hasRegistry,
+			})
+		case hasRegistry:
+			*pairs = append(*pairs, repoTagPair{
+				Path:        path,
+				Registry:    registry,
+				HasRegistry: true,
 			})
 		}
 

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -120,6 +120,106 @@ func GetChartValues(chart config.ChartSpec) ([]byte, error) {
 	return []byte(out), nil
 }
 
+// GetSubchartValues fetches the parent chart dependencies and returns each
+// subchart values.yaml keyed by subchart name.
+func GetSubchartValues(chart config.ChartSpec) (map[string][]byte, error) {
+	if err := discovery.ValidateChartSpec(chart); err != nil {
+		return nil, fmt.Errorf("validate chart spec: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "verity-chartgen-subcharts-")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	chartYAML, err := yaml.Marshal(map[string]any{
+		"apiVersion": "v2",
+		"name":       "verity-subchart-values",
+		"version":    "0.0.0",
+		"dependencies": []map[string]string{{
+			"name":       chart.Name,
+			"version":    chart.Version,
+			"repository": chart.Repository,
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal temp Chart.yaml: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "Chart.yaml"), chartYAML, 0o644); err != nil {
+		return nil, fmt.Errorf("write temp Chart.yaml: %w", err)
+	}
+
+	if _, err := runCommand(context.Background(), 5*time.Minute, "helm", "dependency", "build", tmpDir); err != nil {
+		return nil, fmt.Errorf("helm dependency build for %s: %w", chart.Name, err)
+	}
+
+	chartsDir := filepath.Join(tmpDir, "charts")
+	subchartValues := make(map[string][]byte)
+
+	archives, err := enumerateSubchartArchives(chartsDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, archive := range archives {
+		valuesYAML, chartName, err := extractValuesFromTarball(archive)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping unreadable subchart archive %s: %v\n", filepath.Base(archive), err)
+			continue
+		}
+		if chartName == "" || len(valuesYAML) == 0 {
+			continue
+		}
+		subchartValues[chartName] = valuesYAML
+	}
+
+	entries, err := os.ReadDir(chartsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return subchartValues, nil
+		}
+		return nil, fmt.Errorf("read charts directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		valuesPath := filepath.Join(chartsDir, entry.Name(), "values.yaml")
+		valuesYAML, err := os.ReadFile(valuesPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "warning: skipping unreadable subchart values %s: %v\n", valuesPath, err)
+			continue
+		}
+		subchartValues[entry.Name()] = valuesYAML
+	}
+
+	return subchartValues, nil
+}
+
+func enumerateSubchartArchives(chartsDir string) ([]string, error) {
+	entries, err := os.ReadDir(chartsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read charts directory: %w", err)
+	}
+
+	archives := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".tgz" {
+			continue
+		}
+		archives = append(archives, filepath.Join(chartsDir, entry.Name()))
+	}
+	sort.Strings(archives)
+	return archives, nil
+}
+
 // extractValuesFromTarball reads a Helm chart tarball and returns the chart
 // name together with the raw values.yaml bytes when present.
 func extractValuesFromTarball(tgzPath string) (valuesYAML []byte, chartName string, err error) {

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -251,8 +251,13 @@ func collectParentSubcharts(parentChartDir string, subchartValues map[string][]b
 	return collectSubchartValues(filepath.Join(parentChartDir, "charts"), subchartValues)
 }
 
-func subchartKeyFromArchive(archive string) string {
+func subchartKeyFromArchive(archive, version string) string {
 	base := strings.TrimSuffix(filepath.Base(archive), ".tgz")
+	if version != "" {
+		if stripped, ok := strings.CutSuffix(base, "-"+version); ok {
+			return stripped
+		}
+	}
 	idx := strings.LastIndex(base, "-")
 	if idx > 0 && idx < len(base)-1 {
 		first := base[idx+1]
@@ -289,7 +294,7 @@ func collectSubchartValues(chartsDir string, subchartValues map[string][]byte) e
 		return err
 	}
 	for _, archive := range archives {
-		valuesYAML, _, err := extractValuesFromTarball(archive)
+		valuesYAML, _, version, err := readChartArchive(archive)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping unreadable subchart archive %s: %v\n", filepath.Base(archive), err)
 			continue
@@ -297,7 +302,7 @@ func collectSubchartValues(chartsDir string, subchartValues map[string][]byte) e
 		if len(valuesYAML) == 0 {
 			continue
 		}
-		subchartValues[subchartKeyFromArchive(archive)] = valuesYAML
+		subchartValues[subchartKeyFromArchive(archive, version)] = valuesYAML
 	}
 
 	entries, err := os.ReadDir(chartsDir)
@@ -378,20 +383,45 @@ func extractTarball(tgzPath, destDir string) (string, error) {
 // extractValuesFromTarball reads a Helm chart tarball and returns the chart
 // name together with the raw values.yaml bytes when present.
 func extractValuesFromTarball(tgzPath string) (valuesYAML []byte, chartName string, err error) {
+	valuesYAML, chartName, _, err = readChartArchive(tgzPath)
+	return valuesYAML, chartName, err
+}
+
+func readChartArchive(tgzPath string) (valuesYAML []byte, chartName, version string, err error) {
+	var chartYAML []byte
 	chartName, err = visitTarballEntries(tgzPath, func(_ *tar.Header, name string, tarReader io.Reader) error {
 		parts := strings.Split(name, "/")
-		if len(parts) == 2 && parts[1] == "values.yaml" {
-			valuesYAML, err = io.ReadAll(tarReader)
-			if err != nil {
-				return fmt.Errorf("read values.yaml from %s: %w", filepath.Base(tgzPath), err)
+		if len(parts) != 2 {
+			return nil
+		}
+		switch parts[1] {
+		case "values.yaml":
+			data, readErr := io.ReadAll(tarReader)
+			if readErr != nil {
+				return fmt.Errorf("read values.yaml from %s: %w", filepath.Base(tgzPath), readErr)
 			}
+			valuesYAML = data
+		case "Chart.yaml":
+			data, readErr := io.ReadAll(tarReader)
+			if readErr != nil {
+				return fmt.Errorf("read Chart.yaml from %s: %w", filepath.Base(tgzPath), readErr)
+			}
+			chartYAML = data
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
-	return valuesYAML, chartName, nil
+	if len(chartYAML) > 0 {
+		var doc struct {
+			Version string `yaml:"version"`
+		}
+		if unmarshalErr := yaml.Unmarshal(chartYAML, &doc); unmarshalErr == nil {
+			version = doc.Version
+		}
+	}
+	return valuesYAML, chartName, version, nil
 }
 
 func visitTarballEntries(tgzPath string, visit func(header *tar.Header, name string, tarReader io.Reader) error) (string, error) {

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -402,12 +402,13 @@ func extractTarballRegularEntry(tgzPath, destDir, targetPath, name string, heade
 	if err != nil {
 		return fmt.Errorf("open extracted file %s: %w", targetPath, err)
 	}
-	if _, err := io.Copy(out, tarReader); err != nil {
-		out.Close()
-		return fmt.Errorf("copy file %s from %s: %w", name, filepath.Base(tgzPath), err)
+	_, copyErr := io.Copy(out, tarReader)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return fmt.Errorf("copy file %s from %s: %w", name, filepath.Base(tgzPath), copyErr)
 	}
-	if err := out.Close(); err != nil {
-		return fmt.Errorf("close extracted file %s: %w", targetPath, err)
+	if closeErr != nil {
+		return fmt.Errorf("close extracted file %s: %w", targetPath, closeErr)
 	}
 	return nil
 }
@@ -486,6 +487,10 @@ func visitTarballEntries(tgzPath string, visit func(header *tar.Header, name str
 		name := strings.TrimPrefix(header.Name, "./")
 		if name == "" {
 			continue
+		}
+
+		if !filepath.IsLocal(filepath.FromSlash(name)) {
+			return "", fmt.Errorf("%w: %q", ErrUnsafeTarballEntry, name)
 		}
 
 		parts := strings.Split(name, "/")

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -604,12 +605,16 @@ server:
 			}},
 		},
 		{
-			name: "registry without repository",
+			name: "registry without repository emits registry-only pair",
 			yamlIn: `image:
   registry: "ghcr.io"
   tag: "v1"
 `,
-			want: []repoTagPair{},
+			want: []repoTagPair{{
+				Path:        "image",
+				Registry:    "ghcr.io",
+				HasRegistry: true,
+			}},
 		},
 		{
 			name: "registry non-string ignored",
@@ -775,5 +780,168 @@ func mustWriteFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+}
+
+func writeRawTarball(t *testing.T, entries []*tar.Header, contents []string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "raw.tgz")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create() error = %v", err)
+	}
+	gz := gzip.NewWriter(file)
+	tw := tar.NewWriter(gz)
+	for i, h := range entries {
+		if h.Typeflag == tar.TypeReg && h.Size == 0 {
+			h.Size = int64(len(contents[i]))
+		}
+		if err := tw.WriteHeader(h); err != nil {
+			t.Fatalf("WriteHeader() error = %v", err)
+		}
+		if h.Typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(contents[i])); err != nil {
+				t.Fatalf("tw.Write() error = %v", err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw.Close() error = %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz.Close() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("file.Close() error = %v", err)
+	}
+	return path
+}
+
+func TestSafeExtractPathRejectsTraversal(t *testing.T) {
+	dest := t.TempDir()
+	cases := []string{
+		"../escape.txt",
+		"../../etc/passwd",
+		"foo/../../escape",
+		"/absolute/path",
+		"./..",
+		"..",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := safeExtractPath(dest, name); err == nil {
+				t.Fatalf("safeExtractPath(%q) error = nil, want non-nil", name)
+			}
+		})
+	}
+}
+
+func TestSafeExtractPathAcceptsCleanPaths(t *testing.T) {
+	dest := t.TempDir()
+	cases := []string{
+		"foo.txt",
+		"a/b/c.yaml",
+		"chart/values.yaml",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := safeExtractPath(dest, name)
+			if err != nil {
+				t.Fatalf("safeExtractPath(%q) error = %v", name, err)
+			}
+			if !strings.HasPrefix(got, dest) {
+				t.Fatalf("safeExtractPath(%q) = %q, want prefix %q", name, got, dest)
+			}
+		})
+	}
+}
+
+func TestExtractTarballRejectsPathTraversal(t *testing.T) {
+	tgz := writeRawTarball(t,
+		[]*tar.Header{
+			{Name: "good/", Typeflag: tar.TypeDir, Mode: 0o755},
+			{Name: "../escape.txt", Typeflag: tar.TypeReg, Mode: 0o644},
+		},
+		[]string{"", "owned"},
+	)
+	dest := t.TempDir()
+	if _, err := extractTarball(tgz, dest); !errors.Is(err, ErrUnsafeTarballEntry) {
+		t.Fatalf("extractTarball() error = %v, want ErrUnsafeTarballEntry", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(dest), "escape.txt")); err == nil {
+		t.Fatalf("escape file was created outside dest")
+	}
+}
+
+func TestExtractTarballSkipsSymlinks(t *testing.T) {
+	tgz := writeRawTarball(t,
+		[]*tar.Header{
+			{Name: "good/", Typeflag: tar.TypeDir, Mode: 0o755},
+			{Name: "good/link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"},
+			{Name: "good/hardlink", Typeflag: tar.TypeLink, Linkname: "/etc/passwd"},
+			{Name: "good/regular.txt", Typeflag: tar.TypeReg, Mode: 0o644},
+		},
+		[]string{"", "", "", "ok"},
+	)
+	dest := t.TempDir()
+	if _, err := extractTarball(tgz, dest); err != nil {
+		t.Fatalf("extractTarball() error = %v", err)
+	}
+	for _, link := range []string{"good/link", "good/hardlink"} {
+		if _, err := os.Lstat(filepath.Join(dest, link)); err == nil {
+			t.Fatalf("symlink/hardlink %q should have been skipped", link)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dest, "good", "regular.txt")); err != nil {
+		t.Fatalf("regular file missing: %v", err)
+	}
+}
+
+func TestSubchartKeyFromArchive(t *testing.T) {
+	cases := []struct {
+		archive string
+		want    string
+	}{
+		{"alertmanager-1.13.0.tgz", "alertmanager"},
+		{"kube-state-metrics-5.18.1.tgz", "kube-state-metrics"},
+		{"some/path/prometheus-29.2.1.tgz", "prometheus"},
+		{"plain.tgz", "plain"},
+		{"name-without-version.tgz", "name-without-version"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.archive, func(t *testing.T) {
+			if got := subchartKeyFromArchive(tc.archive); got != tc.want {
+				t.Fatalf("subchartKeyFromArchive(%q) = %q, want %q", tc.archive, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveValuePathsClearRegistryOnRegistryOnlyPath(t *testing.T) {
+	yml := `image:
+  registry: "ghcr.io"
+  tag: "v1"
+`
+	mappings := []ImageMapping{{
+		OriginalRepo: "zalando/postgres-operator",
+		PatchedRepo:  "ghcr.io/verity-org/zalando/postgres-operator",
+		PatchedTag:   "v1",
+	}}
+	overrides := map[string]config.Override{
+		"zalando/postgres-operator": {ValuePath: "image"},
+	}
+
+	got, err := ResolveValuePaths([]byte(yml), mappings, overrides)
+	if err != nil {
+		t.Fatalf("ResolveValuePaths() error = %v", err)
+	}
+	want := []ValueOverride{{
+		Path:          "image",
+		Repository:    "ghcr.io/verity-org/zalando/postgres-operator",
+		Tag:           "v1",
+		ClearRegistry: true,
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveValuePaths() = %#v, want %#v", got, want)
 	}
 }

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -282,6 +283,13 @@ func TestExtractValuesFromTarball(t *testing.T) {
 					t.Fatalf("os.WriteFile() error = %v", err)
 				}
 				return path
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty tarball",
+			setup: func(t *testing.T) string {
+				return writeRawTarball(t, nil, nil)
 			},
 			wantErr: true,
 		},
@@ -894,6 +902,80 @@ func TestExtractTarballSkipsSymlinks(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dest, "good", "regular.txt")); err != nil {
 		t.Fatalf("regular file missing: %v", err)
+	}
+}
+
+func TestExtractTarballEmptyTarballReturnsError(t *testing.T) {
+	tgz := writeRawTarball(t, nil, nil)
+	dest := t.TempDir()
+
+	_, err := extractTarball(tgz, dest)
+	if err == nil {
+		t.Fatal("extractTarball() error = nil, want error")
+	}
+	if got, want := err.Error(), "contains no chart entries"; !strings.Contains(got, want) {
+		t.Fatalf("extractTarball() error = %q, want substring %q", got, want)
+	}
+}
+
+func TestExtractTarballMasksSpecialBitsAndAppliesUmask(t *testing.T) {
+	oldUmask := syscall.Umask(0o022)
+	defer syscall.Umask(oldUmask)
+
+	tgz := writeRawTarball(t,
+		[]*tar.Header{
+			{Name: "chart/", Typeflag: tar.TypeDir, Mode: 0o755},
+			{Name: "chart/values.yaml", Typeflag: tar.TypeReg, Mode: 0o7666},
+		},
+		[]string{"", "image: nginx\n"},
+	)
+	dest := t.TempDir()
+
+	chartName, err := extractTarball(tgz, dest)
+	if err != nil {
+		t.Fatalf("extractTarball() error = %v", err)
+	}
+	if chartName != "chart" {
+		t.Fatalf("extractTarball() chartName = %q, want %q", chartName, "chart")
+	}
+
+	info, err := os.Stat(filepath.Join(dest, "chart", "values.yaml"))
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o644); got != want {
+		t.Fatalf("extracted file mode = %#o, want %#o", got, want)
+	}
+	if info.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 {
+		t.Fatalf("extracted file mode contains special bits: %v", info.Mode())
+	}
+}
+
+func TestExtractTarballStreamsLargeFiles(t *testing.T) {
+	largeContent := strings.Repeat("verity-stream-", (1<<20)/len("verity-stream-")+1)
+	tgz := writeRawTarball(t,
+		[]*tar.Header{
+			{Name: "chart/", Typeflag: tar.TypeDir, Mode: 0o755},
+			{Name: "chart/large.bin", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(largeContent))},
+		},
+		[]string{"", largeContent},
+	)
+	dest := t.TempDir()
+
+	chartName, err := extractTarball(tgz, dest)
+	if err != nil {
+		t.Fatalf("extractTarball() error = %v", err)
+	}
+	if chartName != "chart" {
+		t.Fatalf("extractTarball() chartName = %q, want %q", chartName, "chart")
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, "chart", "large.bin"))
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if string(got) != largeContent {
+		t.Fatalf("extracted file length = %d, want %d", len(got), len(largeContent))
 	}
 }
 

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -339,12 +339,162 @@ func TestEnumerateSubchartArchives(t *testing.T) {
 	}
 }
 
+func TestResolveValuePathsWithSubcharts(t *testing.T) {
+	tests := []struct {
+		name           string
+		parentValues   string
+		subchartValues map[string]string
+		mappings       []ImageMapping
+		overrides      map[string]config.Override
+		want           []ValueOverride
+	}{
+		{
+			name:         "prometheus subchart override",
+			parentValues: "server:\n  enabled: true\n",
+			subchartValues: map[string]string{
+				"alertmanager": `image:
+  repository: quay.io/prometheus/alertmanager
+  tag: v0.28.1
+`,
+				"kube-state-metrics": `image:
+  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+  tag: v2.15.0
+`,
+			},
+			mappings: []ImageMapping{
+				{
+					OriginalRepo: "quay.io/prometheus/alertmanager",
+					PatchedRepo:  "ghcr.io/verity-org/prometheus/alertmanager",
+					PatchedTag:   "v0.28.1",
+				},
+				{
+					OriginalRepo: "registry.k8s.io/kube-state-metrics/kube-state-metrics",
+					PatchedRepo:  "ghcr.io/verity-org/kube-state-metrics/kube-state-metrics",
+					PatchedTag:   "v2.15.0",
+				},
+			},
+			want: []ValueOverride{
+				{
+					Path:       "alertmanager.image",
+					Repository: "ghcr.io/verity-org/prometheus/alertmanager",
+					Tag:        "v0.28.1",
+				},
+				{
+					Path:       "kube-state-metrics.image",
+					Repository: "ghcr.io/verity-org/kube-state-metrics/kube-state-metrics",
+					Tag:        "v2.15.0",
+				},
+			},
+		},
+		{
+			name: "parent + subchart combined",
+			parentValues: `image:
+  repository: nginx
+  tag: "1.25"
+`,
+			subchartValues: map[string]string{
+				"metrics": `image:
+  repository: valkey
+  tag: "7.2"
+`,
+			},
+			mappings: []ImageMapping{
+				{
+					OriginalRepo: "nginx",
+					PatchedRepo:  "ghcr.io/verity-org/library/nginx",
+					PatchedTag:   "1.25",
+				},
+				{
+					OriginalRepo: "valkey",
+					PatchedRepo:  "ghcr.io/verity-org/valkey/valkey",
+					PatchedTag:   "7.2",
+				},
+			},
+			want: []ValueOverride{
+				{
+					Path:       "image",
+					Repository: "ghcr.io/verity-org/library/nginx",
+					Tag:        "1.25",
+				},
+				{
+					Path:       "metrics.image",
+					Repository: "ghcr.io/verity-org/valkey/valkey",
+					Tag:        "7.2",
+				},
+			},
+		},
+		{
+			name:         "subchart without matching mapping",
+			parentValues: "replicaCount: 1\n",
+			subchartValues: map[string]string{
+				"pushgateway": `image:
+  repository: quay.io/prometheus/pushgateway
+  tag: v1.11.1
+`,
+			},
+			mappings: []ImageMapping{ {
+				OriginalRepo: "nginx",
+				PatchedRepo:  "ghcr.io/verity-org/library/nginx",
+				PatchedTag:   "1.25",
+			}},
+			want: []ValueOverride{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subcharts := make(map[string][]byte, len(tt.subchartValues))
+			for name, values := range tt.subchartValues {
+				subcharts[name] = []byte(values)
+			}
+
+			got, err := ResolveValuePathsWithSubcharts([]byte(tt.parentValues), subcharts, tt.mappings, tt.overrides)
+			if err != nil {
+				t.Fatalf("ResolveValuePathsWithSubcharts() error = %v", err)
+			}
+
+			sort.Slice(got, func(i, j int) bool {
+				if got[i].Path != got[j].Path {
+					return got[i].Path < got[j].Path
+				}
+				if got[i].Repository != got[j].Repository {
+					return got[i].Repository < got[j].Repository
+				}
+				return got[i].Tag < got[j].Tag
+			})
+			sort.Slice(tt.want, func(i, j int) bool {
+				if tt.want[i].Path != tt.want[j].Path {
+					return tt.want[i].Path < tt.want[j].Path
+				}
+				if tt.want[i].Repository != tt.want[j].Repository {
+					return tt.want[i].Repository < tt.want[j].Repository
+				}
+				return tt.want[i].Tag < tt.want[j].Tag
+			})
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ResolveValuePathsWithSubcharts() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWalkValues(t *testing.T) {
 	tests := []struct {
 		name   string
+		prefix string
 		yamlIn string
 		want   []repoTagPair
 	}{
+		{
+			name:   "with prefix",
+			prefix: "foo",
+			yamlIn: `image:
+  repository: nginx
+  tag: "1"
+`,
+			want: []repoTagPair{{Path: "foo.image", Repo: "nginx", HasTag: true}},
+		},
 		{
 			name: "flat",
 			yamlIn: `image:
@@ -456,7 +606,7 @@ server:
 			}
 
 			got := make([]repoTagPair, 0)
-			walkValues("", data, &got)
+			walkValues(tt.prefix, data, &got)
 
 			sort.Slice(got, func(i, j int) bool {
 				if got[i].Path != got[j].Path {

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -3,12 +3,17 @@ package chartgen
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -336,6 +341,46 @@ func TestEnumerateSubchartArchives(t *testing.T) {
 	sort.Strings(want)
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("enumerateSubchartArchives() = %#v, want %#v", got, want)
+	}
+}
+
+func TestGetSubchartValues(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not found in PATH")
+	}
+
+	parentDir := filepath.Join(t.TempDir(), "parent")
+	mustWriteFile(t, filepath.Join(parentDir, "Chart.yaml"), "apiVersion: v2\nname: parent\nversion: 1.0.0\n")
+	mustWriteFile(t, filepath.Join(parentDir, "values.yaml"), "replicaCount: 1\n")
+	mustWriteFile(t, filepath.Join(parentDir, "charts", "alertmanager", "Chart.yaml"), "apiVersion: v2\nname: alertmanager\nversion: 0.1.0\n")
+	mustWriteFile(t, filepath.Join(parentDir, "charts", "alertmanager", "values.yaml"), "image:\n  repository: quay.io/prometheus/alertmanager\n  tag: v0.28.1\n")
+	repoDir := t.TempDir()
+	if _, err := runCommand(context.Background(), 2*time.Minute, "helm", "package", parentDir, "--destination", repoDir); err != nil {
+		t.Fatalf("helm package error = %v", err)
+	}
+
+	server := httptest.NewServer(http.FileServer(http.Dir(repoDir)))
+	defer server.Close()
+
+	if _, err := runCommand(context.Background(), 2*time.Minute, "helm", "repo", "index", repoDir, "--url", server.URL); err != nil {
+		t.Fatalf("helm repo index error = %v", err)
+	}
+
+	got, err := GetSubchartValues(config.ChartSpec{
+		Name:       "parent",
+		Version:    "1.0.0",
+		Repository: server.URL,
+	})
+	if err != nil {
+		t.Fatalf("GetSubchartValues() error = %v", err)
+	}
+
+	values, ok := got["alertmanager"]
+	if !ok {
+		t.Fatalf("GetSubchartValues() missing alertmanager entry: %#v", got)
+	}
+	if !strings.Contains(string(values), "quay.io/prometheus/alertmanager") {
+		t.Fatalf("GetSubchartValues() values = %q, want alertmanager repo", string(values))
 	}
 }
 
@@ -721,4 +766,14 @@ func writeTestChartTarballInDir(t *testing.T, dir, chartName string, files map[s
 	}
 
 	return path
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
 }

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -900,18 +900,24 @@ func TestExtractTarballSkipsSymlinks(t *testing.T) {
 func TestSubchartKeyFromArchive(t *testing.T) {
 	cases := []struct {
 		archive string
+		version string
 		want    string
 	}{
-		{"alertmanager-1.13.0.tgz", "alertmanager"},
-		{"kube-state-metrics-5.18.1.tgz", "kube-state-metrics"},
-		{"some/path/prometheus-29.2.1.tgz", "prometheus"},
-		{"plain.tgz", "plain"},
-		{"name-without-version.tgz", "name-without-version"},
+		{"alertmanager-1.13.0.tgz", "1.13.0", "alertmanager"},
+		{"kube-state-metrics-5.18.1.tgz", "5.18.1", "kube-state-metrics"},
+		{"some/path/prometheus-29.2.1.tgz", "29.2.1", "prometheus"},
+		{"plain.tgz", "", "plain"},
+		{"name-without-version.tgz", "", "name-without-version"},
+		{"redis-1.2.3-alpha.1.tgz", "1.2.3-alpha.1", "redis"},
+		{"argo-cd-9.5.4-rc1.tgz", "9.5.4-rc1", "argo-cd"},
+		{"messaging-0.5.0.tgz", "0.5.0", "messaging"},
+		{"chart-1.0.0+build.42.tgz", "1.0.0+build.42", "chart"},
+		{"semver-fallback-9.0.tgz", "", "semver-fallback"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.archive, func(t *testing.T) {
-			if got := subchartKeyFromArchive(tc.archive); got != tc.want {
-				t.Fatalf("subchartKeyFromArchive(%q) = %q, want %q", tc.archive, got, tc.want)
+			if got := subchartKeyFromArchive(tc.archive, tc.version); got != tc.want {
+				t.Fatalf("subchartKeyFromArchive(%q, %q) = %q, want %q", tc.archive, tc.version, got, tc.want)
 			}
 		})
 	}

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -1,8 +1,13 @@
 package chartgen
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -226,6 +231,86 @@ metrics:
 	}
 }
 
+func TestExtractValuesFromTarball(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T) string
+		wantName    string
+		wantValues  string
+		wantErr     bool
+		wantEmpty   bool
+	}{
+		{
+			name: "valid tgz with values.yaml",
+			setup: func(t *testing.T) string {
+				return writeTestChartTarball(t, "myalert", map[string]string{
+					"Chart.yaml":  "name: myalert\nversion: 0.1.0\n",
+					"values.yaml": "image:\n  repository: quay.io/foo\n  tag: \"1.0\"\n",
+				})
+			},
+			wantName:   "myalert",
+			wantValues: "repository: quay.io/foo",
+		},
+		{
+			name: "tgz without values.yaml",
+			setup: func(t *testing.T) string {
+				return writeTestChartTarball(t, "foo", map[string]string{
+					"Chart.yaml": "name: foo\nversion: 0.1.0\n",
+				})
+			},
+			wantName:  "foo",
+			wantEmpty: true,
+		},
+		{
+			name: "non-existent file",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing.tgz")
+			},
+			wantErr: true,
+		},
+		{
+			name: "corrupt tarball",
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "corrupt.tgz")
+				if err := os.WriteFile(path, []byte("not a tarball"), 0o644); err != nil {
+					t.Fatalf("os.WriteFile() error = %v", err)
+				}
+				return path
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.setup(t)
+
+			gotValues, gotName, err := extractValuesFromTarball(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("extractValuesFromTarball() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("extractValuesFromTarball() error = %v", err)
+			}
+			if gotName != tt.wantName {
+				t.Fatalf("extractValuesFromTarball() chartName = %q, want %q", gotName, tt.wantName)
+			}
+			if tt.wantEmpty {
+				if len(gotValues) != 0 {
+					t.Fatalf("extractValuesFromTarball() values = %q, want empty", string(gotValues))
+				}
+				return
+			}
+			if !strings.Contains(string(gotValues), tt.wantValues) {
+				t.Fatalf("extractValuesFromTarball() values = %q, want substring %q", string(gotValues), tt.wantValues)
+			}
+		})
+	}
+}
+
 func TestWalkValues(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -411,4 +496,45 @@ func TestMatchesRepo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func writeTestChartTarball(t *testing.T, chartName string, files map[string]string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), chartName+".tgz")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create() error = %v", err)
+	}
+
+	gz := gzip.NewWriter(file)
+
+	tw := tar.NewWriter(gz)
+
+	for name, content := range files {
+		data := []byte(content)
+		header := &tar.Header{
+			Name: filepath.ToSlash(filepath.Join(chartName, name)),
+			Mode: 0o644,
+			Size: int64(len(data)),
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatalf("tw.WriteHeader() error = %v", err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatalf("tw.Write() error = %v", err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw.Close() error = %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz.Close() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("file.Close() error = %v", err)
+	}
+
+	return path
 }

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -1033,3 +1033,31 @@ func TestResolveValuePathsClearRegistryOnRegistryOnlyPath(t *testing.T) {
 		t.Fatalf("ResolveValuePaths() = %#v, want %#v", got, want)
 	}
 }
+
+func TestResolveValuePathsWithSubchartsErrorIdentifiesFailingSubchart(t *testing.T) {
+	parent := []byte(`image:
+  repository: nginx
+  tag: "1.0"
+`)
+	subcharts := map[string][]byte{
+		"alertmanager": []byte("not: : valid: yaml: ::"),
+	}
+	_, err := ResolveValuePathsWithSubcharts(parent, subcharts, nil, nil)
+	if err == nil {
+		t.Fatal("ResolveValuePathsWithSubcharts() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "alertmanager") {
+		t.Fatalf("error %q must mention failing subchart name 'alertmanager'", err.Error())
+	}
+}
+
+func TestResolveValuePathsWithSubchartsErrorIdentifiesParent(t *testing.T) {
+	parent := []byte("not: : valid: yaml: ::")
+	_, err := ResolveValuePathsWithSubcharts(parent, nil, nil, nil)
+	if err == nil {
+		t.Fatal("ResolveValuePathsWithSubcharts() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "parent chart") {
+		t.Fatalf("error %q must mention 'parent chart' context", err.Error())
+	}
+}

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os/exec"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -238,12 +238,12 @@ metrics:
 
 func TestExtractValuesFromTarball(t *testing.T) {
 	tests := []struct {
-		name        string
-		setup       func(t *testing.T) string
-		wantName    string
-		wantValues  string
-		wantErr     bool
-		wantEmpty   bool
+		name       string
+		setup      func(t *testing.T) string
+		wantName   string
+		wantValues string
+		wantErr    bool
+		wantEmpty  bool
 	}{
 		{
 			name: "valid tgz with values.yaml",
@@ -477,7 +477,7 @@ func TestResolveValuePathsWithSubcharts(t *testing.T) {
   tag: v1.11.1
 `,
 			},
-			mappings: []ImageMapping{ {
+			mappings: []ImageMapping{{
 				OriginalRepo: "nginx",
 				PatchedRepo:  "ghcr.io/verity-org/library/nginx",
 				PatchedTag:   "1.25",

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -311,6 +311,34 @@ func TestExtractValuesFromTarball(t *testing.T) {
 	}
 }
 
+func TestEnumerateSubchartArchives(t *testing.T) {
+	chartsDir := t.TempDir()
+	alpha := writeTestChartTarballInDir(t, chartsDir, "alpha", map[string]string{
+		"Chart.yaml": "name: alpha\nversion: 0.1.0\n",
+	})
+	beta := writeTestChartTarballInDir(t, chartsDir, "beta", map[string]string{
+		"Chart.yaml": "name: beta\nversion: 0.2.0\n",
+	})
+	if err := os.WriteFile(filepath.Join(chartsDir, "notes.txt"), []byte("ignore"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(chartsDir, "gamma"), 0o755); err != nil {
+		t.Fatalf("os.Mkdir() error = %v", err)
+	}
+
+	got, err := enumerateSubchartArchives(chartsDir)
+	if err != nil {
+		t.Fatalf("enumerateSubchartArchives() error = %v", err)
+	}
+
+	want := []string{alpha, beta}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("enumerateSubchartArchives() = %#v, want %#v", got, want)
+	}
+}
+
 func TestWalkValues(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -501,7 +529,13 @@ func TestMatchesRepo(t *testing.T) {
 func writeTestChartTarball(t *testing.T, chartName string, files map[string]string) string {
 	t.Helper()
 
-	path := filepath.Join(t.TempDir(), chartName+".tgz")
+	return writeTestChartTarballInDir(t, t.TempDir(), chartName, files)
+}
+
+func writeTestChartTarballInDir(t *testing.T, dir, chartName string, files map[string]string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, chartName+".tgz")
 	file, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("os.Create() error = %v", err)


### PR DESCRIPTION
Fixes #253.

## Problem

`chart-gen`'s value-path resolver walked only the parent chart's `values.yaml` returned by `helm show values`. Subchart-nested image fields (prometheus → alertmanager / kube-state-metrics / node-exporter / pushgateway; argo-cd subcharts) were not auto-rewritten, so the published wrapper chart left them pointing at upstream registries (quay.io, registry.k8s.io, ...).

Surfaced by chart-integration smoke test on prometheus 29.2.1 (5 leaks) and argo-cd 9.5.4 (10 leaks).

## Fix

After resolving the parent chart's values, chart-gen now also runs `helm dependency build` for each chart and walks each subchart's `values.yaml` from the resulting tarball. Image overrides for subcharts are emitted with the subchart name as path prefix (e.g., `alertmanager.image`), which the existing `buildValuesTree` correctly nests under `<chartName>.<subchartName>.image` — the standard Helm subchart-override convention.

## Implementation

- `extractValuesFromTarball` helper using stdlib `archive/tar` + `compress/gzip`.
- `GetSubchartValues`: writes a temporary `Chart.yaml`, runs `helm dependency build`, enumerates `charts/*.tgz` (and unpacked `charts/<name>/`), recursively walks parent-extracted directories, returns `map[subchartName][]byte`.
- `ResolveValuePathsWithSubcharts` extends `ResolveValuePaths` (kept as a thin wrapper for backward compat): walks parent values with empty prefix and each subchart's values with the subchart's name as prefix; emits ValueOverrides for both.
- `ClearRegistry` propagation now path-indexed across collected pairs, so explicit `override.ValuePath` entries also clear upstream registry on 3-field shapes — for parent and subchart paths uniformly.

## Verification

- TDD-style atomic commits (red tests → green implementation → refactor).
- Unit tests for tarball extraction (synthetic tarballs, missing values.yaml, corrupt tarball).
- Unit tests for archive enumeration (lists `*.tgz` from temp dir).
- Unit tests for `ResolveValuePathsWithSubcharts` covering parent-only, subchart-only, and combined flows.
- `go build ./...`, `go vet`, `go test ./internal/chartgen/...`, `golangci-lint run` all pass locally.
- Helm-dependent integration test skips cleanly when `helm` binary is absent.

## Notes

Does not touch `test/chart-integration/` or any workflow file (per #293, do not weaken the smoke test). Sits cleanly on top of #295's `ClearRegistry` work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `chart-gen` to traverse subchart values and generate image overrides so subchart images are rewritten to our registry. Strengthens tarball extraction, restores `ClearRegistry` for registry‑only image blocks, and fixes subchart key parsing via `Chart.yaml` version; resolves image leaks in Prometheus and Argo CD subcharts.

- **Bug Fixes**
  - Walks subchart values via `helm dependency build`; reads each subchart `values.yaml` and emits `<subchart>.image` overrides.
  - Unifies parent+subchart resolution: adds `ResolveValuePathsWithSubcharts` (keeps `ResolveValuePaths` wrapper) and path-indexed `ClearRegistry` so explicit `override.ValuePath` clears upstream registries, including registry‑only nodes.
  - Tarball hardening: blocks path traversal (`filepath.IsLocal` + `safeExtractPath`/`ErrUnsafeTarballEntry`), skips symlink/hardlink, streams extraction with sane perms, handles empty archives; derives subchart keys from archive name using `Chart.yaml` version (handles pre‑release/build SemVer).
  - Error context: YAML parse errors now name the failing subchart or parent chart.

<sup>Written for commit 3a8cd7536c1eda338f8f04dcb1465fea242350a6. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/296?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

