### PR TITLE
fix(charts,chartgen): kyverno wrapper @3.7.2 — clear chart's defaultRegistry sibling (#254)

### DIFF
--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -161,6 +161,14 @@ func buildValuesTree(chartName string, chartValues map[string]any, overrides []V
 		if override.ClearRegistry {
 			leaf["registry"] = ""
 		}
+		// ClearDefaultRegistry is independent of ClearRegistry — a chart
+		// can use either or both sibling fields. kyverno 3.7.x is the
+		// canonical case for `defaultRegistry`; postgres-operator and
+		// most other 3-field charts use `registry`. See ValueOverride
+		// docs for the full rationale.
+		if override.ClearDefaultRegistry {
+			leaf["defaultRegistry"] = ""
+		}
 
 		setScalarValue(chartRoot, override.Path, leaf)
 	}

--- a/internal/chartgen/chart_test.go
+++ b/internal/chartgen/chart_test.go
@@ -372,6 +372,56 @@ func TestBuildValuesTree(t *testing.T) {
 			},
 		},
 		{
+			// kyverno 3.7.x — clears the chart's hard-coded
+			// `defaultRegistry: reg.kyverno.io` so the wrapper renders
+			// `ghcr.io/verity-org/<comp>:1.17` instead of
+			// `reg.kyverno.io/ghcr.io/verity-org/<comp>:1.17`.
+			name:      "clears upstream defaultRegistry field (kyverno)",
+			chartName: "kyverno",
+			overrides: []ValueOverride{{
+				Path:                 "admissionController.container.image",
+				Repository:           "ghcr.io/verity-org/kyverno",
+				Tag:                  "1.17",
+				ClearDefaultRegistry: true,
+			}},
+			want: map[string]any{
+				"kyverno": map[string]any{
+					"admissionController": map[string]any{
+						"container": map[string]any{
+							"image": map[string]any{
+								"defaultRegistry": "",
+								"repository":      "ghcr.io/verity-org/kyverno",
+								"tag":             "1.17",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// Both flags fire when the upstream chart declares both
+			// sibling fields — neutralise everything we can see.
+			name:      "clears both registry and defaultRegistry",
+			chartName: "hybrid",
+			overrides: []ValueOverride{{
+				Path:                 "image",
+				Repository:           "ghcr.io/verity-org/foo/bar",
+				Tag:                  "v1",
+				ClearRegistry:        true,
+				ClearDefaultRegistry: true,
+			}},
+			want: map[string]any{
+				"hybrid": map[string]any{
+					"image": map[string]any{
+						"registry":        "",
+						"defaultRegistry": "",
+						"repository":      "ghcr.io/verity-org/foo/bar",
+						"tag":             "v1",
+					},
+				},
+			},
+		},
+		{
 			name:      "single path",
 			chartName: "prometheus",
 			overrides: []ValueOverride{{

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -20,19 +20,36 @@ import (
 )
 
 type ValueOverride struct {
-	Path          string `json:"path"`
-	Repository    string `json:"repository"`
-	Tag           string `json:"tag"`
-	Value         string `json:"value,omitempty"`
-	ClearRegistry bool   `json:"clearRegistry,omitempty"`
+	Path       string `json:"path"`
+	Repository string `json:"repository"`
+	Tag        string `json:"tag"`
+	Value      string `json:"value,omitempty"`
+	// ClearRegistry tells the wrapper renderer to set
+	// `<path>.registry: ""` so that an upstream chart's `image.registry`
+	// hostname (e.g. `ghcr.io`, `quay.io`) doesn't get prepended to our
+	// already-FQDN repository override.
+	ClearRegistry bool `json:"clearRegistry,omitempty"`
+	// ClearDefaultRegistry tells the wrapper renderer to set
+	// `<path>.defaultRegistry: ""` for charts that template
+	// `{{ .Values.image.registry | default .Values.image.defaultRegistry }}/...`
+	// (kyverno 3.7.x is the canonical example: per-component image maps
+	// hold a hard-coded `defaultRegistry: reg.kyverno.io` that the
+	// chart concatenates to whatever override repository we set, which
+	// breaks pulls when our repository is already fully qualified). The
+	// flag fires in addition to ClearRegistry, not in place of it — a
+	// chart can use either or both sibling fields, and we neutralize
+	// only the ones it actually declares.
+	ClearDefaultRegistry bool `json:"clearDefaultRegistry,omitempty"`
 }
 
 type repoTagPair struct {
-	Path        string
-	Repo        string
-	HasTag      bool
-	Registry    string
-	HasRegistry bool
+	Path               string
+	Repo               string
+	HasTag             bool
+	Registry           string
+	HasRegistry        bool
+	DefaultRegistry    string
+	HasDefaultRegistry bool
 }
 
 func ResolveValuePaths(valuesYAML []byte, mappings []ImageMapping, overrides map[string]config.Override) ([]ValueOverride, error) {
@@ -75,9 +92,13 @@ func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrid
 	sort.Strings(overrideKeys)
 
 	pathHasRegistry := make(map[string]bool, len(pairs))
+	pathHasDefaultRegistry := make(map[string]bool, len(pairs))
 	for _, p := range pairs {
 		if p.HasRegistry {
 			pathHasRegistry[p.Path] = true
+		}
+		if p.HasDefaultRegistry {
+			pathHasDefaultRegistry[p.Path] = true
 		}
 	}
 
@@ -89,10 +110,11 @@ func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrid
 			}
 			if matchesRepo(m.OriginalRepo, key) {
 				result = append(result, ValueOverride{
-					Path:          override.ValuePath,
-					Repository:    m.PatchedRepo,
-					Tag:           m.PatchedTag,
-					ClearRegistry: pathHasRegistry[override.ValuePath],
+					Path:                 override.ValuePath,
+					Repository:           m.PatchedRepo,
+					Tag:                  m.PatchedTag,
+					ClearRegistry:        pathHasRegistry[override.ValuePath],
+					ClearDefaultRegistry: pathHasDefaultRegistry[override.ValuePath],
 				})
 				matched[i] = true
 				break
@@ -110,10 +132,11 @@ func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrid
 			}
 			if matchesRepo(pair.Repo, m.OriginalRepo) {
 				result = append(result, ValueOverride{
-					Path:          pair.Path,
-					Repository:    m.PatchedRepo,
-					Tag:           m.PatchedTag,
-					ClearRegistry: pair.HasRegistry,
+					Path:                 pair.Path,
+					Repository:           m.PatchedRepo,
+					Tag:                  m.PatchedTag,
+					ClearRegistry:        pair.HasRegistry,
+					ClearDefaultRegistry: pair.HasDefaultRegistry,
 				})
 				matched[i] = true
 				break
@@ -522,22 +545,49 @@ func walkValues(prefix string, node map[string]any, pairs *[]repoTagPair) {
 		repo, hasRepo := child["repository"].(string)
 		registry, registrySibling := child["registry"].(string)
 		hasRegistry := registrySibling && registry != ""
+		// defaultRegistry is the kyverno 3.7.x convention: each component's
+		// image map holds a hard-coded `defaultRegistry: reg.kyverno.io`
+		// that the chart concatenates to the override repository when
+		// `registry` is unset. Without an explicit signal, our wrapper would
+		// inherit that prefix and produce broken refs like
+		// `reg.kyverno.io/ghcr.io/verity-org/kyverno:1.17` (issue #254).
+		// Treat it as a parallel registry-sibling: detect it here, plumb
+		// it through ClearDefaultRegistry, and have buildValuesTree write
+		// `defaultRegistry: ""` into the override leaf.
+		defaultRegistry, defaultRegistrySibling := child["defaultRegistry"].(string)
+		hasDefaultRegistry := defaultRegistrySibling && defaultRegistry != ""
 
 		switch {
 		case hasRepo && repo != "":
 			_, hasTag := child["tag"]
 			*pairs = append(*pairs, repoTagPair{
-				Path:        path,
-				Repo:        repo,
-				HasTag:      hasTag,
-				Registry:    registry,
-				HasRegistry: hasRegistry,
+				Path:               path,
+				Repo:               repo,
+				HasTag:             hasTag,
+				Registry:           registry,
+				HasRegistry:        hasRegistry,
+				DefaultRegistry:    defaultRegistry,
+				HasDefaultRegistry: hasDefaultRegistry,
 			})
 		case hasRegistry:
 			*pairs = append(*pairs, repoTagPair{
-				Path:        path,
-				Registry:    registry,
-				HasRegistry: true,
+				Path:               path,
+				Registry:           registry,
+				HasRegistry:        true,
+				DefaultRegistry:    defaultRegistry,
+				HasDefaultRegistry: hasDefaultRegistry,
+			})
+		case hasDefaultRegistry:
+			// Charts that declare `defaultRegistry` without `registry` or
+			// `repository` at the same map (rare, but possible) still need
+			// neutralisation when an explicit `valuePath` override targets
+			// them. Emit a registry-only pair so the explicit-path branch
+			// in resolveValuePathPairs can pick it up via
+			// pathHasDefaultRegistry.
+			*pairs = append(*pairs, repoTagPair{
+				Path:               path,
+				DefaultRegistry:    defaultRegistry,
+				HasDefaultRegistry: true,
 			})
 		}
 

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -207,33 +207,140 @@ metrics:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ResolveValuePaths([]byte(tt.valuesYML), tt.mappings, tt.overrides)
-			if err != nil {
-				t.Fatalf("ResolveValuePaths() error = %v", err)
-			}
+			runResolveValuePathsCase(t, tt.valuesYML, tt.mappings, tt.overrides, tt.want)
+		})
+	}
+}
 
-			sort.Slice(got, func(i, j int) bool {
-				if got[i].Path != got[j].Path {
-					return got[i].Path < got[j].Path
-				}
-				if got[i].Repository != got[j].Repository {
-					return got[i].Repository < got[j].Repository
-				}
-				return got[i].Tag < got[j].Tag
-			})
-			sort.Slice(tt.want, func(i, j int) bool {
-				if tt.want[i].Path != tt.want[j].Path {
-					return tt.want[i].Path < tt.want[j].Path
-				}
-				if tt.want[i].Repository != tt.want[j].Repository {
-					return tt.want[i].Repository < tt.want[j].Repository
-				}
-				return tt.want[i].Tag < tt.want[j].Tag
-			})
+// resolveValuePathsCase is the shared shape for ResolveValuePaths table
+// entries. Carved out so coverage for the kyverno `defaultRegistry`
+// sibling can live in a sibling test function without re-emitting the
+// whole sort + DeepEqual harness.
+type resolveValuePathsCase struct {
+	name      string
+	valuesYML string
+	mappings  []ImageMapping
+	overrides map[string]config.Override
+	want      []ValueOverride
+}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("ResolveValuePaths() = %#v, want %#v", got, tt.want)
+func runResolveValuePathsCase(t *testing.T, valuesYML string, mappings []ImageMapping, overrides map[string]config.Override, want []ValueOverride) {
+	t.Helper()
+	got, err := ResolveValuePaths([]byte(valuesYML), mappings, overrides)
+	if err != nil {
+		t.Fatalf("ResolveValuePaths() error = %v", err)
+	}
+
+	sortFn := func(s []ValueOverride) {
+		sort.Slice(s, func(i, j int) bool {
+			if s[i].Path != s[j].Path {
+				return s[i].Path < s[j].Path
 			}
+			if s[i].Repository != s[j].Repository {
+				return s[i].Repository < s[j].Repository
+			}
+			return s[i].Tag < s[j].Tag
+		})
+	}
+	sortFn(got)
+	sortFn(want)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveValuePaths() = %#v, want %#v", got, want)
+	}
+}
+
+// TestResolveValuePaths_DefaultRegistry covers the kyverno-shaped
+// `defaultRegistry` sibling that PR #295's `ClearRegistry` plumbing
+// originally missed (issue #254). Split out from TestResolveValuePaths
+// so the parent stays under the maintidx threshold.
+func TestResolveValuePaths_DefaultRegistry(t *testing.T) {
+	tests := []resolveValuePathsCase{
+		{
+			// kyverno 3.7.x admission-controller shape — `registry` is
+			// null, the host lives under `defaultRegistry`. The override
+			// must set ClearDefaultRegistry so the wrapper renders
+			// `defaultRegistry: ""`, otherwise the chart prepends
+			// `reg.kyverno.io/` to our already-FQDN repository.
+			name: "kyverno defaultRegistry sibling override",
+			valuesYML: `admissionController:
+  container:
+    image:
+      registry: ~
+      defaultRegistry: "reg.kyverno.io"
+      repository: "kyverno/kyverno"
+      tag: ~
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "kyverno/kyverno",
+				PatchedRepo:  "ghcr.io/verity-org/kyverno",
+				PatchedTag:   "1.17",
+			}},
+			want: []ValueOverride{{
+				Path:                 "admissionController.container.image",
+				Repository:           "ghcr.io/verity-org/kyverno",
+				Tag:                  "1.17",
+				ClearRegistry:        false,
+				ClearDefaultRegistry: true,
+			}},
+		},
+		{
+			// Hypothetical chart that uses BOTH sibling fields. We must
+			// neutralise both — the chart's registry-resolution logic
+			// usually goes `registry | default defaultRegistry`, so
+			// leaving either populated breaks our override.
+			name: "registry and defaultRegistry both clear",
+			valuesYML: `image:
+  registry: "ghcr.io"
+  defaultRegistry: "fallback.example.com"
+  repository: "foo/bar"
+  tag: "v1"
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "foo/bar",
+				PatchedRepo:  "ghcr.io/verity-org/foo/bar",
+				PatchedTag:   "v1",
+			}},
+			want: []ValueOverride{{
+				Path:                 "image",
+				Repository:           "ghcr.io/verity-org/foo/bar",
+				Tag:                  "v1",
+				ClearRegistry:        true,
+				ClearDefaultRegistry: true,
+			}},
+		},
+		{
+			// Explicit-ValuePath override must also pick up
+			// defaultRegistry from the matching values path.
+			name: "explicit value path clears defaultRegistry",
+			valuesYML: `admissionController:
+  container:
+    image:
+      defaultRegistry: "reg.kyverno.io"
+      repository: "kyverno/kyverno"
+      tag: ~
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "kyverno/kyverno",
+				PatchedRepo:  "ghcr.io/verity-org/kyverno",
+				PatchedTag:   "1.17",
+			}},
+			overrides: map[string]config.Override{
+				"kyverno/kyverno": {ValuePath: "admissionController.container.image"},
+			},
+			want: []ValueOverride{{
+				Path:                 "admissionController.container.image",
+				Repository:           "ghcr.io/verity-org/kyverno",
+				Tag:                  "1.17",
+				ClearRegistry:        false,
+				ClearDefaultRegistry: true,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runResolveValuePathsCase(t, tt.valuesYML, tt.mappings, tt.overrides, tt.want)
 		})
 	}
 }
@@ -654,6 +761,76 @@ server:
 				HasRegistry: false,
 			}},
 		},
+		{
+			// kyverno 3.7.x shape: per-component image map holds a
+			// hard-coded `defaultRegistry: reg.kyverno.io` plus a null
+			// `registry: ~`. walkValues must surface defaultRegistry as a
+			// neutralisation signal so the wrapper override clears it
+			// alongside repository/tag.
+			name: "defaultRegistry sibling kyverno shape",
+			yamlIn: `admissionController:
+  container:
+    image:
+      registry: ~
+      defaultRegistry: "reg.kyverno.io"
+      repository: "kyverno/kyverno"
+      tag: ~
+`,
+			want: []repoTagPair{{
+				Path:               "admissionController.container.image",
+				Repo:               "kyverno/kyverno",
+				HasTag:             true,
+				Registry:           "",
+				HasRegistry:        false,
+				DefaultRegistry:    "reg.kyverno.io",
+				HasDefaultRegistry: true,
+			}},
+		},
+		{
+			name: "defaultRegistry empty string ignored",
+			yamlIn: `image:
+  defaultRegistry: ""
+  repository: "foo"
+  tag: "v1"
+`,
+			want: []repoTagPair{{
+				Path:               "image",
+				Repo:               "foo",
+				HasTag:             true,
+				HasRegistry:        false,
+				HasDefaultRegistry: false,
+			}},
+		},
+		{
+			name: "registry and defaultRegistry both present",
+			yamlIn: `image:
+  registry: "ghcr.io"
+  defaultRegistry: "fallback.example.com"
+  repository: "foo/bar"
+  tag: "v1"
+`,
+			want: []repoTagPair{{
+				Path:               "image",
+				Repo:               "foo/bar",
+				HasTag:             true,
+				Registry:           "ghcr.io",
+				HasRegistry:        true,
+				DefaultRegistry:    "fallback.example.com",
+				HasDefaultRegistry: true,
+			}},
+		},
+		{
+			name: "defaultRegistry without repository emits registry-only pair",
+			yamlIn: `image:
+  defaultRegistry: "reg.kyverno.io"
+  tag: "v1"
+`,
+			want: []repoTagPair{{
+				Path:               "image",
+				DefaultRegistry:    "reg.kyverno.io",
+				HasDefaultRegistry: true,
+			}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -666,42 +843,34 @@ server:
 			got := make([]repoTagPair, 0)
 			walkValues(tt.prefix, data, &got)
 
-			sort.Slice(got, func(i, j int) bool {
-				if got[i].Path != got[j].Path {
-					return got[i].Path < got[j].Path
-				}
-				if got[i].Repo != got[j].Repo {
-					return got[i].Repo < got[j].Repo
-				}
-				if got[i].Registry != got[j].Registry {
-					return got[i].Registry < got[j].Registry
-				}
-				if got[i].HasRegistry != got[j].HasRegistry {
-					return !got[i].HasRegistry && got[j].HasRegistry
-				}
-				if got[i].HasTag == got[j].HasTag {
-					return false
-				}
-				return !got[i].HasTag && got[j].HasTag
-			})
-			sort.Slice(tt.want, func(i, j int) bool {
-				if tt.want[i].Path != tt.want[j].Path {
-					return tt.want[i].Path < tt.want[j].Path
-				}
-				if tt.want[i].Repo != tt.want[j].Repo {
-					return tt.want[i].Repo < tt.want[j].Repo
-				}
-				if tt.want[i].Registry != tt.want[j].Registry {
-					return tt.want[i].Registry < tt.want[j].Registry
-				}
-				if tt.want[i].HasRegistry != tt.want[j].HasRegistry {
-					return !tt.want[i].HasRegistry && tt.want[j].HasRegistry
-				}
-				if tt.want[i].HasTag == tt.want[j].HasTag {
-					return false
-				}
-				return !tt.want[i].HasTag && tt.want[j].HasTag
-			})
+			sortPairs := func(pairs []repoTagPair) {
+				sort.Slice(pairs, func(i, j int) bool {
+					if pairs[i].Path != pairs[j].Path {
+						return pairs[i].Path < pairs[j].Path
+					}
+					if pairs[i].Repo != pairs[j].Repo {
+						return pairs[i].Repo < pairs[j].Repo
+					}
+					if pairs[i].Registry != pairs[j].Registry {
+						return pairs[i].Registry < pairs[j].Registry
+					}
+					if pairs[i].HasRegistry != pairs[j].HasRegistry {
+						return !pairs[i].HasRegistry && pairs[j].HasRegistry
+					}
+					if pairs[i].DefaultRegistry != pairs[j].DefaultRegistry {
+						return pairs[i].DefaultRegistry < pairs[j].DefaultRegistry
+					}
+					if pairs[i].HasDefaultRegistry != pairs[j].HasDefaultRegistry {
+						return !pairs[i].HasDefaultRegistry && pairs[j].HasDefaultRegistry
+					}
+					if pairs[i].HasTag == pairs[j].HasTag {
+						return false
+					}
+					return !pairs[i].HasTag && pairs[j].HasTag
+				})
+			}
+			sortPairs(got)
+			sortPairs(tt.want)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("walkValues() = %#v, want %#v", got, tt.want)

--- a/verity.yaml
+++ b/verity.yaml
@@ -59,6 +59,21 @@ chartValues:
     controller.testEnabled: false
     agent.enabled: false
 
+  # kyverno 3.7.2: disable the post-upgrade `crds.migration` hook. It runs
+  # `kubectl` from `registry.k8s.io/kubectl:v1.34.3`. Verity rebuilds kubectl
+  # on the floating `1.34` minor track (`images/kubectl.yaml`) but does not
+  # publish this exact `v1.34.3` patch tag; the hook is also a no-op on a
+  # fresh `helm install` and would otherwise be the only non-`ghcr.io/verity-org/*`
+  # reference rendered into the wrapper — disabling it avoids both the
+  # unpatched-tag pull and an `AssertImageOrigin` allowlist exception. The
+  # `defaultRegistry: reg.kyverno.io` registry-prefix neutralisation that
+  # admission-controller / background / cleanup / reports / kyvernopre all
+  # need is now handled automatically by chart-gen's `ClearDefaultRegistry`
+  # plumbing (`internal/chartgen/values.go` walks `defaultRegistry` siblings
+  # alongside `registry`); see issue #254 for the original symptom.
+  kyverno:
+    crds.migration.enabled: false
+
 # Image replacements for chart-gen.
 # Maps upstream image path patterns to Verity Integer (Wolfi) images.
 # When chart-gen discovers a chart image matching the key, it generates
@@ -101,27 +116,45 @@ replacements:
   # readiness-checker, and kyvernopre binaries each ship as their own
   # subpackage of the upstream Wolfi `kyverno-1.17` recipe (kyvernopre's
   # subpackage is named `kyverno-init-container-1.17`).
+  #
+  # Tag `1.17` pins the floating-minor track published by images/kyverno*.yaml
+  # (`versions: "1.17": {}`). Without an explicit tag, chart-gen would carry
+  # the chart's appVersion `v1.17.2` through unchanged — but Verity does not
+  # publish `v1.17.2` (or any per-patch tag), only the floating `1.17` plus
+  # `vX.Y.Z-patched` historicals. That tag mismatch was one of two root
+  # causes of issue #254 (admission-controller stuck in ImagePullBackOff
+  # inside the 10-minute helm-install budget); the second was the chart's
+  # per-component `defaultRegistry: reg.kyverno.io` being concatenated with
+  # our already-FQDN repository overrides, now neutralised by chart-gen's
+  # `ClearDefaultRegistry` plumbing in `internal/chartgen/values.go`.
   "kyverno/kyverno":
     registry: "ghcr.io/verity-org"
     image: "kyverno"
+    tag: "1.17"
   "kyverno/background-controller":
     registry: "ghcr.io/verity-org"
     image: "kyverno-background-controller"
+    tag: "1.17"
   "kyverno/reports-controller":
     registry: "ghcr.io/verity-org"
     image: "kyverno-reports-controller"
+    tag: "1.17"
   "kyverno/cleanup-controller":
     registry: "ghcr.io/verity-org"
     image: "kyverno-cleanup-controller"
+    tag: "1.17"
   "kyverno/readiness-checker":
     registry: "ghcr.io/verity-org"
     image: "kyverno-readiness-checker"
+    tag: "1.17"
   "kyverno/kyvernopre":
     registry: "ghcr.io/verity-org"
     image: "kyverno-kyvernopre"
+    tag: "1.17"
   "kyverno/kyverno-cli":
     registry: "ghcr.io/verity-org"
     image: "kyverno-cli"
+    tag: "1.17"
 
   # argo-cd chart (9.5.4) → argocd controller; dex shared with dex chart.
   "argoproj/argocd":


### PR DESCRIPTION
## Summary

Fix [#254](https://github.com/verity-org/verity/issues/254): the published wrapper at `oci://ghcr.io/verity-org/charts/kyverno:3.7.2` ships seven image references that cannot be pulled on any cluster, so the kyverno admission-controller deployment never reaches Ready and `helm install --wait` times out at 10 minutes. This also resolves [#293](https://github.com/verity-org/verity/issues/293) **Mode 2**.

> **History.** v1 of this PR was config-only (`verity.yaml`). A reviewer caught that the `chartValues.kyverno.<comp>.image.defaultRegistry: ""` injections were silently clobbered by chart-gen's wrapper-leaf map replacement (`buildValuesTree` writes `{repository, tag}`, dropping any sibling injected via `chartValues` at the same path). Only `test.image.registry: ""` survived because the chart's test image uses the `registry` sibling, which PR [#295](https://github.com/verity-org/verity/pull/295)'s existing `ClearRegistry` plumbing already handled. v2 (this PR head) adds the missing chart-gen plumbing for the `defaultRegistry` sibling.

## Root cause

Two stacked bugs in the chart-gen → wrapper pipeline:

1. **Tag mismatch** — without an explicit `tag:` on the kyverno `replacements:` entries, chart-gen carried the chart's source tag (`v1.17.2` for runtime components / `v0.1.0` for the readiness-checker) verbatim. Verity publishes neither: only the floating-minor `:1.17` from `images/kyverno*.yaml` (`versions: "1.17": {}`).
2. **Registry concatenation** — chart 3.7.x's per-component image map declares `defaultRegistry: reg.kyverno.io`. The chart's templates resolve image refs as `{{ .Values.image.registry | default .Values.image.defaultRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}`. chart-gen's wrapper override only set `repository` and `tag`, leaving `defaultRegistry` intact. The chart prepended `reg.kyverno.io/` to our already-FQDN `ghcr.io/verity-org/<comp>` repository → `reg.kyverno.io/ghcr.io/verity-org/kyverno:1.17` → ImagePullBackOff.

The four "usual suspects" for a not-Ready kyverno admission-controller (TLS bootstrap timing, probe budgets, leader election, CRD migration) all assume the image pulls. The pod never reached `Running`, so none of them applied.

## Fix

Two layers, single atomic commit:

### `internal/chartgen/` — extend `ClearRegistry` plumbing to recognise `defaultRegistry`

PR [#295](https://github.com/verity-org/verity/pull/295) already introduced `walkValues` detection of sibling `registry:` fields and a `ClearRegistry` flag that makes `buildValuesTree` write `registry: ""` into the wrapper override leaf. v2 adds a parallel `ClearDefaultRegistry` knob:

- `walkValues` now also detects non-empty `defaultRegistry` siblings (kyverno's convention) and emits `HasDefaultRegistry: true` on the corresponding `repoTagPair`.
- `resolveValuePathPairs` plumbs `ClearDefaultRegistry` through both the explicit-`ValuePath` branch and the implicit-walk branch.
- `buildValuesTree` writes `defaultRegistry: ""` into the override leaf when set, independent of `ClearRegistry`. A chart can use either or both sibling fields; we neutralise only what it actually declares.

7 new unit-test cases across `TestWalkValues`, `TestResolveValuePaths`, and `TestBuildValuesTree` lock this in. The `kyverno_defaultRegistry_sibling_override` (`ResolveValuePaths`) and `clears_upstream_defaultRegistry_field_(kyverno)` (`buildValuesTree`) cases are direct regression tests for this bug.

### `verity.yaml`

- Replacements: kyverno entries pin `tag: "1.17"` (unchanged from v1).
- The `chartValues.kyverno` block shrank from 7 keys to 1 — the 6 `<comp>.image.defaultRegistry: ""` entries are now redundant (chart-gen handles them automatically) and `test.image.registry: ""` is also redundant (chart-gen's pre-existing `ClearRegistry` handled it). Only `crds.migration.enabled: false` remains, because that's a non-image setting (disables a post-upgrade hook that pulls `registry.k8s.io/kubectl:v1.34.3`, which has no Verity rebuild and is a no-op on fresh installs).
- Comment cleanup: the dead reference to `docs/research/bug-254-kyverno-admission-controller.md` (gitignored per [#300](https://github.com/verity-org/verity/pull/300)) is dropped from the kyverno replacements comment block; the rationale for `tag: "1.17"` is restated inline so the comment is self-contained when shipped in the wrapper's `values.yaml`.

## Verification

### Static (this PR)

- **chart-gen-built wrapper inspection.** Built the wrapper through the production code path (`BuildWrapperChart` + `PackageChart`), unpacked the resulting `.tgz`, and ran `helm template`. All 5 runtime kyverno workloads render `ghcr.io/verity-org/<comp>:1.17` with **no `reg.kyverno.io/` prefix** anywhere. The chart-gen-emitted `values.yaml` contains the expected `defaultRegistry: ""` clearing per component. Captured locally as evidence (gitignored, not shipped in the PR).
- **Registry truth.** `crane manifest ghcr.io/verity-org/<comp>:1.17` confirms all 7 component tags exist; `:v1.17.2` does not.
- **`AssertImageOrigin` invariant unchanged.** No allowlist additions, no permissive prefixes, no test weakening.
- **Unit tests.** `go test ./internal/... ./cmd/...` 100% pass on the rebased branch (origin/main + this commit). 7 new chart-gen test cases all pass.

### Dynamic (deferred to next nightly)

- The `chart-integration` check on this PR **will be red** until the next `chart-gen.yaml` workflow re-publishes `oci://ghcr.io/verity-org/charts/kyverno:3.7.2` with the corrected values. Today's wrapper artifact is still the broken digest. Expected and known.
- Once chart-gen re-publishes, the next `chart-integration` nightly serves as live verification: `helm install` reaches `Available 1/1` for `Deployment/kyverno/kyverno-admission-controller` well within the 10-minute budget.

## Constraints respected

- No timeout extension to mask the bug.
- No allowlist additions.
- No weakening of `AssertImageOrigin` or `loadAllowlist`.
- Branch was rebased onto `origin/main` (the previous `git merge main` commit `bcc76a272` is gone). Single atomic commit on top of current main.

## Risks

- **Floating `:1.17` tag** silently picks up subsequent `1.17.x` releases. Matches the convention for grafana / loki / mimir / tempo / etc. in the same file. Reproducibility-by-digest would be a separate workstream.
- **Hook-only `kubectl` image** (`registry.k8s.io/kubectl:v1.34.3`) still rendered for `webhooksCleanup` pre-delete. Does not run during install; not observed by `AssertImageOrigin` (inspects Pods after `WaitSettle`, before uninstall). Reviewer flagged as non-blocking follow-up; not in scope here.

## Related

- Closes [#254](https://github.com/verity-org/verity/issues/254)
- Resolves [#293](https://github.com/verity-org/verity/issues/293) Mode 2 (Mode 1 — 41 missing allowlist files — tracked separately)
- Builds on [#295](https://github.com/verity-org/verity/pull/295) (`ClearRegistry` plumbing) and [#296](https://github.com/verity-org/verity/pull/296) (subchart values walk)
- [#300](https://github.com/verity-org/verity/pull/300) gitignored `docs/research/`; this PR drops the dead reference to that file from `verity.yaml`'s comments