### PR TITLE
chore(agents): forbid committing internal research docs; gitignore docs/research/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,11 @@ site/src/data/integer-catalog.json
 node-compile-cache/
 WOLFI_*.md
 WOLFI_*.txt
+
+# Internal research / investigation docs — see AGENTS.md "Research and
+# investigation documents". Exploratory artifacts (root-cause analyses,
+# vendor-doc walks, hypothesis lists) written during diagnosis. NEVER commit
+# new files under this directory; distill findings into issue comments, SCRs,
+# or canonical docs under docs/architecture/, docs/features/, docs/product/.
+# Already-tracked files are grandfathered.
+/docs/research/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,49 @@ searches in sandbox. Only your printed summary enters context.
 |`ctx stats`|Call the `stats` MCP tool and display the full output verbatim|
 |`ctx doctor`|Call the `doctor` MCP tool, run the returned shell command, display as checklist|
 |`ctx upgrade`|Call the `upgrade` MCP tool, run the returned shell command, display as checklist|
+
+# Research and investigation documents — DO NOT COMMIT
+
+`docs/research/` holds exploratory investigation artifacts written by agents
+(or the operator) during diagnosis: root-cause analyses, vendor-doc walks,
+hypothesis lists, dump inspections, log post-mortems, etc. These files are
+**NOT** canonical project documentation and **MUST NEVER** be staged,
+committed, or included in pull requests by agents.
+
+The directory is gitignored to enforce this mechanically. Already-tracked
+files in this directory are grandfathered; the rule applies prospectively
+to all new research material.
+
+## Rules
+
+- Agents MAY freely write into `docs/research/` for their own and the
+  operator's reference during a task.
+- Agents MUST NOT `git add` any file under `docs/research/`.
+- Agents MUST NOT cite or link to research-doc paths in commit messages,
+  PR bodies, or any other artifact that ships to `main`.
+- Agents MUST NOT include research docs as part of an evidence packet that
+  ships outside the local working tree. (Local evidence packets that stay
+  gitignored are fine.)
+
+## If a research finding needs to land in tracked history
+
+Distill it into one of:
+
+- An issue or PR comment (preferred for one-off context that explains
+  decisions or links investigation to outcome).
+- A formal SCR under `docs/scrs/` (for proposed change decisions and
+  policy choices).
+- A canonical doc under `docs/architecture/`, `docs/features/`,
+  `docs/product/`, or similar (for steady-state truth that future
+  contributors will need).
+
+The research doc itself stays untracked.
+
+## Why
+
+Research docs are intentionally rough: half-formed hypotheses, dead
+investigation branches, and verbatim copies of upstream documentation are
+useful at investigation time but become noise in repository history. A
+distilled summary in the right canonical place is more useful to future
+agents and humans than a 400-line research dump committed alongside a
+five-line config fix.


### PR DESCRIPTION
## Summary

Codify the rule that `docs/research/` is for exploratory investigation artifacts only and is never committed by agents. Surfaced after a recent agent run included a 457-line root-cause analysis under `docs/research/` in a routine config-fix PR ([#298](https://github.com/verity-org/verity/pull/298), since amended).

## Changes

- **`AGENTS.md`** — new section *"Research and investigation documents — DO NOT COMMIT"*. Spells out:
  - what `docs/research/` is for (rough investigation artifacts, hypothesis lists, vendor-doc walks, dump inspections);
  - the explicit MUST NOT rules (no `git add`, no path references in commit messages or PR bodies, no inclusion in evidence packets that ship to `main`);
  - the three canonical landing places for any finding that needs to enter tracked history — issue/PR comment, SCR under `docs/scrs/`, or canonical doc under `docs/architecture/` / `docs/features/` / `docs/product/`.
- **`.gitignore`** — `/docs/research/` added (with a comment pointing at AGENTS.md) so the rule is enforced mechanically, not just by convention.

## Grandfathering

Existing tracked files under `docs/research/` (currently only `orchestrator-fanout-fanin-2026.md`) continue to be tracked — `gitignore` only affects untracked files. The rule applies **prospectively** to all new material.

## Verification

After this lands, attempting to `git add docs/research/<new-file>.md` will be a no-op (gitignored). Agents adhering to the AGENTS.md rule won't try in the first place.

## Out of scope

- Removing the existing `orchestrator-fanout-fanin-2026.md` from history. If desired, that's a separate decision.
- Ruling on other forms of internal artifacts (evidence packets, task files, SCRs in `docs/scrs/`) — these have their own conventions and are not affected.