### PR TITLE
feat(ci): SCR-001 infrastructure — typed-error loadAllowlist + namespace image helpers (strict-mode flip deferred) (#293 Mode 1)

### DIFF
--- a/.github/workflows/chart-integration.yaml
+++ b/.github/workflows/chart-integration.yaml
@@ -119,22 +119,24 @@ jobs:
           VERITY_IT_SKIP_CLUSTER: "1"
         run: |
           go test -tags=integration \
-            -run 'TestLoadAllowlist|TestLoadAllowlistMissing|TestIsAccepted|TestHarnessClusterCreatedFieldDefault|TestInstallChartRejectsArgumentInjection' \
+            -run 'TestLoadAllowlist|TestLoadAllowlistMissing|TestLoadAllowlistPresentRegression|TestIsAccepted|TestClassifyMissingAllowlist|TestClassifyMissingAllowlistDoesNotConsultAllowlist|TestHarnessClusterCreatedFieldDefault|TestInstallChartRejectsArgumentInjection' \
             -v ./test/chart-integration/...
 
       - name: Run chart smoke test
         id: smoke
-        # On pull_request: a failing shard means the *published* chart has a
-        # problem (chart-gen rewrite gap, missing patched image, runtime
-        # crash). That's not a regression in this PR, so the per-shard check
-        # stays green to avoid blocking unrelated PRs. The actual failure
-        # is still visible in the step log, the GITHUB_STEP_SUMMARY tab,
-        # and the uploaded diagnostics-<chart> artifact.
-        #
-        # On workflow_run / schedule / workflow_dispatch: this IS a regression
-        # detector, so failures must be loud — leave continue-on-error off so
-        # the workflow conclusion turns red, alerting and dashboards fire,
-        # and the failed run shows up cleanly in `gh run list` filters.
+        # PR-strict policy (SCR-2026-04-30-001, Option E) is **DEFERRED**.
+        # Investigation while landing this PR revealed that ~30 of 41
+        # wrapper charts have chronic helm-install timeouts of the same
+        # class as kyverno's bug #254 (broken image refs / missing
+        # chartValues overrides), not just a missing-allowlist gap.
+        # Flipping strict mode today would surface ~30+ pre-existing
+        # chart-wrapper bugs as red shards on every PR, not the ~9
+        # genuine missing-allowlist cases the SCR anticipated. The
+        # typed-error infrastructure (`errAllowlistMissing`,
+        # `CollectNamespaceImages`, `classifyMissingAllowlist`) lands
+        # in this PR — ready to activate. A follow-up PR will flip
+        # the strictness once the chart-wrapper backlog clears.
+        # Tracking issue: TBD (chart-wrapper backlog).
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: make chart-integration
 
@@ -150,12 +152,12 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload diagnostics on failure
-        # always() is required: when continue-on-error is false (nightly /
-        # schedule / workflow_run / workflow_dispatch) and the smoke step
-        # fails, GHA's default behaviour is to skip subsequent steps. We
-        # want diagnostics uploaded EXACTLY when the smoke step failed —
-        # that's the only time they're useful — so override the skip with
-        # always() and gate on the step outcome.
+        # always() is required: even with continue-on-error: true on
+        # the smoke step (PR events), GHA's default is to skip
+        # subsequent steps when the prior step's `outcome` is failure.
+        # We want diagnostics uploaded EXACTLY when the smoke step
+        # failed — that's the only time they're useful — so override
+        # the skip with always() and gate on the step outcome.
         if: always() && steps.smoke.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/test/chart-integration/assertions.go
+++ b/test/chart-integration/assertions.go
@@ -22,6 +22,16 @@ const (
 var (
 	errContainerRestarted = errors.New("container restarted during settle window")
 	errImageNotAccepted   = errors.New("container image not from ghcr.io/verity-org and not allowlisted")
+	// errAllowlistMissing is returned by loadAllowlist when the
+	// requested allowlist file does not exist on disk. Per
+	// SCR-2026-04-30-001 (Option E), missing-allowlist is a typed
+	// signal — not a silent empty allowlist — so the test driver
+	// can decide policy: hard-fail when any non-verity image is
+	// observed in the namespace, pass cleanly when every image is
+	// already verity-prefixed (the verityRegistryPrefix
+	// short-circuit in isAccepted suffices). Tests must consume
+	// this via errors.Is.
+	errAllowlistMissing = errors.New("allowlist file not found")
 )
 
 type podList struct {
@@ -94,6 +104,70 @@ func collectRestartFailures(pods *podList) []string {
 	return failures
 }
 
+// CollectNamespaceImages returns the deduplicated list of container
+// images observed in the given namespace (main + init containers
+// across all pods). It is exposed for the test driver's
+// missing-allowlist branch in main_test.go: after AssertImageOrigin
+// returns errAllowlistMissing, the driver re-collects images and
+// asks classifyMissingAllowlist whether the absence is acceptable.
+//
+// The function does NOT consult any allowlist — it is a pure
+// observation step. Policy lives in classifyMissingAllowlist.
+func CollectNamespaceImages(ctx context.Context, h *Harness, namespace string) ([]string, error) {
+	pods, err := getPods(ctx, h, namespace)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	// Inner helper to avoid the per-pod slice allocation+copy that an
+	// `append(append([]T{}, a...), b...)` would incur.
+	add := func(statuses []containerStatus) {
+		for _, cs := range statuses {
+			if cs.Image == "" {
+				continue
+			}
+			if _, ok := seen[cs.Image]; ok {
+				continue
+			}
+			seen[cs.Image] = struct{}{}
+			out = append(out, cs.Image)
+		}
+	}
+	for _, p := range pods.Items {
+		add(p.Status.ContainerStatuses)
+		add(p.Status.InitContainerStatuses)
+	}
+	return out, nil
+}
+
+// classifyMissingAllowlist implements the SCR-001 missing-allowlist
+// policy: when an allowlist file is absent, hard-fail iff any
+// observed image is non-verity-prefixed. If every image is already
+// verity-prefixed the chart genuinely doesn't need an allowlist and
+// the absence is a clean pass.
+//
+// Returns the slice of offending (non-verity) images. An empty
+// return slice means "missing-allowlist is acceptable for this
+// namespace". A non-empty return slice means "the test driver must
+// hard-fail and name allowlistPath as the file the chart needs".
+//
+// This helper is unit-tested without a cluster; the driver in
+// main_test.go is responsible for fetching images via
+// CollectNamespaceImages and turning the slice into a t.Errorf
+// (we use Errorf, not Fatalf, so a single missing allowlist does
+// not abort the rest of the chart's checks).
+func classifyMissingAllowlist(images []string) []string {
+	var offenders []string
+	for _, img := range images {
+		if strings.HasPrefix(img, verityRegistryPrefix) {
+			continue
+		}
+		offenders = append(offenders, img)
+	}
+	return offenders
+}
+
 func AssertImageOrigin(ctx context.Context, h *Harness, namespace, allowlistPath string) error {
 	pods, err := getPods(ctx, h, namespace)
 	if err != nil {
@@ -147,7 +221,10 @@ func loadAllowlist(path string) ([]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
+			// Wrap errAllowlistMissing so callers can branch via
+			// errors.Is while still seeing the requested path in
+			// the error message for diagnostics.
+			return nil, fmt.Errorf("%w: %s", errAllowlistMissing, path)
 		}
 		return nil, err
 	}

--- a/test/chart-integration/assertions_test.go
+++ b/test/chart-integration/assertions_test.go
@@ -4,8 +4,10 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/verity-org/verity/internal/config"
@@ -44,12 +46,124 @@ func TestLoadAllowlist(t *testing.T) {
 }
 
 func TestLoadAllowlistMissing(t *testing.T) {
-	got, err := loadAllowlist(filepath.Join(t.TempDir(), "does-not-exist.txt"))
-	if err != nil {
-		t.Fatalf("missing file should return nil, nil: got %v", err)
+	// SCR-2026-04-30-001 (Option E): missing allowlist files are a
+	// typed signal, not a silent empty allowlist. Callers must be
+	// able to branch on errAllowlistMissing via errors.Is. The
+	// returned slice is nil so the previous "(nil, nil)" callers
+	// observe the same slice shape, just with a non-nil error.
+	missingPath := filepath.Join(t.TempDir(), "does-not-exist.txt")
+	got, err := loadAllowlist(missingPath)
+	if err == nil {
+		t.Fatalf("missing file must return errAllowlistMissing, got nil error (slice=%v)", got)
+	}
+	if !errors.Is(err, errAllowlistMissing) {
+		t.Fatalf("missing file must return errAllowlistMissing (errors.Is), got %T: %v", err, err)
 	}
 	if got != nil {
-		t.Fatalf("expected nil slice, got %v", got)
+		t.Fatalf("expected nil slice on missing file, got %v", got)
+	}
+	// The wrapped error must mention the requested path so
+	// diagnostics in the test driver can name the missing file.
+	if !strings.Contains(err.Error(), missingPath) {
+		t.Fatalf("error message must contain requested path %q, got %q", missingPath, err.Error())
+	}
+}
+
+func TestLoadAllowlistPresentRegression(t *testing.T) {
+	// Regression: loadAllowlist still parses an existing file
+	// correctly after the missing-file branch was promoted to a
+	// typed error. Mirrors TestLoadAllowlist with a smaller body
+	// to give the assertion a second, narrower data point.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alist.txt")
+	body := "" +
+		"# comment\n" +
+		"\n" +
+		"  registry.k8s.io/sig-storage/csi-provisioner  \n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadAllowlist(path)
+	if err != nil {
+		t.Fatalf("present file must not error: %v", err)
+	}
+	if errors.Is(err, errAllowlistMissing) {
+		t.Fatalf("present file must NOT return errAllowlistMissing")
+	}
+	if len(got) != 1 || got[0] != "registry.k8s.io/sig-storage/csi-provisioner" {
+		t.Fatalf("got %v, want exactly one trimmed entry", got)
+	}
+}
+
+func TestClassifyMissingAllowlist(t *testing.T) {
+	// SCR-2026-04-30-001 (Option E) policy decision table: the
+	// driver hard-fails iff at least one observed image is non-
+	// verity-prefixed. classifyMissingAllowlist returns the
+	// offenders; an empty return = clean pass.
+	cases := []struct {
+		name      string
+		images    []string
+		offenders []string
+	}{
+		{
+			name:      "missing+all-verity (clean pass)",
+			images:    []string{"ghcr.io/verity-org/prometheus/prometheus:v3.9.1", "ghcr.io/verity-org/library/nginx:1.29.5-patched"},
+			offenders: nil,
+		},
+		{
+			name:      "missing+non-verity (hard fail)",
+			images:    []string{"ghcr.io/verity-org/prometheus/prometheus:v3.9.1", "quay.io/upstream/foo:latest"},
+			offenders: []string{"quay.io/upstream/foo:latest"},
+		},
+		{
+			name:      "missing+empty namespace (clean pass — no images, no policy)",
+			images:    nil,
+			offenders: nil,
+		},
+		{
+			name:      "missing+all-non-verity (hard fail, every image flagged)",
+			images:    []string{"docker.io/library/postgres:17", "registry.k8s.io/sig-storage/csi-provisioner:v5.0.0"},
+			offenders: []string{"docker.io/library/postgres:17", "registry.k8s.io/sig-storage/csi-provisioner:v5.0.0"},
+		},
+		{
+			name:      "missing+double-ghcr-bug-pattern (chart-gen rewrite gap is non-verity)",
+			images:    []string{"ghcr.io/ghcr.io/verity-org/foo:tag"},
+			offenders: []string{"ghcr.io/ghcr.io/verity-org/foo:tag"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classifyMissingAllowlist(c.images)
+			if len(got) != len(c.offenders) {
+				t.Fatalf("len got=%d want=%d (got=%v want=%v)", len(got), len(c.offenders), got, c.offenders)
+			}
+			for i := range c.offenders {
+				if got[i] != c.offenders[i] {
+					t.Fatalf("idx=%d got=%q want=%q", i, got[i], c.offenders[i])
+				}
+			}
+		})
+	}
+}
+
+// TestClassifyMissingAllowlistPresentMixed documents the policy
+// boundary: classifyMissingAllowlist is only used when the
+// allowlist file is *absent*. When present, AssertImageOrigin
+// runs unchanged through isAccepted with a populated allow slice
+// (covered by TestIsAccepted). This test asserts the helper's
+// correct posture: it does NOT consult any allowlist, so a
+// "present+mixed" caller would never reach it. We document that
+// invariant here as a guard against future drift.
+func TestClassifyMissingAllowlistDoesNotConsultAllowlist(t *testing.T) {
+	// Even an image that WOULD be allowlisted under a
+	// hypothetical present-allowlist test is still flagged here,
+	// because classifyMissingAllowlist's whole point is "no
+	// allowlist file exists, so non-verity images have no path
+	// to acceptance."
+	images := []string{"quay.io/special/escape-hatch:latest"}
+	got := classifyMissingAllowlist(images)
+	if len(got) != 1 || got[0] != images[0] {
+		t.Fatalf("classifyMissingAllowlist must not consult an implicit allowlist; got %v", got)
 	}
 }
 

--- a/test/chart-integration/main_test.go
+++ b/test/chart-integration/main_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -123,7 +124,29 @@ func runChart(t *testing.T, spec config.ChartSpec) {
 	}
 
 	allow := filepath.Join(valuesDir, spec.Name+".allowlist.txt")
-	if err := AssertImageOrigin(ctx, testHarness, cc.Namespace, allow); err != nil {
+	err := AssertImageOrigin(ctx, testHarness, cc.Namespace, allow)
+	switch {
+	case err == nil:
+		// allowlist present (or empty file) AND every image accepted
+		// by AssertImageOrigin's existing logic — clean pass.
+	case errors.Is(err, errAllowlistMissing):
+		// SCR-2026-04-30-001 (Option E): missing-allowlist is no
+		// longer silently treated as empty-allowlist. Re-collect
+		// the namespace's images and hard-fail iff any are
+		// non-verity-prefixed. If every image is already verity-
+		// prefixed, the absence is a clean pass — the chart
+		// genuinely doesn't need an allowlist file.
+		images, listErr := CollectNamespaceImages(ctx, testHarness, cc.Namespace)
+		if listErr != nil {
+			t.Errorf("image-origin gate: allowlist missing AND namespace image collection failed: %v (original error: %v)", listErr, err)
+			break
+		}
+		offenders := classifyMissingAllowlist(images)
+		if len(offenders) > 0 {
+			t.Errorf("image-origin gate: chart %q has %d non-verity image(s) but no allowlist file at %s — author the allowlist for this chart (SCR-2026-04-30-001):\n  %s",
+				spec.Name, len(offenders), allow, strings.Join(offenders, "\n  "))
+		}
+	default:
 		t.Errorf("image-origin gate: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Lands the **infrastructure** half of [SCR-2026-04-30-001](docs/scrs/SCR-2026-04-30-001-chart-integration-canary-policy.md) (Option E): typed `errAllowlistMissing` sentinel, `CollectNamespaceImages` and `classifyMissingAllowlist` helpers, and the test-driver `errors.Is` branch. The workflow YAML strictness flip is **deferred** until the chart-wrapper backlog (see "Discovery" below) is addressed; a small follow-up PR will flip `continue-on-error` once it's safe.

## Why deferred

The original task brief assumed activating PR-strict mode would surface ~9 missing-allowlist cases (Option E's intentional fail-loud). While landing this PR, sampling the actual failing shards revealed a broader picture:

| Failure class | Count (sampled) | Cause |
|---|---|---|
| `INSTALLATION FAILED` / Deployment not Ready | ~30 of ~39 | Chronic chart-wrapper bugs, same shape as kyverno's #254 (broken image refs / missing `chartValues` overrides). Always failing; `continue-on-error: true` was hiding them. |
| `image-origin gate` (Option E intentional) | ~9 of ~39 | Missing-allowlist + non-verity image, the case Option E was designed to surface. |

Flipping strict mode today would surface ~30 pre-existing chart-wrapper bugs as red shards on every PR — high noise, none introduced by this PR. The infrastructure ships ready to activate; the policy switch waits for the chart-wrapper backlog to clear.

## What this PR contains

**Code (test/chart-integration/):**
- `errAllowlistMissing` package-level sentinel; `loadAllowlist` returns `fmt.Errorf("%w: %s", errAllowlistMissing, path)` on `os.ErrNotExist` so callers can use `errors.Is`.
- `CollectNamespaceImages(ctx, h, ns)` — pure, deduplicated container-image collector across main + init containers.
- `classifyMissingAllowlist(images)` — pure policy decision returning the slice of non-verity offenders.
- `main_test.go` driver: 3-arm switch on `loadAllowlist`'s typed sentinel, hard-fails via `t.Errorf` only when offenders are present.
- 7 new unit tests: `TestLoadAllowlistMissing`, `TestLoadAllowlistPresentRegression`, `TestClassifyMissingAllowlist` (5 subtests), `TestClassifyMissingAllowlistDoesNotConsultAllowlist`. All run with `VERITY_IT_SKIP_CLUSTER=1`; all wired into the harness `-run` filter so they execute on every PR.

**Workflow (`.github/workflows/chart-integration.yaml`):**
- `continue-on-error: ${{ github.event_name == 'pull_request' }}` **kept** on the smoke step (deferred activation).
- Inline comment block updated to explain why activation is deferred and what the follow-up PR will look like.

## Verification

- Required CI checks (`Unit Tests`, `Go Lint`, `Node Lint`, `Static Analysis`): green.
- All chart-integration shards: same outcome as before this PR (since `continue-on-error: true` is restored). The 39 still-red shards are pre-existing chart-wrapper bugs; this PR neither introduces nor masks them.
- `VERITY_IT_SKIP_CLUSTER=1 go test -tags=integration ...` for the harness gate: 100% pass on the new tests.
- `golangci-lint`: 0 issues.
- `actionlint .github/workflows/chart-integration.yaml`: clean.

## AC coverage vs original task brief

- AC-1 (workflow strictness flip) — **DEFERRED**. Comment block updated; flip queued for follow-up PR after chart-wrapper backlog clears. **Not** in this PR.
- AC-2 (typed `errAllowlistMissing` sentinel, `errors.Is`-testable) — **SATISFIED**.
- AC-3 (driver branch in `main_test.go`, not in `AssertImageOrigin`) — **SATISFIED**.
- AC-4 (unit tests + workflow `-run` filter) — **SATISFIED**.
- AC-5 (security invariant verbatim) — **SATISFIED**.
- AC-6 (end-to-end PR-context demo) — **OBVIATED** by the deferral; a future PR's CI run (after task C narrows the chart-wrapper backlog) will be the natural demo.
- AC-7 (no required-check change) — **SATISFIED**. Branch protection untouched.
- AC-8 (cross-links: SCR, [#293](https://github.com/verity-org/verity/issues/293), task file) — **SATISFIED**.

## Follow-ups

1. **New tracking issue (TBD)** — chart-wrapper backlog: ~30 charts with chronic helm-install timeouts, same class as kyverno's #254. Each needs the same investigation pattern PR [#298](https://github.com/verity-org/verity/pull/298) used (verify image refs at `ghcr.io/verity-org/*`, check for chart-internal `defaultRegistry`/`registry` siblings, add `chartValues:` overrides as needed).
2. **Strict-mode flip PR** — once the wrapper backlog is below ~5 known-broken charts, flip `continue-on-error` and land Option E's visibility. ~5 lines of YAML.
3. **Allowlist authoring (task C)** — for charts whose wrappers are correct but legitimately deploy non-verity images (init containers, sidecars), author `<chart>.allowlist.txt` with per-image justification. Mostly mechanical once the wrapper bugs are out of the way.

## Related

- [SCR-2026-04-30-001](docs/scrs/SCR-2026-04-30-001-chart-integration-canary-policy.md) (Option E)
- [#293](https://github.com/verity-org/verity/issues/293) Mode 1 (allowlist rollout — partially advanced by this PR's infrastructure; remaining work tracked in follow-ups)
- [#254](https://github.com/verity-org/verity/issues/254) (the prototype of the chart-wrapper bug class; ~30 more like it discovered while landing this PR)