### PR TITLE
fix(ci): revert trivy 0.70.0 → 0.69.3 to unblock nightly cron (#304)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@ apko = "1.2.9"
 melange = "0.50.4"
 
 # Security & signing tools
-trivy = "0.70.0"
+trivy = "0.69.3"
 cosign = "3.0.6"
 syft = "1.43.0"
 


### PR DESCRIPTION
## Summary

Restores the nightly cron chain after [PR #303](https://github.com/verity-org/verity/pull/303)'s trivy bump broke `mise` install across all 5 cron workflows.

Closes [#304](https://github.com/verity-org/verity/issues/304).

## Why

All 5 nightly crons failed at 2026-05-02 with the same root cause:

```
mise ERROR Failed to install aqua:aquasecurity/trivy@0.70.0:
  HTTP status client error (404 Not Found) for url
    (https://api.github.com/repos/aquasecurity/trivy/releases/tags/0.70.0):
  HTTP status client error (403 Forbidden) for url
    (https://api.github.com/repos/aquasecurity/trivy/releases/tags/v0.70.0)
```

The cascade starved the rest of the chain — no Patch Image or Integer Build Image runs got dispatched (the orchestrators died at `Install mise`).

## Why only trivy

[PR #303](https://github.com/verity-org/verity/pull/303) bumped 7 tools: `crane 0.21.5`, `melange 0.50.4`, `syft 1.43.0`, `kubectl 1.36.0`, `apko 1.2.9`, `node 24.15.0`, `trivy 0.70.0`. **The other six install cleanly** in the same workflow — only trivy fails. The trivy v0.70.0 release exists upstream (published 2026-04-17, two weeks ago), so this isn't a "release too new" issue. The deeper diagnosis (likely aqua-registry plugin quirk or token-scoping for that one tool) is tracked in [#304](https://github.com/verity-org/verity/issues/304); not blocking this revert.

## Diff

Single line. The other six bumps from [PR #303](https://github.com/verity-org/verity/pull/303) stay.

```diff
-trivy = "0.70.0"
+trivy = "0.69.3"
```

## Verification

Once merged, the next scheduled cron tick will exercise this. Until then:

```bash
# Spot-check locally
mise install
# Spot-check the workflow dry run
gh workflow run integer-orchestrator.yaml
```

## Follow-up (deferred)

[#304](https://github.com/verity-org/verity/issues/304) tracks the diagnosis of *why* mise specifically can't resolve trivy@0.70.0 when other aqua-registry tools resolve fine. Likely an upstream aqua-registry mapping issue or a token-scope quirk; not in scope for this revert.

## Affected nightly runs (today)

| Time (UTC) | Workflow | Run |
|---|---|---|
| 05:16 | Orchestrator | `25244578320` |
| 05:40 | Integer Orchestrator | `25244988164` |
| 06:02 | Chart Generation | `25245360952` |
| 06:58 | chart-integration | `25246331109` |
| 06:58 | Build Site | `25246338084` |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts `trivy` to 0.69.3 in `mise.toml` to fix failing `mise` installs and restore all nightly cron workflows. Keeps the other tool bumps from PR #303; unblocks the nightly chain tracked in #304.

- **Bug Fixes**
  - Set `trivy = "0.69.3"` to avoid aqua/GitHub 404/403 during install.
  - Restores all 5 nightly crons that failed at “Install mise”.
  - Only `trivy` changed; `crane`, `melange`, `syft`, `kubectl`, `apko`, and `node` stay as-is.

<sup>Written for commit 2b16d08477c03ab29f1ef2b3f0ee6ca2f3a7495d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

