### PR TITLE
fix(patch): strip @digest before deriving SOURCE_TAG so copa accepts staging refs

### DIFF
--- a/.github/scripts/patch-image.sh
+++ b/.github/scripts/patch-image.sh
@@ -48,7 +48,22 @@ trap emit_outputs EXIT
 
 PLATFORM_ARCH=$(echo "$PLATFORM" | cut -d/ -f2)
 
-SOURCE_TAG=$(echo "$SOURCE" | cut -d: -f2)
+# Extract the tag portion of the source reference, tolerating both
+# tag-only ("repo:v1.2.3") and tag+digest ("repo:v1.2.3@sha256:abc...") forms.
+#
+# The previous `cut -d: -f2` was incorrect for digest-pinned references such
+# as `quay.io/cilium/operator-generic:v1.19.3@sha256:205b09...`: it returned
+# `v1.19.3@sha256` (the second `:`-separated field), which then leaked the
+# `@sha256` literal into PLATFORM_TAG below as
+# `…:cilium-operator-generic-v1.19.3@sha256-amd64`. Copa's reference parser
+# reads the `@` as the digest separator and rejects `sha256-amd64` as an
+# invalid digest, failing the patch with "invalid reference format".
+#
+# Strip the `@<digest>` suffix first (parameter expansion is a no-op when
+# absent), then take everything after the LAST `:` so registry-with-port
+# forms like `localhost:5000/foo:v1` still resolve to `v1`.
+SOURCE_NO_DIGEST="${SOURCE%@*}"
+SOURCE_TAG="${SOURCE_NO_DIGEST##*:}"
 
 # Sanitize image name: chart images contain registry paths with slashes (invalid in OCI tags)
 SAFE_IMAGE=$(echo "$IMAGE_NAME" | tr '/: ' '---')

--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -120,7 +120,14 @@ jobs:
         id: parse
         run: |
           SOURCE_REF="${{ inputs.source-ref }}"
-          SOURCE_TAG="${SOURCE_REF##*:}"
+          # Strip an optional `@<digest>` suffix before extracting the tag,
+          # otherwise digest-pinned refs like `…:v1.19.3@sha256:205b09…`
+          # would yield SOURCE_TAG="205b09…" (the hex digest after the LAST
+          # `:`). That mismatched the script-side tag built in
+          # `.github/scripts/patch-image.sh`, breaking the combine step's
+          # per-arch tag lookup. Keep this parser in sync with the script.
+          SOURCE_REF_NO_DIGEST="${SOURCE_REF%@*}"
+          SOURCE_TAG="${SOURCE_REF_NO_DIGEST##*:}"
           echo "source-tag=${SOURCE_TAG}" >> "$GITHUB_OUTPUT"
           echo "safe-name=$(echo '${{ inputs.image-name }}' | tr '/: ' '---')" >> "$GITHUB_OUTPUT"
 

--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/moby/buildkit/util/progress/progressui"
@@ -24,6 +25,23 @@ var ErrEmptyTag = errors.New("patched tag is required")
 // ErrEmptyReport is returned when Config.Report is blank. Copa requires a
 // Trivy report to determine which packages to patch.
 var ErrEmptyReport = errors.New("trivy report path is required")
+
+// ErrInvalidPatchedTag is returned when Config.PatchedTag contains characters
+// the OCI distribution spec forbids in tag values — most notably `@`, which
+// is the digest separator. Copa concatenates the staging registry with this
+// tag to form the destination reference; smuggling an `@` past us produces
+// references like `ghcr.io/.../cache:cilium-…-v1.19.3@sha256-amd64` that
+// copa's reference parser then rejects as "invalid reference format". We
+// catch the bad value here so the failure mode is a verity-layer error with
+// a clear message instead of an obscure copa parse error mid-build.
+//
+// Per the OCI distribution spec, tag values match the regex
+// `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}` — `@`, `:`, and whitespace are all
+// disallowed. We only check `@` here because that is the historically
+// observed bug source (`patch-image.sh` mis-parsing digest-pinned source
+// refs); a fuller regex check is intentionally deferred to copa to avoid
+// duplicating its tag-validation surface.
+var ErrInvalidPatchedTag = errors.New("patched tag must not contain '@' (the OCI digest separator)")
 
 // DefaultTimeout matches the upstream `copa patch` CLI default. Callers that
 // leave Config.Timeout as zero are upgraded to this value inside toOptions;
@@ -95,13 +113,18 @@ type Config struct {
 // Copa returns this sentinel when the source image is already fully patched.
 var ErrNoUpdatesFound = types.ErrNoUpdatesFound
 
-// Validate checks that the required fields are populated.
+// Validate checks that the required fields are populated and that PatchedTag
+// is well-formed enough to pass copa's reference parser. See
+// ErrInvalidPatchedTag for the rationale on the `@` check.
 func (c *Config) Validate() error {
 	if c.Image == "" {
 		return ErrEmptyImage
 	}
 	if c.PatchedTag == "" {
 		return ErrEmptyTag
+	}
+	if strings.Contains(c.PatchedTag, "@") {
+		return fmt.Errorf("%w: %q", ErrInvalidPatchedTag, c.PatchedTag)
 	}
 	if c.Report == "" {
 		return ErrEmptyReport

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -54,6 +54,36 @@ func TestConfigValidate(t *testing.T) {
 			},
 			wantErr: ErrEmptyReport,
 		},
+		{
+			// Regression for the chronic Patch Image cache-ref bug:
+			// `patch-image.sh`'s old `cut -d: -f2` produced
+			// SOURCE_TAG="v1.19.3@sha256" for digest-pinned cilium refs
+			// like `quay.io/cilium/operator-generic:v1.19.3@sha256:205b09…`.
+			// That fed into `--tag …-v1.19.3@sha256-amd64`, which copa's
+			// reference parser then rejected as "invalid reference format".
+			// Validate must reject the `@`-tainted tag at the verity layer
+			// before it reaches copa.
+			name: "patched tag with @sha256 digest leak rejected",
+			cfg: Config{
+				Image:      "quay.io/cilium/operator-generic:v1.19.3@sha256:205b09abc",
+				PatchedTag: "cilium-operator-generic-v1.19.3@sha256-amd64",
+				Report:     "trivy.json",
+			},
+			wantErr: ErrInvalidPatchedTag,
+		},
+		{
+			// Tighter form of the same class: any `@` is forbidden, not
+			// only the literal `@sha256-` shape that bit nightly. Future
+			// callers that smuggle a digest into the tag get the same
+			// clear error.
+			name: "patched tag with bare @ rejected",
+			cfg: Config{
+				Image:      "alpine:3.18",
+				PatchedTag: "alpine-patched@something",
+				Report:     "trivy.json",
+			},
+			wantErr: ErrInvalidPatchedTag,
+		},
 	}
 
 	for _, tt := range tests {
@@ -185,6 +215,30 @@ func TestRunValidationFails(t *testing.T) {
 	err := Run(context.Background(), cfg)
 	if !errors.Is(err, ErrEmptyImage) {
 		t.Errorf("Run() = %v, want error wrapping ErrEmptyImage", err)
+	}
+}
+
+// TestRunRejectsDigestSmuggledTag is the end-to-end regression test for the
+// chronic Patch Image cache-ref bug — see the matching subtest in
+// TestConfigValidate for the upstream root-cause analysis. This test asserts
+// that Run() refuses a malformed PatchedTag *before* reaching copa, so the
+// failure surface is `ErrInvalidPatchedTag` (clear, actionable) instead of
+// copa's deep "failed to parse explicit reference … invalid reference
+// format" originating from inside its build pipeline.
+func TestRunRejectsDigestSmuggledTag(t *testing.T) {
+	t.Parallel()
+
+	// Verbatim string from the failing nightly run:
+	//   ghcr.io/verity-org/cache:cilium-operator-generic-v1.19.3@sha256-amd64
+	// The PatchedTag field is the part after the staging registry's `:`.
+	cfg := &Config{
+		Image:      "quay.io/cilium/operator-generic:v1.19.3@sha256:205b09abc",
+		PatchedTag: "cilium-operator-generic-v1.19.3@sha256-amd64",
+		Report:     "trivy.json",
+	}
+	err := Run(context.Background(), cfg)
+	if !errors.Is(err, ErrInvalidPatchedTag) {
+		t.Errorf("Run() = %v, want error wrapping ErrInvalidPatchedTag", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the chronic nightly Patch Image failures (~2-9 runs/night) for digest-pinned multi-arch images (`cilium/operator-generic`, `cilium/cilium-envoy`, `ingress-nginx/kube-webhook-certgen`, …) that fail with:

```
Error: Patch Failed
  failed to parse explicit reference
  ghcr.io/verity-org/cache:cilium-operator-generic-v1.19.3@sha256-amd64:
  invalid reference format
```

Failing nightly run referenced: [#25254490410](https://github.com/verity-org/verity/actions/runs/25254490410).

## Root cause

`.github/scripts/patch-image.sh` derived `SOURCE_TAG` with `cut -d: -f2`. For a digest-pinned source like `quay.io/cilium/operator-generic:v1.19.3@sha256:205b09…`, that returns the **second** `:`-separated field — `v1.19.3@sha256` — instead of the tag. The script then composes:

```
PLATFORM_TAG="${STAGING_REGISTRY}:${SAFE_IMAGE}-${SOURCE_TAG}-${PLATFORM_ARCH}"
              = ghcr.io/verity-org/cache:cilium-operator-generic-v1.19.3@sha256-amd64
```

and passes it to `verity patch --tag`. Copa's reference parser reads the embedded `@` as the OCI digest separator and rejects `sha256-amd64` as an invalid digest. The 18/20-success rate matched intuition: the bug only fires when the catalog entry pins a digest, which is the case for the cilium and a few ingress-nginx images. Tag-only refs (most images) were unaffected.

A second, latent variant of the same bug lived in `.github/workflows/patch-image.yaml`: its `SOURCE_TAG="${SOURCE_REF##*:}"` returns the hex-digest portion (`205b09…`) for digest-pinned refs. That value never reached copa's parser, but it is consumed by the combine step's per-arch tag lookup. The moment the script-side fix lands, the combine step would look for `…-205b09…-amd64` while the patch step had pushed `…-v1.19.3-amd64`, breaking the manifest assembly. Both parsers must agree.

## Fix shape

Option **(b)** from the brief — construct a proper reference. The `@digest` suffix is stripped first, then everything after the last `:` is taken as the tag.

|File|Change|
|----|------|
|`.github/scripts/patch-image.sh`|Replace `cut -d: -f2` with `${SOURCE%@*}` then `${…##*:}`. Preserves behaviour for tag-only and registry-with-port forms.|
|`.github/workflows/patch-image.yaml`|Same parser applied to the workflow-level `SOURCE_TAG`, so the workflow's `staging-tag` output stays in sync with what the script pushes.|
|`internal/patch/patch.go`|`Config.Validate()` now rejects `PatchedTag` values containing `@` (new exported `ErrInvalidPatchedTag`). Defence-in-depth: any future caller that smuggles a digest separator into the tag fails with a clear verity-layer error instead of copa's opaque "invalid reference format" mid-build.|
|`internal/patch/patch_test.go`|Two new `TestConfigValidate` subtests + one `TestRunRejectsDigestSmuggledTag` E2E test using the **verbatim** malformed string from the failing nightly (`cilium-operator-generic-v1.19.3@sha256-amd64`).|

The script-side parser was sanity-checked against the failing nightly inputs *and* against tag-only / registry-with-port forms (`mirror.gcr.io/library/nginx:1.29.3`, `localhost:5000/foo:v1`, `localhost:5000/foo:v1@sha256:abc`); all produce the expected tag.

Per-package `go test ./internal/patch/... ./cmd/...` and `golangci-lint run` are clean. `shellcheck .github/scripts/patch-image.sh` is clean.

## Verification dispatch

Triggered against this branch with the verbatim digest from today's failing nightly:

```
gh workflow run patch-image.yaml --ref fix/patch-cache-ref-digest \
  -f image-name=cilium/operator-generic \
  -f source-ref="quay.io/cilium/operator-generic:v1.19.3@sha256:205b09b0ed6accbf9fe688d312a9f0fcfc6a316fc081c23fbffb472af5dd62cd" \
  -f target-registry=ghcr.io/verity-org \
  -f platforms=linux/amd64,linux/arm64
```

Run: [#25259824672](https://github.com/verity-org/verity/actions/runs/25259824672) — in flight at PR open time. The previous nightly (run [#25254490410](https://github.com/verity-org/verity/actions/runs/25254490410)) failed at the patch step with the malformed-reference error; this dispatch exercises the identical input on the fix branch.

## Risk notes

- For digest-pinned images that have **succeeded** before via a non-digest catalog entry (none observed today), the staging-tag and report-path naming will switch from `…-<hex>-…` to `…-<semver>-…`. Existing reports/metrics under hex paths will be orphaned but harmless; the next nightly will re-populate semver paths. No production image references move.
- `ErrInvalidPatchedTag` only checks for `@`; we deliberately did not duplicate copa's full OCI tag regex here. Anything else copa rejects will still surface as a copa-layer error, which is fine for non-bug inputs.

## Acceptance criteria

- **AC-1** cache-ref fix lands — **SATISFIED** (script + workflow parsers + Go-side guard)
- **AC-2** regression test added — **SATISFIED** (`TestConfigValidate/patched_tag_with_@sha256_digest_leak_rejected`, `TestConfigValidate/patched_tag_with_bare_@_rejected`, `TestRunRejectsDigestSmuggledTag`; verified to fail without the fix by stashing `patch.go` — build breaks on the missing `ErrInvalidPatchedTag` symbol that the regression tests reference)
- **AC-3** verification dispatch — **PARTIAL** (run [#25259824672](https://github.com/verity-org/verity/actions/runs/25259824672) in flight; PMA to confirm green before merge)

Closes the ongoing nightly noise for the three reproducibly-failing images. PMA owns merge + close.