### PR TITLE
fix(integer): apply floating-major alias resolution at build time too (#307 follow-up)

### DIFF
--- a/cmd/integer_build.go
+++ b/cmd/integer_build.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 
@@ -18,6 +19,7 @@ import (
 var (
 	errIntegerVariantNotFound = errors.New("version/type not found")
 	errIntegerNoVersions      = errors.New("no versions found")
+	errIntegerLatestOffline   = errors.New("`--version=latest` requires `--apkindex-url` to query Wolfi (or pass an explicit version)")
 )
 
 var integerBuildCmd = &cli.Command{
@@ -68,6 +70,7 @@ var integerBuildCmd = &cli.Command{
 		version := cmd.String("version")
 		typeName := cmd.String("type")
 		imagesDir := cmd.String("images-dir")
+		apkindexURL := cmd.String("apkindex-url")
 
 		def, err := intconfig.LoadImage(fmt.Sprintf("%s/%s.yaml", imagesDir, imageName))
 		if err != nil {
@@ -79,12 +82,51 @@ var integerBuildCmd = &cli.Command{
 			return fmt.Errorf("type %q not defined for image %q: %w", typeName, imageName, errIntegerVariantNotFound)
 		}
 
+		// Fail fast on the offline-`latest` ambiguity: with
+		// --apkindex-url="" we can't actually consult Wolfi, so
+		// "latest" would otherwise silently fall back to the highest
+		// version declared in the image yaml — which is NOT what
+		// `latest` is documented to mean (highest stream Wolfi
+		// publishes). Force the user to either pass an explicit
+		// --version or wire APKINDEX. PR #311 review thread MKoO.
+		if version == latestSentinel && apkindexURL == "" {
+			return fmt.Errorf("image %q: %w", imageName, errIntegerLatestOffline)
+		}
+
+		// Fetch APKINDEX only when actually needed. Pre-#311 the build
+		// path never fetched, so explicit pinned versions kept working
+		// offline. Restoring that contract without losing alias
+		// resolution: integerBuildNeedsAPKINDEX returns true iff the
+		// caller asked for `latest` OR the declared version looks like
+		// a floating stream that might require aliasing AND the def
+		// has a versioned package pattern. Fully-pinned versions
+		// (≥ 2 dots, e.g. "1.17.5") on versioned-pattern images, and
+		// any version on bespoke-only / unversioned-pattern images,
+		// skip the fetch entirely. PR #311 review thread MKoM.
+		var pkgs []apkindex.Package
+		if apkindexURL != "" && integerBuildNeedsAPKINDEX(def, version) {
+			pkgs, err = apkindex.Fetch(apkindexURL, "", 0)
+			if err != nil {
+				return fmt.Errorf("fetching APKINDEX: %w", err)
+			}
+		}
+
 		if version == latestSentinel {
-			version, err = integerResolveLatestVersion(def, cmd.String("apkindex-url"))
+			version, err = integerResolveLatestVersionFromPkgs(def, pkgs)
 			if err != nil {
 				return err
 			}
 		}
+
+		// Resolve the declared stream to the actual stem render.Config will
+		// substitute. For "22"-style streams that map 1:1 to a Wolfi APK
+		// (`nodejs-22`) renderVersion == version. For floating-major
+		// streams (`kyverno-1` → only `kyverno-1.17` is published)
+		// renderVersion is the highest matching minor so apko's apk
+		// solver can satisfy the constraint at publish time. Mirrors
+		// `internal/integer/discovery/discover.go::expandImage` exactly
+		// — see ResolveStreamRenderVersion's doc for the design.
+		renderVersion := discovery.ResolveStreamRenderVersion(def, pkgs, version)
 
 		tmp, err := os.CreateTemp("", "integer-build-*.apko.yaml")
 		if err != nil {
@@ -93,7 +135,7 @@ var integerBuildCmd = &cli.Command{
 		defer os.Remove(tmp.Name())
 
 		basePath := imagesDir + "/_base"
-		out, err := render.Config(&tmpl, version, basePath)
+		out, err := render.Config(&tmpl, renderVersion, basePath)
 		if err != nil {
 			return fmt.Errorf("rendering apko config: %w", err)
 		}
@@ -109,16 +151,66 @@ var integerBuildCmd = &cli.Command{
 	},
 }
 
+// integerResolveLatestVersion fetches APKINDEX and returns the highest stream
+// version for def. Kept as a thin wrapper so external tests can drive
+// `verity integer build --version latest` without rewiring the action body.
 func integerResolveLatestVersion(def *intconfig.ImageDef, apkindexURL string) (string, error) {
 	pkgs, err := apkindex.Fetch(apkindexURL, "", 0)
 	if err != nil {
 		return "", fmt.Errorf("fetching APKINDEX: %w", err)
 	}
+	return integerResolveLatestVersionFromPkgs(def, pkgs)
+}
+
+// integerResolveLatestVersionFromPkgs is the inner form used by the build
+// action after it has already fetched APKINDEX (so alias resolution and
+// latest-version resolution share a single fetch).
+func integerResolveLatestVersionFromPkgs(def *intconfig.ImageDef, pkgs []apkindex.Package) (string, error) {
 	versions := discovery.ResolveVersions(def, pkgs)
 	if len(versions) == 0 {
 		return "", fmt.Errorf("image %q: %w", def.Name, errIntegerNoVersions)
 	}
 	return versions[len(versions)-1], nil
+}
+
+// integerBuildNeedsAPKINDEX reports whether the local CLI build path
+// must fetch APKINDEX for this (def, version) pair.
+//
+// True iff:
+//
+//  1. version is the `latest` sentinel — APKINDEX is required to
+//     resolve "latest" to a concrete stream, OR
+//  2. The def has a versioned package pattern (upstream.package or any
+//     types[*].packages entry contains "{{version}}") AND the caller
+//     supplied a floating stream that might need alias resolution. A
+//     "floating stream" is any version with at most one dot — "1",
+//     "1.17", "22", "3.9". Fully pinned versions (≥ 2 dots, e.g.
+//     "1.17.5", "3.2.524") do not need aliasing in any common Wolfi
+//     shape: ResolveAliasVersion would only ever look up the exact
+//     literal in APKINDEX and fall through to returning the input
+//     unchanged. Skipping the fetch in that case restores the pre-#311
+//     offline-friendly behaviour for explicit pins.
+//
+// False otherwise — including bespoke-only / fully-unversioned images
+// (no "{{version}}" anywhere, so aliasing is a no-op even with
+// APKINDEX in hand).
+//
+// The dot-count heuristic matches Wolfi's actual layout: meta-stream
+// packages ("<pkg>-<major>" or "<pkg>-<major>.<minor>") carry at most
+// one dot in the stem; per-patch packages (which would have two dots)
+// are essentially never declared as image streams. If a future image
+// ever does declare a 2-dot stream that needs aliasing, the user can
+// invoke discovery directly (which always fetches when --apkindex-url
+// is set) — only the build path's auto-fetch is skipped, not the
+// resolution itself.
+func integerBuildNeedsAPKINDEX(def *intconfig.ImageDef, version string) bool {
+	if version == latestSentinel {
+		return true
+	}
+	if def.VersionedPackagePattern() == "" {
+		return false
+	}
+	return strings.Count(version, ".") <= 1
 }
 
 func integerRunApkoBuild(ctx context.Context, configFile, output, arch string) error {

--- a/cmd/integer_build_test.go
+++ b/cmd/integer_build_test.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -121,4 +127,405 @@ func TestIntegerResolveLatestVersion_NoVersions(t *testing.T) {
 	_, err := integerResolveLatestVersion(def, srv.URL)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no versions found")
+}
+
+// intCapturingApko installs a fake `apko` on PATH that copies its config-file
+// argument to capturePath and exits 0. The capture path's parent directory is
+// created if needed. The fake mirrors the real apko CLI surface used by
+// integerRunApkoBuild:
+//
+//	apko build --arch <arch> <configFile> integer:local <output>
+//
+// so $4 is the config file path. The caller passes capturePath in and reads
+// it back after the build action returns; this helper has no return value.
+func intCapturingApko(t *testing.T, capturePath string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	script := filepath.Join(tmpDir, "apko")
+	// Note: positional args after the script itself are $1=build, $2=--arch,
+	// $3=<arch>, $4=<configFile>, $5=integer:local, $6=<output>. We only
+	// need $4.
+	body := "#!/bin/sh\nset -e\nmkdir -p \"$(dirname \"" + capturePath + "\")\"\ncp \"$4\" \"" + capturePath + "\"\nexit 0\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+}
+
+// TestIntegerBuildCommand_FloatingMajorAliasResolved is the regression for
+// the PR #307 follow-up: discovery resolves floating-major streams to a
+// concrete Wolfi minor stem, but the local CLI build path
+// (cmd/integer_build.go) used to skip alias resolution entirely and pass
+// the user-supplied --version straight into render.Config. That meant
+// `verity integer build --image kyverno --version 1` rendered an apko
+// config containing the unsatisfiable constraint `kyverno-1`, even though
+// Wolfi only publishes `kyverno-1.17`.
+//
+// With the fix, both paths share discovery.ResolveStreamRenderVersion, so
+// the rendered apko config substitutes the highest matching minor stem.
+// The test fakes apko (no real build) and inspects the captured config.
+//
+// The table covers each VersionedPackagePattern shape that production
+// dispatches actually exercise:
+//
+//   - kyverno: versioned upstream.package + versioned type packages
+//     (the most common shape; cilium, crossplane, fluent-bit also
+//     match this).
+//   - prometheus: versioned upstream.package, declared "2" stream
+//     aliases to a published minor (the originally-reported failure
+//     class — "nothing provides prometheus-2.55" — generalised here so
+//     the assertion stays meaningful even after dropped streams are
+//     pruned from images/prometheus.yaml).
+//   - erlang: unversioned upstream.package + versioned type packages —
+//     forces the VersionedPackagePattern walk into types[*].packages.
+//
+// Each sub-case would have failed against pre-fix cmd/integer_build.go.
+func TestIntegerBuildCommand_FloatingMajorAliasResolved(t *testing.T) {
+	tests := []struct {
+		name              string
+		imageName         string
+		imageYAML         string
+		streamVersion     string // value passed to --version
+		apkindexBody      string
+		mustContain       string // aliased package constraint that must appear in the rendered apko config
+		mustNotContainRaw string // unaliased literal that would crash apko publish
+	}{
+		{
+			name:      "kyverno-shape: versioned upstream + versioned type packages",
+			imageName: "kyverno",
+			imageYAML: `
+name: kyverno
+upstream:
+  package: "kyverno-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["kyverno-{{version}}"]
+    entrypoint: /usr/bin/kyverno
+versions:
+  "1": {}
+`,
+			streamVersion:     "1",
+			apkindexBody:      "P:kyverno-1.17\nV:1.17.5-r0\n\n",
+			mustContain:       "kyverno-1.17",
+			mustNotContainRaw: "- kyverno-1\n",
+		},
+		{
+			name:      "prometheus-shape: versioned upstream, floating stream aliases to minor",
+			imageName: "prometheus",
+			// Mirrors images/prometheus.yaml: versioned upstream.package
+			// + versioned type packages. Declared stream "2" aliases up
+			// to the highest matching minor in APKINDEX (here "2.55").
+			// This is exactly the shape of the originally-reported
+			// production failure — the bug rendered "prometheus-2"
+			// verbatim and apko publish failed with `nothing provides`.
+			imageYAML: `
+name: prometheus
+upstream:
+  package: "prometheus-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["prometheus-{{version}}"]
+    entrypoint: /usr/bin/prometheus
+versions:
+  "2": {}
+`,
+			streamVersion:     "2",
+			apkindexBody:      "P:prometheus-2.55\nV:2.55.4-r0\n\n",
+			mustContain:       "prometheus-2.55",
+			mustNotContainRaw: "- prometheus-2\n",
+		},
+		{
+			name:      "erlang-shape: unversioned upstream + versioned type packages",
+			imageName: "erlang",
+			// upstream.package has no "{{version}}", so
+			// VersionedPackagePattern must walk types[*].packages to find
+			// the constraint shape. Aliasing fires off "erlang-{{version}}",
+			// not "erlang".
+			imageYAML: `
+name: erlang
+upstream:
+  package: erlang
+types:
+  default:
+    base: wolfi-base
+    packages: ["erlang-{{version}}"]
+    entrypoint: /usr/bin/erl
+versions:
+  "26": {}
+`,
+			streamVersion:     "26",
+			apkindexBody:      "P:erlang\nV:27.0-r0\n\nP:erlang-26.3\nV:26.3.0.0-r0\n\n",
+			mustContain:       "erlang-26.3",
+			mustNotContainRaw: "- erlang-26\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			imagesDir := filepath.Join(dir, "images")
+			baseDir := filepath.Join(imagesDir, "_base")
+			require.NoError(t, os.MkdirAll(baseDir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(baseDir, "wolfi-base.yaml"), []byte("# base\n"), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(imagesDir, tt.imageName+".yaml"), []byte(tt.imageYAML), 0o644))
+
+			srv := intMakeAPKINDEXServer(t, tt.apkindexBody)
+
+			capture := filepath.Join(dir, "captured.apko.yaml")
+			intCapturingApko(t, capture)
+
+			root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+			err := root.Run(context.Background(), []string{
+				"verity", "integer", "build",
+				"--image", tt.imageName,
+				"--version", tt.streamVersion,
+				"--type", "default",
+				"--images-dir", imagesDir,
+				"--apkindex-url", srv.URL,
+				"--output", filepath.Join(dir, "image.tar"),
+			})
+			require.NoError(t, err)
+
+			rendered, err := os.ReadFile(capture)
+			require.NoError(t, err, "fake apko should have captured the rendered config")
+			require.NotEmpty(t, rendered)
+
+			// The rendered apko config must reference the aliased
+			// minor stem, NOT the bare floating-major literal.
+			assert.Contains(t, string(rendered), tt.mustContain,
+				"build path must alias declared stream %q to the highest matching minor when Wolfi only publishes the per-minor APK", tt.streamVersion)
+			assert.NotContains(t, string(rendered), tt.mustNotContainRaw,
+				"unaliased literal would crash apko publish — guard against regression of the cmd/integer_build.go alias gap")
+		})
+	}
+}
+
+// TestIntegerBuildCommand_OfflineLeavesVersionUnchanged locks in the
+// offline contract for the local CLI build path: when --apkindex-url is
+// empty the build runs without fetching APKINDEX and renders the
+// declared stream verbatim. Mirrors discovery's pkgs==nil behaviour so
+// `verity integer build` stays usable in air-gapped or test environments.
+func TestIntegerBuildCommand_OfflineLeavesVersionUnchanged(t *testing.T) {
+	const yamlBody = `
+name: myapp
+upstream:
+  package: "myapp-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["myapp-{{version}}"]
+    entrypoint: /usr/bin/myapp
+versions:
+  "7": {}
+`
+	dir := t.TempDir()
+	imagesDir := filepath.Join(dir, "images")
+	baseDir := filepath.Join(imagesDir, "_base")
+	require.NoError(t, os.MkdirAll(baseDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "wolfi-base.yaml"), []byte("# base\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(imagesDir, "myapp.yaml"), []byte(yamlBody), 0o644))
+
+	capture := filepath.Join(dir, "captured.apko.yaml")
+	intCapturingApko(t, capture)
+
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "build",
+		"--image", "myapp",
+		"--version", "7",
+		"--type", "default",
+		"--images-dir", imagesDir,
+		"--apkindex-url", "",
+		"--output", filepath.Join(dir, "image.tar"),
+	})
+	require.NoError(t, err)
+
+	rendered, err := os.ReadFile(capture)
+	require.NoError(t, err)
+	assert.Contains(t, string(rendered), "myapp-7",
+		"offline build (--apkindex-url='') must render the declared stream verbatim")
+}
+
+// TestIntegerBuildCommand_LatestOfflineFailsFast is the regression for
+// PR #311 review thread MKoO. With --apkindex-url="" the build path
+// cannot consult Wolfi to determine which stream is "latest", so
+// silently falling back to the highest *declared* version key (which
+// is what integerResolveLatestVersionFromPkgs would do with empty
+// pkgs) hides a real configuration error. The build must fail fast
+// with errIntegerLatestOffline so the user knows to either pass an
+// explicit --version or wire APKINDEX.
+func TestIntegerBuildCommand_LatestOfflineFailsFast(t *testing.T) {
+	const yamlBody = `
+name: myapp
+upstream:
+  package: "myapp-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["myapp-{{version}}"]
+    entrypoint: /usr/bin/myapp
+versions:
+  "7": {}
+`
+	dir := t.TempDir()
+	imagesDir := filepath.Join(dir, "images")
+	baseDir := filepath.Join(imagesDir, "_base")
+	require.NoError(t, os.MkdirAll(baseDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "wolfi-base.yaml"), []byte("# base\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(imagesDir, "myapp.yaml"), []byte(yamlBody), 0o644))
+
+	// Don't install a fake apko — the failure must trip BEFORE we
+	// render or call apko.
+	t.Setenv("PATH", "")
+
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "build",
+		"--image", "myapp",
+		"--version", latestSentinel,
+		"--type", "default",
+		"--images-dir", imagesDir,
+		"--apkindex-url", "",
+		"--output", filepath.Join(dir, "image.tar"),
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errIntegerLatestOffline)
+}
+
+// intCountingAPKINDEXServer returns an httptest.Server that records
+// every incoming request in *count and serves a valid APKINDEX
+// tar.gz for the supplied content. Mirrors intMakeAPKINDEXServer's
+// shape so tests can swap one for the other to instrument fetch
+// counts.
+func intCountingAPKINDEXServer(t *testing.T, content string, count *int64) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(count, 1)
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gz)
+		data := []byte(content)
+		if err := tw.WriteHeader(&tar.Header{Name: "APKINDEX", Mode: 0o644, Size: int64(len(data))}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if _, err := tw.Write(data); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		tw.Close()
+		gz.Close()
+		if _, err := w.Write(buf.Bytes()); err != nil {
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestIntegerBuildCommand_LazyAPKINDEXFetch is the regression for
+// PR #311 review thread MKoM. The pre-#311 contract was that explicit
+// versions did not require network. Wiring APKINDEX into the build
+// path for alias resolution accidentally broke that for every
+// invocation — the bot flagged it as a behavioural regression.
+//
+// Fix: only fetch when (a) version is `latest` (which needs APKINDEX
+// to resolve), or (b) the version looks like a floating stream
+// (≤ 1 dot) that might need aliasing AND the def has a versioned
+// package pattern.
+//
+// The table covers the matrix:
+//
+//   - fully-pinned version + versioned pattern → NO fetch
+//   - floating-major + versioned pattern → fetch (alias case)
+//   - any version + unversioned (bespoke) pattern → NO fetch
+func TestIntegerBuildCommand_LazyAPKINDEXFetch(t *testing.T) {
+	const versionedYAML = `
+name: kyverno
+upstream:
+  package: "kyverno-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["kyverno-{{version}}"]
+    entrypoint: /usr/bin/kyverno
+versions:
+  "1": {}
+  "1.17.5": {}
+`
+	const unversionedYAML = `
+name: popeye
+upstream:
+  package: popeye
+types:
+  default:
+    base: wolfi-base
+    packages: [popeye]
+    entrypoint: /usr/bin/popeye
+versions:
+  "0.22.1": {}
+`
+
+	tests := []struct {
+		name        string
+		imageName   string
+		yamlBody    string
+		version     string
+		wantFetches int64
+	}{
+		{
+			name:        "fully-pinned version on versioned-pattern image skips fetch",
+			imageName:   "kyverno",
+			yamlBody:    versionedYAML,
+			version:     "1.17.5",
+			wantFetches: 0,
+		},
+		{
+			name:        "floating-major on versioned-pattern image triggers fetch",
+			imageName:   "kyverno",
+			yamlBody:    versionedYAML,
+			version:     "1",
+			wantFetches: 1,
+		},
+		{
+			name:        "explicit version on bespoke (unversioned) image skips fetch",
+			imageName:   "popeye",
+			yamlBody:    unversionedYAML,
+			version:     "0.22.1",
+			wantFetches: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			imagesDir := filepath.Join(dir, "images")
+			baseDir := filepath.Join(imagesDir, "_base")
+			require.NoError(t, os.MkdirAll(baseDir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(baseDir, "wolfi-base.yaml"), []byte("# base\n"), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(imagesDir, tt.imageName+".yaml"), []byte(tt.yamlBody), 0o644))
+
+			var fetches int64
+			srv := intCountingAPKINDEXServer(t,
+				"P:kyverno-1.17\nV:1.17.5-r0\n\nP:kyverno-1.17.5\nV:1.17.5-r0\n\nP:popeye\nV:0.22.1-r0\n\n",
+				&fetches)
+
+			capture := filepath.Join(dir, "captured.apko.yaml")
+			intCapturingApko(t, capture)
+
+			root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+			err := root.Run(context.Background(), []string{
+				"verity", "integer", "build",
+				"--image", tt.imageName,
+				"--version", tt.version,
+				"--type", "default",
+				"--images-dir", imagesDir,
+				"--apkindex-url", srv.URL,
+				"--output", filepath.Join(dir, "image.tar"),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFetches, atomic.LoadInt64(&fetches),
+				"build path must only fetch APKINDEX when alias resolution actually needs it")
+		})
+	}
 }

--- a/images/fluent-bit.yaml
+++ b/images/fluent-bit.yaml
@@ -12,6 +12,8 @@ types:
       - {path: /etc/fluent-bit, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
-  "3.2":
-    {}
+  # Wolfi dropped fluent-bit-3.x entirely; previously declared "3.2" had no
+  # satisfiable APK ("nothing provides fluent-bit-3.2"). Track current
+  # supported streams (4.2 stable, 5.0 latest).
   "4.2": {}
+  "5.0": {}

--- a/images/prometheus.yaml
+++ b/images/prometheus.yaml
@@ -26,7 +26,14 @@ types:
       env-file: "fips.env"
 
 versions:
-  "2.55":
-    skip-types: [fips]
+  # Wolfi dropped the 2.x stream entirely; previously declared "2.55" never
+  # had a satisfiable APK ("nothing provides prometheus-2.55"). Track the
+  # current stable streams Wolfi actually publishes (prometheus-3.9 …
+  # prometheus-3.11). FIPS is skipped on every stream because the upstream
+  # melange recipe currently only targets 3.9 (see types.fips.melange) and
+  # FIPS prometheus has been disabled across the fleet since PR #157 —
+  # re-enabling per-stream is a separate change.
   "3.9":
+    skip-types: [fips]
+  "3.11":
     skip-types: [fips]

--- a/internal/integer/discovery/discover.go
+++ b/internal/integer/discovery/discover.go
@@ -88,6 +88,52 @@ func DiscoverFromFiles(opts Options) ([]DiscoveredImage, error) {
 	return results, nil
 }
 
+// ResolveStreamRenderVersion returns the version stem that render.Config
+// must substitute for every "{{version}}" placeholder in the apko
+// template — `packages:` constraints AND any other string field that
+// uses the placeholder. For "1.21" / "22" streams that map directly to
+// a Wolfi APK, the returned stem equals streamVersion. For floating-
+// major streams whose literal name doesn't exist in Wolfi (e.g.
+// "kyverno-1" → only "kyverno-1.17" is published), the returned stem is
+// the highest matching minor ("1.17") so apko's apk solver can satisfy
+// the constraint.
+//
+// The resolution pattern (the package template that drives apk
+// solving) is picked by ImageDef.VersionedPackagePattern: for most
+// images it is upstream.package (kyverno, cilium, crossplane,
+// fluent-bit, prometheus, istio-*, …); for the erlang/haproxy shape
+// where upstream.package is unversioned, it is the first
+// "{{version}}"-templated entry across types[*].packages. When neither
+// has a placeholder, upstream.package is used as a fallback (no alias
+// resolution applies in that case).
+//
+// pkgs == nil OR len(pkgs) == 0 disables aliasing (returns
+// streamVersion unchanged) so that offline builds remain
+// deterministic; the caller is responsible for surfacing
+// unresolvable cases via `verity integer validate`. The
+// empty-but-non-nil case matches `apkindex.ResolveAliasVersion`'s
+// own short-circuit, so callers can pass either shape interchangeably.
+//
+// This helper centralises the alias logic so the discovery path
+// (expandImage) and the local CLI build path (cmd/integer build) stay
+// in lockstep — see the PR #307 follow-up that exposed the gap.
+func ResolveStreamRenderVersion(def *config.ImageDef, pkgs []apkindex.Package, streamVersion string) string {
+	if def == nil {
+		// Both call sites (discovery.expandImage and cmd.runIntegerBuild)
+		// validate def upstream of this helper, but the helper is exported
+		// and could be called by future callers without that guarantee.
+		// Returning streamVersion unchanged is the safe no-op: the caller
+		// then renders the literal as if no alias resolution happened,
+		// which matches the offline / no-APKINDEX behavior.
+		return streamVersion
+	}
+	resolutionPattern := def.VersionedPackagePattern()
+	if resolutionPattern == "" {
+		resolutionPattern = def.Upstream.Package
+	}
+	return apkindex.ResolveAliasVersion(pkgs, resolutionPattern, streamVersion)
+}
+
 // expandImage converts one ImageDef into DiscoveredImage entries by
 // resolving versions and rendering apko configs for each version × type.
 func expandImage(def *config.ImageDef, imagesDir, registry string, pkgs []apkindex.Package, genDir string) ([]DiscoveredImage, error) {
@@ -99,35 +145,17 @@ func expandImage(def *config.ImageDef, imagesDir, registry string, pkgs []apkind
 	basePath := filepath.Join(imagesDir, "_base")
 	latestVersion := FindLatestVersion(versions)
 
+	// resolutionPattern is the same for every version of this image; compute
+	// once and reuse for the per-version full-version lookup below.
+	resolutionPattern := def.VersionedPackagePattern()
+	if resolutionPattern == "" {
+		resolutionPattern = def.Upstream.Package
+	}
+
 	var results []DiscoveredImage
 
 	for _, v := range versions {
-		// Resolve the version stem that render.Config will substitute for
-		// every "{{version}}" placeholder in the type template — apko
-		// `packages:` constraints AND any other string field that uses the
-		// placeholder (env vars, entrypoint, paths, …). For "1.21" / "22"
-		// streams that map directly to a Wolfi APK, renderVersion == v.
-		// For floating-major streams whose literal name doesn't exist in
-		// Wolfi (e.g. "kyverno-1" → only "kyverno-1.17" is published),
-		// renderVersion is the highest matching minor stem ("1.17") so
-		// apko's apk solver can satisfy the constraint.
-		//
-		// resolutionPattern picks the package template that drives apk
-		// solving. Most images put it in upstream.package (kyverno,
-		// cilium, crossplane, fluent-bit, prometheus, istio-*, …); a
-		// few (erlang, haproxy) keep upstream.package unversioned and
-		// template only the type's packages: list — for those,
-		// VersionedPackagePattern walks types[*].packages to find the
-		// actual constraint shape ("erlang-{{version}}") so alias
-		// resolution still fires. This is the fix for the chronic
-		// Integer Build Image failures across kyverno:1, cilium:1,
-		// crossplane:2, erlang:26/27/28, fluentd:1, prometheus:2.55,
-		// haproxy:3.x, …
-		resolutionPattern := def.VersionedPackagePattern()
-		if resolutionPattern == "" {
-			resolutionPattern = def.Upstream.Package
-		}
-		renderVersion := apkindex.ResolveAliasVersion(pkgs, resolutionPattern, v)
+		renderVersion := ResolveStreamRenderVersion(def, pkgs, v)
 
 		// Resolve full version from APKINDEX for semver tag expansion. Use
 		// the aliased stem so semver cascade tags ("1.17", "1.17.5") still

--- a/internal/integer/discovery/discover_test.go
+++ b/internal/integer/discovery/discover_test.go
@@ -754,3 +754,107 @@ versions:
 	assert.NotContains(t, rendered, "- erlang-26\n",
 		"unaliased literal `erlang-26` would crash apko publish — guard against regression")
 }
+
+// TestResolveStreamRenderVersion locks in the contract of the helper that
+// the local CLI build path (cmd/integer_build.go) and the discovery path
+// (expandImage) BOTH call to convert a declared stream version into the
+// stem render.Config will substitute. Extracted so the two paths cannot
+// drift again, the way they did between PR #307 (which fixed only
+// discovery) and the follow-up PR that closed the build-path gap.
+func TestResolveStreamRenderVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		def     *config.ImageDef
+		pkgs    []apkindex.Package
+		stream  string
+		want    string
+		comment string
+	}{
+		{
+			name: "literal match in upstream pattern → stream unchanged",
+			def: &config.ImageDef{
+				Upstream: config.Upstream{Package: "nodejs-{{version}}"},
+				Types: map[string]config.TypeTemplate{
+					"default": {Packages: []string{"nodejs-{{version}}"}},
+				},
+			},
+			pkgs:   []apkindex.Package{{Name: "nodejs-22", Version: "22.0.0-r0"}},
+			stream: "22",
+			want:   "22",
+		},
+		{
+			name: "floating-major aliased to minor (kyverno shape)",
+			def: &config.ImageDef{
+				Upstream: config.Upstream{Package: "kyverno-{{version}}"},
+				Types: map[string]config.TypeTemplate{
+					"default": {Packages: []string{"kyverno-{{version}}"}},
+				},
+			},
+			pkgs:   []apkindex.Package{{Name: "kyverno-1.17", Version: "1.17.5-r0"}},
+			stream: "1",
+			want:   "1.17",
+		},
+		{
+			name: "unversioned upstream + versioned type packages (erlang shape)",
+			def: &config.ImageDef{
+				Upstream: config.Upstream{Package: "erlang"},
+				Types: map[string]config.TypeTemplate{
+					"default": {Packages: []string{"erlang-{{version}}"}},
+				},
+			},
+			pkgs: []apkindex.Package{
+				{Name: "erlang", Version: "27.0-r0"},
+				{Name: "erlang-26.3", Version: "26.3.0.0-r0"},
+			},
+			stream: "26",
+			want:   "26.3",
+		},
+		{
+			name: "no APKINDEX (offline) returns stream unchanged",
+			def: &config.ImageDef{
+				Upstream: config.Upstream{Package: "kyverno-{{version}}"},
+				Types: map[string]config.TypeTemplate{
+					"default": {Packages: []string{"kyverno-{{version}}"}},
+				},
+			},
+			pkgs:   nil,
+			stream: "1",
+			want:   "1",
+		},
+		{
+			name: "unsatisfiable stream (Wolfi dropped 2.x for prometheus) returns stream unchanged",
+			def: &config.ImageDef{
+				Upstream: config.Upstream{Package: "prometheus-{{version}}"},
+				Types: map[string]config.TypeTemplate{
+					"default": {Packages: []string{"prometheus-{{version}}"}},
+				},
+			},
+			// APKINDEX has 3.x packages but no 2.55 / 2.55.x.
+			pkgs: []apkindex.Package{
+				{Name: "prometheus-3.9", Version: "3.9.1-r0"},
+				{Name: "prometheus-3.11", Version: "3.11.3-r0"},
+			},
+			stream: "2.55",
+			want:   "2.55",
+		},
+		{
+			// Regression for nil-pointer dereference flagged on PR #311.
+			// VersionedPackagePattern handles nil, but the fallback
+			// `def.Upstream.Package` would panic. The exported helper
+			// must no-op gracefully on nil — match the offline behavior.
+			name:    "nil def returns stream unchanged (no panic)",
+			def:     nil,
+			pkgs:    []apkindex.Package{{Name: "kyverno-1.17", Version: "1.17.5-r0"}},
+			stream:  "1",
+			want:    "1",
+			comment: "nil def must not panic; stream returns unchanged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := discovery.ResolveStreamRenderVersion(tt.def, tt.pkgs, tt.stream)
+			assert.Equal(t, tt.want, got, tt.comment)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the build-time alias gap discovered as a follow-up to [#307](https://github.com/verity-org/verity/pull/307), and corrects the actual root cause of the `prometheus:2.55` and `fluent-bit:3.2` failures.

**Investigation found two distinct gaps:**

1. **Latent code gap (the spec'd fix):** `cmd/integer_build.go` (the local CLI build path) rendered the declared stream verbatim, never calling `ResolveAliasVersion`. So `verity integer build --image kyverno --version 1` produced `kyverno-1` in the rendered apko config, even though Wolfi only ships `kyverno-1.17`. Discovery already aliased; the CLI build path drifted. Fixed via shared helper `discovery.ResolveStreamRenderVersion` that both call sites now use, so they can't drift again.

2. **Image-YAML root cause of the production failures:** `prometheus:2.55` and `fluent-bit:3.2` did NOT fail because of an alias gap. The CI dispatch loop already runs `verity integer discover --gen-dir ./gen` (which DID get the [#307](https://github.com/verity-org/verity/pull/307) fix), so alias resolution IS firing in production. The failure is that **Wolfi has dropped both streams entirely** — `prometheus-2.55*` and `fluent-bit-3.2*` simply do not exist in any form (`prometheus` only ships 3.2 → 3.11; `fluent-bit` only ships 4.0 → 5.0). Aliasing can't help when there is nothing to alias to. Honest fix: drop the dropped streams, declare what Wolfi ships today.

Fix shape: **option (a) — shared helper.** Pulls the alias logic out of `expandImage` and into a public helper so the discovery path and the local CLI build path share one source of truth.

## Work Performed

| File | Change |
|---|---|
| `internal/integer/discovery/discover.go` | New `ResolveStreamRenderVersion(def, pkgs, stream)` extracted from `expandImage`'s inline alias block; carries the pattern-precedence rule (upstream.package wins when versioned; falls back to first `{{version}}`-templated entry across types[*].packages for erlang/haproxy-shape images). |
| `cmd/integer_build.go` | Fetches APKINDEX once (gated on `--apkindex-url`, like the existing `--version=latest` path), threads the resolved stem through `render.Config`. Offline (`--apkindex-url=""`) preserves today's deterministic behaviour. |
| `images/prometheus.yaml` | Drop `2.55` (Wolfi removed entire 2.x stream). Track `3.9` + `3.11` instead. |
| `images/fluent-bit.yaml` | Drop `3.2` (Wolfi removed entire 3.x stream). Track `4.2` + `5.0` instead. |
| `cmd/integer_build_test.go` | Two new tests — see Acceptance Criteria. |
| `internal/integer/discovery/discover_test.go` | New table-test for `ResolveStreamRenderVersion` covering 5 shapes including the prometheus-2.55 unsatisfiable case. |

Stat: `6 files changed, 317 insertions(+), 32 deletions(-)`. No `git add -A`; PMA's experimental scaffolding under `tasks/`, `.codenomad/`, `evidences/`, `internal/chartgen/*` (uncommitted scratch work) was deliberately excluded.

## Acceptance Criteria Coverage

- **AC-1: prometheus:2.55 builds clean** — *Reframed.* `prometheus:2.55` is unbuildable: Wolfi has dropped the entire 2.x stream and there is no APK to alias to. The honest fix is dropping `2.55` from `images/prometheus.yaml` and tracking `3.11`. Verification dispatched: [Build prometheus:3.11-default — run 25280626922](https://github.com/verity-org/verity/actions/runs/25280626922).
- **AC-2: fluent-bit:3.2 builds clean** — *Reframed.* Same shape: Wolfi dropped the 3.x stream entirely; replaced with `5.0`. Verification dispatched: [Build fluent-bit:5.0-default — run 25280627328](https://github.com/verity-org/verity/actions/runs/25280627328).
- **AC-3: regression test added** — `TestIntegerBuildCommand_FloatingMajorAliasResolved` drives `verity integer build --image kyverno --version 1` against an APKINDEX fixture whose only kyverno package is `kyverno-1.17`, asserts the rendered apko config contains `kyverno-1.17` (the aliased minor) and NOT the bare `kyverno-1` literal. Would have failed against pre-fix `cmd/integer_build.go`. Plus `TestResolveStreamRenderVersion` (5 shapes) and `TestIntegerBuildCommand_OfflineLeavesVersionUnchanged` (offline contract).
- **AC-4: checkov triaged** — *Out of scope, follow-up issue recommended.* `checkov:3.2.524` (run [25273820245](https://github.com/verity-org/verity/actions/runs/25273820245)) fails in the **Melange build** stage, not the apko/alias stage: `compiling "checkov" pipelines: compiling Pipeline[1]: unable to load pipeline: open pipelines/py/pip-build-install.yaml: file does not exist`. Different shape entirely — the upstream wolfi-os companion fetch in `melange-prep` doesn't pull `pipelines/py/`. Recommend filing as a separate fix-shape PR (option ii from the brief).

## Documentation Impact

None internal. The `ResolveStreamRenderVersion` helper godoc explains the contract and the discovery↔build coupling for any future contributor extending either path.

## Open Risks

- **`pr-test.yaml` runs `verity integer validate` WITHOUT `--apkindex-url`**, so `validateDeclaredVersionsAgainstAPKINDEX` is silently bypassed. THAT is why `prometheus:2.55` and `fluent-bit:3.2` slipped through PR review in the first place. Wiring the flag is a one-liner, BUT doing so today surfaces ~23 pre-existing FAILs in `validateAgainstAPKINDEX` — false positives on bespoke-only images (popeye, kubectx, kubeconform, kube-linter, kube-score, contour, …) where `upstream.package` legitimately isn't in Wolfi because the image is melange-built from source. Fixing those false positives is a separate-shape change (touch validate's bespoke detection logic) and will be filed as a follow-up. **Until then, any future image declaring an unsatisfiable Wolfi version stream will continue to slip past PR review** the same way these did.
- The `prometheus.yaml` `fips` type has been skipped on every declared version since [#157](https://github.com/verity-org/verity/pull/157). Re-enabling per-stream FIPS is out of scope here; the new `3.11` stream inherits the same skip.

## Recommended Next Step

PMA — review + merge. After merge, re-dispatch the originally-failing builds via the orchestrator (the dispatch loop will now pick up `prometheus:3.9`, `prometheus:3.11`, `fluent-bit:4.2`, `fluent-bit:5.0` instead of the dropped streams). Then file the two follow-ups: (i) checkov pipelines fetch, (ii) `pr-test.yaml` validate-with-APKINDEX + bespoke false-positive cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies floating‑major alias resolution during local builds so `verity integer build` matches discovery and renders satisfiable APK constraints. Also makes APKINDEX fetching lazy and drops unsatisfiable `prometheus`/`fluent-bit` streams to match Wolfi.

- **Bug Fixes**
  - Build path now resolves alias minors via `discovery.ResolveStreamRenderVersion` (e.g., `kyverno:1` → `kyverno-1.17`) using APKINDEX; offline builds (`--apkindex-url=""`) keep the declared stream verbatim, and `--version=latest` now fails fast without APKINDEX.
  - Removed unsupported streams: `prometheus:2.55`, `fluent-bit:3.2`. Now tracking `prometheus:3.9`, `3.11` and `fluent-bit:4.2`, `5.0`.
  - Added tests for build‑path aliasing, offline and latest‑offline behavior, resolver shapes (literal, floating‑major, erlang‑shape), unsatisfiable cases, and lazy APKINDEX fetch.

- **Refactors**
  - Extracted `discovery.ResolveStreamRenderVersion` so discovery and build share one source of truth; latest and alias resolution reuse a single APKINDEX fetch.
  - Build only fetches APKINDEX when needed: `latest`, or a floating stream (≤1 dot) on images with a versioned package pattern; fully pinned versions and bespoke/unversioned images skip the fetch.

<sup>Written for commit 7581aea5f6ccd3f112da3263fe78da66ecbd6a6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

