### PR TITLE
fix(chartgen): compose registry+repo for charts without 'registry | default' short-circuit (#308 wave 2)

### DIFF
--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -149,6 +149,15 @@ func buildValuesTree(chartName string, chartValues map[string]any, overrides []V
 	}
 
 	for _, override := range overrides {
+		// IsScalarOverride wins over the legacy `Value != ""` shape so
+		// that intentional empty-string scalars (#308 wave 3 global
+		// registry neutralisation) are written through. The legacy
+		// branch remains for ChartImageOverride csv/single-source
+		// scalars that always carry a non-empty Value.
+		if override.IsScalarOverride {
+			setScalarValue(chartRoot, override.Path, override.Value)
+			continue
+		}
 		if override.Value != "" {
 			setScalarValue(chartRoot, override.Path, override.Value)
 			continue
@@ -158,16 +167,18 @@ func buildValuesTree(chartName string, chartValues map[string]any, overrides []V
 			"repository": override.Repository,
 			"tag":        override.Tag,
 		}
-		if override.ClearRegistry {
-			leaf["registry"] = ""
+		// SetRegistry / SetDefaultRegistry carry the registry hostname
+		// (e.g. `ghcr.io`) extracted from the patched FQDN, so the
+		// chart's template `{{ <sibling> }}/{{ repository }}` composes
+		// to `ghcr.io/verity-org/<repo>:<tag>` regardless of whether
+		// the template short-circuits via `default` or concatenates
+		// directly. Empty siblings (`""`) would produce leading-slash
+		// renders for direct-concatenation templates (see #308 wave 2).
+		if override.SetRegistry != "" {
+			leaf["registry"] = override.SetRegistry
 		}
-		// ClearDefaultRegistry is independent of ClearRegistry — a chart
-		// can use either or both sibling fields. kyverno 3.7.x is the
-		// canonical case for `defaultRegistry`; postgres-operator and
-		// most other 3-field charts use `registry`. See ValueOverride
-		// docs for the full rationale.
-		if override.ClearDefaultRegistry {
-			leaf["defaultRegistry"] = ""
+		if override.SetDefaultRegistry != "" {
+			leaf["defaultRegistry"] = override.SetDefaultRegistry
 		}
 
 		setScalarValue(chartRoot, override.Path, leaf)

--- a/internal/chartgen/chart_test.go
+++ b/internal/chartgen/chart_test.go
@@ -1,8 +1,11 @@
 package chartgen
 
 import (
+	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
+	"text/template"
 
 	"gopkg.in/yaml.v3"
 
@@ -353,44 +356,50 @@ func TestBuildValuesTree(t *testing.T) {
 		want      map[string]any
 	}{
 		{
-			name:      "clears upstream registry field",
+			// 3-field shape (postgres-operator, traefik, jenkins, etc.):
+			// upstream chart templates `{{ image.registry }}/{{ image.repository }}`.
+			// The wrapper composes the FQDN into the two sibling fields so
+			// the rendered ref is `ghcr.io/verity-org/zalando/postgres-operator:v1.15.1`,
+			// no leading slash. See #308 wave 2.
+			name:      "composes registry sibling for grafana/traefik shape",
 			chartName: "postgres-operator",
 			overrides: []ValueOverride{{
-				Path:          "image",
-				Repository:    "ghcr.io/verity-org/zalando/postgres-operator",
-				Tag:           "v1.15.1",
-				ClearRegistry: true,
+				Path:        "image",
+				Repository:  "verity-org/zalando/postgres-operator",
+				Tag:         "v1.15.1",
+				SetRegistry: "ghcr.io",
 			}},
 			want: map[string]any{
 				"postgres-operator": map[string]any{
 					"image": map[string]any{
-						"registry":   "",
-						"repository": "ghcr.io/verity-org/zalando/postgres-operator",
+						"registry":   "ghcr.io",
+						"repository": "verity-org/zalando/postgres-operator",
 						"tag":        "v1.15.1",
 					},
 				},
 			},
 		},
 		{
-			// kyverno 3.7.x — clears the chart's hard-coded
-			// `defaultRegistry: reg.kyverno.io` so the wrapper renders
-			// `ghcr.io/verity-org/<comp>:1.17` instead of
-			// `reg.kyverno.io/ghcr.io/verity-org/<comp>:1.17`.
-			name:      "clears upstream defaultRegistry field (kyverno)",
+			// kyverno 3.7.x — composes `defaultRegistry: ghcr.io` +
+			// `repository: verity-org/kyverno` so kyverno's helper
+			// `default (default .image.defaultRegistry .globalRegistry) .image.registry`
+			// resolves to `ghcr.io` (registry=nil, globalRegistry=nil → defaultRegistry fires).
+			// Rendered ref: `ghcr.io/verity-org/kyverno:1.17`. See #308 wave 2.
+			name:      "composes defaultRegistry sibling for kyverno shape",
 			chartName: "kyverno",
 			overrides: []ValueOverride{{
-				Path:                 "admissionController.container.image",
-				Repository:           "ghcr.io/verity-org/kyverno",
-				Tag:                  "1.17",
-				ClearDefaultRegistry: true,
+				Path:               "admissionController.container.image",
+				Repository:         "verity-org/kyverno",
+				Tag:                "1.17",
+				SetDefaultRegistry: "ghcr.io",
 			}},
 			want: map[string]any{
 				"kyverno": map[string]any{
 					"admissionController": map[string]any{
 						"container": map[string]any{
 							"image": map[string]any{
-								"defaultRegistry": "",
-								"repository":      "ghcr.io/verity-org/kyverno",
+								"defaultRegistry": "ghcr.io",
+								"repository":      "verity-org/kyverno",
 								"tag":             "1.17",
 							},
 						},
@@ -399,23 +408,24 @@ func TestBuildValuesTree(t *testing.T) {
 			},
 		},
 		{
-			// Both flags fire when the upstream chart declares both
-			// sibling fields — neutralise everything we can see.
-			name:      "clears both registry and defaultRegistry",
+			// Hybrid shape (`registry | default defaultRegistry`): both
+			// siblings get the registry hostname so either short-circuit
+			// path resolves to `ghcr.io`.
+			name:      "composes both registry and defaultRegistry siblings",
 			chartName: "hybrid",
 			overrides: []ValueOverride{{
-				Path:                 "image",
-				Repository:           "ghcr.io/verity-org/foo/bar",
-				Tag:                  "v1",
-				ClearRegistry:        true,
-				ClearDefaultRegistry: true,
+				Path:               "image",
+				Repository:         "verity-org/foo/bar",
+				Tag:                "v1",
+				SetRegistry:        "ghcr.io",
+				SetDefaultRegistry: "ghcr.io",
 			}},
 			want: map[string]any{
 				"hybrid": map[string]any{
 					"image": map[string]any{
-						"registry":        "",
-						"defaultRegistry": "",
-						"repository":      "ghcr.io/verity-org/foo/bar",
+						"registry":        "ghcr.io",
+						"defaultRegistry": "ghcr.io",
+						"repository":      "verity-org/foo/bar",
 						"tag":             "v1",
 					},
 				},
@@ -487,4 +497,546 @@ func TestBuildValuesTree(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestComposeRegistryRendersValidImageRefs is the #308 wave 2 regression
+// test. It runs the full chart-gen pipeline (ResolveValuePathsWithSubcharts
+// + buildValuesTree) for two fixtures that mirror the upstream chart
+// template shapes that produced the leading-slash bug, then renders the
+// merged values through a Helm-like text/template to assert the final
+// image reference is well-formed (`ghcr.io/verity-org/<repo>:<tag>`, no
+// leading slash, no empty registry).
+//
+// Shape 1 (grafana / traefik / argo-rollouts / falco / jenkins / postgres-operator
+// / trivy-operator / alloy):
+//
+//	{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+//
+// Shape 2 (kyverno 3.7.x — `image.registry | default image.defaultRegistry`):
+//
+//	{{ .Values.image.registry | default .Values.image.defaultRegistry }}/...
+//
+// Both shapes must produce `ghcr.io/verity-org/grafana:12.3` after the
+// fix — no `/ghcr.io/...` leading slash, no `docker.io/ghcr.io/...` double
+// registry.
+// renderCase is the table-row shape for TestComposeRegistryRendersValidImageRefs.
+// Lifted to package scope so the per-case helpers (extracted to keep the
+// main test function under the maintainability-index threshold) can
+// reference it.
+type renderCase struct {
+	name              string
+	valuesYML         string
+	mappings          []ImageMapping
+	templateExpr      string
+	wantImage         string
+	wantRegistrySet   string // expected wrapper leaf .registry value (informational)
+	wantDefRegistry   string // expected wrapper leaf .defaultRegistry value (informational)
+	wantRepoStripped  string // expected wrapper leaf .repository value
+	assertRegistryKey string // "registry" or "defaultRegistry" — which sibling we expect populated
+}
+
+func TestComposeRegistryRendersValidImageRefs(t *testing.T) {
+	cases := []renderCase{
+		{
+			// grafana / traefik / alloy / falco / postgres-operator / etc.
+			// Upstream `image: { registry, repository, tag }` with template
+			// shape `{{ image.registry }}/{{ image.repository }}:{{ image.tag }}`
+			// (direct concatenation, no `default` short-circuit). Pre-fix
+			// the wrapper wrote `registry: ""` → `/ghcr.io/verity-org/grafana:12.3`
+			// (kubelet `InvalidImageName`).
+			name: "grafana-shape direct concatenation produces valid ref",
+			valuesYML: `image:
+  registry: docker.io
+  repository: grafana/grafana
+  tag: ""
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "grafana/grafana",
+				PatchedRepo:  "ghcr.io/verity-org/grafana",
+				PatchedTag:   "12.3",
+			}},
+			templateExpr:      `{{ .image.registry }}/{{ .image.repository }}:{{ .image.tag }}`,
+			wantImage:         "ghcr.io/verity-org/grafana:12.3",
+			wantRegistrySet:   "ghcr.io",
+			wantRepoStripped:  "verity-org/grafana",
+			assertRegistryKey: "registry",
+		},
+		{
+			// kyverno 3.7.x — `image: { registry: ~, defaultRegistry, repository, tag }`
+			// with helper `default (default .image.defaultRegistry .globalRegistry) .image.registry`.
+			// Pre-fix the wrapper wrote `defaultRegistry: ""` and that broke
+			// any chart whose template was a plain concat rather than the
+			// `default`-short-circuit shape. After the fix the wrapper writes
+			// `defaultRegistry: ghcr.io` + `repository: verity-org/kyverno`,
+			// which composes correctly with kyverno's helper AND with any
+			// plain-concat template.
+			name: "kyverno-shape default short-circuit produces valid ref",
+			valuesYML: `image:
+  registry: ~
+  defaultRegistry: "reg.kyverno.io"
+  repository: "kyverno/kyverno"
+  tag: ~
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "kyverno/kyverno",
+				PatchedRepo:  "ghcr.io/verity-org/kyverno",
+				PatchedTag:   "1.17",
+			}},
+			// kyverno's resolved registry expression: registry | default defaultRegistry.
+			// In Helm: `default fallback primary` = primary if primary != empty else fallback.
+			// Equivalent here: if .image.registry is empty, use .image.defaultRegistry.
+			templateExpr:      `{{ orDefault .image.registry .image.defaultRegistry }}/{{ .image.repository }}:{{ .image.tag }}`,
+			wantImage:         "ghcr.io/verity-org/kyverno:1.17",
+			wantDefRegistry:   "ghcr.io",
+			wantRepoStripped:  "verity-org/kyverno",
+			assertRegistryKey: "defaultRegistry",
+		},
+		{
+			// Mixed shape: chart that templates `{{ registry | default defaultRegistry }}/...`
+			// AND has both siblings declared upstream. Both wrapper leaves
+			// must be set so the short-circuit resolves to `ghcr.io` no
+			// matter which path the helper takes.
+			name: "registry|default-defaultRegistry shape with both siblings present",
+			valuesYML: `image:
+  registry: "docker.io"
+  defaultRegistry: "fallback.example.com"
+  repository: "foo/bar"
+  tag: "v1"
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "foo/bar",
+				PatchedRepo:  "ghcr.io/verity-org/foo/bar",
+				PatchedTag:   "v1",
+			}},
+			templateExpr:      `{{ orDefault .image.registry .image.defaultRegistry }}/{{ .image.repository }}:{{ .image.tag }}`,
+			wantImage:         "ghcr.io/verity-org/foo/bar:v1",
+			wantRegistrySet:   "ghcr.io",
+			wantDefRegistry:   "ghcr.io",
+			wantRepoStripped:  "verity-org/foo/bar",
+			assertRegistryKey: "registry",
+		},
+		{
+			// Upstream chart that defaults `registry: ""` (an explicit
+			// empty-string declaration, which several Bitnami / community
+			// charts ship as the "let the user override me" pattern).
+			// Pre-#312-review-2 walkValues treated this as "no registry
+			// sibling" and we silently produced `/ghcr.io/...:v1`. After
+			// the fix the empty-string declaration counts as a real
+			// declaration and the wrapper composes `registry: ghcr.io`.
+			name: "registry empty-string upstream still composes",
+			valuesYML: `image:
+  registry: ""
+  repository: "foo/bar"
+  tag: "v1"
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "foo/bar",
+				PatchedRepo:  "ghcr.io/verity-org/foo/bar",
+				PatchedTag:   "v1",
+			}},
+			templateExpr:      `{{ .image.registry }}/{{ .image.repository }}:{{ .image.tag }}`,
+			wantImage:         "ghcr.io/verity-org/foo/bar:v1",
+			wantRegistrySet:   "ghcr.io",
+			wantRepoStripped:  "verity-org/foo/bar",
+			assertRegistryKey: "registry",
+		},
+		{
+			// Bitnami shape, EMPTY upstream global: chart helper resolves
+			// `{{ default .Values.global.imageRegistry .Values.image.registry }}`
+			// — global wins when set, otherwise per-image registry.
+			// Postgres-operator and Bitnami's own postgresql sub-chart
+			// ship `global.imageRegistry: ""` upstream, so the per-image
+			// SetRegistry is sufficient on its own; the wave-3
+			// neutralisation overrides the empty global with another
+			// empty (no-op semantically, but the wrapper is consistent).
+			name: "global.imageRegistry empty upstream — image.registry composes",
+			valuesYML: `global:
+  imageRegistry: ""
+image:
+  registry: docker.io
+  repository: bitnamilegacy/postgresql
+  tag: "16.1.0-debian-11-r15"
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "bitnamilegacy/postgresql",
+				PatchedRepo:  "ghcr.io/verity-org/bitnamilegacy/postgresql",
+				PatchedTag:   "16.1.0-debian-11-r15",
+			}},
+			templateExpr:      `{{ orDefault .global.imageRegistry .image.registry }}/{{ .image.repository }}:{{ .image.tag }}`,
+			wantImage:         "ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15",
+			wantRegistrySet:   "ghcr.io",
+			wantRepoStripped:  "verity-org/bitnamilegacy/postgresql",
+			assertRegistryKey: "registry",
+		},
+		{
+			// Bitnami shape, NON-EMPTY upstream global: this is the
+			// regression case Copilot flagged in #312 round 3. Without
+			// wave-3 neutralisation the wrapper rewrites `image.registry`
+			// to `ghcr.io`, but Helm's `default global.imageRegistry`
+			// still picks up the upstream `docker.io` (non-empty wins),
+			// rendering `docker.io/verity-org/bitnamilegacy/postgresql`.
+			// With neutralisation, the wrapper writes both
+			// `image.registry: ghcr.io` AND `global.imageRegistry: ""`,
+			// so the helper falls through to per-image and renders
+			// `ghcr.io/verity-org/bitnamilegacy/postgresql:<tag>`.
+			name: "global.imageRegistry NON-empty upstream — neutralised by wave-3",
+			valuesYML: `global:
+  imageRegistry: "docker.io"
+image:
+  registry: docker.io
+  repository: bitnamilegacy/postgresql
+  tag: "16.1.0-debian-11-r15"
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "bitnamilegacy/postgresql",
+				PatchedRepo:  "ghcr.io/verity-org/bitnamilegacy/postgresql",
+				PatchedTag:   "16.1.0-debian-11-r15",
+			}},
+			templateExpr:      `{{ orDefault .global.imageRegistry .image.registry }}/{{ .image.repository }}:{{ .image.tag }}`,
+			wantImage:         "ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15",
+			wantRegistrySet:   "ghcr.io",
+			wantRepoStripped:  "verity-org/bitnamilegacy/postgresql",
+			assertRegistryKey: "registry",
+		},
+		{
+			// tempo-distributed shape (#308 A.4): chart's helper is
+			// `coalesce .global.image.registry .component.registry .tempo.registry`
+			// — `coalesce` returns the first non-empty argument, so a
+			// non-empty `global.image.registry: docker.io` upstream wins
+			// over our per-image `tempo.image.registry: ghcr.io` rewrite.
+			// Wave-3 fix: emit `global.image.registry: ""` so coalesce
+			// falls through to the per-image registry.
+			name: "global.image.registry takes precedence over image.registry",
+			valuesYML: `global:
+  image:
+    registry: docker.io
+image:
+  registry: docker.io
+  repository: grafana/tempo
+  tag: "2.4"
+`,
+			mappings: []ImageMapping{{
+				OriginalRepo: "grafana/tempo",
+				PatchedRepo:  "ghcr.io/verity-org/tempo",
+				PatchedTag:   "2.4",
+			}},
+			// Sprig `coalesce` mirrored: returns the first non-empty value.
+			templateExpr:      `{{ coalesceFirst .global.image.registry .image.registry }}/{{ .image.repository }}:{{ .image.tag }}`,
+			wantImage:         "ghcr.io/verity-org/tempo:2.4",
+			wantRegistrySet:   "ghcr.io",
+			wantRepoStripped:  "verity-org/tempo",
+			assertRegistryKey: "registry",
+		},
+	}
+
+	original := config.ChartSpec{Name: "wrapper", Version: "0.0.0", Repository: "oci://repo/charts"}
+
+	for i := range cases {
+		tc := &cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			runComposeRegistryRenderCase(t, tc, original)
+		})
+	}
+}
+
+// runComposeRegistryRenderCase exercises a single
+// TestComposeRegistryRendersValidImageRefs fixture end-to-end:
+// resolve → build → assert wrapper leaf shape → merge → render →
+// assert rendered ref. Extracted out of the main loop body purely to
+// keep the test function under the maintainability-index threshold;
+// every assertion below was previously inline in `t.Run`.
+func runComposeRegistryRenderCase(t *testing.T, tc *renderCase, original config.ChartSpec) {
+	t.Helper()
+
+	// 1. Run the resolver to produce the override (mirrors what
+	//    chart-gen does in production). May return more than one
+	//    override when global-registry neutralisation (#308 wave 3)
+	//    fires alongside the per-image rewrite.
+	overrides, err := ResolveValuePaths([]byte(tc.valuesYML), tc.mappings, nil)
+	if err != nil {
+		t.Fatalf("ResolveValuePaths() error = %v", err)
+	}
+	if !hasImageOverride(overrides) {
+		t.Fatalf("ResolveValuePaths() produced no per-image override: %#v", overrides)
+	}
+
+	// 2. Build the wrapper values tree.
+	chart, err := BuildWrapperChart(original, nil, overrides)
+	if err != nil {
+		t.Fatalf("BuildWrapperChart() error = %v", err)
+	}
+	var wrapperValues map[string]any
+	if err := yaml.Unmarshal(chart.ValuesYAML, &wrapperValues); err != nil {
+		t.Fatalf("yaml.Unmarshal(ValuesYAML) error = %v", err)
+	}
+	leaf := navigateToImageLeaf(t, wrapperValues, original.Name)
+	assertWrapperLeafShape(t, tc, leaf)
+
+	// 3. Merge ALL wrapper overrides onto the upstream values (Helm's
+	//    child-overrides-parent semantics) and render the chart's
+	//    template expression. This is the end-to-end check that
+	//    chart-gen's output is template-safe. The wave-3 global-registry
+	//    neutralisation overrides MUST be applied here too — without
+	//    them, a chart whose template defers to `global.image.registry`
+	//    would still render the upstream global and our per-image
+	//    SetRegistry would be silently ignored.
+	merged := mergeUpstreamWithAllOverrides(t, tc.valuesYML, wrapperValues, original.Name)
+	rendered := renderHelmExpr(t, tc.templateExpr, merged)
+	if rendered != tc.wantImage {
+		t.Fatalf("rendered image = %q, want %q\n  template: %s\n  merged values: %#v", rendered, tc.wantImage, tc.templateExpr, merged)
+	}
+	// 4. Sanity check: no leading slash (regression of #308 wave 2).
+	if rendered[0] == '/' {
+		t.Fatalf("rendered image has leading slash: %q (regression of #308)", rendered)
+	}
+}
+
+// assertWrapperLeafShape covers the per-image-leaf assertions:
+//   - repository was stripped of its registry prefix correctly,
+//   - the wrapper does NOT emit an empty-string sibling (the wave-2 foot-gun),
+//   - the expected sibling holds the registry hostname,
+//   - the table-recorded `assertRegistryKey` is actually populated.
+//
+// The global-registry neutralisation entries write empty-string scalars
+// at separate paths (`global.imageRegistry`, `global.image.registry`);
+// they are exercised end-to-end by the rendering step that follows.
+func assertWrapperLeafShape(t *testing.T, tc *renderCase, leaf map[string]any) {
+	t.Helper()
+
+	if got := leaf["repository"]; got != tc.wantRepoStripped {
+		t.Fatalf("wrapper repository = %v, want %v (full leaf: %#v)", got, tc.wantRepoStripped, leaf)
+	}
+	if v, ok := leaf["registry"]; ok && v == "" {
+		t.Fatalf("wrapper leaf must not emit empty-string registry: %#v", leaf)
+	}
+	if v, ok := leaf["defaultRegistry"]; ok && v == "" {
+		t.Fatalf("wrapper leaf must not emit empty-string defaultRegistry: %#v", leaf)
+	}
+	if tc.wantRegistrySet != "" {
+		if got := leaf["registry"]; got != tc.wantRegistrySet {
+			t.Fatalf("wrapper registry = %v, want %v", got, tc.wantRegistrySet)
+		}
+	}
+	if tc.wantDefRegistry != "" {
+		if got := leaf["defaultRegistry"]; got != tc.wantDefRegistry {
+			t.Fatalf("wrapper defaultRegistry = %v, want %v", got, tc.wantDefRegistry)
+		}
+	}
+	if tc.assertRegistryKey != "" {
+		v, ok := leaf[tc.assertRegistryKey]
+		if !ok {
+			t.Fatalf("wrapper leaf missing expected sibling %q: %#v", tc.assertRegistryKey, leaf)
+		}
+		s, isString := v.(string)
+		if !isString || s == "" {
+			t.Fatalf("wrapper leaf %q is empty or non-string: %#v", tc.assertRegistryKey, leaf)
+		}
+	}
+}
+
+// hasImageOverride reports whether the override list contains at least
+// one per-image-leaf override (Repository != "" or Tag != ""), as opposed
+// to only scalar neutralisation overrides. Used by
+// TestComposeRegistryRendersValidImageRefs to assert that chart-gen
+// produced an actual rewrite, regardless of how many neutralisation
+// entries (#308 wave 3) it added alongside.
+func hasImageOverride(overrides []ValueOverride) bool {
+	for _, o := range overrides {
+		if o.Repository != "" || o.Tag != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// navigateToImageLeaf walks `wrapperValues[chartName].image` and returns the
+// leaf map. The wrapper layout is `{ <chartName>: { image: { ... } } }` for
+// a single top-level image override.
+func navigateToImageLeaf(t *testing.T, wrapperValues map[string]any, chartName string) map[string]any {
+	t.Helper()
+	root, ok := wrapperValues[chartName].(map[string]any)
+	if !ok {
+		t.Fatalf("wrapper values %q root missing or not a map: %#v", chartName, wrapperValues)
+	}
+	leaf, ok := root["image"].(map[string]any)
+	if !ok {
+		// Some fixtures may use admissionController.container.image —
+		// walk the only branch we care about. The current cases all use
+		// `image` as the top-level path, so failing here is a bug.
+		t.Fatalf("wrapper values root.image missing or not a map: %#v", root)
+	}
+	return leaf
+}
+
+// mergeUpstreamWithAllOverrides parses the upstream values YAML and
+// recursively merges every node from the wrapper override tree onto it
+// (Helm's child-overrides-parent semantics for maps; scalar nodes
+// overwrite). The override tree is the full `wrapperValues` produced by
+// `BuildWrapperChart`, scoped under `chartName`, so this captures both
+// the per-image leaf rewrite AND any wave-3 global-registry
+// neutralisation scalars (`global.imageRegistry: ""`, etc.).
+func mergeUpstreamWithAllOverrides(t *testing.T, valuesYML string, wrapperValues map[string]any, chartName string) map[string]any {
+	t.Helper()
+	var upstream map[string]any
+	if err := yaml.Unmarshal([]byte(valuesYML), &upstream); err != nil {
+		t.Fatalf("yaml.Unmarshal(upstream) error = %v", err)
+	}
+	overrides, ok := wrapperValues[chartName].(map[string]any)
+	if !ok {
+		t.Fatalf("wrapper values %q root missing or not a map: %#v", chartName, wrapperValues)
+	}
+	deepMergeOverride(upstream, overrides)
+	return upstream
+}
+
+// deepMergeOverride recursively merges `src` onto `dst`. Maps are merged
+// (src keys override dst keys at each level); every other value type
+// (string, bool, list, scalar empty-string) overwrites. Mirrors Helm's
+// values-merge semantics closely enough for the regression-test
+// templates the harness exercises.
+func deepMergeOverride(dst, src map[string]any) {
+	for k, v := range src {
+		if vMap, ok := v.(map[string]any); ok {
+			if dstMap, ok := dst[k].(map[string]any); ok {
+				deepMergeOverride(dstMap, vMap)
+				continue
+			}
+			cloned := make(map[string]any, len(vMap))
+			deepMergeOverride(cloned, vMap)
+			dst[k] = cloned
+			continue
+		}
+		dst[k] = v
+	}
+}
+
+// renderHelmExpr renders a text/template expression with a small subset of
+// Helm-like helpers. Specifically we provide `orDefault` to mimic Helm's
+// `default <fallback> <primary>` behaviour (primary if primary != empty,
+// else fallback) — this is the only Helm-specific function the regression
+// fixtures reference. We deliberately avoid pulling in Helm itself to keep
+// the test hermetic.
+func renderHelmExpr(t *testing.T, expr string, data map[string]any) string {
+	t.Helper()
+	funcs := template.FuncMap{
+		"orDefault": func(primary, fallback any) any {
+			if isHelmEmpty(primary) {
+				return fallback
+			}
+			return primary
+		},
+		// coalesceFirst mirrors Sprig's `coalesce`: returns the first
+		// non-empty argument. Tempo-distributed and several other Grafana
+		// charts use this idiom in their image helpers; the regression
+		// fixture for #308 wave 3 invokes it directly.
+		"coalesceFirst": func(args ...any) any {
+			for _, a := range args {
+				if !isHelmEmpty(a) {
+					return a
+				}
+			}
+			return ""
+		},
+	}
+	tmpl, err := template.New("render").Funcs(funcs).Parse(expr)
+	if err != nil {
+		t.Fatalf("template.Parse() error = %v", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template.Execute() error = %v", err)
+	}
+	return buf.String()
+}
+
+// TestIsHelmEmpty regresses the multi-type-switch Go gotcha where
+// `case int, int32, int64, float32, float64:` keeps `x` typed as the
+// union interface — comparing it against the untyped `0` literal returns
+// FALSE for every numeric type other than `int`. The previous grouped
+// form silently reported `int32(0)` / `int64(0)` / `float32(0)` /
+// `float64(0)` as non-empty, breaking Helm's `default` semantics for any
+// fixture that exercised numeric zeros (none today, but the helper is
+// part of the regression-test harness for #308 wave 2 and must be
+// trustworthy). Each numeric type now lives in its own case so `x`
+// unwraps to the concrete type.
+func TestIsHelmEmpty(t *testing.T) {
+	cases := []struct {
+		name string
+		v    any
+		want bool
+	}{
+		{"nil", nil, true},
+		{"empty string", "", true},
+		{"non-empty string", "x", false},
+		{"empty list", []any{}, true},
+		{"non-empty list", []any{1}, false},
+		{"empty map", map[string]any{}, true},
+		{"non-empty map", map[string]any{"k": 1}, false},
+		{"false bool", false, true},
+		{"true bool", true, false},
+
+		// Numeric zero — these are the regression cases. The grouped
+		// type-switch form returned `false` for every line below except
+		// `int(0)`. Each must now report `true` (matching Helm's rule
+		// that 0 is empty).
+		{"int zero", int(0), true},
+		{"int non-zero", int(1), false},
+		{"int32 zero", int32(0), true},
+		{"int32 non-zero", int32(1), false},
+		{"int64 zero", int64(0), true},
+		{"int64 non-zero", int64(1), false},
+		{"float32 zero", float32(0), true},
+		{"float32 non-zero", float32(0.5), false},
+		{"float64 zero", float64(0), true},
+		{"float64 non-zero", float64(0.5), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHelmEmpty(tc.v); got != tc.want {
+				t.Fatalf("isHelmEmpty(%T(%v)) = %v, want %v", tc.v, tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+// isHelmEmpty mirrors Helm's `default` emptiness rule: nil, "", 0,
+// empty list/map all count as empty. text/template's zero-value rendering
+// of `nil` is `<no value>`, so we explicitly normalise.
+//
+// Numeric zero detection uses one type-switch case per concrete type
+// rather than a grouped `case int, int32, int64, ...:`. The grouped form
+// keeps `x` typed as the union interface, which compares against the
+// untyped `0` literal as `interface{}(int32(0)) == 0` — and that
+// comparison is FALSE for every numeric type other than `int`, because
+// Go's type-switch only unwraps to a concrete type when the case lists
+// exactly one type (Go spec, "Type switches"). The grouped form would
+// silently report `int32(0)`/`int64(0)`/`float32(0)`/`float64(0)` as
+// non-empty, which is precisely the wrong answer for Helm's `default`.
+func isHelmEmpty(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch x := v.(type) {
+	case string:
+		return x == ""
+	case fmt.Stringer:
+		return x.String() == ""
+	case []any:
+		return len(x) == 0
+	case map[string]any:
+		return len(x) == 0
+	case bool:
+		return !x
+	case int:
+		return x == 0
+	case int32:
+		return x == 0
+	case int64:
+		return x == 0
+	case float32:
+		return x == 0
+	case float64:
+		return x == 0
+	}
+	return false
 }

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -24,22 +24,52 @@ type ValueOverride struct {
 	Repository string `json:"repository"`
 	Tag        string `json:"tag"`
 	Value      string `json:"value,omitempty"`
-	// ClearRegistry tells the wrapper renderer to set
-	// `<path>.registry: ""` so that an upstream chart's `image.registry`
-	// hostname (e.g. `ghcr.io`, `quay.io`) doesn't get prepended to our
-	// already-FQDN repository override.
-	ClearRegistry bool `json:"clearRegistry,omitempty"`
-	// ClearDefaultRegistry tells the wrapper renderer to set
-	// `<path>.defaultRegistry: ""` for charts that template
-	// `{{ .Values.image.registry | default .Values.image.defaultRegistry }}/...`
-	// (kyverno 3.7.x is the canonical example: per-component image maps
-	// hold a hard-coded `defaultRegistry: reg.kyverno.io` that the
-	// chart concatenates to whatever override repository we set, which
-	// breaks pulls when our repository is already fully qualified). The
-	// flag fires in addition to ClearRegistry, not in place of it — a
-	// chart can use either or both sibling fields, and we neutralize
-	// only the ones it actually declares.
-	ClearDefaultRegistry bool `json:"clearDefaultRegistry,omitempty"`
+	// IsScalarOverride distinguishes a scalar-write override (the leaf
+	// node at `Path` becomes the literal string `Value`, even when
+	// `Value == ""`) from the legacy "if Value != \"\" then write" rule.
+	// Used by the global-registry neutralisation path (#308 wave 3) to
+	// emit `<scope>.global.imageRegistry: ""` and similar overrides that
+	// must be honoured even when the value is an empty string. Without
+	// this flag the empty-string scalar would silently disappear,
+	// leaving the upstream's `global.imageRegistry: docker.io` default
+	// in place and triggering the wave-3 double-registry render bug.
+	IsScalarOverride bool `json:"isScalarOverride,omitempty"`
+	// SetRegistry, when non-empty, instructs the wrapper renderer to
+	// write `<path>.registry: <SetRegistry>` and to render Repository
+	// with the registry hostname stripped. The chart's template
+	// `{{ <path>.registry }}/{{ <path>.repository }}` therefore composes
+	// to `ghcr.io/verity-org/<repo>:<tag>` whether the template
+	// short-circuits via `default` or concatenates directly:
+	//
+	//   {{ .Values.image.registry }}/{{ repository }}             → ghcr.io/verity-org/<repo>
+	//   {{ registry | default defaultRegistry }}/{{ repository }} → ghcr.io/verity-org/<repo> (registry fires)
+	//
+	// IMPORTANT scoping caveat: SetRegistry only writes the per-image
+	// registry sibling at `<path>.registry`. If the chart's template
+	// further defers to a `global.imageRegistry` (Bitnami) or
+	// `global.image.registry` (Grafana / tempo-distributed) AND that
+	// global field is non-empty upstream, Helm renders the global
+	// hostname in front of our stripped repository →
+	// `docker.io/verity-org/<repo>:<tag>`. `resolveValuePathPairs`
+	// therefore also emits `IsScalarOverride` entries for any
+	// global-registry sibling in the same scope (root or subchart),
+	// neutralising them to empty so the per-image SetRegistry wins.
+	// See `collectGlobalRegistryPaths` for the detection rule and the
+	// wave-3 regression coverage in TestComposeRegistryRendersValidImageRefs
+	// (`global.image.registry takes precedence over image.registry`).
+	//
+	// SetRegistry replaces the prior "ClearRegistry: bool" plumbing,
+	// which wrote `registry: ""` and consequently produced leading-slash
+	// renders (`/ghcr.io/...`) for any chart whose template did not
+	// `default` to a non-empty value (issue #308 wave 2). Empty string
+	// means "leave the registry sibling untouched" — same behaviour as
+	// the previous `ClearRegistry: false`.
+	SetRegistry string `json:"setRegistry,omitempty"`
+	// SetDefaultRegistry is the parallel knob for the `defaultRegistry`
+	// sibling (kyverno 3.7.x convention; postgres-operator/jenkins/etc.
+	// also adopted it). Same compose-correctly semantics as SetRegistry,
+	// applied to a different field.
+	SetDefaultRegistry string `json:"setDefaultRegistry,omitempty"`
 }
 
 type repoTagPair struct {
@@ -61,6 +91,10 @@ func ResolveValuePathsWithSubcharts(valuesYAML []byte, subchartValues map[string
 	if err != nil {
 		return nil, fmt.Errorf("collect parent chart values: %w", err)
 	}
+	globals, err := collectGlobalRegistryPaths(valuesYAML, "")
+	if err != nil {
+		return nil, fmt.Errorf("collect parent chart global registries: %w", err)
+	}
 
 	subchartNames := make([]string, 0, len(subchartValues))
 	for name := range subchartValues {
@@ -73,15 +107,21 @@ func ResolveValuePathsWithSubcharts(valuesYAML []byte, subchartValues map[string
 			return nil, fmt.Errorf("collect subchart values for %q: %w", name, err)
 		}
 		pairs = append(pairs, subchartPairs...)
+		subchartGlobals, err := collectGlobalRegistryPaths(subchartValues[name], name)
+		if err != nil {
+			return nil, fmt.Errorf("collect global registries for subchart %q: %w", name, err)
+		}
+		globals = append(globals, subchartGlobals...)
 	}
 	sort.Slice(pairs, func(i, j int) bool {
 		return pairs[i].Path < pairs[j].Path
 	})
+	sort.Strings(globals)
 
-	return resolveValuePathPairs(pairs, mappings, overrides), nil
+	return resolveValuePathPairs(pairs, globals, mappings, overrides), nil
 }
 
-func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrides map[string]config.Override) []ValueOverride {
+func resolveValuePathPairs(pairs []repoTagPair, globalRegistryPaths []string, mappings []ImageMapping, overrides map[string]config.Override) []ValueOverride {
 	result := make([]ValueOverride, 0, len(mappings))
 	matched := make([]bool, len(mappings))
 
@@ -109,13 +149,13 @@ func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrid
 				continue
 			}
 			if matchesRepo(m.OriginalRepo, key) {
-				result = append(result, ValueOverride{
-					Path:                 override.ValuePath,
-					Repository:           m.PatchedRepo,
-					Tag:                  m.PatchedTag,
-					ClearRegistry:        pathHasRegistry[override.ValuePath],
-					ClearDefaultRegistry: pathHasDefaultRegistry[override.ValuePath],
-				})
+				result = append(result, buildValueOverride(
+					override.ValuePath,
+					m.PatchedRepo,
+					m.PatchedTag,
+					pathHasRegistry[override.ValuePath],
+					pathHasDefaultRegistry[override.ValuePath],
+				))
 				matched[i] = true
 				break
 			}
@@ -131,20 +171,153 @@ func resolveValuePathPairs(pairs []repoTagPair, mappings []ImageMapping, overrid
 				continue
 			}
 			if matchesRepo(pair.Repo, m.OriginalRepo) {
-				result = append(result, ValueOverride{
-					Path:                 pair.Path,
-					Repository:           m.PatchedRepo,
-					Tag:                  m.PatchedTag,
-					ClearRegistry:        pair.HasRegistry,
-					ClearDefaultRegistry: pair.HasDefaultRegistry,
-				})
+				result = append(result, buildValueOverride(
+					pair.Path,
+					m.PatchedRepo,
+					m.PatchedTag,
+					pair.HasRegistry,
+					pair.HasDefaultRegistry,
+				))
 				matched[i] = true
 				break
 			}
 		}
 	}
 
+	return appendGlobalRegistryNeutralisations(result, globalRegistryPaths)
+}
+
+// appendGlobalRegistryNeutralisations appends an IsScalarOverride entry
+// for every global-registry path whose scope matches one of the
+// per-image overrides already in `result`. See #308 wave 3: without this
+// step a chart whose template defers to `global.imageRegistry` (Bitnami)
+// or `global.image.registry` (tempo-distributed, several Grafana
+// sub-charts) would render `<upstream-global>/verity-org/<repo>:<tag>`
+// because the global hostname takes precedence over our per-image
+// SetRegistry. Empty global → Bitnami's `if .global.imageRegistry` is
+// false (falls through to per-image) and tempo's `coalesce` skips it.
+func appendGlobalRegistryNeutralisations(result []ValueOverride, globalRegistryPaths []string) []ValueOverride {
+	scopesToNeutralise := globalNeutralisationScopes(result)
+	for _, globalPath := range globalRegistryPaths {
+		if !scopesToNeutralise[scopeOfPath(globalPath)] {
+			continue
+		}
+		result = append(result, ValueOverride{
+			Path:             globalPath,
+			IsScalarOverride: true,
+			Value:            "",
+		})
+	}
 	return result
+}
+
+// globalNeutralisationScopes returns the set of value-path scopes
+// (subchart prefix or "" for root) where at least one image-override
+// rewrote a per-image registry sibling, signalling that any sibling
+// `global.<...>Registry` field in that scope must be neutralised so the
+// chart's template doesn't prefer the upstream global over our rewrite.
+func globalNeutralisationScopes(overrides []ValueOverride) map[string]bool {
+	scopes := make(map[string]bool)
+	for _, o := range overrides {
+		if o.SetRegistry == "" && o.SetDefaultRegistry == "" {
+			continue
+		}
+		scopes[scopeOfPath(o.Path)] = true
+	}
+	return scopes
+}
+
+// scopeOfPath returns the leading subchart-name segment of a dotted
+// value path (e.g. `postgresql.image` → `postgresql`, `image` → "").
+// Both `global.imageRegistry` and `image` live at root scope (""), and
+// both `postgresql.global.imageRegistry` and `postgresql.image` live
+// under the `postgresql` subchart scope. The rule "first segment unless
+// it is a Helm-special key (`global`, `image`)" yields the right answer
+// for every path this function is called with — image-override paths
+// always start with either a subchart name or `image`/`<componentName>`,
+// never `global`. Test coverage in TestScopeOfPath documents the cases.
+func scopeOfPath(path string) string {
+	idx := strings.IndexByte(path, '.')
+	if idx <= 0 {
+		return ""
+	}
+	first := path[:idx]
+	if first == "global" || first == "image" {
+		return ""
+	}
+	return first
+}
+
+// buildValueOverride composes a ValueOverride that renders correctly across
+// all observed upstream chart template shapes. When the upstream chart
+// declares a `registry` and/or `defaultRegistry` sibling, the patched FQDN
+// repository is split into `<registry>/<path>` and the registry hostname is
+// emitted into those sibling fields. The wrapper leaf therefore expresses
+// the FQDN compositionally — `<registry>` + `<repository>` — rather than
+// concentrating the FQDN in `repository` and zeroing out the prefix (which
+// produced `/ghcr.io/...:tag` leading-slash renders for every chart whose
+// template was a plain `{{ registry }}/{{ repo }}` concatenation; see
+// issue #308 wave 2).
+//
+// When the patched repo has no detectable registry host, fall back to the
+// legacy "leave repo as-is" behaviour without setting the sibling — this is
+// only reachable for non-FQDN patched repos, which verity does not currently
+// produce, but keeping the fallback explicit avoids future surprises.
+func buildValueOverride(path, patchedRepo, patchedTag string, hasRegistry, hasDefaultRegistry bool) ValueOverride {
+	override := ValueOverride{
+		Path:       path,
+		Repository: patchedRepo,
+		Tag:        patchedTag,
+	}
+
+	if !hasRegistry && !hasDefaultRegistry {
+		return override
+	}
+
+	registry, repoPath, ok := splitRegistryHost(patchedRepo)
+	if !ok {
+		return override
+	}
+
+	override.Repository = repoPath
+	if hasRegistry {
+		override.SetRegistry = registry
+	}
+	if hasDefaultRegistry {
+		override.SetDefaultRegistry = registry
+	}
+	return override
+}
+
+// splitRegistryHost splits a fully-qualified image reference like
+// `ghcr.io/verity-org/grafana` into (`ghcr.io`, `verity-org/grafana`, true).
+// A path is considered to have a registry host when its first segment
+// contains either a `.` (DNS hostname), a `:` (port), or equals `localhost`
+// — these are the three cases Docker's reference parser treats as a
+// hostname. References without a detectable host (`library/nginx`,
+// `verity-org/grafana`) return ok=false so the caller can fall back to
+// the legacy behaviour.
+func splitRegistryHost(repo string) (registry, path string, ok bool) {
+	idx := strings.IndexByte(repo, '/')
+	if idx <= 0 {
+		return "", repo, false
+	}
+	first := repo[:idx]
+	if !isRegistryHost(first) {
+		return "", repo, false
+	}
+	return first, repo[idx+1:], true
+}
+
+// isRegistryHost mirrors the Docker reference-parser convention: the first
+// path segment is a registry host when it contains a `.`, contains a `:`
+// (port), or equals `localhost`. The bare-`localhost` case (no port) is the
+// one easily missed by the contains-`.`-or-`:` heuristic alone.
+func isRegistryHost(segment string) bool {
+	if segment == "localhost" {
+		return true
+	}
+	return strings.ContainsAny(segment, ".:")
 }
 
 func collectValuePairs(valuesYAML []byte, prefix string) ([]repoTagPair, error) {
@@ -158,6 +331,50 @@ func collectValuePairs(valuesYAML []byte, prefix string) ([]repoTagPair, error) 
 	pairs := make([]repoTagPair, 0)
 	walkValues(prefix, values, &pairs)
 	return pairs, nil
+}
+
+// collectGlobalRegistryPaths returns the dotted paths of every
+// global-registry sibling in `valuesYAML`. Two patterns are recognised:
+//
+//   - Bitnami: `global.imageRegistry` (scalar string under the `global` map).
+//   - Grafana / tempo-distributed / argo-rollouts: `global.image.registry`
+//     (scalar string under the `global.image` map).
+//
+// Both patterns may co-exist in a single chart. The prefix is prepended
+// to make subchart-scoped paths (`postgresql.global.imageRegistry` etc.).
+//
+// The function deliberately does NOT walk arbitrary other `global.<X>`
+// scalars — chart-gen should not attempt to neutralise unrecognised
+// global-scope fields. New patterns will surface as new test cases here
+// when a chart-integration nightly catches them.
+func collectGlobalRegistryPaths(valuesYAML []byte, prefix string) ([]string, error) {
+	values := make(map[string]any)
+	if len(valuesYAML) > 0 {
+		if err := yaml.Unmarshal(valuesYAML, &values); err != nil {
+			return nil, fmt.Errorf("unmarshal values YAML: %w", err)
+		}
+	}
+
+	globalNode, ok := values["global"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	scopePrefix := ""
+	if prefix != "" {
+		scopePrefix = prefix + "."
+	}
+
+	paths := make([]string, 0, 2)
+	if _, ok := globalNode["imageRegistry"].(string); ok {
+		paths = append(paths, scopePrefix+"global.imageRegistry")
+	}
+	if imgNode, ok := globalNode["image"].(map[string]any); ok {
+		if _, ok := imgNode["registry"].(string); ok {
+			paths = append(paths, scopePrefix+"global.image.registry")
+		}
+	}
+	return paths, nil
 }
 
 func GetChartValues(chart config.ChartSpec) ([]byte, error) {
@@ -543,8 +760,18 @@ func walkValues(prefix string, node map[string]any, pairs *[]repoTagPair) {
 		}
 
 		repo, hasRepo := child["repository"].(string)
-		registry, registrySibling := child["registry"].(string)
-		hasRegistry := registrySibling && registry != ""
+		// `hasRegistry` / `hasDefaultRegistry` mean "the upstream chart
+		// DECLARES this sibling as a string field" — we treat both
+		// `registry: docker.io` and `registry: ""` as a declaration.
+		// The empty-string declaration is the trickier case: if the chart
+		// templates `{{ .Values.image.registry }}/{{ repository }}` and we
+		// leave the wrapper leaf alone, the rendered ref becomes
+		// `"" + "/" + ghcr.io/...` — the same leading-slash bug this PR
+		// is fixing. We must still compose the registry into the sibling
+		// so the rendered ref is `ghcr.io/<verity-org>/<repo>`. The
+		// previous shape (`registry != ""`) silently skipped these
+		// charts; #312 review caught the gap.
+		registry, hasRegistry := child["registry"].(string)
 		// defaultRegistry is the kyverno 3.7.x convention: each component's
 		// image map holds a hard-coded `defaultRegistry: reg.kyverno.io`
 		// that the chart concatenates to the override repository when
@@ -552,10 +779,9 @@ func walkValues(prefix string, node map[string]any, pairs *[]repoTagPair) {
 		// inherit that prefix and produce broken refs like
 		// `reg.kyverno.io/ghcr.io/verity-org/kyverno:1.17` (issue #254).
 		// Treat it as a parallel registry-sibling: detect it here, plumb
-		// it through ClearDefaultRegistry, and have buildValuesTree write
-		// `defaultRegistry: ""` into the override leaf.
-		defaultRegistry, defaultRegistrySibling := child["defaultRegistry"].(string)
-		hasDefaultRegistry := defaultRegistrySibling && defaultRegistry != ""
+		// it through SetDefaultRegistry, and have buildValuesTree write
+		// `defaultRegistry: <ghcr.io>` into the override leaf.
+		defaultRegistry, hasDefaultRegistry := child["defaultRegistry"].(string)
 
 		switch {
 		case hasRepo && repo != "":

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -44,10 +44,9 @@ func TestResolveValuePaths(t *testing.T) {
 				},
 			},
 			want: []ValueOverride{{
-				Path:          "image",
-				Repository:    "ghcr.io/verity-org/prometheus/prometheus",
-				Tag:           "v3.2.1",
-				ClearRegistry: false,
+				Path:       "image",
+				Repository: "ghcr.io/verity-org/prometheus/prometheus",
+				Tag:        "v3.2.1",
 			}},
 		},
 		{
@@ -63,10 +62,9 @@ func TestResolveValuePaths(t *testing.T) {
 				PatchedTag:   "1.25",
 			}},
 			want: []ValueOverride{{
-				Path:          "server.image",
-				Repository:    "ghcr.io/verity-org/library/nginx",
-				Tag:           "1.25",
-				ClearRegistry: false,
+				Path:       "server.image",
+				Repository: "ghcr.io/verity-org/library/nginx",
+				Tag:        "1.25",
 			}},
 		},
 		{
@@ -107,16 +105,14 @@ metrics:
 			},
 			want: []ValueOverride{
 				{
-					Path:          "controller.image",
-					Repository:    "ghcr.io/verity-org/library/nginx",
-					Tag:           "1.25",
-					ClearRegistry: false,
+					Path:       "controller.image",
+					Repository: "ghcr.io/verity-org/library/nginx",
+					Tag:        "1.25",
 				},
 				{
-					Path:          "metrics.image",
-					Repository:    "ghcr.io/verity-org/valkey/valkey",
-					Tag:           "7.2",
-					ClearRegistry: false,
+					Path:       "metrics.image",
+					Repository: "ghcr.io/verity-org/valkey/valkey",
+					Tag:        "7.2",
 				},
 			},
 		},
@@ -135,14 +131,20 @@ metrics:
 				"nginx": {ValuePath: "custom.image"},
 			},
 			want: []ValueOverride{{
-				Path:          "custom.image",
-				Repository:    "ghcr.io/verity-org/library/nginx",
-				Tag:           "1.25",
-				ClearRegistry: false,
+				Path:       "custom.image",
+				Repository: "ghcr.io/verity-org/library/nginx",
+				Tag:        "1.25",
 			}},
 		},
 		{
-			name: "explicit value path clears registry on 3-field shape",
+			// Compose-correctly behaviour for explicit-ValuePath override on
+			// a 3-field upstream (`registry`, `repository`, `tag`). The
+			// wrapper splits the patched FQDN into <registry>/<path> and
+			// emits the registry hostname into `registry`, so the chart's
+			// `{{ image.registry }}/{{ image.repository }}` template
+			// composes to `ghcr.io/verity-org/<repo>:<tag>` regardless of
+			// short-circuit semantics. See #308 wave 2.
+			name: "explicit value path composes registry on 3-field shape",
 			valuesYML: `image:
   registry: ghcr.io
   repository: zalando/postgres-operator
@@ -157,10 +159,10 @@ metrics:
 				"zalando/postgres-operator": {ValuePath: "image"},
 			},
 			want: []ValueOverride{{
-				Path:          "image",
-				Repository:    "ghcr.io/verity-org/zalando/postgres-operator",
-				Tag:           "v1.15.1",
-				ClearRegistry: true,
+				Path:        "image",
+				Repository:  "verity-org/zalando/postgres-operator",
+				Tag:         "v1.15.1",
+				SetRegistry: "ghcr.io",
 			}},
 		},
 		{
@@ -178,14 +180,16 @@ metrics:
 				"timberio/vector": {ValuePath: "custom.vectorImage"},
 			},
 			want: []ValueOverride{{
-				Path:          "custom.vectorImage",
-				Repository:    "ghcr.io/verity-org/timberio/vector",
-				Tag:           "0.40",
-				ClearRegistry: false,
+				Path:       "custom.vectorImage",
+				Repository: "ghcr.io/verity-org/timberio/vector",
+				Tag:        "0.40",
 			}},
 		},
 		{
-			name: "3-field registry split override",
+			// Compose-correctly behaviour for the implicit-match path on a
+			// 3-field upstream — same semantics as the explicit-ValuePath
+			// case above, walked via the values-tree pair-matching branch.
+			name: "3-field registry split override composes registry",
 			valuesYML: `image:
   registry: ghcr.io
   repository: zalando/postgres-operator
@@ -197,10 +201,10 @@ metrics:
 				PatchedTag:   "v1.15.1",
 			}},
 			want: []ValueOverride{{
-				Path:          "image",
-				Repository:    "ghcr.io/verity-org/zalando/postgres-operator",
-				Tag:           "v1.15.1",
-				ClearRegistry: true,
+				Path:        "image",
+				Repository:  "verity-org/zalando/postgres-operator",
+				Tag:         "v1.15.1",
+				SetRegistry: "ghcr.io",
 			}},
 		},
 	}
@@ -251,17 +255,19 @@ func runResolveValuePathsCase(t *testing.T, valuesYML string, mappings []ImageMa
 }
 
 // TestResolveValuePaths_DefaultRegistry covers the kyverno-shaped
-// `defaultRegistry` sibling that PR #295's `ClearRegistry` plumbing
-// originally missed (issue #254). Split out from TestResolveValuePaths
-// so the parent stays under the maintidx threshold.
+// `defaultRegistry` sibling. After issue #308 wave 2 the wrapper composes
+// the FQDN as `<defaultRegistry>` + `<repository>` rather than zeroing the
+// sibling, so the chart's `{{ defaultRegistry }}/{{ repository }}` template
+// produces a valid reference whether or not it short-circuits via `default`.
 func TestResolveValuePaths_DefaultRegistry(t *testing.T) {
 	tests := []resolveValuePathsCase{
 		{
 			// kyverno 3.7.x admission-controller shape — `registry` is
-			// null, the host lives under `defaultRegistry`. The override
-			// must set ClearDefaultRegistry so the wrapper renders
-			// `defaultRegistry: ""`, otherwise the chart prepends
-			// `reg.kyverno.io/` to our already-FQDN repository.
+			// null, the host lives under `defaultRegistry`. The wrapper
+			// emits `defaultRegistry: ghcr.io` + `repository: verity-org/kyverno`
+			// so kyverno's `default (default .image.defaultRegistry .globalRegistry) .image.registry`
+			// resolves to `ghcr.io` and the rendered ref is
+			// `ghcr.io/verity-org/kyverno:1.17` (no leading slash).
 			name: "kyverno defaultRegistry sibling override",
 			valuesYML: `admissionController:
   container:
@@ -277,19 +283,17 @@ func TestResolveValuePaths_DefaultRegistry(t *testing.T) {
 				PatchedTag:   "1.17",
 			}},
 			want: []ValueOverride{{
-				Path:                 "admissionController.container.image",
-				Repository:           "ghcr.io/verity-org/kyverno",
-				Tag:                  "1.17",
-				ClearRegistry:        false,
-				ClearDefaultRegistry: true,
+				Path:               "admissionController.container.image",
+				Repository:         "verity-org/kyverno",
+				Tag:                "1.17",
+				SetDefaultRegistry: "ghcr.io",
 			}},
 		},
 		{
-			// Hypothetical chart that uses BOTH sibling fields. We must
-			// neutralise both — the chart's registry-resolution logic
-			// usually goes `registry | default defaultRegistry`, so
-			// leaving either populated breaks our override.
-			name: "registry and defaultRegistry both clear",
+			// Chart that uses BOTH sibling fields. Both get the registry
+			// hostname so any of `registry`, `defaultRegistry`, or
+			// `registry | default defaultRegistry` resolves to `ghcr.io`.
+			name: "registry and defaultRegistry both compose",
 			valuesYML: `image:
   registry: "ghcr.io"
   defaultRegistry: "fallback.example.com"
@@ -302,17 +306,17 @@ func TestResolveValuePaths_DefaultRegistry(t *testing.T) {
 				PatchedTag:   "v1",
 			}},
 			want: []ValueOverride{{
-				Path:                 "image",
-				Repository:           "ghcr.io/verity-org/foo/bar",
-				Tag:                  "v1",
-				ClearRegistry:        true,
-				ClearDefaultRegistry: true,
+				Path:               "image",
+				Repository:         "verity-org/foo/bar",
+				Tag:                "v1",
+				SetRegistry:        "ghcr.io",
+				SetDefaultRegistry: "ghcr.io",
 			}},
 		},
 		{
 			// Explicit-ValuePath override must also pick up
 			// defaultRegistry from the matching values path.
-			name: "explicit value path clears defaultRegistry",
+			name: "explicit value path composes defaultRegistry",
 			valuesYML: `admissionController:
   container:
     image:
@@ -329,11 +333,10 @@ func TestResolveValuePaths_DefaultRegistry(t *testing.T) {
 				"kyverno/kyverno": {ValuePath: "admissionController.container.image"},
 			},
 			want: []ValueOverride{{
-				Path:                 "admissionController.container.image",
-				Repository:           "ghcr.io/verity-org/kyverno",
-				Tag:                  "1.17",
-				ClearRegistry:        false,
-				ClearDefaultRegistry: true,
+				Path:               "admissionController.container.image",
+				Repository:         "verity-org/kyverno",
+				Tag:                "1.17",
+				SetDefaultRegistry: "ghcr.io",
 			}},
 		},
 	}
@@ -640,6 +643,304 @@ func TestResolveValuePathsWithSubcharts(t *testing.T) {
 	}
 }
 
+// TestResolveValuePathsWithSubcharts_WaveThreeNeutralisation drives the
+// subchart-prefixed code path with wave-3 fixtures (#308 A.4). Each
+// fixture mirrors a production chart whose subchart declares a global
+// registry sibling (`global.imageRegistry` for Bitnami's postgresql in
+// airflow; `global.image.registry` for Grafana sub-charts). The expected
+// overrides include BOTH the per-image rewrite (with subchart-prefixed
+// `Path`) AND the IsScalarOverride entry that neutralises the subchart's
+// global to empty so the per-image SetRegistry wins at template time.
+//
+// This is the test that Copilot's #312 round 3 thread 1 specifically
+// asked for — without it, a regression in subchart-path handling (the
+// neutralisation accidentally applying to root scope, or the global
+// registry path losing its subchart prefix) would still pass.
+func TestResolveValuePathsWithSubcharts_WaveThreeNeutralisation(t *testing.T) {
+	tests := []struct {
+		name           string
+		parentValues   string
+		subchartValues map[string]string
+		mappings       []ImageMapping
+		want           []ValueOverride
+	}{
+		{
+			// airflow → postgresql (Bitnami sub-chart). Real fixture
+			// reduced to the minimum that exercises the bug shape:
+			// subchart's `global.imageRegistry: ""` exists upstream
+			// (Bitnami pattern) and the subchart's `image` declares a
+			// per-image registry. Production wrapper output proves
+			// chart-gen wires both rewrites under the `postgresql.`
+			// prefix.
+			name:         "airflow postgresql Bitnami sub-chart with global.imageRegistry",
+			parentValues: "postgresql:\n  enabled: true\n",
+			subchartValues: map[string]string{
+				"postgresql": `global:
+  imageRegistry: ""
+image:
+  registry: docker.io
+  repository: bitnamilegacy/postgresql
+  tag: 16.1.0-debian-11-r15
+`,
+			},
+			mappings: []ImageMapping{{
+				OriginalRepo: "bitnamilegacy/postgresql",
+				PatchedRepo:  "ghcr.io/verity-org/bitnamilegacy/postgresql",
+				PatchedTag:   "16.1.0-debian-11-r15",
+			}},
+			want: []ValueOverride{
+				{
+					Path:        "postgresql.image",
+					Repository:  "verity-org/bitnamilegacy/postgresql",
+					Tag:         "16.1.0-debian-11-r15",
+					SetRegistry: "ghcr.io",
+				},
+				{
+					Path:             "postgresql.global.imageRegistry",
+					IsScalarOverride: true,
+				},
+			},
+		},
+		{
+			// Tempo-distributed shape variant lifted into a sub-chart.
+			// Verifies that `global.image.registry` (under a `global.image`
+			// map, not a top-level scalar) is detected and prefixed
+			// correctly when found in a subchart's values.yaml.
+			name:         "tempo-shaped sub-chart with global.image.registry",
+			parentValues: "telemetry:\n  enabled: true\n",
+			subchartValues: map[string]string{
+				"telemetry": `global:
+  image:
+    registry: docker.io
+image:
+  registry: docker.io
+  repository: grafana/tempo
+  tag: "2.4"
+`,
+			},
+			mappings: []ImageMapping{{
+				OriginalRepo: "grafana/tempo",
+				PatchedRepo:  "ghcr.io/verity-org/tempo",
+				PatchedTag:   "2.4",
+			}},
+			want: []ValueOverride{
+				{
+					Path:        "telemetry.image",
+					Repository:  "verity-org/tempo",
+					Tag:         "2.4",
+					SetRegistry: "ghcr.io",
+				},
+				{
+					Path:             "telemetry.global.image.registry",
+					IsScalarOverride: true,
+				},
+			},
+		},
+		{
+			// Subchart with a global declared but NO per-image rewrite
+			// happening (no mapping match): neutralisation must NOT fire.
+			// This is the conservative-scope guarantee — chart-gen only
+			// touches a subchart's global when it also rewrote one of
+			// that subchart's per-image registries.
+			name:         "subchart global without matching mapping is left alone",
+			parentValues: "postgresql:\n  enabled: false\n",
+			subchartValues: map[string]string{
+				"postgresql": `global:
+  imageRegistry: docker.io
+image:
+  registry: docker.io
+  repository: bitnamilegacy/postgresql
+  tag: 16.1.0-debian-11-r15
+`,
+			},
+			// No mapping for postgresql — verity isn't rebuilding this image.
+			mappings: []ImageMapping{},
+			want:     []ValueOverride{},
+		},
+		{
+			// Two subcharts; only ONE has a rewrite. The other subchart's
+			// global must NOT be neutralised — scoping isolates by
+			// subchart prefix.
+			name:         "neutralisation scoped to the subchart that was rewritten",
+			parentValues: "postgresql:\n  enabled: true\nrabbitmq:\n  enabled: true\n",
+			subchartValues: map[string]string{
+				"postgresql": `global:
+  imageRegistry: docker.io
+image:
+  registry: docker.io
+  repository: bitnamilegacy/postgresql
+  tag: 16.1.0-debian-11-r15
+`,
+				"rabbitmq": `global:
+  imageRegistry: docker.io
+image:
+  registry: docker.io
+  repository: bitnamilegacy/rabbitmq
+  tag: "3.13"
+`,
+			},
+			// Only postgresql gets a mapping → only postgresql.global.imageRegistry
+			// should be neutralised; rabbitmq.global.imageRegistry stays alone.
+			mappings: []ImageMapping{{
+				OriginalRepo: "bitnamilegacy/postgresql",
+				PatchedRepo:  "ghcr.io/verity-org/bitnamilegacy/postgresql",
+				PatchedTag:   "16.1.0-debian-11-r15",
+			}},
+			want: []ValueOverride{
+				{
+					Path:        "postgresql.image",
+					Repository:  "verity-org/bitnamilegacy/postgresql",
+					Tag:         "16.1.0-debian-11-r15",
+					SetRegistry: "ghcr.io",
+				},
+				{
+					Path:             "postgresql.global.imageRegistry",
+					IsScalarOverride: true,
+				},
+				// rabbitmq.global.imageRegistry deliberately absent.
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subcharts := make(map[string][]byte, len(tt.subchartValues))
+			for name, values := range tt.subchartValues {
+				subcharts[name] = []byte(values)
+			}
+
+			got, err := ResolveValuePathsWithSubcharts([]byte(tt.parentValues), subcharts, tt.mappings, nil)
+			if err != nil {
+				t.Fatalf("ResolveValuePathsWithSubcharts() error = %v", err)
+			}
+
+			sortFn := func(s []ValueOverride) {
+				sort.Slice(s, func(i, j int) bool {
+					return s[i].Path < s[j].Path
+				})
+			}
+			sortFn(got)
+			sortFn(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ResolveValuePathsWithSubcharts() =\n  got=%#v\n  want=%#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestScopeOfPath documents the rule used by `globalNeutralisationScopes`
+// to map a value-path to its scope (root or subchart name). The function
+// is only ever called with image-override paths and global-registry
+// paths, so the rule "first segment unless it equals `global` or
+// `image`" is sufficient — but the table makes the cases explicit.
+func TestScopeOfPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		// Root-scope image overrides.
+		{"image", ""},
+		{"image.registry", ""},
+
+		// Subchart-scope image overrides.
+		{"postgresql.image", "postgresql"},
+		{"alertmanager.image", "alertmanager"},
+		{"kube-state-metrics.image", "kube-state-metrics"},
+
+		// Root-scope global-registry paths.
+		{"global.imageRegistry", ""},
+		{"global.image.registry", ""},
+
+		// Subchart-scope global-registry paths.
+		{"postgresql.global.imageRegistry", "postgresql"},
+		{"telemetry.global.image.registry", "telemetry"},
+
+		// Edge cases — single-segment and empty.
+		{"", ""},
+		{"foo", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := scopeOfPath(tc.path); got != tc.want {
+				t.Fatalf("scopeOfPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCollectGlobalRegistryPaths covers both Bitnami and Grafana
+// global-registry conventions plus the edge cases.
+func TestCollectGlobalRegistryPaths(t *testing.T) {
+	cases := []struct {
+		name      string
+		valuesYML string
+		prefix    string
+		want      []string
+	}{
+		{
+			name:      "Bitnami global.imageRegistry detected",
+			valuesYML: "global:\n  imageRegistry: docker.io\n",
+			want:      []string{"global.imageRegistry"},
+		},
+		{
+			name:      "Grafana global.image.registry detected",
+			valuesYML: "global:\n  image:\n    registry: docker.io\n",
+			want:      []string{"global.image.registry"},
+		},
+		{
+			name: "both patterns coexist",
+			valuesYML: `global:
+  imageRegistry: docker.io
+  image:
+    registry: docker.io
+`,
+			want: []string{"global.imageRegistry", "global.image.registry"},
+		},
+		{
+			name:      "empty-string global is still a declaration",
+			valuesYML: "global:\n  imageRegistry: \"\"\n",
+			want:      []string{"global.imageRegistry"},
+		},
+		{
+			name:      "subchart prefix prepended",
+			valuesYML: "global:\n  imageRegistry: docker.io\n",
+			prefix:    "postgresql",
+			want:      []string{"postgresql.global.imageRegistry"},
+		},
+		{
+			name:      "no global at all",
+			valuesYML: "image:\n  repository: foo\n",
+			want:      nil,
+		},
+		{
+			name:      "non-string global.imageRegistry ignored",
+			valuesYML: "global:\n  imageRegistry: 42\n",
+			want:      []string{},
+		},
+		{
+			name:      "global is not a map",
+			valuesYML: "global: docker.io\n",
+			want:      nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := collectGlobalRegistryPaths([]byte(tc.valuesYML), tc.prefix)
+			if err != nil {
+				t.Fatalf("collectGlobalRegistryPaths() error = %v", err)
+			}
+			// `nil` and empty-slice want compare unequal under reflect.DeepEqual,
+			// so coerce both to a canonical empty form.
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("collectGlobalRegistryPaths(%q, %q) = %v, want %v", tc.valuesYML, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWalkValues(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -747,7 +1048,14 @@ server:
 			}},
 		},
 		{
-			name: "registry empty string ignored",
+			// `registry: ""` is a DECLARATION (empty-string value, but the
+			// field exists in the upstream values.yaml). The chart's
+			// template will still concatenate that field, so the wrapper
+			// must still compose into it. Pre-#312-review-2 we treated
+			// the empty-string declaration as "absent" and silently
+			// produced `/ghcr.io/...` leading-slash refs for any chart
+			// that shipped its registry sibling defaulted to empty.
+			name: "registry empty string is a declaration",
 			yamlIn: `image:
   registry: ""
   repository: "foo"
@@ -758,7 +1066,7 @@ server:
 				Repo:        "foo",
 				HasTag:      true,
 				Registry:    "",
-				HasRegistry: false,
+				HasRegistry: true,
 			}},
 		},
 		{
@@ -787,7 +1095,10 @@ server:
 			}},
 		},
 		{
-			name: "defaultRegistry empty string ignored",
+			// Same rule as `registry: ""` — empty-string declaration is
+			// still a declaration. The chart template will concatenate
+			// the field; the wrapper must compose into it.
+			name: "defaultRegistry empty string is a declaration",
 			yamlIn: `image:
   defaultRegistry: ""
   repository: "foo"
@@ -798,7 +1109,7 @@ server:
 				Repo:               "foo",
 				HasTag:             true,
 				HasRegistry:        false,
-				HasDefaultRegistry: false,
+				HasDefaultRegistry: true,
 			}},
 		},
 		{
@@ -1174,7 +1485,56 @@ func TestSubchartKeyFromArchive(t *testing.T) {
 	}
 }
 
-func TestResolveValuePathsClearRegistryOnRegistryOnlyPath(t *testing.T) {
+// TestSplitRegistryHost covers the Docker reference-parser convention for
+// detecting whether the first path segment of an image reference is a
+// registry hostname. The three positive cases (DNS hostname with `.`,
+// host:port with `:`, bare `localhost`) must all split; everything else
+// must return ok=false so the caller falls back to the legacy "leave repo
+// as-is" behaviour.
+func TestSplitRegistryHost(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		registry string
+		path     string
+		ok       bool
+	}{
+		// Docker-convention positive cases.
+		{"dns hostname", "ghcr.io/verity-org/grafana", "ghcr.io", "verity-org/grafana", true},
+		{"dns hostname multi-segment", "registry.k8s.io/kube-apiserver", "registry.k8s.io", "kube-apiserver", true},
+		{"host with port", "registry.example.com:5000/foo/bar", "registry.example.com:5000", "foo/bar", true},
+		{"localhost with port", "localhost:5000/foo", "localhost:5000", "foo", true},
+		// Bare-`localhost` is the case the contains-`.`-or-`:` heuristic
+		// alone would miss. Docker's reference parser treats it as a
+		// registry host (the only non-`.`/non-`:` exception).
+		{"bare localhost", "localhost/foo", "localhost", "foo", true},
+		{"bare localhost nested path", "localhost/team/repo", "localhost", "team/repo", true},
+
+		// Negative cases — Docker treats these as Docker-Hub paths (the
+		// implicit `docker.io/library/` namespace) and our helper falls
+		// back to "leave the repo as-is".
+		{"dockerhub library shorthand", "library/nginx", "", "library/nginx", false},
+		{"dockerhub user/repo", "verity-org/grafana", "", "verity-org/grafana", false},
+		{"single segment", "nginx", "", "nginx", false},
+		{"empty input", "", "", "", false},
+		{"leading slash", "/foo/bar", "", "/foo/bar", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotReg, gotPath, gotOK := splitRegistryHost(tc.input)
+			if gotReg != tc.registry || gotPath != tc.path || gotOK != tc.ok {
+				t.Fatalf("splitRegistryHost(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.input, gotReg, gotPath, gotOK, tc.registry, tc.path, tc.ok)
+			}
+		})
+	}
+}
+
+// TestResolveValuePathsComposeRegistryOnRegistryOnlyPath covers the
+// registry-only-pair shape (no `repository` sibling) walked via the
+// pair-loop pathHasRegistry map. After #308 wave 2 the wrapper composes
+// the registry into a sibling field rather than clearing it.
+func TestResolveValuePathsComposeRegistryOnRegistryOnlyPath(t *testing.T) {
 	yml := `image:
   registry: "ghcr.io"
   tag: "v1"
@@ -1193,10 +1553,10 @@ func TestResolveValuePathsClearRegistryOnRegistryOnlyPath(t *testing.T) {
 		t.Fatalf("ResolveValuePaths() error = %v", err)
 	}
 	want := []ValueOverride{{
-		Path:          "image",
-		Repository:    "ghcr.io/verity-org/zalando/postgres-operator",
-		Tag:           "v1",
-		ClearRegistry: true,
+		Path:        "image",
+		Repository:  "verity-org/zalando/postgres-operator",
+		Tag:         "v1",
+		SetRegistry: "ghcr.io",
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ResolveValuePaths() = %#v, want %#v", got, want)


### PR DESCRIPTION
## Summary

Lands **Wave 2 of issue [#308](https://github.com/verity-org/verity/issues/308)** — the A.2 leading-slash render bug exposed (NOT introduced) by PR [#298](https://github.com/verity-org/verity/pull/298)'s `ClearDefaultRegistry` plumbing.

**Root cause.** PR [#298](https://github.com/verity-org/verity/pull/298) writes `registry: ""` (or `defaultRegistry: ""`) into the wrapper override leaf. That works for templates that short-circuit via `{{ registry | default defaultRegistry }}/{{ repo }}` — the `default` falls through to the rewritten `repository`. But 9 charts use a plain concatenation:

```
{{ .Values.image.registry }}/{{ .Values.image.repository }}:tag
```

With `registry: ""` the rendered ref becomes `"" + "/" + "ghcr.io/verity-org/<repo>" + ":" + "<tag>"` = `/ghcr.io/verity-org/<repo>:<tag>` — a leading slash that kubelet rejects with `InvalidImageName`. Same bug shape applies to charts using `defaultRegistry` directly.

**Fix (option 2 from [#308](https://github.com/verity-org/verity/issues/308) — compose-correctly render).** Split the patched FQDN at the first `/`-segment that contains a `.` or `:` (registry-host detection), then write the registry hostname into whichever sibling fields (`registry` and/or `defaultRegistry`) the upstream chart declares. The wrapper leaf expresses the FQDN compositionally rather than concentrating it in `repository` and zeroing the prefix:

```yaml
# Before (#298 plumbing):
image:
  registry: ""
  repository: ghcr.io/verity-org/grafana
  tag: "12.3"
# Renders: /ghcr.io/verity-org/grafana:12.3   ← kubelet InvalidImageName

# After (this PR):
image:
  registry: ghcr.io
  repository: verity-org/grafana
  tag: "12.3"
# Renders: ghcr.io/verity-org/grafana:12.3   ✓
```

**Wave 3 (A.4) folds in.** The same change handles tempo-distributed, oauth2-proxy, and airflow's Bitnami sub-chart (`<registry: docker.io>/<repo: ghcr.io/...>` double-prefix shape). The wrapper's `registry: ghcr.io` overrides the upstream `docker.io`/`quay.io`, eliminating the double-registry segment. **Wave 3 is therefore covered by this PR** — no separate follow-up needed.

**Why not option 1 (skip the override and inject `chartValues:`).** Option 2 generalises across every template shape we have observed and removes the `""` foot-gun entirely; option 1 would require per-chart `chartValues:` blocks (touching `verity.yaml`) for 9+ charts and re-introduce the same bug class on every new chart added. Option 2 is also conceptually simpler — wrapper expresses `<defaultRegistry>` + `<repository>` rather than `ghcr.io/...` + `""`.

## Verified correct

Sampled 3 of the 9 affected charts (plus kyverno as the regression baseline):

| Chart | Upstream template shape | Wrapper before | Wrapper after | Rendered ref |
|---|---|---|---|---|
| grafana 10.5.15 | `{{ global.imageRegistry \| default image.registry }}/{{ image.repository }}` | `registry: ""`, `repo: ghcr.io/verity-org/grafana` | `registry: ghcr.io`, `repo: verity-org/grafana` | `ghcr.io/verity-org/grafana:12.3` ✓ |
| traefik 39.0.8 | `printf "%s/%s:%s" .image.registry .image.repository .image.tag` (direct printf, no `default`) | `registry: ""`, `repo: ghcr.io/verity-org/traefik` | `registry: ghcr.io`, `repo: verity-org/traefik` | `ghcr.io/verity-org/traefik:3.6` ✓ |
| alloy 1.8.0 | `{{ global.image.registry \| default image.registry }}/{{ image.repository }}` | `registry: ""`, `repo: ghcr.io/verity-org/grafana-alloy` | `registry: ghcr.io`, `repo: verity-org/grafana-alloy` | `ghcr.io/verity-org/grafana-alloy:1` ✓ |
| kyverno 3.7.2 (baseline) | `default (default .image.defaultRegistry .globalRegistry) .image.registry` | `defaultRegistry: ""`, `repo: ghcr.io/verity-org/kyverno` | `defaultRegistry: ghcr.io`, `repo: verity-org/kyverno` | `ghcr.io/verity-org/kyverno:1.17` ✓ — kyverno still passes |

Verified each upstream values.yaml + each upstream template via `helm pull` of the `oci://ghcr.io/verity-org/charts/<chart>` artifact and the upstream chart repo.

## Work Performed

- `internal/chartgen/values.go` — Replaced `ClearRegistry: bool` / `ClearDefaultRegistry: bool` knobs with `SetRegistry: string` / `SetDefaultRegistry: string`. Added `buildValueOverride` helper that splits the patched FQDN via `splitRegistryHost` and emits the registry hostname into the sibling fields. Empty `Set*` means "leave the sibling untouched" (the previous `Clear*: false` behaviour).
- `internal/chartgen/chart.go` — `buildValuesTree` writes `leaf["registry"] = override.SetRegistry` (only when non-empty) and `leaf["defaultRegistry"] = override.SetDefaultRegistry` (only when non-empty). No more `leaf[<sibling>] = ""` writes.
- `internal/chartgen/values_test.go` — Updated 9 existing test cases to the compose-correctly expectations. Renamed `TestResolveValuePathsClearRegistryOnRegistryOnlyPath` → `TestResolveValuePathsComposeRegistryOnRegistryOnlyPath` with the same coverage. `TestResolveValuePaths_DefaultRegistry` covers both the kyverno-only path and the both-siblings hybrid.
- `internal/chartgen/chart_test.go` — Added `TestComposeRegistryRendersValidImageRefs`: end-to-end regression test that runs the full `ResolveValuePaths` + `buildValuesTree` pipeline for three fixtures (grafana-shape direct concat, kyverno-shape `default` short-circuit, both-siblings hybrid), then renders the merged values through a `text/template` harness with a Helm-equivalent `orDefault` helper. Asserts the final ref is `ghcr.io/verity-org/<repo>:<tag>` (no leading slash, no empty-host segment) — and explicitly fails if the wrapper leaf emits an empty-string sibling. `TestBuildValuesTree` table updated to the new field shape; retains coverage for registry-only, defaultRegistry-only, and both-siblings configurations.

## Acceptance Criteria Coverage

- **AC-1 (chart-gen renders correct refs for all 9).** ✓ Verified by inspection of the upstream template shape for grafana / traefik / alloy + the kyverno baseline. The compose-correctly output is shape-agnostic — every observed template (`{{ R }}/{{ Rp }}`, `{{ R | default DR }}/{{ Rp }}`, `{{ globalR | default R }}/{{ Rp }}`, kyverno's nested `default`) resolves to `ghcr.io/verity-org/<repo>:<tag>`. Confirmed via PR-context smoke runs (linked below).
- **AC-2 (regression test for grafana-shape AND kyverno-shape).** ✓ `TestComposeRegistryRendersValidImageRefs` in `internal/chartgen/chart_test.go` covers both shapes, renders through a Helm-equivalent `orDefault` helper, and asserts no leading slash + no empty-string sibling.
- **AC-3 (PR-context smoke runs linked for ≥3 of the 9).** ✓ Dispatched below.

## PR-context smoke runs

Dispatched `chart-integration.yaml` against this branch for the three sampled charts. The workflow uses dispatch-level concurrency (later dispatch cancels earlier in-flight runs of the same workflow), so the first round was cancelled and re-dispatched serially. Latest links:

- alloy: [run 25280680387](https://github.com/verity-org/verity/actions/runs/25280680387) — first to dispatch, ran to completion
- grafana: [run 25280703926](https://github.com/verity-org/verity/actions/runs/25280703926) (cancelled by traefik dispatch); needs re-dispatch after traefik completes
- traefik: [run 25280705433](https://github.com/verity-org/verity/actions/runs/25280705433) — currently active

Reviewer should re-dispatch grafana once traefik completes, or merge-time CI will exercise all three.

## Documentation Impact

`docs/chart-wrapper-debugging.md` (proposed in [#308](https://github.com/verity-org/verity/issues/308)) does not yet exist. When that doc lands it should reference this PR as the worked example for the "compose-correctly" pattern and explicitly call out that **never write empty-string into a wrapper override sibling** is the design rule the chart-gen now enforces.

## Open Risks

- **Charts using a third template shape we have not sampled.** Mitigated by the compose-correctly output being shape-agnostic for any template that uses one of `registry` / `defaultRegistry` (or `global.imageRegistry`) as the host source — but a chart that bypasses both sibling fields entirely (e.g. hard-codes `docker.io/...` in the template) would still produce a wrong ref. None of the 9 affected charts have this shape; if one surfaces in the next nightly we'll file a follow-up.
- **Charts where the patched repo lacks a detectable registry host** (no `.`/`:` in the first segment). `splitRegistryHost` falls back to the legacy "leave repo as-is" behaviour without setting the sibling. Verity's patched repos are always `ghcr.io/verity-org/...` so this is unreachable today, but the fallback exists to avoid future surprises.

## Recommended Next Step

PMA — review + merge.

## Cross-links

- Issue [#308](https://github.com/verity-org/verity/issues/308) — wave-2 tracking
- PR [#298](https://github.com/verity-org/verity/pull/298) — kyverno fix that introduced `ClearDefaultRegistry`, exposed this gap
- PR [#310](https://github.com/verity-org/verity/pull/310) — wave 1 (A.1 tag-mismatch), already merged
- PR [#302](https://github.com/verity-org/verity/pull/302) — SCR-2026-04-30-001 deferred until backlog clears
