### PR TITLE
feat(charts): add cluster-autoscaler, nfs-subdir, azure-workload-identity wave-12 wrappers

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -210,3 +210,15 @@ dependencies:
   - name: fluent-bit
     version: "0.57.3"
     repository: "https://fluent.github.io/helm-charts"
+
+  - name: cluster-autoscaler
+    version: "9.57.0"
+    repository: "https://kubernetes.github.io/autoscaler"
+
+  - name: nfs-subdir-external-provisioner
+    version: "4.0.18"
+    repository: "https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/"
+
+  - name: workload-identity-webhook
+    version: "1.5.1"
+    repository: "https://azure.github.io/azure-workload-identity/charts"

--- a/verity.yaml
+++ b/verity.yaml
@@ -478,7 +478,9 @@ replacements:
     tag: "4.2"
 
   # Wave 12 charts (autoscaling + storage + cloud identity).
-  # cluster-autoscaler 9.57.0 (app 1.35.0) → exact tag match.
+  # cluster-autoscaler 9.57.0 (app 1.35.0) → v1.35 major.minor track.
+  # Rebuild config declares `versions: "1.35"` which publishes a 1.35 floating
+  # tag tracking the latest 1.35.x package release.
   "autoscaling/cluster-autoscaler":
     registry: "ghcr.io/verity-org"
     image: "cluster-autoscaler"

--- a/verity.yaml
+++ b/verity.yaml
@@ -483,17 +483,20 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "cluster-autoscaler"
     tag: "1.35"
-  # nfs-subdir-external-provisioner 4.0.18 (app 4.0.2) → v4.0 major.minor track.
+  # nfs-subdir-external-provisioner 4.0.18 (app 4.0.2) → v4 major track.
+  # Rebuild config declares `versions: "4"` (major-only), so the durable tag
+  # is "4". Pinning to "4.0" would break when Wolfi advances to 4.1.x.
   "sig-storage/nfs-subdir-external-provisioner":
     registry: "ghcr.io/verity-org"
     image: "nfs-subdir-external-provisioner"
-    tag: "4.0"
-  # workload-identity-webhook 1.5.1 (app v1.5.1) → exact tag match. Image path
-  # has 3 segments (azure/workload-identity/webhook).
+    tag: "4"
+  # workload-identity-webhook 1.5.1 (app v1.5.1) → v1 major track.
+  # Rebuild config declares `versions: "1"` (major-only), so the durable tag
+  # is "1". Image path has 3 segments (azure/workload-identity/webhook).
   "azure/workload-identity/webhook":
     registry: "ghcr.io/verity-org"
     image: "azure-workload-identity-webhook"
-    tag: "1.5"
+    tag: "1"
 
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this

--- a/verity.yaml
+++ b/verity.yaml
@@ -52,6 +52,16 @@ chartValues:
   aws-load-balancer-controller:
     clusterName: verity-placeholder
 
+  # cluster-autoscaler requires autoDiscovery.clusterName to render templates.
+  # The wrapper chart consumers MUST override this to their actual cluster name.
+  cluster-autoscaler:
+    autoDiscovery.clusterName: verity-placeholder
+
+  # workload-identity-webhook requires azureTenantID to render templates.
+  # The wrapper chart consumers MUST override this to their actual tenant ID.
+  workload-identity-webhook:
+    azureTenantID: verity-placeholder
+
   # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
   # default inbound agent image. Keep the wrapper focused on the controller and
   # the existing kiwigrid sidecar image.
@@ -466,6 +476,24 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "fluent-bit"
     tag: "4.2"
+
+  # Wave 12 charts (autoscaling + storage + cloud identity).
+  # cluster-autoscaler 9.57.0 (app 1.35.0) → exact tag match.
+  "autoscaling/cluster-autoscaler":
+    registry: "ghcr.io/verity-org"
+    image: "cluster-autoscaler"
+    tag: "1.35"
+  # nfs-subdir-external-provisioner 4.0.18 (app 4.0.2) → v4.0 major.minor track.
+  "sig-storage/nfs-subdir-external-provisioner":
+    registry: "ghcr.io/verity-org"
+    image: "nfs-subdir-external-provisioner"
+    tag: "4.0"
+  # workload-identity-webhook 1.5.1 (app v1.5.1) → exact tag match. Image path
+  # has 3 segments (azure/workload-identity/webhook).
+  "azure/workload-identity/webhook":
+    registry: "ghcr.io/verity-org"
+    image: "azure-workload-identity-webhook"
+    tag: "1.5"
 
 # Images the orchestrator should skip entirely, regardless of source
 # (standalone copa-config.yaml entry OR chart-discovered). Reserve this


### PR DESCRIPTION
## Summary

Adds 3 single-image charts to the wrapper-chart pipeline:

- **cluster-autoscaler 9.57.0** (app 1.35.0) → \`autoscaling/cluster-autoscaler:v1.35.0\` routed to \`images/cluster-autoscaler.yaml\` Wolfi rebuild (exact tag match). chartValues entry for \`autoDiscovery.clusterName\` placeholder is required; consumers MUST override.
- **nfs-subdir-external-provisioner 4.0.18** (app 4.0.2) → \`sig-storage/nfs-subdir-external-provisioner:v4.0.2\` routed to \`images/nfs-subdir-external-provisioner.yaml\` Wolfi rebuild (\`4.0\` major.minor track).
- **workload-identity-webhook 1.5.1** (app v1.5.1) → \`mcr.microsoft.com/oss/azure/workload-identity/webhook:v1.5.1\` routed to \`images/azure-workload-identity-webhook.yaml\` Wolfi rebuild (\`1.5\` track). 3-segment image path (azure/workload-identity/webhook). chartValues entry for \`azureTenantID\` placeholder is required.

## Verification

- \`verity doctor\`: all checks passed
- \`chart-gen --strict --dry-run\`: 53 charts in Chart.yaml, would produce 53 wrappers, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds wave-12 wrapper charts for `cluster-autoscaler`, `nfs-subdir-external-provisioner`, and `workload-identity-webhook`, wiring `Chart.yaml` deps and `verity.yaml` image replacements to `ghcr.io/verity-org` with durable tags.

- **New Features**
  - `cluster-autoscaler` 9.57.0 (app 1.35.0) → replace `autoscaling/cluster-autoscaler` with `ghcr.io/verity-org/cluster-autoscaler:1.35` (major.minor stream).
  - `nfs-subdir-external-provisioner` 4.0.18 (app 4.0.2) → replace `sig-storage/nfs-subdir-external-provisioner` with `ghcr.io/verity-org/nfs-subdir-external-provisioner:4` (major-only).
  - `workload-identity-webhook` 1.5.1 (app v1.5.1) → replace `azure/workload-identity/webhook` with `ghcr.io/verity-org/azure-workload-identity-webhook:1` (major-only).

- **Migration**
  - Set `chartValues.cluster-autoscaler.autoDiscovery.clusterName`.
  - Set `chartValues.workload-identity-webhook.azureTenantID`.

<sup>Written for commit 00517b1eb9c40fd437bd0998d28af3053a42d5e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

