### PR TITLE
fix(charts): revert kyverno 3.8.0 → 3.7.2 + pin postgres-operator tag (#308)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -20,8 +20,15 @@ dependencies:
     version: "1.15.1"
     repository: "https://opensource.zalando.com/postgres-operator/charts/postgres-operator"
 
+  # Pinned at 3.7.2 — chart 3.8.0 (#314 bump) deployment passes
+  # `--apiCallTimeout=30s` to the kyverno binary, but Verity's wolfi-rebuilt
+  # `kyverno-1.17` doesn't recognise that flag (added upstream in 1.18+).
+  # Result: container CrashLoopBackOff with "flag provided but not defined:
+  # -apiCallTimeout". Bumping back to 3.7.2 restores yesterday's working
+  # state. The 3.8.0 bump is unblocked once the kyverno-1.18+ rebuild lands
+  # in `images/kyverno*.yaml`.
   - name: kyverno
-    version: "3.8.0"
+    version: "3.7.2"
     repository: "oci://ghcr.io/kyverno/charts"
 
   - name: argo-cd

--- a/images/postgres-operator.yaml
+++ b/images/postgres-operator.yaml
@@ -11,3 +11,10 @@ types:
 
 versions:
   "1": {}
+  # Maintained minor stream — verity-org/verity#317 (Wave 1 catch-up of #308)
+  # pins the wrapper chart at `tag: "1.15"`, so this stream needs to keep
+  # publishing across Wolfi minor bumps rather than relying on the
+  # semver cascade alias from the `1` build (which would disappear the moment
+  # Wolfi advances postgres-operator to 1.16.x). Same pattern as
+  # images/metrics-server.yaml's "0.8" declaration (#310).
+  "1.15": {}

--- a/verity.yaml
+++ b/verity.yaml
@@ -205,10 +205,19 @@ replacements:
 
   # postgres-operator chart (1.15.1). Migrated Copa→Integer; this entry
   # routes the chart's image to the existing images/postgres-operator.yaml
-  # rebuild.
+  # rebuild. Tag `1.15` pins the maintained floating-minor track declared
+  # by images/postgres-operator.yaml (`versions: "1.15": {}` alongside the
+  # `"1"` catch-all). Without an explicit tag, chart-gen carries the
+  # chart's appVersion `v1.15.1` through verbatim, but Verity publishes
+  # non-v tags only — same v-prefix mismatch as argocd/dex (Wave 1, #310).
+  # The dedicated `1.15` stream survives Wolfi minor bumps; if/when 1.16.x
+  # ships, declare `"1.16": {}` too and bump this pin. Sample pre-fix
+  # failure: `ghcr.io/verity-org/postgres-operator:v1.15.1: not found`
+  # (run 25318761444 → diagnostics-postgres-operator).
   "zalando/postgres-operator":
     registry: "ghcr.io/verity-org"
     image: "postgres-operator"
+    tag: "1.15"
 
   # cert-manager chart (1.20.2). Jetstack chart image refs keep the upstream
   # quay.io/jetstack path and v-prefixed tag; Verity publishes the rebuilds at


### PR DESCRIPTION
## Summary

Two surgical fixes from the May 4 chart-integration triage (Issue [#308](https://github.com/verity-org/verity/issues/308)):

1. **Revert PR [#314](https://github.com/verity-org/verity/pull/314)'s kyverno 3.7.2 → 3.8.0 bump** — chart 3.8.0 caused a regression because its deployment passes `--apiCallTimeout=30s` to the kyverno binary, but Verity's wolfi-rebuilt `kyverno-1.17` doesn't recognise that flag (added upstream in 1.18+). All 4 kyverno controllers entered `CrashLoopBackOff` with `flag provided but not defined: -apiCallTimeout`.

2. **Pin postgres-operator tag** to `1.15.1` in `verity.yaml`'s `replacements:`. The chart wants `ghcr.io/verity-org/postgres-operator:v1.15.1` (v-prefixed). Verity publishes non-v tags only (`:1`, `:1.15`, `:1.15.1`). Same v-prefix mismatch as argocd / dex / metrics-server (Wave 1, [PR #310](https://github.com/verity-org/verity/pull/310)); postgres-operator was missed in that batch.

## Investigation evidence

Pod-level dumps from chart-integration run [25318761444](https://github.com/verity-org/verity/actions/runs/25318761444) (`diagnostics-kyverno`, `diagnostics-postgres-operator` artifacts):

```
kyverno-admission-controller (CrashLoopBackOff, 6 restarts):
  flag provided but not defined: -apiCallTimeout
  Usage of /usr/bin/kyverno: ...

postgres-operator (ImagePullBackOff):
  Failed to pull image "ghcr.io/verity-org/postgres-operator:v1.15.1":
  rpc error: NotFound — failed to resolve reference
```

## Why selective revert (not full revert of [#314](https://github.com/verity-org/verity/pull/314))

PR [#314](https://github.com/verity-org/verity/pull/314) bumped 10 chart dependencies. Only kyverno's bump caused a verified regression. Three charts that the bump cleared are passing today (`victoria-logs-single`, `victoria-metrics-single`, `prometheus-blackbox-exporter`). A full revert would risk breaking those. Selective revert keeps the wins, removes the regression.

## Out of scope

[#308](https://github.com/verity-org/verity/issues/308)'s broader categories require separate work and are tracked separately:

- **(A) Verity rebuild incompatibilities** — argo-cd binary structure (chart wants `argocd-server` binary, verity has `argocd` monolith), grafana FHS layout (config paths, nonroot user), kyverno-1.18+ flag-set sync.
- **(C) True wrapper-rendering bugs** — already cleared by PR [#312](https://github.com/verity-org/verity/pull/312) for alloy, argo-rollouts, traefik, oauth2-proxy.
- **(B) Tag-format mismatches beyond Wave 1+ this PR** — none observed today; this PR closes the v-prefix subset.

## Verification

After merge, the next chart-gen run will re-publish:
- `oci://ghcr.io/verity-org/charts/kyverno:3.7.2` (chart bumped back)
- The wrapper for the postgres-operator chart with the new tag pin

Then chart-integration will exercise both. Expected: kyverno regression cleared (was passing on May 3, started failing May 4 morning post-#314), postgres-operator clears its image-pull failure.

## Refs

- Closes Wave 1 follow-up for postgres-operator subset of [#308](https://github.com/verity-org/verity/issues/308)
- Reverts the kyverno bump from [#314](https://github.com/verity-org/verity/pull/314)
- Builds on methodology from PR [#310](https://github.com/verity-org/verity/pull/310) (Wave 1) and [#298](https://github.com/verity-org/verity/pull/298) (kyverno root cause)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `kyverno` CrashLoopBackOff and `postgres-operator` ImagePullBackOff by reverting the chart and pinning the image to a stable minor stream, addressing #308.

- **Bug Fixes**
  - Reverted `kyverno` chart to 3.7.2; 3.8.0 passes `--apiCallTimeout=30s`, which `kyverno-1.17` doesn’t support, causing crashes.
  - Pinned `postgres-operator` image to tag `1.15` in `verity.yaml` and added a `versions: "1.15"` stream in `images/postgres-operator.yaml` to avoid the `v`-prefix tag mismatch and ensure availability.

<sup>Written for commit bf6f3e8f32cdeef11bcbefb54866c2d279f6dabe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

