### PR TITLE
chore(ci): hold kyverno + aws-load-balancer-controller helm bumps (#318)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -89,6 +89,12 @@
       "groupName": "helm charts",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
+    },
+    {
+      "description": "Hold kyverno + aws-load-balancer-controller helm bumps until #318 verity-rebuild incompatibilities clear (the kyverno 3.7.2 → 3.8.0 automerge in #314 broke nightly because the chart expects binary >=1.18 while verity ships 1.17; reverted in #317. aws-load-balancer-controller is in #318's suspected (A) cluster and a v3 major is queued in #68.)",
+      "matchManagers": ["helmv3"],
+      "matchPackageNames": ["kyverno", "aws-load-balancer-controller"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

Adds a Renovate `packageRule` that disables update PRs for the `kyverno` and `aws-load-balancer-controller` helm charts until [#318](https://github.com/verity-org/verity/issues/318)'s verity-rebuild-incompat (A) cluster clears them.

## Why

### kyverno
- [#314](https://github.com/verity-org/verity/pull/314) auto-merged the kyverno chart 3.7.2 → 3.8.0 bump
- Chart 3.8.0 invokes the kyverno binary with `--apiCallTimeout`, added in upstream kyverno >= 1.18
- Verity's `images/kyverno*.yaml` track wolfi's `kyverno-1.17` stream
- Result: all four kyverno controllers (`admission`, `background`, `cleanup`, `reports`) → `CrashLoopBackOff` with `flag provided but not defined: -apiCallTimeout`
- [#317](https://github.com/verity-org/verity/pull/317) reverted the chart bump as immediate fix
- Without this rule, the next Renovate cycle (Mondays before 04:00 UTC) re-bumps the chart and re-breaks nightly

### aws-load-balancer-controller
- [#68](https://github.com/verity-org/verity/issues/68) (Renovate dashboard) has a v3 major bump queued
- Sits in [#318](https://github.com/verity-org/verity/issues/318)'s suspected verity-rebuild-incompat (A) cluster (failure mode TBD pending diagnostic pull)
- Major bumping while the chart is still red on existing version is a recipe for re-failure with no diagnostic signal

## Behavior

`enabled: false` on a `packageRule` causes Renovate to skip those packages entirely — no PRs created, no dashboard checkboxes, no automerge.

## How to re-enable

Remove the new `packageRules` entry. Do this when:
- `kyverno`: wolfi publishes `kyverno-1.18` AND `images/kyverno*.yaml` is bumped to track it (then chart 3.8.0+ will work), OR a chart-vs-binary mismatch detector lands in chart-gen
- `aws-load-balancer-controller`: [#318](https://github.com/verity-org/verity/issues/318) confirms the failure mode and a fix lands

## Verification

- `jq . .github/renovate.json` — JSON is valid
- Diff is +6 lines, single packageRule append
- No existing rule semantics changed

Refs: [#308](https://github.com/verity-org/verity/issues/308) (closed, superseded), [#314](https://github.com/verity-org/verity/pull/314), [#317](https://github.com/verity-org/verity/pull/317), [#318](https://github.com/verity-org/verity/issues/318), [#68](https://github.com/verity-org/verity/issues/68)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Renovate updates for the `kyverno` and `aws-load-balancer-controller` Helm charts to prevent breaking bumps while #318 is resolved. This avoids the kyverno 3.8.0 vs 1.17 binary mismatch (crash-loop; reverted in #317) and pauses a risky major bump queued for the ALB controller (#68).

- **Dependencies**
  - Add a `packageRule` in `.github/renovate.json` for `helmv3` matching `kyverno` and `aws-load-balancer-controller` with `enabled: false`.

<sup>Written for commit 50d539ad0eeeb0c02c8845d5cd03b40292ca02dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

