### PR TITLE
fix(images): add Wolfi rebuild for external-dns + repoint replacement (#309)

### DIFF
--- a/images/external-dns.yaml
+++ b/images/external-dns.yaml
@@ -1,0 +1,22 @@
+name: external-dns
+description: "ExternalDNS Kubernetes DNS controller — Wolfi rebuild targets upstream CVEs (chart 1.20.x; #309)"
+upstream:
+  package: external-dns
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["external-dns"]
+    entrypoint: /usr/bin/external-dns
+
+versions:
+  "0": {}
+  # Maintained minor stream — verity-org/verity#309 unblocks #318 Wave 1 by
+  # publishing this rebuild. Chart `external-dns 1.20.0` ships with
+  # appVersion `v0.20.0` but Wolfi currently only ships up to
+  # `external-dns-0.18.x`; verity.yaml `replacements:` therefore pins
+  # `tag: "0.18"` (chart-vs-binary skew is two minors). When Wolfi
+  # publishes 0.19 / 0.20, add the matching `"0.19": {}` / `"0.20": {}`
+  # entries here AND bump the `tag:` in verity.yaml in lock-step (mirror
+  # the metrics-server `"0.8"` precedent).
+  "0.18": {}

--- a/verity.yaml
+++ b/verity.yaml
@@ -254,9 +254,18 @@ replacements:
   "ingress-nginx/kube-webhook-certgen":
     registry: "ghcr.io/verity-org"
     image: "kubernetes/ingress-nginx/kube-webhook-certgen"
+  # external-dns chart 1.20.0 ships appVersion v0.20.0; Wolfi currently
+  # only publishes up to external-dns-0.18.x. The rebuild lives at
+  # ghcr.io/verity-org/external-dns (see images/external-dns.yaml).
+  # Pin to "0.18" — the highest minor Wolfi actually publishes — until
+  # upstream catches up. Chart-vs-binary skew is two minors but the
+  # external-dns CLI flags consumed by the chart Deployment have been
+  # stable since 0.10+, so this is expected to render and run.
+  # Tracked: verity-org/verity#309 (#318 Wave 1 follow-up).
   "external-dns/external-dns":
     registry: "ghcr.io/verity-org"
-    image: "kubernetes-sigs/external-dns"
+    image: "external-dns"
+    tag: "0.18"
 
   # Integer-backed free wins.
   "valkey/valkey":


### PR DESCRIPTION
## Summary

Closes [#309](https://github.com/verity-org/verity/issues/309) via Option 1 (the recommended path). Unblocks [#318](https://github.com/verity-org/verity/issues/318) Wave 1 for the A.1 (tag-mismatch) cluster.

[#309](https://github.com/verity-org/verity/issues/309) discovered that the existing \`external-dns/external-dns\` entry in \`verity.yaml\`'s \`replacements:\` block routes to a non-existent image — \`crane manifest ghcr.io/verity-org/kubernetes-sigs/external-dns:*\` returns \`NAME_UNKNOWN\` for every tag, because verity never published a Wolfi rebuild for this chart.

## What changes

### \`images/external-dns.yaml\` (new)
Authored as a Wolfi rebuild mirroring the [\`dex.yaml\`](https://github.com/verity-org/verity/blob/main/images/dex.yaml) / [\`metrics-server.yaml\`](https://github.com/verity-org/verity/blob/main/images/metrics-server.yaml) shape — single binary, entrypoint at \`/usr/bin/external-dns\`, no extra paths.

Declares two version tracks:
- \`\"0\": {}\` — floating-major
- \`\"0.18\": {}\` — pinned-minor (mirrors the [\`metrics-server\` \`\"0.8\"\` precedent](https://github.com/verity-org/verity/blob/main/images/metrics-server.yaml) so the build keeps publishing across Wolfi minor bumps without depending on the semver cascade alias)

### \`verity.yaml\`
Fix the \`external-dns/external-dns\` replacement entry:
- \`image: \"kubernetes-sigs/external-dns\"\` → \`\"external-dns\"\` — matches where the new rebuild actually publishes (\`ghcr.io/verity-org/external-dns\`)
- add \`tag: \"0.18\"\` — same [Wave 1 methodology used in #310](https://github.com/verity-org/verity/pull/310)

## ⚠️ Known limitation: chart-vs-binary skew

| | |
|--|--|
| Chart version | external-dns 1.20.0 |
| Chart appVersion | v0.20.0 |
| Wolfi package | external-dns 0.18.0-r1 (highest available, verified via \`packages.wolfi.dev/os/x86_64/APKINDEX\`) |
| **Skew** | **2 minor versions** |

This pins the highest minor Wolfi actually publishes. Chart deploys with binary 0.18 instead of 0.20.

**Why this is expected to work**: external-dns CLI flag set consumed by the chart's Deployment template has been stable since ~0.10. If the next chart-integration nightly surfaces an unsupported flag, the follow-up is either:

1. Bump Wolfi to 0.19 / 0.20 then add the matching version entry here AND bump the \`tag:\` in lock-step, OR
2. Hold the helm chart at a 1.18.x line that uses appVersion 0.18 (mirror the [kyverno 3.7.2 hold pattern from #317](https://github.com/verity-org/verity/pull/317))

## Verification

- [x] \`make integer-validate\` → all 325 images valid (including new file)
- [x] JSON/YAML structure mirrors existing rebuilds (dex.yaml, metrics-server.yaml)
- [x] \`verity.yaml replacements:\` entry now produces a resolvable \`ghcr.io/verity-org/external-dns:0.18\` reference (vs. previous \`ghcr.io/verity-org/kubernetes-sigs/external-dns:<unset>\` 404)

## Refs

- Closes [#309](https://github.com/verity-org/verity/issues/309) (Option 1 path)
- Unblocks Wave 1 for [#318](https://github.com/verity-org/verity/issues/318) A.1 (tag-mismatch) cluster
- Methodology: [#310](https://github.com/verity-org/verity/pull/310), [#317](https://github.com/verity-org/verity/pull/317)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Wolfi rebuild for `external-dns` and repoints the `verity.yaml` replacement to `ghcr.io/verity-org/external-dns:0.18` to fix the broken image reference. Closes #309 and unblocks Wave 1 in #318.

- **Bug Fixes**
  - Added `images/external-dns.yaml` Wolfi rebuild (single binary, entrypoint `/usr/bin/external-dns`) with versions `"0"` and `"0.18"`.
  - Updated `verity.yaml` replacement from `kubernetes-sigs/external-dns` to `external-dns` and pinned `tag: "0.18"` at `ghcr.io/verity-org/external-dns`.
  - Note: chart `external-dns` 1.20.0 (appVersion `v0.20.0`) runs with Wolfi `0.18.x`; flags used by the chart are stable. Bump both files when Wolfi publishes `0.19`/`0.20`.

<sup>Written for commit 9f0845b6d3450236fc360fd982060a890b6913f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

