### PR TITLE
fix(charts): pin pushgateway tag to floating minor "1.11" (#318 A.3)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -94,9 +94,15 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "kube-state-metrics"
     tag: "2.18.0"
+  # prometheus chart pulls pushgateway:v1.11.2 (with v prefix); verity-org
+  # publishes only non-v tags (`latest`, `1.11`, `1.11.2`). Pin floating-minor
+  # `1.11` per the Wave 1 methodology in #310 so chart-gen writes a tag that
+  # actually resolves. Closes the prometheus shard's only red pod (the rest
+  # of the chart is green per nightly diagnostics).
   "prometheus/pushgateway":
     registry: "ghcr.io/verity-org"
     image: "pushgateway"
+    tag: "1.11"
 
   # Observability wave 2. The prometheus chart was dropped from this PR
   # (kube-prometheus-stack rendered images for jkroepke/kube-webhook-certgen


### PR DESCRIPTION
## Summary

1-line tag-format fix surfaced by [#318](https://github.com/verity-org/verity/issues/318)'s May 5 diagnostic dump. The prometheus shard's only red pod is `prometheus-prometheus-pushgateway` because the chart pulls \`ghcr.io/verity-org/pushgateway:v1.11.2\` (with v prefix) which 404s — verity-org publishes only non-v tags.

## Verified

```bash
$ crane ls ghcr.io/verity-org/pushgateway
latest
1.11
1.11.2
[...digest tags...]

$ crane manifest ghcr.io/verity-org/pushgateway:v1.11.2
# NAME_UNKNOWN

$ crane manifest ghcr.io/verity-org/pushgateway:1.11
# returns OCI index manifest with amd64 + arm64 platforms
```

## Why this slipped through Wave 1

[#310](https://github.com/verity-org/verity/pull/310) (Wave 1) added \`tag:\` pins for the 5 A.1 charts that the May 3 triage caught (argo-cd, dex, metrics-server, opensearch, opensearch-dashboards). pushgateway was inside the prometheus chart's tree and rendered as part of the kube-prometheus-stack — it surfaced only when the May 5 diagnostic dump on [#318](https://github.com/verity-org/verity/issues/318) inspected the prometheus shard pod-by-pod and isolated it from the chart's green nodes.

This is the same fix shape as [#310](https://github.com/verity-org/verity/pull/310): pin \`tag:\` to the floating-minor (\`1.11\`) so chart-gen writes a tag that actually resolves.

## Verification

- [x] \`make integer-validate\` → all 325 images valid
- [x] \`crane manifest ghcr.io/verity-org/pushgateway:1.11\` returns a valid OCI index
- [x] Diff is +6 lines, single \`tag:\` addition + comment

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (A.3 image-not-published / tag-format sub-cluster — see [my May 5 categorization comment](https://github.com/verity-org/verity/issues/318#issuecomment-4382388804))
- Methodology mirrors [#310](https://github.com/verity-org/verity/pull/310)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `prometheus/pushgateway` image tag to `1.11` to match published non-v tags and stop `v1.11.2` 404s. Fixes the pushgateway image pull and returns the Prometheus shard to green (refs #318).

<sup>Written for commit 907aab5c361490ef10705f9f5feafe249966c0e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

