### PR TITLE
fix(images): add busybox subpackage to valkey rebuild (#318 A.1)

### DIFF
--- a/images/valkey.yaml
+++ b/images/valkey.yaml
@@ -6,14 +6,18 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["valkey-{{version}}"]
+    # busybox supplies /bin/sh + coreutils for chart wrapper scripts
+    # (bitnami/valkey chart's pod command is `sh -c '...'`). Without it the
+    # main container fails at runc exec with `/bin/sh: no such file or
+    # directory`. See verity-org/verity#318 (A.1 shell-missing cluster).
+    packages: ["valkey-{{version}}", "busybox"]
     entrypoint: /usr/bin/valkey-server
     paths:
       - {path: /data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
   fips:
     base: wolfi-fips
-    packages: ["valkey-{{version}}"]
+    packages: ["valkey-{{version}}", "busybox"]
     entrypoint: /usr/bin/valkey-server
     environment:
       OPENSSL_MODULES: /usr/lib/ossl-modules


### PR DESCRIPTION
## Summary

Adds `busybox` to the valkey rebuild's package list (both `default` and `fips` types) so the rendered image ships `/bin/sh` and coreutils. Without it, the main container exits at runc exec time before valkey-server ever runs.

This is one of three charts in [#318](https://github.com/verity-org/verity/issues/318)'s confirmed (A.1) shell-missing cluster. Valkey is the cleanest of the three to fix — its failure is in the **main** container (not an init), so the rebuild must provide the shell. argo-cd and jenkins are different shape (init container running with main image, both compounded with other bugs) and need separate decisions — see follow-up comment on [#318](https://github.com/verity-org/verity/issues/318).

## Findings (run [25380884388](https://github.com/verity-org/verity/actions/runs/25380884388))

```
valkey-0  Running  valkey=waiting(CrashLoopBackOff)

BackOff: Back-off restarting failed container valkey in pod valkey-0
Failed: Error: failed to create containerd task: failed to create shim
  task: OCI runtime create failed: runc create failed: unable to start
  container process: error during container init:
  exec: "/bin/sh": stat /bin/sh: no such file or directory
```

The chart's pod command is `sh -c '...'` for entrypoint setup; verity's wolfi `valkey-9.0` rebuild ships only `valkey-server` at `/usr/bin/valkey-server` — no shell.

## What changes

`images/valkey.yaml`:

```diff
   default:
     base: wolfi-base
-    packages: [\"valkey-{{version}}\"]
+    packages: [\"valkey-{{version}}\", \"busybox\"]
     entrypoint: /usr/bin/valkey-server

   fips:
     base: wolfi-fips
-    packages: [\"valkey-{{version}}\"]
+    packages: [\"valkey-{{version}}\", \"busybox\"]
```

Plus a code comment explaining why and pointing at [#318](https://github.com/verity-org/verity/issues/318).

## Trade-off

Adding busybox enlarges the rebuild's CVE surface marginally (busybox is small + actively patched in wolfi). Alternative — overriding the chart command to invoke the binary directly — is more chart-specific and harder to maintain across chart bumps. Standard wolfi pattern for chart-targeted rebuilds is to add busybox/bash when the upstream chart's command requires a shell.

## Verification

- [x] `make integer-validate` → all 325 images valid
- [x] `images/busybox.yaml` already exists in this repo and ships `/bin/sh` as its entrypoint, so we know the wolfi `busybox` package places the binary at `/bin/sh` (the exact path the chart needs)
- [x] Diff is minimal (+4 lines, -2)

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (A.1 shell-missing sub-cluster, see [my categorization comment](https://github.com/verity-org/verity/issues/318#issuecomment-4382388804))
- argo-cd / jenkins (the other two A.1 charts) tracked in [#318](https://github.com/verity-org/verity/issues/318) follow-up — different fix shape required

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `busybox` to the Valkey image (default and FIPS) to provide `/bin/sh`, so the chart’s `sh -c` command works and the main container no longer CrashLoopBackOffs. Addresses the shell-missing failure tracked in #318 (A.1).

- **Bug Fixes**
  - Added `busybox` to `images/valkey.yaml` packages for `default` and `fips` to supply `/bin/sh` and coreutils.

<sup>Written for commit ccc9c6b08cfc11510459a40522e27ee2d18ba3a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

