### PR TITLE
fix(images): add busybox subpackage to jenkins rebuild (#318 A.1)

### DIFF
--- a/images/jenkins.yaml
+++ b/images/jenkins.yaml
@@ -9,8 +9,8 @@ types:
     # busybox supplies /bin/sh + coreutils for the chart's `init` container,
     # which runs `sh -c '...'` to apply jcasc config before the main jenkins
     # process starts. Without it the init container fails at runc exec with
-    # `sh: executable file not found`. Same shape as the valkey fix in #327.
-    # See verity-org/verity#318 (A.1 shell-missing cluster).
+    # `sh: executable file not found`. Same shape as the valkey fix in
+    # verity-org/verity#327. See verity-org/verity#318 (A.1 shell-missing cluster).
     packages: ["jenkins-{{version}}", "busybox"]
     entrypoint: /usr/bin/java -jar /usr/share/java/jenkins/jenkins.war
     environment:

--- a/images/jenkins.yaml
+++ b/images/jenkins.yaml
@@ -6,7 +6,12 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["jenkins-{{version}}"]
+    # busybox supplies /bin/sh + coreutils for the chart's `init` container,
+    # which runs `sh -c '...'` to apply jcasc config before the main jenkins
+    # process starts. Without it the init container fails at runc exec with
+    # `sh: executable file not found`. Same shape as the valkey fix in #327.
+    # See verity-org/verity#318 (A.1 shell-missing cluster).
+    packages: ["jenkins-{{version}}", "busybox"]
     entrypoint: /usr/bin/java -jar /usr/share/java/jenkins/jenkins.war
     environment:
       JENKINS_HOME: /var/jenkins_home


### PR DESCRIPTION
## Summary

Mirrors the just-merged [#327](https://github.com/verity-org/verity/pull/327) (valkey busybox) for the jenkins chart. Adds \`busybox\` to \`images/jenkins.yaml\` packages so the chart's \`init\` container's \`sh -c '...'\` jcasc-config-apply succeeds.

## Findings (run [25380884388](https://github.com/verity-org/verity/actions/runs/25380884388))

\`\`\`
jenkins-0  Pending  init=waiting(CrashLoopBackOff)
                    config-reload-init=terminated(Completed)  ← kiwigrid sidecar, fine

BackOff: Back-off restarting failed container init in pod jenkins-0_jenkins
Failed: Error: failed to create containerd task: ... runc create failed:
  exec: \"sh\": executable file not found in \$PATH
\`\`\`

The \`init\` container runs with the **main jenkins image** (\`ghcr.io/verity-org/jenkins:...\`) and invokes \`sh -c '...'\` to apply jcasc config before the JVM starts. Verity's wolfi rebuild ships only the JVM binary chain (\`/usr/bin/java -jar jenkins.war\`) — no shell.

## What changes

\`images/jenkins.yaml\`:

\`\`\`diff
   default:
     base: wolfi-base
-    packages: [\"jenkins-{{version}}\"]
+    packages: [\"jenkins-{{version}}\", \"busybox\"]
     entrypoint: /usr/bin/java -jar /usr/share/java/jenkins/jenkins.war
\`\`\`

Plus a code comment cross-referencing the bug.

## Verification

- [x] \`make integer-validate\` → all 325 images valid
- [x] same shape as merged [#327](https://github.com/verity-org/verity/pull/327) (valkey)

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (A.1 shell-missing sub-cluster — see [my categorization comment](https://github.com/verity-org/verity/issues/318#issuecomment-4382388804))
- [#327](https://github.com/verity-org/verity/pull/327) (valkey, same shape)
- argo-cd (third A.1 chart) deferred — compounds with multi-binary issue, needs separate decision

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `busybox` to the Jenkins image in `images/jenkins.yaml` so the Helm chart’s init container can run `sh -c '...'` and apply JCasC, fixing the CrashLoopBackOff from missing `/bin/sh`. Mirrors the valkey fix in verity-org/verity#327 and addresses verity-org/verity#318 (A.1 shell-missing) for Jenkins.

<sup>Written for commit bfd0777ecb273bac542fc251f3644543e1036421. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

