### PR TITLE
fix(charts): drop loki + minio replicas/resources for kind CI (#322)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -33,6 +33,22 @@ chartValues:
     gateway.enabled: false
     chunksCache.enabled: false
     resultsCache.enabled: false
+    # Default replicas: 3 per component with anti-affinity. Single-node kind
+    # can only place 1; the others sit Pending forever (FailedScheduling:
+    # didn't match pod anti-affinity rules). Drop to 1 each for CI smoke
+    # — see verity-org/verity#322.
+    backend.replicas: 1
+    read.replicas: 1
+    write.replicas: 1
+
+  # minio 5.4.0 (charts.min.io) defaults to mode: distributed with 16-replica
+  # StatefulSet and 16Gi memory requests — kind cannot place even one pod
+  # (FailedScheduling: Insufficient memory). Standalone mode + 1 replica +
+  # 256Mi requests fits CI smoke. See verity-org/verity#322.
+  minio:
+    mode: standalone
+    replicas: 1
+    resources.requests.memory: 256Mi
 
   # mimir-distributed 6.0.6 can render as a single-image runtime if we turn off
   # optional bundled infra components (MinIO, Kafka, nginx gateway, rollout-operator).


### PR DESCRIPTION
## Summary

Closes [#322](https://github.com/verity-org/verity/issues/322). Pure \`chartValues:\` PR (no rebuild changes) — fits both charts inside the single-node kind cluster the chart-integration nightly runs on.

## Findings (run [25380884388](https://github.com/verity-org/verity/actions/runs/25380884388))

### loki
\`\`\`
FailedScheduling: 0/1 nodes are available: 1 node(s) didn't match pod
anti-affinity rules. no new claims to deallocate, preemption: 0/1 nodes
are available: 1 No preemption victims found for incoming pod.
\`\`\`
Chart 7.0.0's \`read\`/\`write\`/\`backend\` components default to **3 replicas each with pod anti-affinity**. Single-node kind can only place 1 of each — the rest sit Pending forever.

### minio
\`\`\`
FailedScheduling: 0/1 nodes are available: 1 Insufficient memory.
no new claims to deallocate, preemption: 0/1 nodes are available: 1
Preemption is not helpful for scheduling.
\`\`\`
\`charts.min.io/minio\` 5.4.0 defaults to \`mode: distributed\` with **16-replica StatefulSet and 16Gi memory requests** — kind cannot place even one pod.

## What changes

\`verity.yaml\` \`chartValues:\` block — additions only:

### loki (extends existing entry)
\`\`\`yaml
loki:
  ...
  backend.replicas: 1
  read.replicas: 1
  write.replicas: 1
\`\`\`

### minio (new entry)
\`\`\`yaml
minio:
  mode: standalone
  replicas: 1
  resources.requests.memory: 256Mi
\`\`\`

Mirrors the established precedent set by \`mimir-distributed\` (\`kafka.enabled=false\`, \`minio.enabled=false\`, \`rollout_operator.enabled=false\`) — disable/shrink optional components rather than build heavyweight infra for smoke tests.

## Verification

- [x] \`make integer-validate\` → all 325 images valid (verity.yaml parses)
- [x] No rebuild changes — image side untouched

## Refs

- Closes [#322](https://github.com/verity-org/verity/issues/322) (kind-resource-sizing carve-out)
- [#318](https://github.com/verity-org/verity/issues/318) (the original misclassification — May 5 ground-truth showed these aren't rebuild-incompat at all)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce `loki` and `minio` replicas/resources so charts schedule on single-node `kind` in CI. Changes are `chartValues`-only in `verity.yaml` (closes #322).

- **Bug Fixes**
  - `loki`: set `backend.replicas`, `read.replicas`, and `write.replicas` to `1` to avoid anti-affinity blocking.
  - `minio`: switch to `mode: standalone`, `replicas: 1`, and `resources.requests.memory: 256Mi` to fit CI memory limits.

<sup>Written for commit 6b5a98f3bed1b7b85e0acd6bcf37867fa26f7055. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

