### PR TITLE
feat(integer): symlink path support; apply to etcd/fluent-bit/velero (#318 A.2)

### DIFF
--- a/images/etcd.yaml
+++ b/images/etcd.yaml
@@ -10,6 +10,10 @@ types:
     entrypoint: /usr/bin/etcd
     paths:
       - {path: /var/lib/etcd, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
+      # bitnami/etcd helm chart hardcodes /usr/local/bin/etcd in the StatefulSet
+      # command — verity's wolfi rebuild ships at /usr/bin/etcd (FHS).
+      # Symlink keeps both layouts working. See verity-org/verity#318 (A.2).
+      - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
 
   fips:
     base: wolfi-fips
@@ -17,6 +21,7 @@ types:
     entrypoint: /usr/bin/etcd
     paths:
       - {path: /var/lib/etcd, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
+      - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
 
 versions:
   "3.5":

--- a/images/fluent-bit.yaml
+++ b/images/fluent-bit.yaml
@@ -10,6 +10,12 @@ types:
     entrypoint: /usr/bin/fluent-bit
     paths:
       - {path: /etc/fluent-bit, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+      # fluent/fluent-bit helm chart hardcodes /fluent-bit/bin/fluent-bit in the
+      # DaemonSet command — verity's wolfi rebuild ships at /usr/bin/fluent-bit
+      # (FHS). Need parent directory entry first, then the symlink itself.
+      # See verity-org/verity#318 (A.2).
+      - {path: /fluent-bit/bin, type: directory, uid: 0, gid: 0, permissions: 0o755}
+      - {path: /fluent-bit/bin/fluent-bit, type: symlink, source: /usr/bin/fluent-bit, uid: 0, gid: 0}
 
 versions:
   # Wolfi dropped fluent-bit-3.x entirely; previously declared "3.2" had no

--- a/images/velero.yaml
+++ b/images/velero.yaml
@@ -8,6 +8,12 @@ types:
     base: wolfi-base
     packages: ["velero"]
     entrypoint: /usr/bin/velero
+    paths:
+      # vmware-tanzu/velero helm chart's upgrade-crds Job runs `/velero install`
+      # — chart hardcodes /velero in the Job command. Verity's wolfi rebuild
+      # ships at /usr/bin/velero (FHS). Symlink keeps both layouts working.
+      # See verity-org/verity#318 (A.2 FHS-path mismatch sub-cluster).
+      - {path: /velero, type: symlink, source: /usr/bin/velero, uid: 0, gid: 0}
 
 versions:
   "1": {}

--- a/internal/integer/config/types.go
+++ b/internal/integer/config/types.go
@@ -129,9 +129,21 @@ type MelangeSpec struct {
 }
 
 // PathDef is one path entry in an apko config.
+//
+// For type: "directory" (the default), set Path/UID/GID/Permissions.
+// For type: "symlink", set Path (the link location) and Source (the target
+// the link points to). UID/GID/Permissions are accepted by apko for
+// symlinks but the kernel ignores them at use time.
+//
+// Symlink entries are how chart-target rebuilds can satisfy chart Deployment
+// templates that hardcode binaries at non-FHS paths (e.g. chart expects
+// /usr/local/bin/etcd; verity's wolfi rebuild ships /usr/bin/etcd) without
+// duplicating the binary or modifying the upstream wolfi melange recipe.
+// See verity-org/verity#318 (A.2 FHS-path mismatch sub-cluster).
 type PathDef struct {
 	Path        string `yaml:"path"`
-	Type        string `yaml:"type,omitempty"` // defaults to "directory"
+	Type        string `yaml:"type,omitempty"`   // defaults to "directory"; supports "symlink"
+	Source      string `yaml:"source,omitempty"` // for type: symlink — the target path the link points to
 	UID         int    `yaml:"uid"`
 	GID         int    `yaml:"gid"`
 	Permissions string `yaml:"permissions,omitempty"` // e.g. "0o755"

--- a/internal/integer/render/render.go
+++ b/internal/integer/render/render.go
@@ -104,40 +104,54 @@ func Config(tmpl *config.TypeTemplate, version, basePath string) ([]byte, error)
 
 	// Paths.
 	if len(tmpl.Paths) > 0 {
-		cfg.Paths = make([]apkoPath, len(tmpl.Paths))
-		for i, p := range tmpl.Paths {
-			ptype := p.Type
-			if ptype == "" {
-				ptype = "directory"
-			}
-			// Enforce source/type invariants at render time so misconfigured
-			// YAML fails fast with a clear error instead of producing apko
-			// config that fails opaquely at build time. apko rejects source
-			// on directory entries and rejects symlink entries with no source.
-			if ptype == "symlink" && p.Source == "" {
-				return nil, fmt.Errorf("path %q: %w", p.Path, ErrSymlinkRequiresSource)
-			}
-			if ptype != "symlink" && p.Source != "" {
-				return nil, fmt.Errorf("path %q (got type=%q): %w", p.Path, ptype, ErrSourceOnNonSymlink)
-			}
-			perms, err := parsePermissions(p.Permissions)
-			if err != nil {
-				return nil, fmt.Errorf("path %q: %w", p.Path, err)
-			}
-			cfg.Paths[i] = apkoPath{
-				Path:        sub(p.Path, version),
-				Type:        ptype,
-				Source:      sub(p.Source, version),
-				UID:         p.UID,
-				GID:         p.GID,
-				Permissions: perms,
-			}
+		paths, err := convertPaths(tmpl.Paths, version)
+		if err != nil {
+			return nil, err
 		}
+		cfg.Paths = paths
 	}
 
 	out, err := yaml.Marshal(&cfg)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling apko config: %w", err)
+	}
+	return out, nil
+}
+
+// convertPaths transforms a slice of config.PathDef entries into the apko
+// representation, applying {{version}} substitution and enforcing the
+// source/type invariants apko itself enforces at build time:
+//
+//   - type=symlink requires Source (apko rejects symlinks without a target)
+//   - Source set on any non-symlink type is invalid (apko rejects it)
+//
+// Failing fast at render keeps misconfigured YAML errors close to their YAML
+// source instead of surfacing as opaque apko/melange build failures.
+func convertPaths(in []config.PathDef, version string) ([]apkoPath, error) {
+	out := make([]apkoPath, len(in))
+	for i, p := range in {
+		ptype := p.Type
+		if ptype == "" {
+			ptype = "directory"
+		}
+		if ptype == "symlink" && p.Source == "" {
+			return nil, fmt.Errorf("path %q: %w", p.Path, ErrSymlinkRequiresSource)
+		}
+		if ptype != "symlink" && p.Source != "" {
+			return nil, fmt.Errorf("path %q (got type=%q): %w", p.Path, ptype, ErrSourceOnNonSymlink)
+		}
+		perms, err := parsePermissions(p.Permissions)
+		if err != nil {
+			return nil, fmt.Errorf("path %q: %w", p.Path, err)
+		}
+		out[i] = apkoPath{
+			Path:        sub(p.Path, version),
+			Type:        ptype,
+			Source:      sub(p.Source, version),
+			UID:         p.UID,
+			GID:         p.GID,
+			Permissions: perms,
+		}
 	}
 	return out, nil
 }

--- a/internal/integer/render/render.go
+++ b/internal/integer/render/render.go
@@ -41,6 +41,7 @@ type apkoEntrypoint struct {
 type apkoPath struct {
 	Path        string `yaml:"path"`
 	Type        string `yaml:"type,omitempty"`
+	Source      string `yaml:"source,omitempty"`
 	UID         int    `yaml:"uid"`
 	GID         int    `yaml:"gid"`
 	Permissions uint32 `yaml:"permissions,omitempty"`
@@ -102,6 +103,7 @@ func Config(tmpl *config.TypeTemplate, version, basePath string) ([]byte, error)
 			cfg.Paths[i] = apkoPath{
 				Path:        sub(p.Path, version),
 				Type:        ptype,
+				Source:      sub(p.Source, version),
 				UID:         p.UID,
 				GID:         p.GID,
 				Permissions: perms,

--- a/internal/integer/render/render.go
+++ b/internal/integer/render/render.go
@@ -96,6 +96,16 @@ func Config(tmpl *config.TypeTemplate, version, basePath string) ([]byte, error)
 			if ptype == "" {
 				ptype = "directory"
 			}
+			// Enforce source/type invariants at render time so misconfigured
+			// YAML fails fast with a clear error instead of producing apko
+			// config that fails opaquely at build time. apko rejects source
+			// on directory entries and rejects symlink entries with no source.
+			if ptype == "symlink" && p.Source == "" {
+				return nil, fmt.Errorf("path %q: type=symlink requires source", p.Path)
+			}
+			if ptype != "symlink" && p.Source != "" {
+				return nil, fmt.Errorf("path %q: source is only valid for type=symlink (got type=%q)", p.Path, ptype)
+			}
 			perms, err := parsePermissions(p.Permissions)
 			if err != nil {
 				return nil, fmt.Errorf("path %q: %w", p.Path, err)

--- a/internal/integer/render/render.go
+++ b/internal/integer/render/render.go
@@ -2,6 +2,7 @@
 package render
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -13,6 +14,19 @@ import (
 )
 
 const placeholder = "{{version}}"
+
+// Sentinel errors returned by Config when path entries violate the
+// type/source invariants enforced for apko compatibility.
+var (
+	// ErrSymlinkRequiresSource is returned when a path entry has
+	// type=symlink but no Source. apko rejects symlink entries without
+	// a target at melange/apko build time; we fail fast at render.
+	ErrSymlinkRequiresSource = errors.New("type=symlink requires source")
+	// ErrSourceOnNonSymlink is returned when a path entry sets Source
+	// without type=symlink. apko rejects source on directory (and other)
+	// types; we fail fast at render.
+	ErrSourceOnNonSymlink = errors.New("source is only valid for type=symlink")
+)
 
 // apkoConfig is the YAML structure written for apko. Only fields used by
 // integer are represented here; apko ignores unknown fields.
@@ -101,10 +115,10 @@ func Config(tmpl *config.TypeTemplate, version, basePath string) ([]byte, error)
 			// config that fails opaquely at build time. apko rejects source
 			// on directory entries and rejects symlink entries with no source.
 			if ptype == "symlink" && p.Source == "" {
-				return nil, fmt.Errorf("path %q: type=symlink requires source", p.Path)
+				return nil, fmt.Errorf("path %q: %w", p.Path, ErrSymlinkRequiresSource)
 			}
 			if ptype != "symlink" && p.Source != "" {
-				return nil, fmt.Errorf("path %q: source is only valid for type=symlink (got type=%q)", p.Path, ptype)
+				return nil, fmt.Errorf("path %q (got type=%q): %w", p.Path, ptype, ErrSourceOnNonSymlink)
 			}
 			perms, err := parsePermissions(p.Permissions)
 			if err != nil {

--- a/internal/integer/render/render_test.go
+++ b/internal/integer/render/render_test.go
@@ -173,4 +173,65 @@ func TestConfig_PathDefaultType(t *testing.T) {
 	p, ok := paths[0].(map[string]any)
 	require.True(t, ok, "expected path entry to be map[string]any")
 	assert.Equal(t, "directory", p["type"])
+	// directory entries must NOT emit a source field — apko rejects it.
+	_, hasSource := p["source"]
+	assert.False(t, hasSource, "directory path should not emit source field")
+}
+
+// TestConfig_PathSymlink covers the symlink path type added for #318 (A.2
+// FHS-path mismatch). Charts that hardcode binaries at non-FHS paths (e.g.
+// /usr/local/bin/etcd, /fluent-bit/bin/fluent-bit, /velero) are routed to
+// verity's wolfi-FHS layout (/usr/bin/<x>) via these symlinks instead of
+// duplicating binaries or modifying the upstream wolfi melange recipe.
+//
+// Regression guard: a previous schema rev had no Source field, so authors
+// could not express symlinks at all and were forced into chart-command
+// overrides per chart. This test fails against that schema and passes
+// against the current one.
+func TestConfig_PathSymlink(t *testing.T) {
+	tmpl := config.TypeTemplate{
+		Base: "wolfi-base",
+		Paths: []config.PathDef{
+			{Path: "/usr/local/bin/etcd", Type: "symlink", Source: "/usr/bin/etcd", UID: 0, GID: 0},
+		},
+	}
+	out, err := render.Config(&tmpl, "latest", "_base")
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &cfg))
+
+	paths, ok := cfg["paths"].([]any)
+	require.True(t, ok, "expected paths key to be []any")
+	require.Len(t, paths, 1)
+	p, ok := paths[0].(map[string]any)
+	require.True(t, ok, "expected path entry to be map[string]any")
+	assert.Equal(t, "/usr/local/bin/etcd", p["path"])
+	assert.Equal(t, "symlink", p["type"])
+	assert.Equal(t, "/usr/bin/etcd", p["source"])
+	assert.Equal(t, 0, p["uid"])
+	assert.Equal(t, 0, p["gid"])
+}
+
+// TestConfig_PathSymlink_VersionSubstitution confirms {{version}} substitution
+// applies inside Source (so version-templated symlink targets work).
+func TestConfig_PathSymlink_VersionSubstitution(t *testing.T) {
+	tmpl := config.TypeTemplate{
+		Base: "wolfi-base",
+		Paths: []config.PathDef{
+			{Path: "/usr/local/bin/etcd-{{version}}", Type: "symlink", Source: "/usr/bin/etcd-{{version}}", UID: 0, GID: 0},
+		},
+	}
+	out, err := render.Config(&tmpl, "3.6", "_base")
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &cfg))
+
+	paths, ok := cfg["paths"].([]any)
+	require.True(t, ok, "expected paths key to be []any")
+	p, ok := paths[0].(map[string]any)
+	require.True(t, ok, "expected path entry to be map[string]any")
+	assert.Equal(t, "/usr/local/bin/etcd-3.6", p["path"])
+	assert.Equal(t, "/usr/bin/etcd-3.6", p["source"])
 }

--- a/internal/integer/render/render_test.go
+++ b/internal/integer/render/render_test.go
@@ -230,8 +230,44 @@ func TestConfig_PathSymlink_VersionSubstitution(t *testing.T) {
 
 	paths, ok := cfg["paths"].([]any)
 	require.True(t, ok, "expected paths key to be []any")
+	require.Len(t, paths, 1)
 	p, ok := paths[0].(map[string]any)
 	require.True(t, ok, "expected path entry to be map[string]any")
 	assert.Equal(t, "/usr/local/bin/etcd-3.6", p["path"])
 	assert.Equal(t, "/usr/bin/etcd-3.6", p["source"])
+}
+
+// TestConfig_PathSymlink_RequiresSource is a regression guard: type=symlink
+// without a Source field is misconfigured and apko would reject it at build
+// time. Render should fail fast with a clear error instead. (Caught by code
+// review on PR #330 — the renderer originally accepted this silently.)
+func TestConfig_PathSymlink_RequiresSource(t *testing.T) {
+	tmpl := config.TypeTemplate{
+		Base: "wolfi-base",
+		Paths: []config.PathDef{
+			{Path: "/usr/local/bin/etcd", Type: "symlink", UID: 0, GID: 0}, // no Source
+		},
+	}
+	_, err := render.Config(&tmpl, "latest", "_base")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "type=symlink requires source")
+	assert.Contains(t, err.Error(), "/usr/local/bin/etcd")
+}
+
+// TestConfig_PathSourceOnNonSymlink_Errors is the inverse regression guard:
+// Source is only valid for type=symlink. Any other type with Source set is a
+// misconfiguration; apko rejects it at build. Render should fail fast.
+// (Caught by code review on PR #330 — same root cause as RequiresSource.)
+func TestConfig_PathSourceOnNonSymlink_Errors(t *testing.T) {
+	tmpl := config.TypeTemplate{
+		Base: "wolfi-base",
+		Paths: []config.PathDef{
+			// type defaults to "directory" — Source on a directory is invalid.
+			{Path: "/usr/local/bin/etcd", Source: "/usr/bin/etcd", UID: 0, GID: 0},
+		},
+	}
+	_, err := render.Config(&tmpl, "latest", "_base")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source is only valid for type=symlink")
+	assert.Contains(t, err.Error(), "/usr/local/bin/etcd")
 }

--- a/internal/integer/render/render_test.go
+++ b/internal/integer/render/render_test.go
@@ -250,7 +250,7 @@ func TestConfig_PathSymlink_RequiresSource(t *testing.T) {
 	}
 	_, err := render.Config(&tmpl, "latest", "_base")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "type=symlink requires source")
+	assert.ErrorIs(t, err, render.ErrSymlinkRequiresSource)
 	assert.Contains(t, err.Error(), "/usr/local/bin/etcd")
 }
 
@@ -268,6 +268,7 @@ func TestConfig_PathSourceOnNonSymlink_Errors(t *testing.T) {
 	}
 	_, err := render.Config(&tmpl, "latest", "_base")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "source is only valid for type=symlink")
+	assert.ErrorIs(t, err, render.ErrSourceOnNonSymlink)
 	assert.Contains(t, err.Error(), "/usr/local/bin/etcd")
+	assert.Contains(t, err.Error(), `type="directory"`) // ensure the actual type is reported
 }


### PR DESCRIPTION
## Summary

Schema extension + first uses. Adds \`type: symlink\` support to \`PathDef\` so chart-target rebuilds can satisfy Helm Deployment templates that hardcode binaries at non-FHS paths — without duplicating binaries or modifying the upstream wolfi melange recipe.

Closes the [#318](https://github.com/verity-org/verity/issues/318) (A.2) FHS-path-mismatch sub-cluster for **3 of 4 charts**: etcd, fluent-bit, velero. (mimir-distributed deferred — the May 5 dump showed \`/usr/bin/mimir\` missing entirely, not a path-mismatch — separate melange-side investigation.)

## Why this needed a schema change first

Pre-PR, every \`paths:\` entry across all 325 images uses \`type: directory\` because that's the only type the schema actually supported — \`PathDef\` had no \`Source\` field. The renderer ignored anything else even though apko itself accepts \`type: symlink\`. Author intent for a chart-FHS-adapter symlink was unrepresentable.

This PR adds a single \`Source string\` field + plumbs it through. **3 lines of struct field + 1 line in the renderer + 2 new tests + 1 amended test.** The 3 image YAML edits are then trivial.

## Files

| File | Change |
|------|--------|
| \`internal/integer/config/types.go\` | Add \`Source\` field to \`PathDef\` + doc-comment explaining symlink semantics and intent |
| \`internal/integer/render/render.go\` | Add \`Source\` to \`apkoPath\`; pass through with \`{{version}}\` substitution |
| \`internal/integer/render/render_test.go\` | New: \`TestConfig_PathSymlink\`, \`TestConfig_PathSymlink_VersionSubstitution\`. Amended: \`TestConfig_PathDefaultType\` (regression guard — directory entries must NOT emit \`source\`) |
| \`images/etcd.yaml\` | Add \`/usr/local/bin/etcd → /usr/bin/etcd\` symlink (default + fips types) |
| \`images/fluent-bit.yaml\` | Add \`/fluent-bit/bin\` directory + \`/fluent-bit/bin/fluent-bit → /usr/bin/fluent-bit\` symlink |
| \`images/velero.yaml\` | Add \`/velero → /usr/bin/velero\` symlink |

## Findings (run [25380884388](https://github.com/verity-org/verity/actions/runs/25380884388))

\`\`\`
etcd:        exec: \"/usr/local/bin/etcd\": stat /usr/local/bin/etcd: no such file or directory
fluent-bit:  exec: \"/fluent-bit/bin/fluent-bit\": stat /fluent-bit/bin/fluent-bit: no such file or directory
velero:      exec: \"/velero\": stat /velero: no such file or directory
\`\`\`

In all three cases verity's wolfi rebuild correctly installs the binary at \`/usr/bin/<name>\` (FHS); the chart's Deployment template hardcodes a different path. Symlinks adapt without touching either side.

## Why not patch the chart or the wolfi melange recipe

- **Charts**: too invasive, fork-divergence risk, every chart bump re-races
- **Melange (wolfi-os)**: changing the canonical install path affects all consumers, not just chart deployments. Symlinks are the apko-blessed adapter pattern for this exact case

## Verification

- [x] \`go test ./internal/integer/...\` — all pass (2 new tests for symlink rendering, 1 amended for the directory-source-must-be-absent regression guard)
- [x] \`make integer-validate\` — all 325 images valid (incl. 3 modified)
- [x] Diff is +93/-1 across 6 files; pure additive changes to schema

### Regression test mapping

| Caught case | Test |
|---|---|
| Schema doesn't support symlinks (the gap that blocked A.2 work for weeks) | \`TestConfig_PathSymlink\` — fails against the pre-PR schema |
| Source field doesn't get \`{{version}}\` substituted | \`TestConfig_PathSymlink_VersionSubstitution\` |
| Future regression: directory entry accidentally emits \`source\` (apko would reject) | \`TestConfig_PathDefaultType\` regression guard amendment |

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (A.2 FHS-path mismatch sub-cluster — covers etcd, fluent-bit, velero; mimir-distributed deferred). See [my May 5 categorization comment](https://github.com/verity-org/verity/issues/318#issuecomment-4382388804) for the full diagnosis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds symlink path support to `PathDef` and updates etcd, fluent-bit, and velero to bridge chart hardcoded paths to FHS `/usr/bin/*`, resolving #318 (A.2). The renderer now enforces symlink/source rules and was refactored (`convertPaths`) to reduce complexity with no behavior changes.

- New Features
  - Schema/Renderer: add `source` to `PathDef`, pass through with `{{version}}` substitution; directories omit `source`. Enforce invariants (symlink requires source; source only valid on symlink) with clear sentinel errors.
  - Images:
    - etcd: `/usr/local/bin/etcd -> /usr/bin/etcd` (default + fips).
    - fluent-bit: add `/fluent-bit/bin` dir and `/fluent-bit/bin/fluent-bit -> /usr/bin/fluent-bit`.
    - velero: `/velero -> /usr/bin/velero`.

- Refactors
  - Extract `convertPaths` from `Config` to satisfy `gocyclo`/`nestif`; no functional change.

<sup>Written for commit 2411cb1de140bb2d35f87d9bf4a60968f5765799. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

