### PR TITLE
fix(charts): chart-config-gap chartValues for atlantis/alb-c/openbao/gitea (#323 #326)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -49,8 +49,12 @@ chartValues:
 
   # aws-load-balancer-controller requires a clusterName to render templates.
   # The wrapper chart consumers MUST override this to their actual cluster name.
+  # Also requires `region:` — chart relies on EC2 IMDS for auto-detection,
+  # which kind has no endpoint for; setting any value satisfies the validator
+  # so the controller can finish startup. See verity-org/verity#323.
   aws-load-balancer-controller:
     clusterName: verity-placeholder
+    region: us-east-1
 
   # cluster-autoscaler requires autoDiscovery.clusterName to render templates.
   # The wrapper chart consumers MUST override this to their actual cluster name.
@@ -68,6 +72,33 @@ chartValues:
   jenkins:
     controller.testEnabled: false
     agent.enabled: false
+
+  # atlantis chart's CI-default values include no VCS credentials, so the
+  # binary aborts at startup with `--gh-user/--gh-token ... must be set`.
+  # Set dummy github creds so the smoke test can confirm the chart deploys
+  # and the binary renders the help/usage path correctly. Real users would
+  # override these with valid GitHub App creds. See verity-org/verity#323.
+  atlantis:
+    github.user: verity-ci-placeholder
+    github.token: verity-ci-placeholder-token-not-real
+
+  # openbao chart starts the server in standalone mode by default — the
+  # server runs but stays sealed (`Initialized: false`, `Sealed: true`)
+  # forever because nothing auto-initializes it. Enable dev mode for CI
+  # smoke so the server boots fully unsealed and the smoke check can
+  # complete. dev mode is in-memory only — never use in production.
+  # See verity-org/verity#323.
+  openbao:
+    server.dev.enabled: true
+
+  # gitea chart defaults `image.rootless: true`, which pulls
+  # `ghcr.io/verity-org/gitea:1-rootless` — a tag verity does not publish
+  # (only `gitea:1` is rebuilt). Switch to the non-rootless image so the
+  # chart pulls a tag that actually resolves. Trade-off: chart drops the
+  # rootless-only security context default; acceptable for CI smoke.
+  # See verity-org/verity#326.
+  gitea:
+    image.rootless: false
 
   # kyverno 3.7.2: disable the post-upgrade `crds.migration` hook. It runs
   # `kubectl` from `registry.k8s.io/kubectl:v1.34.3`. Verity rebuilds kubectl


### PR DESCRIPTION
## Summary

Closes [#323](https://github.com/verity-org/verity/issues/323) (chart-config-gap cluster: atlantis, aws-load-balancer-controller, openbao) and [#326](https://github.com/verity-org/verity/issues/326) (gitea image-not-published variant). All four are CI-friendly \`chartValues:\` overrides — pure \`verity.yaml\` change, no rebuild work, orthogonal surface to today's 9-PR rebuild batch.

## What changes

\`verity.yaml\` \`chartValues:\` block:

### atlantis (new entry) — closes [#323](https://github.com/verity-org/verity/issues/323) atlantis row

\`\`\`yaml
atlantis:
  github.user: verity-ci-placeholder
  github.token: verity-ci-placeholder-token-not-real
\`\`\`

Chart's binary aborts at startup with \`--gh-user/--gh-token ... must be set\` (verified via May 5 diagnostic dump). Dummy creds satisfy the flag validator; real users override with GitHub App credentials.

### aws-load-balancer-controller (extends existing entry) — closes [#323](https://github.com/verity-org/verity/issues/323) alb-c row

\`\`\`diff
 aws-load-balancer-controller:
   clusterName: verity-placeholder
+  region: us-east-1
\`\`\`

Chart relies on EC2 IMDS for region auto-detection; kind has no IMDS endpoint. Setting \`region:\` satisfies the validator. Mirrors the existing \`clusterName: verity-placeholder\` precedent.

Note: this chart is currently in the [#319](https://github.com/verity-org/verity/pull/319) Renovate suppression. Once this PR + the next nightly green up the alb-c shard, the suppression rule could drop alb-c (kyverno would stay).

### openbao (new entry) — closes [#323](https://github.com/verity-org/verity/issues/323) openbao row

\`\`\`yaml
openbao:
  server.dev.enabled: true
\`\`\`

Server starts in standalone mode by default; stays \`sealed: true\` forever in CI because nothing auto-initializes it. Dev mode boots fully unsealed (in-memory only — never for production).

### gitea (new entry) — closes [#326](https://github.com/verity-org/verity/issues/326)

\`\`\`yaml
gitea:
  image.rootless: false
\`\`\`

Chart defaults \`image.rootless: true\` → pulls \`ghcr.io/verity-org/gitea:1-rootless\` which verity doesn't publish (only \`gitea:1\` is rebuilt). Setting \`false\` switches to the published image. Trade-off: chart drops its rootless security-context default; acceptable for CI smoke. Investigated this option per [#326](https://github.com/verity-org/verity/issues/326) — the chart natively supports the flip, no new image variant needed.

## Verification

- [x] \`make integer-validate\` → 325 images valid (verity.yaml parses)
- [x] Chart values keys confirmed via \`helm show values <chart>\` for each of the 4 charts before authoring:
  - atlantis: \`github.user\` / \`github.token\` (chart values comment shows \`# github:\\n#   user: foo\\n#   token: bar\`)
  - alb-c: top-level \`region:\`
  - openbao: \`server.dev.enabled\` + \`server.dev.devRootToken\` (defaults to \`\"root\"\`)
  - gitea: \`image.rootless\` (default true; documented since chart 1.14+)
- [x] No code changes; chartValues entries follow existing dot-notation precedent (cf. \`grafana.testFramework.enabled\`, \`jenkins.controller.testEnabled\`)

## Refs

- Closes [#323](https://github.com/verity-org/verity/issues/323) (chart-config-gap cluster)
- Closes [#326](https://github.com/verity-org/verity/issues/326) (gitea-rootless image-not-published variant)
- [#318](https://github.com/verity-org/verity/issues/318) (re-decomposition carve-outs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CI-friendly `chartValues:` overrides in `verity.yaml` for `atlantis`, `aws-load-balancer-controller`, `openbao`, and `gitea` so charts render and start in CI using published images. Pure config change; no rebuilds. Addresses #323 and #326.

- **Bug Fixes**
  - `atlantis`: set `github.user` and `github.token` placeholders to satisfy required flags in CI.
  - `aws-load-balancer-controller`: add `region: us-east-1` to work without EC2 IMDS; keeps `clusterName` placeholder.
  - `openbao`: enable `server.dev.enabled: true` so the server starts unsealed for smoke tests.
  - `gitea`: set `image.rootless: false` to pull published `ghcr.io/verity-org/gitea:1` instead of the unpublished `:1-rootless`.

<sup>Written for commit dd2d1066312931c5a6a7889aca00b9422abca178. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

