### PR TITLE
fix(charts): add atlantis github.secret to satisfy chart template ([#331](https://github.com/verity-org/verity/pull/331) follow-up)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -94,9 +94,18 @@ chartValues:
   # Set dummy github creds so the smoke test can confirm the chart deploys
   # and the binary renders the help/usage path correctly. Real users would
   # override these with valid GitHub App creds. See verity-org/verity#323.
+  #
+  # github.secret is the webhook-validation HMAC secret. The chart's
+  # secret-webhook.yaml template requires it whenever any github.*
+  # config is set (or chart-gen / helm template aborts with
+  # "github.secret is required if github configuration is specified" —
+  # caught by Chart Generation failure on the original #331 merge).
+  # Verified via `helm template atlantis ... -f values.yaml` locally
+  # with all three fields present.
   atlantis:
     github.user: verity-ci-placeholder
     github.token: verity-ci-placeholder-token-not-real
+    github.secret: verity-ci-placeholder-webhook-secret
 
   # openbao chart starts the server in standalone mode by default — the
   # server runs but stays sealed (`Initialized: false`, `Sealed: true`)


### PR DESCRIPTION
## Summary

[#331](https://github.com/verity-org/verity/pull/331) introduced \`atlantis.github.user\` and \`atlantis.github.token\` chartValues but not \`atlantis.github.secret\`. The atlantis chart 6.3.0's \`secret-webhook.yaml\` template enforces all-three-or-none for the GitHub provider block, so Chart Generation aborted on the [#331](https://github.com/verity-org/verity/pull/331) merge:

\`\`\`
Error: chart-gen failed: extract images for chart atlantis: helm template atlantis: exit status 1
stderr: Error: execution error at (atlantis/templates/secret-webhook.yaml:25:20):
  github.secret is required if github configuration is specified.
\`\`\`

This blocked **chart-integration auto-triggering for today's 8-PR work** — the auto-trigger only fires when Chart Generation completes successfully. So none of today's chart-integration validation has run yet against the latest main.

## Fix

Adds \`github.secret: verity-ci-placeholder-webhook-secret\` to the atlantis \`chartValues:\` entry, mirroring the placeholder-style of \`user\` and \`token\`.

\`\`\`diff
 atlantis:
   github.user: verity-ci-placeholder
   github.token: verity-ci-placeholder-token-not-real
+  github.secret: verity-ci-placeholder-webhook-secret
\`\`\`

Plus a comment explaining why the third field is required (so future chart bumps that re-render this template don't trip the same trap).

## Pre-flight verification

Ran \`helm template <chart>\` locally with the proposed [#331](https://github.com/verity-org/verity/pull/331) values for all four affected charts to catch any other missing-required-field issues:

| Chart | helm template | Notes |
|-------|---------------|-------|
| atlantis | ❌ → ✅ after adding secret | Was the [#331](https://github.com/verity-org/verity/pull/331) blocker; this PR fixes it |
| openbao | ✅ | \`server.dev.enabled: true\` renders cleanly |
| gitea | ✅ | \`image.rootless: false\` renders cleanly |
| aws-load-balancer-controller | ✅ | \`region: us-east-1\` renders cleanly |

So atlantis was the **only** chart with a missing-required-field issue from [#331](https://github.com/verity-org/verity/pull/331).

## Verification

- [x] \`make integer-validate\` → all 325 images valid
- [x] \`helm template atlantis atlantis/atlantis -f <values-with-secret>\` → renders cleanly

## Refs

- [#331](https://github.com/verity-org/verity/pull/331) (the broken merge — Chart Generation [run 25451111197](https://github.com/verity-org/verity/actions/runs/25451111197) failed)
- [#323](https://github.com/verity-org/verity/issues/323) (atlantis chart-config-gap closed by [#331](https://github.com/verity-org/verity/pull/331); this PR makes the close real)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `atlantis.github.secret` to chart values to satisfy the Atlantis chart’s all-three-or-none GitHub config requirement. Fixes the Chart Generation failure from #331 and re-enables the chart-integration auto-trigger.

<sup>Written for commit 48576fb487960f7213045bbc13c380c7e94bfc5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

