### PR TITLE
fix(images): add valkey-cli to valkey rebuild for chart probes (#327 follow-up)

### DIFF
--- a/images/valkey.yaml
+++ b/images/valkey.yaml
@@ -10,14 +10,20 @@ types:
     # (bitnami/valkey chart's pod command is `sh -c '...'`). Without it the
     # main container fails at runc exec with `/bin/sh: no such file or
     # directory`. See verity-org/verity#318 (A.1 shell-missing cluster).
-    packages: ["valkey-{{version}}", "busybox"]
+    #
+    # valkey-{{version}}-cli ships the `valkey-cli` binary, which the chart
+    # uses for liveness/readiness probes (`valkey-cli ping` etc.). Without
+    # it the pod runs but probes fail with `/bin/sh: valkey-cli: not found`,
+    # keeping the StatefulSet from going Ready. Surfaced by the chart-
+    # integration re-run after #327 landed.
+    packages: ["valkey-{{version}}", "valkey-{{version}}-cli", "busybox"]
     entrypoint: /usr/bin/valkey-server
     paths:
       - {path: /data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
   fips:
     base: wolfi-fips
-    packages: ["valkey-{{version}}", "busybox"]
+    packages: ["valkey-{{version}}", "valkey-{{version}}-cli", "busybox"]
     entrypoint: /usr/bin/valkey-server
     environment:
       OPENSSL_MODULES: /usr/lib/ossl-modules


### PR DESCRIPTION
## Summary

[#327](https://github.com/verity-org/verity/pull/327) added \`busybox\` to the valkey rebuild — that fixed the \`/bin/sh: no such file\` runc error. The chart-integration re-run confirmed valkey now **starts and runs**, but reveals a layered probe failure:

\`\`\`
valkey-0  Running  valkey=running(running)

Unhealthy: Liveness probe failed: /bin/sh: valkey-cli: not found
Unhealthy: Readiness probe failed: /bin/sh: valkey-cli: not found
\`\`\`

The chart's probe spec runs \`valkey-cli ping\`. Wolfi splits server and CLI into separate packages — \`valkey-9.0\` ships \`valkey-server\`, while \`valkey-9.0-cli\` ships \`valkey-cli\`. The rebuild was missing the latter.

## Fix

\`\`\`diff
   default:
     base: wolfi-base
-    packages: [\"valkey-{{version}}\", \"busybox\"]
+    packages: [\"valkey-{{version}}\", \"valkey-{{version}}-cli\", \"busybox\"]

   fips:
     base: wolfi-fips
-    packages: [\"valkey-{{version}}\", \"busybox\"]
+    packages: [\"valkey-{{version}}\", \"valkey-{{version}}-cli\", \"busybox\"]
\`\`\`

Plus a code comment explaining why the cli package is required.

## Verification

- [x] \`make integer-validate\` → all 325 images valid
- [x] Wolfi packages confirmed: \`apk search valkey-9.0-cli\` against \`packages.wolfi.dev\` shows the package exists for both 8.1 and 9.0 streams (mirrors valkey itself)
- [x] Same shape as other chart-targeted rebuilds with split server/cli or server/client packages

## Refs

- [#327](https://github.com/verity-org/verity/pull/327) (added busybox; this PR completes the valkey shell-missing fix)
- [#318](https://github.com/verity-org/verity/issues/318) (A.1 shell-missing cluster — valkey needs both \`busybox\` AND \`valkey-cli\`)

After merging, the orchestrator will rebuild valkey and the next chart-integration should clear the valkey shard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `valkey-{{version}}-cli` to the valkey image (default and `fips`) so chart probes using `valkey-cli ping` pass. This fixes pods that started but stayed Unready due to "valkey-cli: not found".

<sup>Written for commit e2527c021d223f4d037dc9d07b6cf9d73fc164c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

