### PR TITLE
fix(charts): pin jenkins tag to floating-major "2" ([#328](https://github.com/verity-org/verity/pull/328) follow-up)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -351,11 +351,19 @@ replacements:
     image: "minio-operator"
     tag: "7.1.1"
 
-  # jenkins 5.9.18.
+  # jenkins 5.9.18 — chart's appVersion is `2.555.1-jdk21`. chart-gen
+  # was previously pinning the rendered image tag at the exact patch
+  # (`2.555.1`), but verity's jenkins rebuild lives on the `2.x` floating
+  # stream — fixes added to `images/jenkins.yaml` (e.g. busybox in #328)
+  # only land in NEW patch builds and don't republish older tags. Pinning
+  # `tag: "2"` cascades to whatever wolfi's latest `jenkins-2` patch is,
+  # so chart-side updates pick up the rebuild's package list immediately.
+  # Mirrors the floating-minor methodology used by metrics-server / valkey
+  # / external-dns. See verity-org/verity#328 follow-up.
   "jenkins/jenkins":
     registry: "ghcr.io/verity-org"
     image: "jenkins"
-    tag: "2.555.1"
+    tag: "2"
 
   # Wave 4 charts (mesh + observability).
   # traefik 39.0.8 → traefik 3.6.x; rebuild publishes major.minor tag.

--- a/verity.yaml
+++ b/verity.yaml
@@ -351,15 +351,27 @@ replacements:
     image: "minio-operator"
     tag: "7.1.1"
 
-  # jenkins 5.9.18 — chart's appVersion is `2.555.1-jdk21`. chart-gen
-  # was previously pinning the rendered image tag at the exact patch
-  # (`2.555.1`), but verity's jenkins rebuild lives on the `2.x` floating
-  # stream — fixes added to `images/jenkins.yaml` (e.g. busybox in #328)
-  # only land in NEW patch builds and don't republish older tags. Pinning
-  # `tag: "2"` cascades to whatever wolfi's latest `jenkins-2` patch is,
-  # so chart-side updates pick up the rebuild's package list immediately.
-  # Mirrors the floating-minor methodology used by metrics-server / valkey
-  # / external-dns. See verity-org/verity#328 follow-up.
+  # jenkins 5.9.18 — chart's appVersion is `2.555.1-jdk21`. This entry was
+  # previously pinned at `tag: "2.555.1"` here in verity.yaml (chart-gen
+  # then propagated that exact patch into the wrapper values, which is
+  # what reached the registry). Fixes added to `images/jenkins.yaml`
+  # (e.g. busybox in #328) only land in NEW patch builds; older patch
+  # tags like `:2.555.1` and even `:2.555` (which aliases to `:2.555.1`)
+  # don't get republished. Verified via `crane digest`:
+  #   :2       → e40b4fd... (latest, has busybox)
+  #   :2.555.1 → d3f1891... (frozen, no busybox)
+  #   :2.555   → d3f1891... (alias of :2.555.1, also frozen)
+  #
+  # Floating-major `tag: "2"` is the only stream that cascades forward
+  # to the latest jenkins-2 patch (currently :2.560), so chart-side
+  # updates pick up rebuild package-list changes immediately.
+  #
+  # This is one floating-stream level coarser than the floating-minor
+  # pattern used by metrics-server (`0.8`), valkey (`9.0`), external-dns
+  # (`0.18`), kyverno (`1.34`), pushgateway (`1.11`), but the principle
+  # is the same: pin the smallest floating-stream that wolfi actively
+  # republishes when the rebuild changes. For jenkins, that's the major.
+  # See verity-org/verity#328 follow-up for the original busybox addition.
   "jenkins/jenkins":
     registry: "ghcr.io/verity-org"
     image: "jenkins"


### PR DESCRIPTION
## Summary

Discovered via chart-integration re-run after [#328](https://github.com/verity-org/verity/pull/328) merged. Jenkins still failed with the original \`exec: \"sh\"\` error even though \`jenkins:2\` (floating-major) contains busybox now.

**Root cause**: \`verity.yaml\` pinned \`tag: \"2.555.1\"\` — a specific patch published BEFORE [#328](https://github.com/verity-org/verity/pull/328). chart-gen wrote that exact patch into the wrapper, so the chart pulled the pre-busybox image, not the post-[#328](https://github.com/verity-org/verity/pull/328) floating-major.

\`crane manifest\` confirmed:
- \`jenkins:2.555.1\` → digest \`sha256:d3f1891...\` (older, no busybox)
- \`jenkins:2\` → digest \`sha256:e40b4fd...\` (latest, has busybox)

## Fix

\`\`\`diff
   "jenkins/jenkins":
     registry: \"ghcr.io/verity-org\"
     image: \"jenkins\"
-    tag: \"2.555.1\"
+    tag: \"2\"
\`\`\`

Plus an extensive code comment explaining the floating-major rationale and cross-referencing [#328](https://github.com/verity-org/verity/pull/328).

This mirrors the established codebase pattern — \`metrics-server: \"0.8\"\`, \`valkey: \"9.0\"\`, \`external-dns: \"0.18\"\`, \`kyverno: \"1.34\"\`, \`pushgateway: \"1.11\"\`. The Wave 1 PRs ([#310](https://github.com/verity-org/verity/pull/310), [#317](https://github.com/verity-org/verity/pull/317)) all use floating-minor. [#321](https://github.com/verity-org/verity/pull/321) defended the methodology against a copilot review push for digest-pin alternatives.

## Verification

- [x] \`make integer-validate\` → 325 images valid
- [x] \`crane manifest ghcr.io/verity-org/jenkins:2\` returns valid OCI index for amd64+arm64
- [x] Latest jenkins-2 patch (\`:2.560\`) has busybox confirmed via \`tar -tvf\`
- [x] Once merged, the next chart-integration should clear the jenkins shard

## Refs

- [#328](https://github.com/verity-org/verity/pull/328) (added busybox to \`images/jenkins.yaml\`; this PR makes the chart actually pull it)
- [#318](https://github.com/verity-org/verity/issues/318) (A.1 shell-missing cluster)
- Mirrors [#321](https://github.com/verity-org/verity/pull/321)'s floating-minor methodology defense

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `jenkins` chart image from `tag: "2.555.1"` to floating-major `tag: "2"` so the chart pulls the latest rebuild with busybox, fixing the `exec: "sh"` startup error after #328. Also clarifies the inline comment to state the floating-major rationale and that the previous patch pin originated in `verity.yaml` (not chart-gen).

<sup>Written for commit 2ff6f54af677f75fb26634ec1a8ee5f7b6fdb32a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

