### PR TITLE
feat(integer): bespoke wave 3 — earthly, vcluster, kubeshark, tracee (falco/hadolint blocked)

### DIFF
--- a/images/earthly.yaml
+++ b/images/earthly.yaml
@@ -1,0 +1,16 @@
+name: earthly
+description: "Earthly — build automation for the container era; bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: earthly
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["earthly"]
+    entrypoint: /usr/bin/earthly
+    melange:
+      bespoke: "earthly.yaml"
+
+versions:
+  "0.8.16":
+    latest: true

--- a/images/kubeshark.yaml
+++ b/images/kubeshark.yaml
@@ -1,0 +1,16 @@
+name: kubeshark
+description: "Kubeshark — Wireshark-like API traffic viewer for Kubernetes; bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: kubeshark
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["kubeshark"]
+    entrypoint: /usr/bin/kubeshark
+    melange:
+      bespoke: "kubeshark.yaml"
+
+versions:
+  "53.2.5":
+    latest: true

--- a/images/tracee.yaml
+++ b/images/tracee.yaml
@@ -1,0 +1,16 @@
+name: tracee
+description: "Tracee — eBPF-based runtime security and forensics; bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: tracee
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["tracee"]
+    entrypoint: /usr/bin/tracee
+    melange:
+      bespoke: "tracee.yaml"
+
+versions:
+  "0.24.1":
+    latest: true

--- a/images/vcluster.yaml
+++ b/images/vcluster.yaml
@@ -1,0 +1,16 @@
+name: vcluster
+description: "vcluster — virtual Kubernetes clusters in a namespace; bespoke Wolfi build (avoids transitive helm-3 CVEs in upstream Wolfi apk)"
+upstream:
+  package: vcluster
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["vcluster"]
+    entrypoint: /usr/bin/vcluster
+    melange:
+      bespoke: "vcluster.yaml"
+
+versions:
+  "0.34.0":
+    latest: true

--- a/packages/bespoke/earthly.yaml
+++ b/packages/bespoke/earthly.yaml
@@ -1,0 +1,50 @@
+package:
+  name: earthly
+  version: "0.8.16"
+  epoch: 0
+  description: "Build automation for the container era"
+  copyright:
+    - license: MPL-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/earthly/earthly
+      tag: v${{package.version}}
+      expected-commit: c48905267920d5599e849e8e043f801c6baab94a
+
+  - uses: go/build
+    with:
+      packages: ./cmd/earthly
+      output: earthly
+      ldflags: |
+        -X main.Version=v${{package.version}}
+        -X main.GitSha=$(git rev-parse HEAD)
+        -X main.BuiltBy=verity
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: earthly/earthly
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        earthly --version
+        earthly --help

--- a/packages/bespoke/kubeshark.yaml
+++ b/packages/bespoke/kubeshark.yaml
@@ -1,0 +1,53 @@
+package:
+  name: kubeshark
+  version: "53.2.5"
+  epoch: 0
+  description: "API traffic viewer for Kubernetes — Wireshark-like in-cluster traffic analysis"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+      - libpcap
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - libpcap
+  environment:
+    CGO_ENABLED: "1"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubeshark/kubeshark
+      tag: v${{package.version}}
+      expected-commit: ab81b0c3a75bc07c19e5092e94775a633408c170
+
+  - uses: go/build
+    with:
+      packages: .
+      output: kubeshark
+      ldflags: |
+        -X github.com/kubeshark/kubeshark/misc.Ver=${{package.version}}
+        -X github.com/kubeshark/kubeshark/misc.Branch=v${{package.version}}
+        -X github.com/kubeshark/kubeshark/misc.GitCommitHash=$(git rev-parse HEAD)
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubeshark/kubeshark
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        kubeshark version
+        kubeshark --help

--- a/packages/bespoke/tracee.yaml
+++ b/packages/bespoke/tracee.yaml
@@ -10,6 +10,7 @@ package:
       - ca-certificates-bundle
       - libelf
       - zlib
+      - zstd
 
 environment:
   contents:
@@ -30,6 +31,8 @@ environment:
       - pkgconf-dev
       - zlib-dev
       - zlib-static
+      - zstd-dev
+      - zstd-static
   environment:
     CGO_ENABLED: "1"
     GO111MODULE: "on"

--- a/packages/bespoke/tracee.yaml
+++ b/packages/bespoke/tracee.yaml
@@ -1,0 +1,64 @@
+package:
+  name: tracee
+  version: "0.24.1"
+  epoch: 0
+  description: "Runtime security and forensics for containers — eBPF-based"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+      - libelf
+      - zlib
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-16
+      - elfutils-dev
+      - gcc
+      - go
+      - libbpf-dev
+      - libelf
+      - libelf-static
+      - linux-headers
+      - llvm-16
+      - make
+      - pkgconf-dev
+      - zlib-dev
+      - zlib-static
+  environment:
+    CGO_ENABLED: "1"
+    GO111MODULE: "on"
+    CC: clang-16
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/aquasecurity/tracee
+      tag: v${{package.version}}
+      expected-commit: b40e7f3f89ade93b7f480b9007ab8aafeb978472
+      recurse-submodules: true
+
+  - runs: |
+        make bpf
+        make tracee BUILD_FLAGS="-trimpath" \
+          STATIC=1
+        install -Dm755 dist/tracee "${{targets.destdir}}/usr/bin/tracee"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: aquasecurity/tracee
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        tracee --version
+        tracee --help

--- a/packages/bespoke/vcluster.yaml
+++ b/packages/bespoke/vcluster.yaml
@@ -1,7 +1,11 @@
 package:
   name: vcluster
   version: "0.34.0"
-  epoch: 0
+  # Epoch 99 ensures our bespoke (built without bundling vulnerable helm-3)
+  # outranks Wolfi's upstream vcluster apk (currently epoch 3, which transitively
+  # pulls helm-3 3.19.2-r2 with 4 unfixed CRIT/HIGH CVEs). When Wolfi catches
+  # up on its apk repo, we can drop the bespoke override.
+  epoch: 99
   description: "Virtual Kubernetes clusters running inside a namespace of a host cluster"
   copyright:
     - license: Apache-2.0

--- a/packages/bespoke/vcluster.yaml
+++ b/packages/bespoke/vcluster.yaml
@@ -1,0 +1,57 @@
+package:
+  name: vcluster
+  version: "0.34.0"
+  epoch: 0
+  description: "Virtual Kubernetes clusters running inside a namespace of a host cluster"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/loft-sh/vcluster
+      tag: v${{package.version}}
+      expected-commit: bb9e88b0a9e45c68d744eebe6bde5c4664cdb676
+
+  - uses: go/build
+    with:
+      packages: ./cmd/vcluster
+      output: vcluster
+      ldflags: |
+        -X github.com/loft-sh/vcluster/pkg/upgrade.version=v${{package.version}}
+        -X github.com/loft-sh/vcluster/pkg/upgrade.commit=$(git rev-parse HEAD)
+
+  - uses: go/build
+    with:
+      packages: ./cmd/vclusterctl
+      output: vclusterctl
+      ldflags: |
+        -X github.com/loft-sh/vcluster/pkg/upgrade.version=v${{package.version}}
+        -X github.com/loft-sh/vcluster/pkg/upgrade.commit=$(git rev-parse HEAD)
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: loft-sh/vcluster
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        vcluster --version
+        vclusterctl --help


### PR DESCRIPTION
## Summary

Closes out the deferred items from #297 and #315. 4 of 6 are shipped here as bespoke; 2 are genuinely blocked and documented as such.

## Shipped — 4 new bespoke

| Tool | Version | License | Build complexity |
|---|---|---|---|
| **earthly** | 0.8.16 | MPL-2.0 | Pure Go (`./cmd/earthly`) |
| **vcluster** | 0.34.0 | Apache-2.0 | Pure Go; builds both `vcluster` + `vclusterctl` |
| **kubeshark** | 53.2.5 | Apache-2.0 | Go + cgo + libpcap (CGO_ENABLED=1, runtime dep on `libpcap`) |
| **tracee** | 0.24.1 | Apache-2.0 | Go + cgo + libbpf + clang-16 + LLVM; uses upstream Makefile (`make bpf && make tracee STATIC=1`) instead of bare `go/build` because eBPF program compilation needs the project's own pipeline |

`vcluster` is shipped as bespoke (rather than a Wolfi-wrap as attempted in #315) specifically to avoid the transitive `helm-3 3.19.2-r2` CVEs in the upstream Wolfi `vcluster` apk that blocked the wave-2 wrap.

## NOT attempted — genuinely blocked

### `falco` (C++/CMake)
This is a CMake/C++ project, not a Go binary. Building it needs a dedicated CMake melange pipeline (`uses: cmake/configure` + `cmake/build` + `cmake/install`), not the `go/build` pattern used by every other bespoke in this repo. Wolfi already ships `falco-libs`, `falco-rules`, `falco-exporter`, and `falcoctl` as separate apks — adding the main `falco` binary would meaningfully expand the bespoke pipeline surface. **Recommendation:** out of scope for a Go-tooling-focused bespoke wave; file as a standalone task if/when Verity wants C++ melange capability.

### `hadolint` (Haskell)
Verified via `api.github.com/repos/wolfi-dev/os/contents/<name>.yaml`:
- `ghc.yaml` → 404
- `ghc-9.yaml` → 404
- `haskell-stack.yaml` → 404
- `stack.yaml` → 404

**No Haskell toolchain exists in upstream Wolfi.** Without `ghc` or `stack`, hadolint cannot be compiled from source in a Wolfi melange pipeline — the binary is unreachable until Haskell support lands in Wolfi (or hadolint is repackaged via a release-binary pipeline, which Verity doesn't currently support).

**Recommendation:** mark as permanently deferred; revisit only if Wolfi adds Haskell tooling.

## Validation

- ✅ `./verity integer validate` — **All 329 image configs valid** (was 325, +4)
- ⚠️ `tracee` and `kubeshark` are higher-risk than the wave 1/2 bespokes (cgo + native deps); CI will be authoritative

## Risk notes

- **kubeshark**: requires `libpcap` headers from Wolfi at build time (`libpcap` package ships dev headers as subpackage in standard Wolfi practice). If CI can't find the headers, may need to pin a specific `libpcap-X.Y` package.
- **tracee**: shells out to upstream Makefile (`make bpf` + `make tracee STATIC=1`) rather than `go/build`. Two main risk vectors: (1) Makefile may need additional vars set (`STATIC_LIBELF`, `BPFTOOL`, etc.); (2) eBPF program compilation may require kernel headers Wolfi ships under a different package name. Will iterate based on CI feedback.
- **vcluster**: bespoke build vs the broken Wolfi-wrap means we're now responsible for keeping the Go module versions current — added `update.github` block for renovate.
- **earthly**: lowest risk — straightforward Go bespoke, MPL-2.0 (compatible with most policies; if your policy disallows MPL, this is the one to drop).

## Files changed

8 new files:
- `packages/bespoke/{earthly,vcluster,kubeshark,tracee}.yaml`
- `images/{earthly,vcluster,kubeshark,tracee}.yaml`

## Relationship to prior PRs

- #297 (merged): wave 1 — kubectx, popeye, kube-linter, kubeconform, kube-score + crane/dive/ko orphan wires
- #315 (merged): wave 2 — vegeta, goss, kured, pack, ghz + 5 Wolfi wraps
- This PR (wave 3): the long-tail deferrals; closes the deferred-items list opened in #297 and #315 except for falco/hadolint which are documented as blocked above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bespoke builds for `earthly` 0.8.16, `vcluster` 0.34.0, `kubeshark` 53.2.5, and `tracee` 0.24.1. `falco` and `hadolint` remain blocked (CMake/C++ scope; missing Haskell toolchain in Wolfi).

- **New Features**
  - `earthly` — container-native build automation.
  - `vcluster` — virtual K8s clusters; also ships `vclusterctl`.
  - `kubeshark` — K8s API traffic viewer (CGO; runtime `libpcap`).
  - `tracee` — eBPF runtime security (Makefile build; static binary).

- **Bug Fixes**
  - `vcluster`: set bespoke epoch to 99 to outrank Wolfi apk and avoid transitive `helm-3` CVEs.
  - `tracee`: add `zstd-dev`/`zstd-static` to build and `zstd` to runtime to fix static link errors.

<sup>Written for commit e025938ca1a47b5ac718bc3c762089004c34c7a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

