### PR TITLE
fix(charts): minio busybox + vault dev mode (#318)

### DIFF
--- a/images/minio.yaml
+++ b/images/minio.yaml
@@ -6,7 +6,13 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["minio"]
+    # busybox supplies /bin/sh + coreutils for chart wrapper scripts.
+    # The minio chart's Deployment runs `sh -c '...'` for its container
+    # command (sets up data dir / TLS / env before launching minio).
+    # Without it the main container fails at runc exec with
+    # `/bin/sh: stat /bin/sh: no such file or directory`. Same shape as
+    # the valkey fix (verity-org/verity#327). See verity-org/verity#318.
+    packages: ["minio", "busybox"]
     entrypoint: minio server /data
     paths:
       - {path: /data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}

--- a/verity.yaml
+++ b/verity.yaml
@@ -86,17 +86,16 @@ chartValues:
   # default inbound agent image. Keep the wrapper focused on the controller and
   # the existing kiwigrid sidecar image.
   #
-  # `controller.installPlugins: []` skips the chart's plugin-installation
-  # init step, which calls `/usr/local/bin/install-plugins.sh`. The verity
-  # jenkins rebuild ships only the JVM + jenkins.war (no helper scripts) —
-  # without this override, the `init` container crashes with
-  # `/var/jenkins_config/apply_config.sh: line 14: /usr/local/bin/install-plugins.sh: not found`.
-  # Skipping plugin install at smoke-test time is fine; real users can
-  # install plugins post-deploy via the UI / configuration-as-code.
-  # See verity-org/verity#318 (A.1 jenkins layered bug after #328+#334).
+  # NOTE: jenkins is still red after #328 (busybox) + #334 (tag pin). The
+  # init container surfaces a layered failure — chart's apply_config.sh
+  # calls /usr/local/bin/install-plugins.sh which the verity wolfi rebuild
+  # doesn't ship. The natural chartValues fix would be
+  # `controller.installPlugins: []` to skip plugin install entirely, but
+  # internal/discovery/charts.go's helmSetPair only supports scalar types
+  # (string/bool/number) — empty-list values would fail with
+  # ErrChartValueUnsupportedType. Tracked separately; see verity-org/verity#318.
   jenkins:
     controller.testEnabled: false
-    controller.installPlugins: []
     agent.enabled: false
 
   # atlantis chart's CI-default values include no VCS credentials, so the

--- a/verity.yaml
+++ b/verity.yaml
@@ -85,8 +85,18 @@ chartValues:
   # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
   # default inbound agent image. Keep the wrapper focused on the controller and
   # the existing kiwigrid sidecar image.
+  #
+  # `controller.installPlugins: []` skips the chart's plugin-installation
+  # init step, which calls `/usr/local/bin/install-plugins.sh`. The verity
+  # jenkins rebuild ships only the JVM + jenkins.war (no helper scripts) —
+  # without this override, the `init` container crashes with
+  # `/var/jenkins_config/apply_config.sh: line 14: /usr/local/bin/install-plugins.sh: not found`.
+  # Skipping plugin install at smoke-test time is fine; real users can
+  # install plugins post-deploy via the UI / configuration-as-code.
+  # See verity-org/verity#318 (A.1 jenkins layered bug after #328+#334).
   jenkins:
     controller.testEnabled: false
+    controller.installPlugins: []
     agent.enabled: false
 
   # atlantis chart's CI-default values include no VCS credentials, so the
@@ -114,6 +124,15 @@ chartValues:
   # complete. dev mode is in-memory only — never use in production.
   # See verity-org/verity#323.
   openbao:
+    server.dev.enabled: true
+
+  # vault — same pattern as openbao (vault is the upstream openbao forked
+  # from). Standalone mode boots the server but leaves it sealed forever
+  # in CI; dev mode auto-init+auto-unseal so smoke test can verify the
+  # API responds. dev mode is in-memory only — never use in production.
+  # Diagnostic showed `Initialized: false / Sealed: true` post-deploy,
+  # identical to the pre-#331 openbao failure shape.
+  vault:
     server.dev.enabled: true
 
   # gitea chart defaults `image.rootless: true`, which pulls


### PR DESCRIPTION
## Summary

Two quick-win fixes from the May 7 systematic red-chart review. Both same shape as already-shipped today — pure additive, low-risk, helm-template-validated locally.

> **Originally also included a jenkins `controller.installPlugins: []` chartValues attempt — dropped per [@copilot-pull-request-reviewer](https://github.com/copilot-pull-request-reviewer)'s catch.** `helmSetPair` only supports scalar types; the slice would have failed chart discovery with `ErrChartValueUnsupportedType`. Jenkins fix needs either (a) a follow-up extending `helmSetPair` to support `--set-json`, or (b) a scalar disable knob in the chart (no obvious one). See [resolved review thread](https://github.com/verity-org/verity/pull/336/files#r-PRRT_kwDORIdZzc6AsPBq) for full discussion.

## Changes

### 1. `images/minio.yaml` — add busybox

Mirrors [#327](https://github.com/verity-org/verity/pull/327) (valkey busybox). minio chart's Deployment runs `sh -c '...'` for container setup; without busybox the runc exec fails with `/bin/sh: no such file or directory`.

```diff
   default:
     base: wolfi-base
-    packages: ["minio"]
+    packages: ["minio", "busybox"]
```

### 2. `verity.yaml` vault — `server.dev.enabled: true`

Identical fix shape to the openbao chartValues in [#331](https://github.com/verity-org/verity/pull/331) (vault is the upstream openbao forked from). Diagnostic dump shows `Initialized: false / Sealed: true` post-install — server runs but stays sealed forever in CI. Dev mode auto-inits + auto-unseals in-memory so smoke test verifies the API responds.

```yaml
vault:
  server.dev.enabled: true
```

Never used in production.

## Pre-flight verification

Ran `helm template <chart>` locally with the proposed values for vault — renders cleanly (no missing-required-field surprises like the [#331](https://github.com/verity-org/verity/pull/331) → [#332](https://github.com/verity-org/verity/pull/332) atlantis trap).

| Chart | helm template | Notes |
|-------|---------------|-------|
| vault | ✅ | `server.dev.enabled: true` accepted |
| minio | (image-only change, no chart-gen impact) | `make integer-validate` ✅ |

Plus `make integer-validate` → all 325 images valid.

## Expected outcome

After merge + Chart Generation + image rebuild:
- `minio` → green (busybox in image)
- `vault` → green (server boots fully initialized)

Combined with [#327](https://github.com/verity-org/verity/pull/327) (valkey, already green), [#329](https://github.com/verity-org/verity/pull/329) (loki, already green), [#320](https://github.com/verity-org/verity/pull/320) (external-dns, already green), and [#331](https://github.com/verity-org/verity/pull/331) (openbao via dev-mode), nightly should reach **22 green / 32 red** (up from 20/34 today). Jenkins remains red pending the helmSetPair extension.

## CI note

Go Lint may fail on `govulncheck` — unrelated to this PR, govulncheck published `GO-2026-4971` (net@go1.26.2) and `GO-2026-4918` (net/http) between yesterday's main run and today. Affects every PR until Go is bumped. Last main Lint at 2026-05-07 13:55 was green; today it would also fail.

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (chart-wrapper backlog — May 7 categorization)
- Mirrors [#327](https://github.com/verity-org/verity/pull/327) (valkey busybox) for minio
- Mirrors [#331](https://github.com/verity-org/verity/pull/331)'s openbao dev-mode pattern for vault