### PR TITLE
chore(deps): bump Go 1.26.2 → 1.26.3 (govulncheck stdlib vulns)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/verity-org/verity
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/mise.lock
+++ b/mise.lock
@@ -154,36 +154,36 @@ checksum = "sha256:4524c5de25c2b1e7ac778104dbaca36288d461d26572ae18d16a4ce9fb5e8
 url = "https://github.com/google/go-containerregistry/releases/download/v0.21.0/go-containerregistry_Windows_x86_64.tar.gz"
 
 [[tools.go]]
-version = "1.26.2"
+version = "1.26.3"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23"
-url = "https://dl.google.com/go/go1.26.2.linux-arm64.tar.gz"
+checksum = "sha256:9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565"
+url = "https://dl.google.com/go/go1.26.3.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-arm64-musl"]
-checksum = "sha256:c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23"
-url = "https://dl.google.com/go/go1.26.2.linux-arm64.tar.gz"
+checksum = "sha256:9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565"
+url = "https://dl.google.com/go/go1.26.3.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
-url = "https://dl.google.com/go/go1.26.2.linux-amd64.tar.gz"
+checksum = "sha256:2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556"
+url = "https://dl.google.com/go/go1.26.3.linux-amd64.tar.gz"
 
 [tools.go."platforms.linux-x64-musl"]
-checksum = "sha256:990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
-url = "https://dl.google.com/go/go1.26.2.linux-amd64.tar.gz"
+checksum = "sha256:2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556"
+url = "https://dl.google.com/go/go1.26.3.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:32af1522bf3e3ff3975864780a429cc0b41d190ec7bf90faa661d6d64566e7af"
-url = "https://dl.google.com/go/go1.26.2.darwin-arm64.tar.gz"
+checksum = "sha256:875cf54a15311eee2c99b9dd67c68c4a49351d489ab622bf2cfd28c8f2078d3c"
+url = "https://dl.google.com/go/go1.26.3.darwin-arm64.tar.gz"
 
 [tools.go."platforms.macos-x64"]
-checksum = "sha256:bc3f1500d9968c36d705442d90ba91addf9271665033748b82532682e90a7966"
-url = "https://dl.google.com/go/go1.26.2.darwin-amd64.tar.gz"
+checksum = "sha256:278d580b32e299fe4a9c990fcf2d02acfe538c7e551a6ee18f9c7164573d2c63"
+url = "https://dl.google.com/go/go1.26.3.darwin-amd64.tar.gz"
 
 [tools.go."platforms.windows-x64"]
-checksum = "sha256:98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708"
-url = "https://dl.google.com/go/go1.26.2.windows-amd64.zip"
+checksum = "sha256:20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d3224a"
+url = "https://dl.google.com/go/go1.26.3.windows-amd64.zip"
 
 [[tools."go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint"]]
 version = "2.11.4"


### PR DESCRIPTION
## Summary

Unblock CI for every open PR. govulncheck published four Go stdlib vulnerabilities in 1.26.2 between yesterday's main run (May 7 13:55 ✅) and today's first PR runs (May 8 17:17 ❌), making the `Go Lint` workflow fail repo-wide until Go is bumped to 1.26.3.

## Vulnerabilities cleared

| ID | Affected | Trace example |
|----|----------|---------------|
| [GO-2026-4971](https://pkg.go.dev/vuln/GO-2026-4971) | `net@go1.26.2` — `net.Dial` / `LookupPort` panic on Windows on NUL byte | `internal/patch/patch.go:184 → patch.Patch → net.DialTimeout` |
| [GO-2026-4918](https://pkg.go.dev/vuln/GO-2026-4918) | `net/http@go1.26.2` — infinite loop in HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE` | `internal/preflight/manifest.go:54 → http.Client.Do` |
| [GO-2026-4980](https://pkg.go.dev/vuln/GO-2026-4980) | `html/template@go1.26.2` | (multiple) |
| [GO-2026-4982](https://pkg.go.dev/vuln/GO-2026-4982) | `html/template@go1.26.2` | (multiple) |

All four `Fixed in: ...@go1.26.3`.

## Why mise.toml's `go = "latest"` wasn't enough

`mise.toml` already declares `go = "latest"`, but `mise.lock` snapshots the resolved version + per-platform checksums. The lock was generated when 1.26.2 was latest and never regenerated when 1.26.3 dropped, so CI kept installing 1.26.2 from the locked URLs.

## Changes

### `mise.lock`

Bump `tools.go.version` + all 7 platform checksums + URLs to go1.26.3. Checksums pulled from `https://go.dev/dl/?mode=json` (canonical source).

| Platform | New SHA256 |
|----------|-----------|
| linux-arm64 / linux-arm64-musl | `9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565` |
| linux-x64 / linux-x64-musl | `2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556` |
| macos-arm64 | `875cf54a15311eee2c99b9dd67c68c4a49351d489ab622bf2cfd28c8f2078d3c` |
| macos-x64 | `278d580b32e299fe4a9c990fcf2d02acfe538c7e551a6ee18f9c7164573d2c63` |
| windows-x64 | `20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d3224a` |

### `go.mod`

Bump `go 1.26.2` → `go 1.26.3` to keep the minimum-version directive aligned with the toolchain mise installs. No code or dependency changes.

## Verification

- [x] `mise install go=1.26.3` succeeded; `go version` reports `go1.26.3 linux/amd64`
- [x] `go build -o verity .` succeeds against the new toolchain
- [x] `go test ./internal/...` — all pass (discovery, eol, render, patch, preflight, etc.)
- [x] Diff is +16/-16 lines, only `mise.lock` checksum/URL swaps + 1-line `go.mod` change

## Refs

After merge, every open PR's `Go Lint` should auto-recover on the next CI run. Specifically unblocks [#336](https://github.com/verity-org/verity/pull/336) (chart quickwins) which is otherwise ready to merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps Go from 1.26.2 to 1.26.3 to clear newly published stdlib vulnerabilities that broke Go Lint in CI. Restores green builds and unblocks open PRs.

- **Dependencies**
  - Updated `mise.lock` `tools.go.version` to 1.26.3 with refreshed platform URLs and SHA256s.
  - Updated `go.mod` `go` directive to 1.26.3.
  - Regenerated lockfile so CI installs 1.26.3 (was pinned to 1.26.2 despite `go = "latest"`).

<sup>Written for commit dcd8c6a4a9918b763077b9f5fc63eaa5b574ffd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

