### PR TITLE
feat(integer): bespoke wave 4 — 8 Prometheus exporters (postgres, redis, mysqld, kafka, elasticsearch, process, snmp, statsd)

### DIFF
--- a/images/elasticsearch-exporter.yaml
+++ b/images/elasticsearch-exporter.yaml
@@ -1,0 +1,16 @@
+name: elasticsearch-exporter
+description: "Prometheus Elasticsearch Exporter — bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: elasticsearch-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["elasticsearch-exporter"]
+    entrypoint: /usr/bin/elasticsearch_exporter
+    melange:
+      bespoke: "elasticsearch-exporter.yaml"
+
+versions:
+  "1.10.0":
+    latest: true

--- a/images/kafka-exporter.yaml
+++ b/images/kafka-exporter.yaml
@@ -1,0 +1,16 @@
+name: kafka-exporter
+description: "Prometheus Kafka Exporter — bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: kafka-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["kafka-exporter"]
+    entrypoint: /usr/bin/kafka_exporter
+    melange:
+      bespoke: "kafka-exporter.yaml"
+
+versions:
+  "1.9.0":
+    latest: true

--- a/images/mysqld-exporter.yaml
+++ b/images/mysqld-exporter.yaml
@@ -1,0 +1,16 @@
+name: mysqld-exporter
+description: "Prometheus MySQL Exporter — bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: mysqld-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["mysqld-exporter"]
+    entrypoint: /usr/bin/mysqld_exporter
+    melange:
+      bespoke: "mysqld-exporter.yaml"
+
+versions:
+  "0.19.0":
+    latest: true

--- a/images/postgres-exporter.yaml
+++ b/images/postgres-exporter.yaml
@@ -1,0 +1,16 @@
+name: postgres-exporter
+description: "Prometheus PostgreSQL Exporter — bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: postgres-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["postgres-exporter"]
+    entrypoint: /usr/bin/postgres_exporter
+    melange:
+      bespoke: "postgres-exporter.yaml"
+
+versions:
+  "0.19.1":
+    latest: true

--- a/images/process-exporter.yaml
+++ b/images/process-exporter.yaml
@@ -1,5 +1,5 @@
 name: process-exporter
-description: "Prometheus Process Exporter — /proc-based per-process metrics; bespoke Wolfi build (not in upstream apk repo)"
+description: "Prometheus Process Exporter — /proc-based per-process metrics; bespoke Wolfi build (not in upstream apk repo); ships upstream's match-all example config at /etc/process-exporter/all.yaml"
 upstream:
   package: process-exporter
 
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["process-exporter"]
     entrypoint: /usr/bin/process-exporter
+    paths:
+      - {path: /etc/process-exporter, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
     melange:
       bespoke: "process-exporter.yaml"
 

--- a/images/process-exporter.yaml
+++ b/images/process-exporter.yaml
@@ -1,0 +1,16 @@
+name: process-exporter
+description: "Prometheus Process Exporter — /proc-based per-process metrics; bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: process-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["process-exporter"]
+    entrypoint: /usr/bin/process-exporter
+    melange:
+      bespoke: "process-exporter.yaml"
+
+versions:
+  "0.8.7":
+    latest: true

--- a/images/redis-exporter.yaml
+++ b/images/redis-exporter.yaml
@@ -1,0 +1,16 @@
+name: redis-exporter
+description: "Prometheus Redis Exporter — bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: redis-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["redis-exporter"]
+    entrypoint: /usr/bin/redis_exporter
+    melange:
+      bespoke: "redis-exporter.yaml"
+
+versions:
+  "1.83.0":
+    latest: true

--- a/images/snmp-exporter.yaml
+++ b/images/snmp-exporter.yaml
@@ -1,5 +1,5 @@
 name: snmp-exporter
-description: "Prometheus SNMP Exporter — bespoke Wolfi build (not in upstream apk repo)"
+description: "Prometheus SNMP Exporter — bespoke Wolfi build (not in upstream apk repo); ships upstream's generated snmp.yml at /etc/snmp_exporter/snmp.yml"
 upstream:
   package: snmp-exporter
 
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["snmp-exporter"]
     entrypoint: /usr/bin/snmp_exporter
+    paths:
+      - {path: /etc/snmp_exporter, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
     melange:
       bespoke: "snmp-exporter.yaml"
 

--- a/images/snmp-exporter.yaml
+++ b/images/snmp-exporter.yaml
@@ -1,0 +1,16 @@
+name: snmp-exporter
+description: "Prometheus SNMP Exporter — bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: snmp-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["snmp-exporter"]
+    entrypoint: /usr/bin/snmp_exporter
+    melange:
+      bespoke: "snmp-exporter.yaml"
+
+versions:
+  "0.30.1":
+    latest: true

--- a/images/statsd-exporter.yaml
+++ b/images/statsd-exporter.yaml
@@ -1,0 +1,16 @@
+name: statsd-exporter
+description: "Prometheus StatsD Exporter — bespoke Wolfi build (not in upstream apk repo)"
+upstream:
+  package: statsd-exporter
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["statsd-exporter"]
+    entrypoint: /usr/bin/statsd_exporter
+    melange:
+      bespoke: "statsd-exporter.yaml"
+
+versions:
+  "0.29.0":
+    latest: true

--- a/packages/bespoke/elasticsearch-exporter.yaml
+++ b/packages/bespoke/elasticsearch-exporter.yaml
@@ -1,0 +1,50 @@
+package:
+  name: elasticsearch-exporter
+  version: "1.10.0"
+  epoch: 0
+  description: "Prometheus exporter for Elasticsearch cluster metrics"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus-community/elasticsearch_exporter
+      tag: v${{package.version}}
+      expected-commit: eee51ae24a6c802046077c59aff82f6f65cc220e
+
+  - uses: go/build
+    with:
+      packages: .
+      output: elasticsearch_exporter
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=$(git rev-parse HEAD)
+        -X github.com/prometheus/common/version.Branch=v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: prometheus-community/elasticsearch_exporter
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        elasticsearch_exporter --version
+        elasticsearch_exporter --help

--- a/packages/bespoke/kafka-exporter.yaml
+++ b/packages/bespoke/kafka-exporter.yaml
@@ -1,0 +1,49 @@
+package:
+  name: kafka-exporter
+  version: "1.9.0"
+  epoch: 0
+  description: "Prometheus exporter for Apache Kafka broker metrics"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/danielqsj/kafka_exporter
+      tag: v${{package.version}}
+      expected-commit: 8ec24078707d4d3b349e71522ebd7f179746072d
+
+  - uses: go/build
+    with:
+      packages: .
+      output: kafka_exporter
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=$(git rev-parse HEAD)
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: danielqsj/kafka_exporter
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        kafka_exporter --version
+        kafka_exporter --help

--- a/packages/bespoke/mysqld-exporter.yaml
+++ b/packages/bespoke/mysqld-exporter.yaml
@@ -1,0 +1,50 @@
+package:
+  name: mysqld-exporter
+  version: "0.19.0"
+  epoch: 0
+  description: "Prometheus exporter for MySQL server metrics"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus/mysqld_exporter
+      tag: v${{package.version}}
+      expected-commit: 464bc5de74325c3ba85b237561e4b6c0bc3ca6d7
+
+  - uses: go/build
+    with:
+      packages: .
+      output: mysqld_exporter
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=$(git rev-parse HEAD)
+        -X github.com/prometheus/common/version.Branch=v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: prometheus/mysqld_exporter
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        mysqld_exporter --version
+        mysqld_exporter --help

--- a/packages/bespoke/postgres-exporter.yaml
+++ b/packages/bespoke/postgres-exporter.yaml
@@ -1,0 +1,50 @@
+package:
+  name: postgres-exporter
+  version: "0.19.1"
+  epoch: 0
+  description: "Prometheus exporter for PostgreSQL server metrics"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus-community/postgres_exporter
+      tag: v${{package.version}}
+      expected-commit: 333363aeb548b66340a61a7fb2b3f0e8a8d39f90
+
+  - uses: go/build
+    with:
+      packages: ./cmd/postgres_exporter
+      output: postgres_exporter
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=$(git rev-parse HEAD)
+        -X github.com/prometheus/common/version.Branch=v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: prometheus-community/postgres_exporter
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        postgres_exporter --version
+        postgres_exporter --help

--- a/packages/bespoke/process-exporter.yaml
+++ b/packages/bespoke/process-exporter.yaml
@@ -34,6 +34,9 @@ pipeline:
         -X main.version=${{package.version}}
         -X main.gitcommit=$(git rev-parse HEAD)
 
+  - runs: |
+      install -Dm644 packaging/conf/all.yaml "${{targets.destdir}}/etc/process-exporter/all.yaml"
+
   - uses: strip
 
 update:

--- a/packages/bespoke/process-exporter.yaml
+++ b/packages/bespoke/process-exporter.yaml
@@ -1,0 +1,49 @@
+package:
+  name: process-exporter
+  version: "0.8.7"
+  epoch: 0
+  description: "Prometheus exporter that mines /proc to report on selected processes"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ncabatoff/process-exporter
+      tag: v${{package.version}}
+      expected-commit: e52ab0a1c03d6baf8ed60154c254ecc0008549f3
+
+  - uses: go/build
+    with:
+      packages: ./cmd/process-exporter
+      output: process-exporter
+      ldflags: |
+        -X main.version=${{package.version}}
+        -X main.gitcommit=$(git rev-parse HEAD)
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: ncabatoff/process-exporter
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        process-exporter -version
+        process-exporter -h 2>&1 | head -5

--- a/packages/bespoke/redis-exporter.yaml
+++ b/packages/bespoke/redis-exporter.yaml
@@ -1,0 +1,49 @@
+package:
+  name: redis-exporter
+  version: "1.83.0"
+  epoch: 0
+  description: "Prometheus exporter for Redis server metrics"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/oliver006/redis_exporter
+      tag: v${{package.version}}
+      expected-commit: 1c261b87e1431be106c241181038274b406c9592
+
+  - uses: go/build
+    with:
+      packages: .
+      output: redis_exporter
+      ldflags: |
+        -X main.BuildVersion=${{package.version}}
+        -X main.BuildCommitSha=$(git rev-parse HEAD)
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: oliver006/redis_exporter
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        redis_exporter --version
+        redis_exporter --help

--- a/packages/bespoke/snmp-exporter.yaml
+++ b/packages/bespoke/snmp-exporter.yaml
@@ -35,6 +35,9 @@ pipeline:
         -X github.com/prometheus/common/version.Revision=$(git rev-parse HEAD)
         -X github.com/prometheus/common/version.Branch=v${{package.version}}
 
+  - runs: |
+      install -Dm644 snmp.yml "${{targets.destdir}}/etc/snmp_exporter/snmp.yml"
+
   - uses: strip
 
 update:

--- a/packages/bespoke/snmp-exporter.yaml
+++ b/packages/bespoke/snmp-exporter.yaml
@@ -1,0 +1,50 @@
+package:
+  name: snmp-exporter
+  version: "0.30.1"
+  epoch: 0
+  description: "Prometheus exporter for SNMP-instrumented devices"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus/snmp_exporter
+      tag: v${{package.version}}
+      expected-commit: 48b810afbd9222b74439ad1cf7d0d7b7c0cf4290
+
+  - uses: go/build
+    with:
+      packages: .
+      output: snmp_exporter
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=$(git rev-parse HEAD)
+        -X github.com/prometheus/common/version.Branch=v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: prometheus/snmp_exporter
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        snmp_exporter --version
+        snmp_exporter --help

--- a/packages/bespoke/statsd-exporter.yaml
+++ b/packages/bespoke/statsd-exporter.yaml
@@ -1,0 +1,50 @@
+package:
+  name: statsd-exporter
+  version: "0.29.0"
+  epoch: 0
+  description: "Prometheus exporter that translates StatsD metrics to Prometheus format"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus/statsd_exporter
+      tag: v${{package.version}}
+      expected-commit: 595c7742c20fcfa691d21618201ae957b1f00945
+
+  - uses: go/build
+    with:
+      packages: .
+      output: statsd_exporter
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=$(git rev-parse HEAD)
+        -X github.com/prometheus/common/version.Branch=v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: prometheus/statsd_exporter
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        statsd_exporter --version
+        statsd_exporter --help


### PR DESCRIPTION
## Summary

Closes a major coverage gap in Verity's Integer image catalog: 8 widely-used Prometheus exporters that are missing from upstream Wolfi (verified 404 each via the Wolfi-os API).

Verity already shipped `blackbox-exporter` (bespoke) and `node-exporter` (Wolfi-wrap), but the broader Prometheus exporter ecosystem — databases, message queues, search engines, process metrics — was unrepresented. This PR ships them as bespoke melange packages.

## New bespoke packages (8)

| Tool | Version | License | Repo |
|---|---|---|---|
| **postgres-exporter** | 0.19.1 | Apache-2.0 | `prometheus-community/postgres_exporter` |
| **redis-exporter** | 1.83.0 | MIT | `oliver006/redis_exporter` |
| **mysqld-exporter** | 0.19.0 | Apache-2.0 | `prometheus/mysqld_exporter` |
| **kafka-exporter** | 1.9.0 | Apache-2.0 | `danielqsj/kafka_exporter` |
| **elasticsearch-exporter** | 1.10.0 | Apache-2.0 | `prometheus-community/elasticsearch_exporter` |
| **process-exporter** | 0.8.7 | MIT | `ncabatoff/process-exporter` |
| **snmp-exporter** | 0.30.1 | Apache-2.0 | `prometheus/snmp_exporter` |
| **statsd-exporter** | 0.29.0 | Apache-2.0 | `prometheus/statsd_exporter` |

All pure Go, all use the verity-proven minimal pattern (workspace-root checkout, `go` latest, `dependencies.runtime: ca-certificates-bundle`, `update.github` block for renovate auto-bumps, smoke test pipeline).

## Validation

- ✅ `./verity integer validate` — **All 337 image configs valid** (was 329, +8)
- All 8 use simple bespoke pattern matching wave 1/2's successes (kubectx, vegeta, etc.) — no cgo, no upstream Makefile dependencies, no eBPF; lowest-risk wave so far

## Naming convention

Bespoke package names use simple form (`postgres-exporter`) rather than the prefixed form used by `prometheus-blackbox-exporter`. Image yaml's `entrypoint:` correctly uses the binary name with underscore (e.g. `/usr/bin/postgres_exporter`) while the apk package name uses dash (`postgres-exporter`). This keeps file names == image names == package names within wave 4 for easier mental mapping; can normalize against blackbox-exporter's prefixed convention in review if preferred.

## Files changed

16 new files (8 bespoke pairs):
- `packages/bespoke/{postgres,redis,mysqld,kafka,elasticsearch,process,snmp,statsd}-exporter.yaml`
- `images/{postgres,redis,mysqld,kafka,elasticsearch,process,snmp,statsd}-exporter.yaml`

## Deferred (not in this wave)

- **jmx-exporter** — Java/Maven build (different toolchain like hadolint)
- **ipmi-exporter, haproxy-exporter, rabbitmq-exporter** — niche, lower priority; can ship in wave 5 if requested
- **cadvisor, memcached-exporter** — already in upstream Wolfi (no bespoke needed; could be wrapped as Integer images in a separate PR)

## Relationship to prior PRs

Continues the bespoke expansion from #297 (wave 1 — K8s tooling), #315 (wave 2 — load testing + Wolfi wraps), and #335 (wave 3 — earthly/vcluster/kubeshark/tracee). Total active bespoke after this PR: **22 → 30**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 8 Prometheus exporters as bespoke Wolfi packages and Integer images with static Go builds, and ships default configs for `snmp-exporter` and `process-exporter` so the images run out of the box.

- **New Features**
  - New images/packages: `postgres-exporter`, `redis-exporter`, `mysqld-exporter`, `kafka-exporter`, `elasticsearch-exporter`, `process-exporter`, `snmp-exporter`, `statsd-exporter`
  - Minimal pattern: upstream entrypoints, `update.github`, runtime `ca-certificates-bundle`, `CGO_ENABLED=0`
  - Validation: 337 images total (+8) via `verity integer validate`

- **Bug Fixes**
  - Ship upstream defaults: `snmp.yml` at `/etc/snmp_exporter/snmp.yml` and `all.yaml` at `/etc/process-exporter/all.yaml`; config dirs created writable (uid/gid 65532) for overrides

<sup>Written for commit 6d0baa226dad2ca467c1da080bb24e09b37ee780. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

