### PR TITLE
fix(images): add /cluster-autoscaler symlink for chart's relative-path command (#318 A.2)

### DIFF
--- a/images/cluster-autoscaler.yaml
+++ b/images/cluster-autoscaler.yaml
@@ -8,6 +8,15 @@ types:
     base: wolfi-base
     packages: ["cluster-autoscaler-1.35"]
     entrypoint: /usr/bin/cluster-autoscaler
+    paths:
+      # kubernetes/autoscaler helm chart's StatefulSet hardcodes the
+      # container command as `["./cluster-autoscaler", ...]` with the
+      # default workingDir (`/`), so the kernel resolves it as
+      # `/cluster-autoscaler`. Verity's wolfi rebuild ships at
+      # `/usr/bin/cluster-autoscaler` (FHS). Symlink keeps both layouts
+      # working. Same shape as velero (#330) and etcd (#330).
+      # See verity-org/verity#318 (A.2 FHS-path mismatch sub-cluster).
+      - {path: /cluster-autoscaler, type: symlink, source: /usr/bin/cluster-autoscaler, uid: 0, gid: 0}
 
 versions:
   "1.35": {}


### PR DESCRIPTION
## Summary

Same fix shape as [#330](https://github.com/verity-org/verity/pull/330) (velero `/velero`, etcd `/usr/local/bin/etcd`, fluent-bit `/fluent-bit/bin/fluent-bit`) — chart hardcodes a non-FHS path; we adapt with an apko symlink.

Diagnostic from May 8 chart-integration nightly:

\`\`\`
exec: \"./cluster-autoscaler\": stat ./cluster-autoscaler: no such file or directory
\`\`\`

Inspecting the chart's StatefulSet:

\`\`\`yaml
command: [\"./cluster-autoscaler\", \"--cloud-provider=aws\", \"--namespace=cluster-autoscaler\", \"--node-group-auto-discovery=...\", ...]
workingDir: <default>
\`\`\`

Default workingDir is \`/\`, so the kernel resolves \`./cluster-autoscaler\` as \`/cluster-autoscaler\`. Verity's wolfi \`cluster-autoscaler-1.35\` package ships the binary at \`/usr/bin/cluster-autoscaler\` (FHS).

## Fix

\`\`\`diff
   default:
     base: wolfi-base
     packages: [\"cluster-autoscaler-1.35\"]
     entrypoint: /usr/bin/cluster-autoscaler
+    paths:
+      - {path: /cluster-autoscaler, type: symlink, source: /usr/bin/cluster-autoscaler, uid: 0, gid: 0}
\`\`\`

## Verification

- [x] \`make integer-validate\` → 329 images valid
- [x] PathDef \`type: symlink\` schema landed in [#330](https://github.com/verity-org/verity/pull/330) with full regression test coverage in \`internal/integer/render/render_test.go\`

## ⚠️ Wolfi-perms bug caveat

\`fluent-bit\` and \`velero\` (also [#330](https://github.com/verity-org/verity/pull/330) symlink targets) currently fail with \`permission denied\` because their wolfi packages ship with mode \`----------\`. \`cluster-autoscaler\`'s wolfi package may or may not have the same issue — if it does, the next nightly will surface \`/cluster-autoscaler: permission denied\` instead of clean. Either way this PR is correct; the perms bug is a separate upstream investigation track.

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (A.2 FHS-path cluster)
- Mirrors [#330](https://github.com/verity-org/verity/pull/330) for cluster-autoscaler

## Argo-cd defer note

Per the May 9 systematic review, \`argo-cd\` was originally a candidate in this batch (multi-binary symlinks). On closer inspection the chart sets \`args=[\"/usr/local/bin/argocd-application-controller\", ...]\` with \`command=<inherited>\`, meaning the apko entrypoint (\`/usr/bin/argocd\`) treats the path as a subcommand string. The symlinks alone wouldn't fix this — needs either an entrypoint-wrapper change or chart-side per-component command overrides. Tracking separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a symlink at /cluster-autoscaler → /usr/bin/cluster-autoscaler in the `cluster-autoscaler-1.35` image so the Helm chart’s `./cluster-autoscaler` command works. Fixes container start failures ("stat ./cluster-autoscaler: no such file or directory") and mirrors the velero/etcd symlink fixes (refs #318 A.2).

<sup>Written for commit 44cb12d1e187494b998d8b16017cc748c433bd36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

