### PR TITLE
feat(discovery): add --set-json support to chartValues + apply to jenkins (#318)

### DIFF
--- a/internal/discovery/charts.go
+++ b/internal/discovery/charts.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"os/exec"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -57,12 +58,10 @@ const helmSetFlag = "--set"
 // type coercion that --set applies (e.g. "false" parsed as bool).
 const helmSetStringFlag = "--set-string"
 
-// helmSetJSONFlag is the helm CLI flag for complex (slice or map) values.
-// helm parses the value as JSON and merges it into the chart values tree,
-// preserving list-typed and nested-map-typed configuration that --set's
-// strvals parser cannot represent (e.g. `controller.installPlugins: []`
-// for the jenkins chart, or per-component `command: [<list>]` overrides
-// for argo-cd). See verity-org/verity#318 (jenkins/argo-cd unblock).
+// helmSetJSONFlag is the helm CLI flag for values that cannot be expressed
+// in --set's strvals syntax. The value is parsed as JSON and merged into
+// the chart values tree, so it supports lists, nested maps, and any other
+// shape JSON can represent.
 const helmSetJSONFlag = "--set-json"
 
 // ExtractChartImages runs helm template for a chart and returns all unique image references found.
@@ -168,6 +167,47 @@ func escapeHelmSetValue(v string) string {
 	return v
 }
 
+// helmSetJSONValue encodes value as JSON and returns the --set-json flag
+// pair. Used for any non-scalar value that JSON can represent (slice,
+// array, string-keyed map, etc.) — helm's --set strvals parser cannot
+// represent these shapes.
+func helmSetJSONValue(path string, value any) (flag, encoded string, err error) {
+	jsonBytes, jerr := json.Marshal(value)
+	if jerr != nil {
+		return "", "", fmt.Errorf("path %q: failed to JSON-encode value: %w", path, jerr)
+	}
+	return helmSetJSONFlag, string(jsonBytes), nil
+}
+
+// tryHelmSetJSON checks via reflection whether value is a JSON-encodable
+// container (slice/array, or map with string keys). Returns handled=true
+// when value matches; handled=false leaves the caller to reject with
+// ErrChartValueUnsupportedType.
+//
+// Reflection here intentionally widens beyond the type-switch fast paths
+// (`[]any`, `map[string]any`) so callers constructing chartValues
+// programmatically (e.g. `[]string`, `map[string]string`,
+// `[]int{1, 2, 3}`) don't hit ErrChartValueUnsupportedType for shapes
+// that JSON encoding handles natively.
+func tryHelmSetJSON(path string, value any) (flag, encoded string, err error, handled bool) {
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return "", "", nil, false
+	}
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		flag, encoded, err = helmSetJSONValue(path, value)
+		return flag, encoded, err, true
+	case reflect.Map:
+		// Only string-keyed maps round-trip cleanly to JSON objects.
+		if rv.Type().Key().Kind() == reflect.String {
+			flag, encoded, err = helmSetJSONValue(path, value)
+			return flag, encoded, err, true
+		}
+	}
+	return "", "", nil, false
+}
+
 func helmSetPair(path string, value any) (flag, encoded string, err error) {
 	switch v := value.(type) {
 	case string:
@@ -190,30 +230,19 @@ func helmSetPair(path string, value any) (flag, encoded string, err error) {
 			return "", "", fmt.Errorf("%w: %q=%v", ErrChartValueUnsupportedFloat, path, v)
 		}
 		return helmSetFlag, strconv.FormatFloat(v, 'f', -1, 64), nil
-	case []any:
-		// Slice values cannot be expressed via helm --set's strvals
-		// syntax, so we encode the slice as JSON and use --set-json.
-		// Empty lists `[]` are also handled here, which is exactly
-		// what charts like jenkins (`controller.installPlugins: []`)
-		// require to disable a default-populated list field.
-		jsonBytes, jerr := json.Marshal(v)
-		if jerr != nil {
-			return "", "", fmt.Errorf("path %q: failed to JSON-encode list: %w", path, jerr)
-		}
-		return helmSetJSONFlag, string(jsonBytes), nil
-	case map[string]any:
-		// Nested map values (e.g. struct-shaped overrides) need
-		// --set-json for the same reason as slices.
-		jsonBytes, jerr := json.Marshal(v)
-		if jerr != nil {
-			return "", "", fmt.Errorf("path %q: failed to JSON-encode map: %w", path, jerr)
-		}
-		return helmSetJSONFlag, string(jsonBytes), nil
 	case nil:
 		return "", "", fmt.Errorf("%w: %q", ErrChartValueNil, path)
-	default:
-		return "", "", fmt.Errorf("%w: %q has type %T", ErrChartValueUnsupportedType, path, value)
 	}
+	// Slice/array/string-keyed-map fall through to the JSON path via
+	// reflection. The reflection branch widens support beyond the
+	// concrete `[]any` and `map[string]any` types decoded by yaml.v3
+	// (which is the common case via verity.yaml chartValues) to also
+	// handle programmatically-constructed values like `[]string` /
+	// `map[string]int` that JSON can encode just fine.
+	if flag, encoded, jerr, handled := tryHelmSetJSON(path, value); handled {
+		return flag, encoded, jerr
+	}
+	return "", "", fmt.Errorf("%w: %q has type %T", ErrChartValueUnsupportedType, path, value)
 }
 
 // extractImagesFromManifests parses multi-document Helm YAML output and collects unique image references.

--- a/internal/discovery/charts.go
+++ b/internal/discovery/charts.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -37,9 +38,12 @@ var (
 	ErrChartValueNil = errors.New("chart value is nil")
 
 	// ErrChartValueUnsupportedType is wrapped when a chartValues entry
-	// is a complex type (slice/map/struct) instead of one of the scalar
-	// types Helm's --set / --set-string accept.
-	ErrChartValueUnsupportedType = errors.New("chart value type is unsupported (use scalar string/bool/number)")
+	// is a type that none of helm's --set / --set-string / --set-json
+	// flags can represent. Scalars (string/bool/number) go through
+	// --set-string / --set; slices ([]any) and string-keyed maps
+	// (map[string]any) go through --set-json. Any other type (struct,
+	// channel, etc.) is rejected.
+	ErrChartValueUnsupportedType = errors.New("chart value type is unsupported (use scalar string/bool/number, slice, or string-keyed map)")
 
 	imageTagPattern    = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 	imageDigestPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
@@ -52,6 +56,14 @@ const helmSetFlag = "--set"
 // helmSetStringFlag is the helm CLI flag for string values, avoiding the
 // type coercion that --set applies (e.g. "false" parsed as bool).
 const helmSetStringFlag = "--set-string"
+
+// helmSetJSONFlag is the helm CLI flag for complex (slice or map) values.
+// helm parses the value as JSON and merges it into the chart values tree,
+// preserving list-typed and nested-map-typed configuration that --set's
+// strvals parser cannot represent (e.g. `controller.installPlugins: []`
+// for the jenkins chart, or per-component `command: [<list>]` overrides
+// for argo-cd). See verity-org/verity#318 (jenkins/argo-cd unblock).
+const helmSetJSONFlag = "--set-json"
 
 // ExtractChartImages runs helm template for a chart and returns all unique image references found.
 // Overrides are applied to substitute tag variants (e.g., distroless-libc → debian).
@@ -178,6 +190,25 @@ func helmSetPair(path string, value any) (flag, encoded string, err error) {
 			return "", "", fmt.Errorf("%w: %q=%v", ErrChartValueUnsupportedFloat, path, v)
 		}
 		return helmSetFlag, strconv.FormatFloat(v, 'f', -1, 64), nil
+	case []any:
+		// Slice values cannot be expressed via helm --set's strvals
+		// syntax, so we encode the slice as JSON and use --set-json.
+		// Empty lists `[]` are also handled here, which is exactly
+		// what charts like jenkins (`controller.installPlugins: []`)
+		// require to disable a default-populated list field.
+		jsonBytes, jerr := json.Marshal(v)
+		if jerr != nil {
+			return "", "", fmt.Errorf("path %q: failed to JSON-encode list: %w", path, jerr)
+		}
+		return helmSetJSONFlag, string(jsonBytes), nil
+	case map[string]any:
+		// Nested map values (e.g. struct-shaped overrides) need
+		// --set-json for the same reason as slices.
+		jsonBytes, jerr := json.Marshal(v)
+		if jerr != nil {
+			return "", "", fmt.Errorf("path %q: failed to JSON-encode map: %w", path, jerr)
+		}
+		return helmSetJSONFlag, string(jsonBytes), nil
 	case nil:
 		return "", "", fmt.Errorf("%w: %q", ErrChartValueNil, path)
 	default:

--- a/internal/discovery/charts_test.go
+++ b/internal/discovery/charts_test.go
@@ -556,6 +556,45 @@ func TestHelmSetArgs(t *testing.T) {
 			},
 			wantErr: ErrChartValueUnsupportedType,
 		},
+		// Programmatic-construction cases — copilot review on PR #342
+		// flagged that the type-switch-only path would reject these
+		// even though JSON encoding handles them natively. The
+		// reflection fall-through in tryHelmSetJSON covers them.
+		{
+			name: "[]string slice uses --set-json (programmatic, not yaml.v3-decoded)",
+			chartValues: map[string]any{
+				"controller.command": []string{"/usr/local/bin/argocd-server", "--port", "8080"},
+			},
+			want: []string{"--set-json", `controller.command=["/usr/local/bin/argocd-server","--port","8080"]`},
+		},
+		{
+			name: "[]int slice uses --set-json (programmatic)",
+			chartValues: map[string]any{
+				"replicas": []int{1, 2, 3},
+			},
+			want: []string{"--set-json", "replicas=[1,2,3]"},
+		},
+		{
+			name: "fixed-size array uses --set-json",
+			chartValues: map[string]any{
+				"ports": [3]int{80, 443, 8080},
+			},
+			want: []string{"--set-json", "ports=[80,443,8080]"},
+		},
+		{
+			name: "map[string]string uses --set-json (programmatic, not yaml.v3-decoded)",
+			chartValues: map[string]any{
+				"labels": map[string]string{"app": "argo-cd", "tier": "backend"},
+			},
+			want: []string{"--set-json", `labels={"app":"argo-cd","tier":"backend"}`},
+		},
+		{
+			name: "map[string]int uses --set-json (programmatic)",
+			chartValues: map[string]any{
+				"resources": map[string]int{"cpu": 100, "memory": 128},
+			},
+			want: []string{"--set-json", `resources={"cpu":100,"memory":128}`},
+		},
 		{
 			name: "deterministic key ordering",
 			chartValues: map[string]any{

--- a/internal/discovery/charts_test.go
+++ b/internal/discovery/charts_test.go
@@ -509,9 +509,50 @@ func TestHelmSetArgs(t *testing.T) {
 			wantErr: ErrChartValueNil,
 		},
 		{
-			name: "map value rejected",
+			name: "empty list value uses --set-json",
+			chartValues: map[string]any{
+				"controller.installPlugins": []any{},
+			},
+			want: []string{"--set-json", "controller.installPlugins=[]"},
+		},
+		{
+			name: "list of strings uses --set-json",
+			chartValues: map[string]any{
+				"command": []any{"/usr/local/bin/argocd-server", "--port", "8080"},
+			},
+			want: []string{"--set-json", `command=["/usr/local/bin/argocd-server","--port","8080"]`},
+		},
+		{
+			name: "list of mixed types uses --set-json",
+			chartValues: map[string]any{
+				"args": []any{"--replicas", 3, "--enabled", true},
+			},
+			want: []string{"--set-json", `args=["--replicas",3,"--enabled",true]`},
+		},
+		{
+			name: "map value uses --set-json (was rejected pre-list-support)",
 			chartValues: map[string]any{
 				"x": map[string]any{"y": 1},
+			},
+			want: []string{"--set-json", `x={"y":1}`},
+		},
+		{
+			name: "nested map value uses --set-json",
+			chartValues: map[string]any{
+				"controller.resources": map[string]any{
+					"requests": map[string]any{"cpu": "100m", "memory": "128Mi"},
+					"limits":   map[string]any{"cpu": "500m", "memory": "512Mi"},
+				},
+			},
+			want: []string{
+				"--set-json",
+				`controller.resources={"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}`,
+			},
+		},
+		{
+			name: "non-string-keyed map still rejected",
+			chartValues: map[string]any{
+				"x": map[int]string{1: "a"},
 			},
 			wantErr: ErrChartValueUnsupportedType,
 		},

--- a/verity.yaml
+++ b/verity.yaml
@@ -86,16 +86,23 @@ chartValues:
   # default inbound agent image. Keep the wrapper focused on the controller and
   # the existing kiwigrid sidecar image.
   #
-  # NOTE: jenkins is still red after #328 (busybox) + #334 (tag pin). The
-  # init container surfaces a layered failure — chart's apply_config.sh
-  # calls /usr/local/bin/install-plugins.sh which the verity wolfi rebuild
-  # doesn't ship. The natural chartValues fix would be
-  # `controller.installPlugins: []` to skip plugin install entirely, but
-  # internal/discovery/charts.go's helmSetPair only supports scalar types
-  # (string/bool/number) — empty-list values would fail with
-  # ErrChartValueUnsupportedType. Tracked separately; see verity-org/verity#318.
+  # `controller.installPlugins: []` skips the chart's plugin-installation
+  # init step, which calls `/usr/local/bin/install-plugins.sh`. Verity's
+  # wolfi rebuild ships only the JVM + jenkins.war (no helper scripts) —
+  # without this override, the `init` container crashes with
+  # `/var/jenkins_config/apply_config.sh: line 14: /usr/local/bin/install-plugins.sh: not found`.
+  # Skipping plugin install at smoke-test time is fine; real users can
+  # install plugins post-deploy via the UI / configuration-as-code.
+  #
+  # The empty-list override only works because of the helmSetPair
+  # --set-json support added in this same PR (was previously rejected
+  # with ErrChartValueUnsupportedType — see #336 review history).
+  # Verified end-to-end: `helm template jenkins/jenkins --set-json
+  # 'controller.installPlugins=[]'` drops install-plugins.sh references
+  # from the rendered chart (1 → 0).
   jenkins:
     controller.testEnabled: false
+    controller.installPlugins: []
     agent.enabled: false
 
   # atlantis chart's CI-default values include no VCS credentials, so the


### PR DESCRIPTION
## Summary

Extend `internal/discovery/charts.go:helmSetPair` to handle list (`[]any`) and string-keyed map (`map[string]any`) values via `--set-json`. Apply the new capability to the jenkins chartValues entry in `verity.yaml`, finally enabling the `controller.installPlugins: []` override that was rejected during [#336](https://github.com/verity-org/verity/pull/336) review.

This unblocks **two charts** in [#318](https://github.com/verity-org/verity/issues/318)'s backlog with one Go-side improvement:
- 🟢 **jenkins** — closes here (`installPlugins: []` to skip the chart's `apply_config.sh` → `install-plugins.sh` call that wolfi doesn't ship)
- 🟡 **argo-cd** — follow-up PR will consume this for per-component `command:` overrides (the entrypoint-vs-args mismatch that [#336](https://github.com/verity-org/verity/pull/336)/[#341](https://github.com/verity-org/verity/pull/341) design discussion identified)

## Changes

### `internal/discovery/charts.go`

| Before | After |
|--------|-------|
| `helmSetPair` only accepts scalars (`string`/`bool`/`int`/`uint`/`float`) | Also accepts `[]any` and `map[string]any`, JSON-encoded via `--set-json` |

```diff
+const helmSetJSONFlag = "--set-json"

 func helmSetPair(path string, value any) (flag, encoded string, err error) {
   switch v := value.(type) {
   ...
+  case []any:
+    jsonBytes, jerr := json.Marshal(v)
+    ...
+    return helmSetJSONFlag, string(jsonBytes), nil
+  case map[string]any:
+    jsonBytes, jerr := json.Marshal(v)
+    ...
+    return helmSetJSONFlag, string(jsonBytes), nil
   ...
 }
```

Updated `ErrChartValueUnsupportedType` doc-comment to reflect the broader supported set.

### `internal/discovery/charts_test.go`

Replaced the now-stale "map value rejected" test (which would fail against the new code) with six new cases covering the new capability:

| Case | Input | Output |
|------|-------|--------|
| Empty list (jenkins shape) | `controller.installPlugins: []` | `--set-json controller.installPlugins=[]` |
| List of strings (argo-cd shape) | `command: ["/usr/local/bin/argocd-server", "--port", "8080"]` | `--set-json command=["/usr/local/bin/argocd-server","--port","8080"]` |
| List of mixed types | `args: ["--replicas", 3, "--enabled", true]` | `--set-json args=["--replicas",3,"--enabled",true]` |
| Map (was rejected, now supported) | `x: {y: 1}` | `--set-json x={"y":1}` |
| Nested map | `controller.resources: {requests: {cpu: 100m, ...}, limits: {...}}` | `--set-json controller.resources={"limits":{...},"requests":{...}}` |
| Non-string-keyed map (still rejected) | `x: map[int]string{1: "a"}` | `ErrChartValueUnsupportedType` |

All 19 `TestHelmSetArgs` cases pass; full discovery-package suite passes.

### `verity.yaml`

Re-add `controller.installPlugins: []` to the jenkins chartValues entry (was dropped in [#336](https://github.com/verity-org/verity/pull/336)'s review fix because the schema rejected it). Updated the inline comment to document the layered fix history.

## End-to-end verification

```bash
$ go test ./internal/... 
ok      github.com/verity-org/verity/internal/discovery   0.067s   # incl. all 19 TestHelmSetArgs cases
ok      github.com/verity-org/verity/internal/...         # all packages pass
$ make integer-validate
All configs valid (329 images checked)
$ helm template jenkins jenkins/jenkins --set-json 'controller.installPlugins=[]' \
    | grep -c install-plugins.sh
0   # default = 1; with our flag = 0 (init step removed cleanly)
```

## Why now

[#336](https://github.com/verity-org/verity/pull/336) attempted to set `controller.installPlugins: []` directly. [@copilot-pull-request-reviewer](https://github.com/copilot-pull-request-reviewer) caught that the schema only supported scalars and the slice would fail with `ErrChartValueUnsupportedType`. We dropped the line from [#336](https://github.com/verity-org/verity/pull/336) and tracked the helmSetPair extension as a separate work item (this PR).

The May 9 systematic red-chart review also identified `argo-cd`'s blocker as needing per-component `command:` list-typed overrides — the same gap. So fixing `helmSetPair` once unblocks both charts.

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (chart-wrapper backlog)
- [#336](https://github.com/verity-org/verity/pull/336) (where the jenkins fix was first attempted, then deferred)
- [#341](https://github.com/verity-org/verity/pull/341) (cluster-autoscaler, also from May 9 review)
- Argo-cd follow-up PR will consume this capability

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--set-json` support to chartValues so we can pass lists/arrays and string-keyed maps, and applies it to `jenkins` to skip plugin installation. This unblocks `jenkins` now and prepares `argo-cd` command overrides tracked in #318.

- **New Features**
  - `internal/discovery/charts.go` `helmSetPair` now JSON-encodes any slice/array and string-keyed map and emits `--set-json` (via reflection).
  - Keeps scalar handling via `--set`/`--set-string`; rejects `nil`, non-string-keyed maps, and unsupported types.
  - Tests cover empty/mixed lists, nested maps, and programmatic shapes (`[]string`, `[]int`, fixed arrays, `map[string]string`/`map[string]int`); non-string-keyed maps remain rejected.
  - Re-adds `controller.installPlugins: []` to `jenkins` in `verity.yaml` to remove the plugin-install init step.

<sup>Written for commit c16ea85546d15fc8e966752892ddc1545cf8e1b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

