### PR TITLE
fix(integer): pack bespoke ldflags target wrong Go variable path (showed version 0.0.0)

### DIFF
--- a/packages/bespoke/pack.yaml
+++ b/packages/bespoke/pack.yaml
@@ -31,7 +31,7 @@ pipeline:
       packages: .
       output: pack
       ldflags: |
-        -X github.com/buildpacks/pack.Version=${{package.version}}
+        -X github.com/buildpacks/pack/pkg/client.Version=${{package.version}}
 
   - uses: strip
 


### PR DESCRIPTION
## Summary

Caught while smoke-testing all 30 published Integer images from waves 1-4.

## Reproduction

\`\`\`bash
$ docker run ghcr.io/verity-org/pack:0.40.4 version
0.0.0
\`\`\`

## Root cause

\`packages/bespoke/pack.yaml\` injected version into the wrong Go variable path:

\`\`\`yaml
ldflags: |
  -X github.com/buildpacks/pack.Version=${{package.version}}   # ← no such var
\`\`\`

Upstream's [Makefile at v0.40.4](https://github.com/buildpacks/pack/blob/v0.40.4/Makefile) defines the variable at:

\`\`\`
-X 'github.com/buildpacks/pack/pkg/client.Version=${PACK_VERSION}'
\`\`\`

Since our -X path didn't match any actual var, the linker silently kept the default \`PACK_VERSION?=0.0.0\` baked in by upstream's Makefile.

## Fix

Align bespoke ldflags with upstream's variable location:

\`\`\`diff
-        -X github.com/buildpacks/pack.Version=${{package.version}}
+        -X github.com/buildpacks/pack/pkg/client.Version=${{package.version}}
\`\`\`

After the next published build, \`docker run ghcr.io/verity-org/pack:0.40.4 version\` should output \`0.40.4\` instead of \`0.0.0\`.

## Validation

- ✅ \`./verity integer validate\` — all 329 image configs valid
- Will be observable post-publish: re-run smoke test on \`ghcr.io/verity-org/pack:0.40.4 version\`

## Context

Found during a broader smoke test of all published Integer images from waves 1-4 (#297, #315, #335, #340). 22 of 30 images tested PASS; the remaining 8 (wave-4 exporters) are still queued for build/publish at time of testing. Pack was the only image with a real defect — runs correctly, just reports the wrong version string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect version reporting in the `pack` image by pointing ldflags to the correct Go variable path. Updated `packages/bespoke/pack.yaml` from `github.com/buildpacks/pack.Version` to `github.com/buildpacks/pack/pkg/client.Version`, so `pack version` shows the real version instead of 0.0.0.

<sup>Written for commit c7cd3d98b64617f318f12e6b350d18ca664792ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

