### PR TITLE
fix(charts): nfs-subdir-external-provisioner placeholder nfs.server (#318)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -82,6 +82,20 @@ chartValues:
   workload-identity-webhook:
     azureTenantID: verity-placeholder
 
+  # nfs-subdir-external-provisioner chart's Deployment requires `nfs.server`
+  # to render — without it, helm install aborts with:
+  #   Deployment.apps "nfs-subdir-external-provisioner" is invalid:
+  #     spec.template.spec.volumes[0].nfs.server: Required value
+  # CI smoke just needs the provisioner pod up; it doesn't actually request
+  # storage from NFS at startup, so any placeholder satisfies the validator.
+  # Real users would set this to their actual NFS server hostname/IP and
+  # `nfs.path` to the export root. Mirror the `verity-placeholder` pattern
+  # used by aws-load-balancer-controller / cluster-autoscaler /
+  # workload-identity-webhook.
+  nfs-subdir-external-provisioner:
+    nfs.server: 10.0.0.1
+    nfs.path: /
+
   # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
   # default inbound agent image. Keep the wrapper focused on the controller and
   # the existing kiwigrid sidecar image.


### PR DESCRIPTION
## Summary

Trivial chart-config-gap fix. helm install aborts with:

\`\`\`
Deployment.apps \"nfs-subdir-external-provisioner\" is invalid:
  spec.template.spec.volumes[0].nfs.server: Required value
  spec.template.spec.containers[0].volumeMounts[0].name:
    Not found: \"nfs-subdir-external-provisioner-root\"
\`\`\`

Chart's Deployment template requires \`nfs.server\` to render the NFS volume spec. Without it the rendered Deployment is invalid and the apiserver rejects it.

CI smoke just needs the provisioner Pod up — the pod doesn't mount NFS at startup, only when storage requests come in. Any placeholder satisfies the validator. Real users would set this to their actual NFS server hostname/IP.

## Fix

\`\`\`yaml
nfs-subdir-external-provisioner:
  nfs.server: 10.0.0.1
  nfs.path: /
\`\`\`

Mirrors the \`verity-placeholder\` pattern from \`aws-load-balancer-controller\` / \`cluster-autoscaler\` / \`workload-identity-webhook\`.

## Verification

- [x] \`make integer-validate\` → 337 images valid
- [x] \`helm template nfs-subdir --set nfs.server=10.0.0.1 --set nfs.path=/\` → renders cleanly

## Refs

[#318](https://github.com/verity-org/verity/issues/318) (chart-wrapper backlog)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add placeholder `nfs.server` (10.0.0.1) and `nfs.path` (/) for the `nfs-subdir-external-provisioner` chart so `helm install` doesn’t fail on a required value and the Deployment renders valid. This unblocks CI by letting the provisioner Pod start; users should override with their actual NFS host and export path.

<sup>Written for commit 952327c29a1d96edd23a25664bd94282fe4c00d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

