### PR TITLE
fix(charts): grafana run-as-nonroot + GF_PATHS_HOME for verity wolfi rebuild (#318)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -17,8 +17,38 @@ overrides:
 chartValues:
   # grafana chart 10.5.15 otherwise renders a bats test pod. Disable it so the
   # wrapper only needs to route the primary Grafana workload image.
+  #
+  # Plus two CI-compat fixes for verity's wolfi grafana rebuild:
+  #
+  # 1. securityContext.run{AsUser,AsGroup,fsGroup}: 65532
+  #    Chart defaults runAsUser=runAsGroup=fsGroup=472 (matching the
+  #    upstream `grafana/grafana` image's `grafana` user uid). Verity's
+  #    wolfi rebuild has no uid 472 in /etc/passwd — it ships only `root`
+  #    (0) and `nonroot` (65532). Without a passwd entry for the running
+  #    uid, grafana fails at startup with:
+  #      "could not get current OS user to detect process privileges"
+  #    Pinning to verity's wolfi `nonroot` uid 65532 (which DOES have
+  #    a /etc/passwd entry) lets grafana detect its own user. The
+  #    chart's `runAsNonRoot: true` invariant stays intact (65532 is
+  #    a nonroot uid).
+  #
+  # 2. env.GF_PATHS_HOME: /usr/share/grafana
+  #    Grafana looks for `defaults.ini` relative to `homepath` (default
+  #    is the working dir, which is `/`). Verity's image installs the
+  #    config at `/usr/share/grafana/conf/defaults.ini` (matching the
+  #    wolfi package layout). Without this env var, grafana fails:
+  #      "Could not find config defaults, make sure homepath command
+  #       line parameter is set or working directory is homepath"
+  #    Setting GF_PATHS_HOME points grafana at the right install root.
+  #
+  # See verity-org/verity#318 (was originally suspected to be wolfi-
+  # package issue; turned out chartValues fully address it).
   grafana:
     testFramework.enabled: false
+    securityContext.runAsUser: 65532
+    securityContext.runAsGroup: 65532
+    securityContext.fsGroup: 65532
+    env.GF_PATHS_HOME: /usr/share/grafana
 
   # loki 7.0.0 requires explicit test schema + bucket names to render, and its
   # default gateway/caches add unpatchable auxiliary images. Keep a minimal


### PR DESCRIPTION
## Summary

Two CI-compat chartValues fixes for grafana to actually run against verity's wolfi rebuild. Diagnosed via May 9 chart-integration nightly log-dive.

## 1. \`securityContext.run{AsUser,AsGroup,fsGroup}: 472 → 65532\`

**Diagnostic**:
\`\`\`
Error checking server process execution privilege.
  error: could not get current OS user to detect process privileges
\`\`\`

Chart defaults \`runAsUser/Group/fsGroup: 472\` matching the upstream \`grafana/grafana\` image's \`grafana\` user. Verity's wolfi rebuild has **no uid 472** in /etc/passwd:

\`\`\`
$ tar -xOf <verity-grafana-rootfs>.tar etc/passwd
root:x:0:0:root:/root:/bin/ash
...
nonroot:x:65532:65532:Account created by apko:/home/nonroot:/bin/sh
\`\`\`

Pinning to wolfi's \`nonroot\` uid 65532 — which has a passwd entry — lets grafana resolve its own identity. Chart's \`runAsNonRoot: true\` invariant stays intact (65532 is nonroot).

## 2. \`env.GF_PATHS_HOME: /usr/share/grafana\`

**Diagnostic**:
\`\`\`
Grafana-server Init Failed: Could not find config defaults, make
  sure homepath command line parameter is set or working directory
  is homepath
\`\`\`

Grafana looks for \`defaults.ini\` relative to \`--homepath\` (default = container WORKDIR = \`/\`). Verity's image ships the config at \`/usr/share/grafana/conf/defaults.ini\` (wolfi package layout):

\`\`\`
$ crane export grafana:12.3 - | tar -tvf - | grep defaults.ini
-rw-r--r-- root/root 91934 usr/share/grafana/conf/defaults.ini
\`\`\`

Setting \`GF_PATHS_HOME\` via the chart's existing \`env:\` hook points grafana at the right install root. Other \`GF_PATHS_*\` env vars are already populated by the chart (DATA, LOGS, PLUGINS, PROVISIONING) — only HOME was missing.

## Pre-flight verification

| Check | Result |
|-------|--------|
| \`make integer-validate\` | 337 images valid |
| \`helm template grafana --set securityContext.runAsUser=65532 ...\` | All four securityContext values + GF_PATHS_HOME render correctly |

## Refs

[#318](https://github.com/verity-org/verity/issues/318) — was originally suspected as wolfi-package issue requiring upstream fix; turned out chartValues fully address it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Grafana run on Verity’s Wolfi rebuild by running as uid/gid 65532 (nonroot) and setting `GF_PATHS_HOME=/usr/share/grafana`. Fixes startup errors for OS-user detection and missing config defaults (refs verity-org/verity#318).

- **Bug Fixes**
  - Set `securityContext.runAsUser`, `runAsGroup`, and `fsGroup` to `65532`.
  - Add `env.GF_PATHS_HOME=/usr/share/grafana` so Grafana finds `conf/defaults.ini`.

<sup>Written for commit d543cb14ce725e8019852eafe7d75134d5cb26ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

