### PR TITLE
fix(images): add /usr/lib/jvm/default-jvm symlink to opensearch (#318)

### DIFF
--- a/images/opensearch.yaml
+++ b/images/opensearch.yaml
@@ -15,6 +15,20 @@ types:
       - {path: /usr/share/opensearch/data, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
       - {path: /usr/share/opensearch/logs, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /usr/share/opensearch/config, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+      # Wolfi's openjdk package installs at `/usr/lib/jvm/java-25-openjdk/`
+      # (verified via `crane export ghcr.io/verity-org/opensearch:3`).
+      # The image's `OPENSEARCH_JAVA_HOME` env (above) points at
+      # `/usr/lib/jvm/default-jvm` — a conventional Debian/Wolfi alias
+      # that the openjdk package doesn't itself create. Without a symlink
+      # opensearch fails at startup with:
+      #   could not find java in OPENSEARCH_JAVA_HOME at
+      #     /usr/lib/jvm/default-jvm/bin/java
+      # Symlinking `default-jvm` → the actual openjdk install root keeps
+      # the env-var-pointed path resolvable. Same FHS-adapter pattern as
+      # etcd / fluent-bit / velero in #330. Fixes both opensearch and
+      # opensearch-dashboards (which uses the same OPENSEARCH_JAVA_HOME
+      # convention via the shared opensearch image).
+      - {path: /usr/lib/jvm/default-jvm, type: symlink, source: /usr/lib/jvm/java-25-openjdk, uid: 0, gid: 0}
 
 versions:
   "3": {}

--- a/images/opensearch.yaml
+++ b/images/opensearch.yaml
@@ -6,7 +6,20 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["opensearch-{{version}}"]
+    # `opensearch-{{version}}` provides the OpenSearch binaries + bundled
+    # JDK. `openjdk-25-default-jvm` is wolfi's alias subpackage that
+    # creates `/usr/lib/jvm/default-jvm` → `/usr/lib/jvm/java-25-openjdk`,
+    # which the image's OPENSEARCH_JAVA_HOME env (below) points at.
+    # Without this alias package the symlink is missing and opensearch
+    # fails at startup with:
+    #   could not find java in OPENSEARCH_JAVA_HOME at
+    #     /usr/lib/jvm/default-jvm/bin/java
+    # When wolfi bumps to openjdk-26, swap to `openjdk-26-default-jvm`
+    # (and verify OPENSEARCH_JAVA_HOME still resolves). Letting wolfi own
+    # the symlink-vs-actual-install mapping is more maintainable than the
+    # repo authoring the symlink itself. See verity-org/verity#318 and
+    # verity-org/verity#351 review for the original symlink discussion.
+    packages: ["opensearch-{{version}}", "openjdk-25-default-jvm"]
     entrypoint: /usr/share/opensearch/opensearch-docker-entrypoint.sh
     environment:
       OPENSEARCH_HOME: /usr/share/opensearch
@@ -15,20 +28,6 @@ types:
       - {path: /usr/share/opensearch/data, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
       - {path: /usr/share/opensearch/logs, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /usr/share/opensearch/config, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
-      # Wolfi's openjdk package installs at `/usr/lib/jvm/java-25-openjdk/`
-      # (verified via `crane export ghcr.io/verity-org/opensearch:3`).
-      # The image's `OPENSEARCH_JAVA_HOME` env (above) points at
-      # `/usr/lib/jvm/default-jvm` — a conventional Debian/Wolfi alias
-      # that the openjdk package doesn't itself create. Without a symlink
-      # opensearch fails at startup with:
-      #   could not find java in OPENSEARCH_JAVA_HOME at
-      #     /usr/lib/jvm/default-jvm/bin/java
-      # Symlinking `default-jvm` → the actual openjdk install root keeps
-      # the env-var-pointed path resolvable. Same FHS-adapter pattern as
-      # etcd / fluent-bit / velero in #330. Fixes both opensearch and
-      # opensearch-dashboards (which uses the same OPENSEARCH_JAVA_HOME
-      # convention via the shared opensearch image).
-      - {path: /usr/lib/jvm/default-jvm, type: symlink, source: /usr/lib/jvm/java-25-openjdk, uid: 0, gid: 0}
 
 versions:
   "3": {}


### PR DESCRIPTION
## Summary

opensearch + opensearch-dashboards crashloop because \`OPENSEARCH_JAVA_HOME\` points at a path that doesn't exist in the verity wolfi rebuild. One symlink fixes both shards.

## Diagnostic

\`\`\`
opensearch-cluster-master-0  Running  opensearch=waiting(CrashLoopBackOff)

could not find java in OPENSEARCH_JAVA_HOME at /usr/lib/jvm/default-jvm/bin/java
\`\`\`

Wolfi's \`opensearch-3\` package installs OpenJDK at \`/usr/lib/jvm/java-25-openjdk/bin/java\` (verified via \`crane export ghcr.io/verity-org/opensearch:3\`). But \`images/opensearch.yaml\`'s pre-existing \`OPENSEARCH_JAVA_HOME: /usr/lib/jvm/default-jvm\` env var points at the conventional Debian/Wolfi alias that the openjdk package itself doesn't create.

## Fix

\`\`\`diff
   paths:
     - {path: /usr/share/opensearch/data, ...}
     - {path: /usr/share/opensearch/logs, ...}
     - {path: /usr/share/opensearch/config, ...}
+    - {path: /usr/lib/jvm/default-jvm, type: symlink, source: /usr/lib/jvm/java-25-openjdk, uid: 0, gid: 0}
\`\`\`

Same FHS-adapter pattern as etcd / fluent-bit / velero / mimir / cluster-autoscaler.

## Side-effect win

\`opensearch-dashboards\` chart uses the same shared opensearch image and the same \`OPENSEARCH_JAVA_HOME\` convention. **One symlink unblocks both shards.**

## Verification

- [x] \`make integer-validate\` → 337 images valid
- [x] \`crane export ghcr.io/verity-org/opensearch:3 - | tar -tvf - | grep java\` → confirmed \`/usr/lib/jvm/java-25-openjdk/bin/java -rwxr-xr-x\`
- [x] PathDef \`type: symlink\` schema landed in [#330](https://github.com/verity-org/verity/pull/330) with full regression test coverage

## Refs

[#318](https://github.com/verity-org/verity/issues/318) (chart-wrapper backlog)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Wolfi’s `openjdk-25-default-jvm` package in the `opensearch` image to install `/usr/lib/jvm/default-jvm` → `/usr/lib/jvm/java-25-openjdk`, so `OPENSEARCH_JAVA_HOME` resolves. Fixes CrashLoopBackOff in `opensearch` and unblocks `opensearch-dashboards`.

<sup>Written for commit f51298b7ddb4759dbe4d22af992caebae1f1d03c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

