### PR TITLE
fix(charts): cilium drop digest pins + 1-replica operator (#318)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -149,6 +149,30 @@ chartValues:
     nfs.server: 10.0.0.1
     nfs.path: /
 
+  # cilium chart pins each component image by digest (e.g.
+  # `image.digest: sha256:2e61680...`) AND has `image.useDigest: true`,
+  # so the rendered pod spec is `image@sha256:...`. chart-gen replaces
+  # the repository with `ghcr.io/verity-org/cilium`, but the upstream
+  # digest doesn't match verity's rebuild content — pull fails:
+  #   Failed to pull image "ghcr.io/verity-org/cilium:1.19@sha256:2e616...":
+  #     failed to resolve reference (digest mismatch)
+  # Disable per-component useDigest so the chart pulls by tag only.
+  # Same `useDigest: false` flip needed for the operator image (chart
+  # tracks digests separately per component).
+  #
+  # Also: `operator.replicas: 1` — chart defaults to 2 with anti-affinity,
+  # but a single-node kind cluster can only place 1. Mirror the loki /
+  # minio kind-sizing pattern.
+  #
+  # See verity-org/verity#318. The upstream chart's digest pinning is
+  # intentional for production users (sigstore/cosign verification),
+  # but cannot survive chart-gen's repository rewrite.
+  cilium:
+    image.useDigest: false
+    operator.image.useDigest: false
+    envoy.image.useDigest: false
+    operator.replicas: 1
+
   # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
   # default inbound agent image. Keep the wrapper focused on the controller and
   # the existing kiwigrid sidecar image.


### PR DESCRIPTION
## Summary

Two-part chartValues fix for cilium chart, both diagnosed via May 9 nightly chart-integration log dump.

## 1. Drop \`useDigest: true\` for all 3 cilium components

**Diagnostic**:
\`\`\`
Failed to pull image \"ghcr.io/verity-org/cilium:1.19@sha256:2e61680593...\":
  failed to resolve reference (digest mismatch)
\`\`\`

Cilium chart pins each component image by digest with \`useDigest: true\`, so rendered specs are \`image@sha256:...\`. chart-gen replaces the repo with \`ghcr.io/verity-org/cilium\`, but verity's rebuild has a different digest from upstream — pull fails.

Disabling per-component \`useDigest\` makes the chart pull by tag only (\`image.tag: 1.19\`), which chart-gen rewrites cleanly. Three components have separate digest configs (cilium agent, operator, envoy), so we flip all three.

\`\`\`yaml
cilium:
  image.useDigest: false
  operator.image.useDigest: false
  envoy.image.useDigest: false
\`\`\`

Upstream chart's digest pinning is intentional for production users (sigstore/cosign verification), but cannot survive chart-gen's repository rewrite.

## 2. \`operator.replicas: 1\`

\`cilium-operator\` defaults to 2 replicas with pod-anti-affinity. Single-node kind cluster can only place 1 — the second pod sits FailedScheduling. Same kind-sizing pattern as loki / minio ([#329](https://github.com/verity-org/verity/pull/329) / [#322](https://github.com/verity-org/verity/issues/322)).

## Verification

| Check | Result |
|-------|--------|
| \`make integer-validate\` | 337 images valid |
| \`helm template cilium --set image.useDigest=false ...\` | All 3 image refs render WITHOUT \`@sha256:...\` pins; operator replicas: 1 |

After merge + Chart Generation regenerates wrappers, cilium expected to flip green.

## Refs

[#318](https://github.com/verity-org/verity/issues/318) (chart-wrapper backlog)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix image pull failures in the `cilium` chart and ensure the operator schedules on single-node clusters. Addresses #318.

- **Bug Fixes**
  - Set `cilium.image.useDigest`, `operator.image.useDigest`, and `envoy.image.useDigest` to `false` to pull by tag (`1.19`) and avoid digest mismatch after repo rewrite to `ghcr.io/verity-org/cilium`.
  - Set `operator.replicas` to `1` to work with anti-affinity on single-node kind.

<sup>Written for commit ac52765e04105b426b42a9c9b74526ce70fd69a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

