### PR TITLE
fix(chart-integration): author Category B allowlist files (SCR-2026-04-30-001)

### DIFF
--- a/test/chart-integration/values/consul.allowlist.txt
+++ b/test/chart-integration/values/consul.allowlist.txt
@@ -1,8 +1,8 @@
 # consul upstream image allowlist (SCR-2026-04-30-001)
 #
 # The hashicorp/consul chart pulls these two upstream images directly
-# from `hashicorp/...` (not via verity.yaml's `consul/consul` replacement
-# entry which only covers a different chart-image path):
+# from `hashicorp/...`. Verity.yaml's `consul/consul` replacement only
+# covers a different chart-image path, not these:
 #
 #   hashicorp/consul:1.22.7              — main consul server binary
 #   hashicorp/consul-k8s-control-plane:1.9.7
@@ -10,7 +10,14 @@
 #                                          for connect-inject /
 #                                          partition-init / sync-catalog
 #
-# Allowlist until verity adds rebuilds for both. Chart's main pods are
-# healthy after the connect-inject disable in #348.
-hashicorp/consul
-hashicorp/consul-k8s-control-plane
+# Format note: isAccepted (test/chart-integration/assertions.go:205) uses
+# strings.HasPrefix, so we add separators (`:` for tag refs, `@` for
+# digest refs) to ensure each prefix only matches its intended repo and
+# not unrelated `hashicorp/consul*` repos. Per copilot review on PR #353:
+# without `:` / `@`, `hashicorp/consul` would also match
+# `hashicorp/consul-k8s-control-plane` (making the second entry redundant)
+# and could broaden allowance to any `hashicorp/consul*` repo.
+hashicorp/consul:
+hashicorp/consul@
+hashicorp/consul-k8s-control-plane:
+hashicorp/consul-k8s-control-plane@

--- a/test/chart-integration/values/consul.allowlist.txt
+++ b/test/chart-integration/values/consul.allowlist.txt
@@ -1,0 +1,16 @@
+# consul upstream image allowlist (SCR-2026-04-30-001)
+#
+# The hashicorp/consul chart pulls these two upstream images directly
+# from `hashicorp/...` (not via verity.yaml's `consul/consul` replacement
+# entry which only covers a different chart-image path):
+#
+#   hashicorp/consul:1.22.7              — main consul server binary
+#   hashicorp/consul-k8s-control-plane:1.9.7
+#                                        — k8s-specific control plane
+#                                          for connect-inject /
+#                                          partition-init / sync-catalog
+#
+# Allowlist until verity adds rebuilds for both. Chart's main pods are
+# healthy after the connect-inject disable in #348.
+hashicorp/consul
+hashicorp/consul-k8s-control-plane

--- a/test/chart-integration/values/ingress-nginx.allowlist.txt
+++ b/test/chart-integration/values/ingress-nginx.allowlist.txt
@@ -1,0 +1,13 @@
+# ingress-nginx upstream image allowlist (SCR-2026-04-30-001)
+#
+# The chart pulls registry.k8s.io/ingress-nginx/controller pinned by both
+# tag (v1.15.1) and digest (@sha256:594ceea...). verity.yaml does have a
+# `ingress-nginx/controller` replacement entry pointing at
+# `ghcr.io/verity-org/kubernetes/ingress-nginx/controller`, but chart-gen's
+# replacement logic doesn't strip the upstream digest pin, so the rendered
+# pod spec keeps the digest and pulls the upstream image directly.
+#
+# Allowlisting the upstream prefix unblocks the chart-integration smoke
+# test while a separate chart-gen fix (similar to cilium #352's
+# useDigest: false chartValues) lands.
+registry.k8s.io/ingress-nginx/controller

--- a/test/chart-integration/values/ingress-nginx.allowlist.txt
+++ b/test/chart-integration/values/ingress-nginx.allowlist.txt
@@ -8,6 +8,11 @@
 # pod spec keeps the digest and pulls the upstream image directly.
 #
 # Allowlisting the upstream prefix unblocks the chart-integration smoke
-# test while a separate chart-gen fix (similar to cilium #352's
-# useDigest: false chartValues) lands.
-registry.k8s.io/ingress-nginx/controller
+# test while a separate chart-gen fix (similar to cilium's
+# useDigest: false chartValues in verity-org/verity#352) lands.
+#
+# Format note: isAccepted (test/chart-integration/assertions.go:205) uses
+# strings.HasPrefix; using `:` and `@` separators ensures the prefix only
+# matches the controller image's tag/digest forms, not unrelated repos.
+registry.k8s.io/ingress-nginx/controller:
+registry.k8s.io/ingress-nginx/controller@

--- a/test/chart-integration/values/nats.allowlist.txt
+++ b/test/chart-integration/values/nats.allowlist.txt
@@ -14,8 +14,17 @@
 #                                                         configmap
 #                                                         changes
 #
-# Allowlist these until verity adds rebuilds OR the chart's
-# `natsBox.enabled: false` / `reloader.enabled: false` chartValues
-# disable them for CI smoke. Chart's main pods are healthy.
-docker.io/natsio/nats-box
-docker.io/natsio/nats-server-config-reloader
+# Format note: isAccepted (test/chart-integration/assertions.go:205) uses
+# strings.HasPrefix, and Docker Hub images may render in chart manifests
+# either with or without the `docker.io/` registry prefix depending on
+# how the chart constructs the image string. Adding both forms ensures
+# the allowlist matches regardless. Plus `:` / `@` separators per the
+# pattern used in consul.allowlist.txt (review on PR #353).
+docker.io/natsio/nats-box:
+docker.io/natsio/nats-box@
+docker.io/natsio/nats-server-config-reloader:
+docker.io/natsio/nats-server-config-reloader@
+natsio/nats-box:
+natsio/nats-box@
+natsio/nats-server-config-reloader:
+natsio/nats-server-config-reloader@

--- a/test/chart-integration/values/nats.allowlist.txt
+++ b/test/chart-integration/values/nats.allowlist.txt
@@ -1,0 +1,21 @@
+# nats upstream image allowlist (SCR-2026-04-30-001)
+#
+# The nats chart pulls two auxiliary images that verity does not
+# currently rebuild. The main nats binary itself runs from
+# ghcr.io/verity-org/nats:* (the verity rebuild handles that). These
+# auxiliaries are a CLI shell helper and a config-reloader sidecar:
+#
+#   docker.io/natsio/nats-box:0.19.3                     — interactive
+#                                                         shell pod for
+#                                                         debugging
+#   docker.io/natsio/nats-server-config-reloader:0.21.1  — sidecar that
+#                                                         SIGHUPs the
+#                                                         server on
+#                                                         configmap
+#                                                         changes
+#
+# Allowlist these until verity adds rebuilds OR the chart's
+# `natsBox.enabled: false` / `reloader.enabled: false` chartValues
+# disable them for CI smoke. Chart's main pods are healthy.
+docker.io/natsio/nats-box
+docker.io/natsio/nats-server-config-reloader

--- a/test/chart-integration/values/trivy-operator.allowlist.txt
+++ b/test/chart-integration/values/trivy-operator.allowlist.txt
@@ -15,4 +15,9 @@
 # scanner-image references inside operator ConfigMap data. Allowlist
 # the upstream until either the operator config gets a verity-aware
 # scanner override OR chart-gen learns to walk operator ConfigMap data.
-mirror.gcr.io/aquasec/trivy
+#
+# Format note: isAccepted (test/chart-integration/assertions.go:205) uses
+# strings.HasPrefix; using `:` and `@` separators ensures the prefix only
+# matches this specific image's tag/digest forms.
+mirror.gcr.io/aquasec/trivy:
+mirror.gcr.io/aquasec/trivy@

--- a/test/chart-integration/values/trivy-operator.allowlist.txt
+++ b/test/chart-integration/values/trivy-operator.allowlist.txt
@@ -1,0 +1,18 @@
+# trivy-operator upstream image allowlist (SCR-2026-04-30-001)
+#
+# The trivy-operator chart launches scan jobs that pull the trivy
+# scanner image. verity.yaml has a `trivy-operator` replacement (the
+# operator controller itself runs from the verity rebuild), but the
+# scanner image referenced from operator config is a separate image:
+#
+#   mirror.gcr.io/aquasec/trivy:0.69.3   — trivy CVE-scanner CLI,
+#                                          launched per scan job to
+#                                          analyze cluster image
+#                                          contents
+#
+# verity has its own `trivy.yaml` rebuild — but the chart references
+# the upstream by digest/tag and chart-gen doesn't currently rewrite
+# scanner-image references inside operator ConfigMap data. Allowlist
+# the upstream until either the operator config gets a verity-aware
+# scanner override OR chart-gen learns to walk operator ConfigMap data.
+mirror.gcr.io/aquasec/trivy


### PR DESCRIPTION
## Summary

Adds four \`*.allowlist.txt\` files to satisfy \`test/chart-integration\`'s SCR-2026-04-30-001 image-origin gate (now hard-fail) for the [#308](https://github.com/verity-org/verity/issues/308) Category B charts. Each chart is healthy at the helm-install level — the smoke test was failing only because non-verity image references weren't allowlisted.

## Format reference

\`test/chart-integration/assertions.go:loadAllowlist\` parses one-prefix-per-line, \`#\`-comments. \`isAccepted\` accepts \`ghcr.io/verity-org/*\` automatically + any allowlist prefix.

## Files added

| File | Allowlisted prefix(es) | Why |
|------|------------------------|-----|
| \`ingress-nginx.allowlist.txt\` | \`registry.k8s.io/ingress-nginx/controller\` | verity has a rebuild (\`kubernetes/ingress-nginx/controller\`) but chart pins by digest+tag and chart-gen doesn't strip digests — separate fix shape from [#352](https://github.com/verity-org/verity/pull/352) |
| \`nats.allowlist.txt\` | \`docker.io/natsio/nats-box\`, \`docker.io/natsio/nats-server-config-reloader\` | Auxiliary CLI + reloader sidecar — main nats binary uses verity rebuild |
| \`consul.allowlist.txt\` | \`hashicorp/consul\`, \`hashicorp/consul-k8s-control-plane\` | verity.yaml's \`consul/consul\` replacement only covers chart's standalone image path; main hashicorp images are separate refs |
| \`trivy-operator.allowlist.txt\` | \`mirror.gcr.io/aquasec/trivy\` | Operator launches scan jobs with the scanner image — chart-gen doesn't walk operator ConfigMap data; verity has \`trivy.yaml\` rebuild but routing requires separate plumbing |

## Per-chart status (post-merge expectation)

Each Category B chart's main pods were already healthy per dump:

- \`ingress-nginx\`: controller pod Running ✅ — only image-origin gate blocking
- \`nats\`: server pod Running, ready=true ✅
- \`consul\`: server pod Running ✅ (after [#348](https://github.com/verity-org/verity/pull/348)'s connect-inject disable)
- \`trivy-operator\`: operator + scan jobs Running ✅

After merge, all four shards expected to flip green.

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (chart-wrapper backlog)
- [#308](https://github.com/verity-org/verity/issues/308) (Category B cluster origin)
- SCR-2026-04-30-001 (image-origin gate)
- [#302](https://github.com/verity-org/verity/pull/302) (which deferred the gate; now re-enabled and these allowlists complete the original deferral)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four Category B `*.allowlist.txt` files and tightens prefixes with `:`/`@` delimiters (plus bare Docker Hub forms for `nats`) to satisfy the SCR-2026-04-30-001 image-origin gate and unblock `test/chart-integration` smoke tests by allowlisting required upstream images where no `ghcr.io/verity-org/*` rebuild exists.

- **Bug Fixes**
  - `ingress-nginx.allowlist.txt`: `registry.k8s.io/ingress-nginx/controller` with `:` and `@`
  - `nats.allowlist.txt`: `docker.io/natsio/{nats-box,nats-server-config-reloader}` with `:` and `@`, plus bare `natsio/{nats-box,nats-server-config-reloader}` forms
  - `consul.allowlist.txt`: `hashicorp/{consul,consul-k8s-control-plane}` with `:` and `@`
  - `trivy-operator.allowlist.txt`: `mirror.gcr.io/aquasec/trivy` with `:` and `@`

<sup>Written for commit 6b3d0003d1cbfdf1efb5fa4cc4aa2f4c29209e3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

