### PR TITLE
fix(charts): airflow postgres registry override (#318)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -173,6 +173,20 @@ chartValues:
     envoy.image.useDigest: false
     operator.replicas: 1
 
+  # airflow chart bundles a `postgresql` sub-chart with image
+  # `bitnamilegacy/postgresql:16.1.0-debian-11-r15`. chart-gen rewrites
+  # the repository to `verity-org/bitnamilegacy/postgresql` (and that
+  # tag DOES exist in verity-org/), but the chart's own
+  # `postgresql.image.registry: docker.io` default is preserved,
+  # producing the broken `docker.io/verity-org/bitnamilegacy/postgresql:...`
+  # double-prefix. Setting `postgresql.image.registry: ghcr.io` clears
+  # the docker.io prefix so the rendered ref becomes
+  # `ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`,
+  # which resolves cleanly. Same shape as the tempo-distributed fix.
+  # See verity-org/verity#318.
+  airflow:
+    postgresql.image.registry: ghcr.io
+
   # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
   # default inbound agent image. Keep the wrapper focused on the controller and
   # the existing kiwigrid sidecar image.

--- a/verity.yaml
+++ b/verity.yaml
@@ -175,15 +175,27 @@ chartValues:
 
   # airflow chart bundles a `postgresql` sub-chart with image
   # `bitnamilegacy/postgresql:16.1.0-debian-11-r15`. chart-gen rewrites
-  # the repository to `verity-org/bitnamilegacy/postgresql` (and that
-  # tag DOES exist in verity-org/), but the chart's own
-  # `postgresql.image.registry: docker.io` default is preserved,
-  # producing the broken `docker.io/verity-org/bitnamilegacy/postgresql:...`
-  # double-prefix. Setting `postgresql.image.registry: ghcr.io` clears
-  # the docker.io prefix so the rendered ref becomes
-  # `ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`,
-  # which resolves cleanly. Same shape as the tempo-distributed fix.
-  # See verity-org/verity#318.
+  # the repository (`bitnamilegacy/postgresql` →
+  # `verity-org/bitnamilegacy/postgresql`) but doesn't touch the
+  # chart's own `postgresql.image.registry: docker.io` default, so the
+  # rendered reference is the broken double-prefix:
+  #
+  #   docker.io/ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15
+  #                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  #                                          (chart-gen-rewritten repo,
+  #                                           with docker.io still
+  #                                           prepended from the
+  #                                           untouched image.registry
+  #                                           field)
+  #
+  # The `ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`
+  # tag DOES exist in verity-org/ — the only thing wrong with the
+  # generated wrapper is the extraneous `docker.io/` prefix.
+  #
+  # Setting `postgresql.image.registry: ghcr.io` overrides the chart's
+  # `image.registry` default so the rendered reference becomes the
+  # clean `ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`.
+  # Same shape as the tempo-distributed fix. See verity-org/verity#318.
   airflow:
     postgresql.image.registry: ghcr.io
 


### PR DESCRIPTION
## Summary

Same fix shape as [#346](https://github.com/verity-org/verity/pull/346)'s tempo-distributed override. The airflow chart bundles a postgres sub-chart that renders broken \`docker.io/<rewritten-repo>\` references because chart-gen doesn't strip the chart's \`image.registry: docker.io\` default.

## Diagnostic

\`\`\`
Failed to pull image \"docker.io/ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15\":
  failed to resolve reference
\`\`\`

The image path has a **double registry prefix**: \`docker.io/ghcr.io/verity-org/...\`.

## Root cause

Chart-gen rewrites \`postgresql.image.repository\` (\`bitnamilegacy/postgresql\` → \`verity-org/bitnamilegacy/postgresql\`) but doesn't clear the chart's \`postgresql.image.registry: docker.io\` default — so the rendered ref is \`docker.io/<rewritten-repo>\`.

## Verification: verity has the rebuild

\`\`\`bash
$ crane ls ghcr.io/verity-org/bitnamilegacy/postgresql
16.1.0-debian-11-r15
\`\`\`

So \`ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15\` resolves — the only thing wrong is the \`docker.io\` prefix.

## Fix

\`\`\`yaml
airflow:
  postgresql.image.registry: ghcr.io
\`\`\`

Clears the \`docker.io\` default. Rendered ref becomes \`ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15\` (resolves cleanly).

## Expected outcome

After merge + Chart Generation, airflow's:
- \`airflow-postgresql-0\` Pod: ImagePullBackOff → Running ✅
- \`wait-for-airflow-migrations\` init: CrashLoopBackOff → succeeds (depends on postgres)
- \`airflow-{api-server,dag-processor,scheduler,triggerer,worker}\` Pods: PodInitializing → Running ✅

Single chartValues addition unblocks the entire airflow stack.

## Refs

- [#318](https://github.com/verity-org/verity/issues/318) (chart-wrapper backlog)
- [#346](https://github.com/verity-org/verity/pull/346) (same shape — tempo-distributed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Override the Airflow Postgres sub-chart registry to `ghcr.io` so image pulls succeed and Airflow pods start.

- **Bug Fixes**
  - Root cause: chart-gen rewrote `postgresql.image.repository` but kept `postgresql.image.registry: docker.io`, creating `docker.io/ghcr.io/...`.
  - Change: Set `airflow.postgresql.image.registry: ghcr.io` in `verity.yaml`, rendering `ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`.
  - Docs: Updated the inline comment to show the actual double-prefix failure and call it out for future readers.

<sup>Written for commit 8fabbac55dde493b70173508d10a0bc30cccb54c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

