### PR TITLE
fix(charts): airflow postgres registry override (#318, supersedes #354)

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -275,6 +275,18 @@ chartValues:
   meilisearch:
     environment.MEILI_DB_PATH: /meili_data
 
+  # airflow 1.21.0 bundles a bitnamilegacy/postgresql sub-chart that defaults
+  # to image.registry: docker.io. Chart-gen rewrites the repository part
+  # (bitnamilegacy/postgresql → verity-org/bitnamilegacy/postgresql) but
+  # doesn't clear the registry default, producing a broken double-prefix:
+  #   docker.io/ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15
+  # which fails with "failed to resolve reference". Verity already ships the
+  # rebuild at ghcr.io/verity-org/bitnamilegacy/postgresql, so just clearing
+  # the docker.io prefix lets the chart use Verity's image cleanly.
+  # See verity-org/verity#354 / #318.
+  airflow:
+    postgresql.image.registry: ghcr.io
+
   # metrics-server scrapes the kubelet's `/metrics/resource` endpoint over
   # TLS. In kind clusters the kubelet uses a self-signed cert without IP
   # SANs, which fails Go's TLS validation:


### PR DESCRIPTION
Re-applies [#354](https://github.com/verity-org/verity/pull/354) cleanly against current main. The original branch had diverged too far to rebase after 8 chartValues merges in the same area, so this is a fresh single-commit superseder.

## Issue
Airflow bundles a `bitnamilegacy/postgresql` sub-chart with `image.registry: docker.io` default. Chart-gen rewrites the repository (bitnamilegacy/postgresql → verity-org/bitnamilegacy/postgresql) but doesn't clear the registry, producing:
`docker.io/ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15` — fails with `failed to resolve reference`.

## Fix
```yaml
airflow:
  postgresql.image.registry: ghcr.io
```

Closes [#354](https://github.com/verity-org/verity/pull/354).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a broken image reference in the `airflow` chart by overriding the bundled `bitnamilegacy/postgresql` sub-chart registry to `ghcr.io`. This prevents the `docker.io/ghcr.io/...` double-prefix and ensures the chart pulls `ghcr.io/verity-org/bitnamilegacy/postgresql` correctly.

- **Bug Fixes**
  - Set `airflow.postgresql.image.registry: ghcr.io` in `verity.yaml`.
  - Stops image resolution failures and aligns with our published image location.

<sup>Written for commit fea470a19ed8c8fc54ae863e7ad79b4f1d52a5c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

