### PR TITLE
fix(chart-integration): close 5 more allowlist gaps + bare-digest fallback (SCR-2026-04-30-001)

### DIFF
--- a/test/chart-integration/assertions.go
+++ b/test/chart-integration/assertions.go
@@ -48,8 +48,25 @@ type podList struct {
 }
 
 type containerStatus struct {
-	Name                 string `json:"name"`
+	Name string `json:"name"`
+	// Image is the container image string as reported by kubelet in
+	// .status.containerStatuses[].image. For most pods this is the
+	// same registry-prefixed reference present in the pod spec
+	// (e.g. "registry.k8s.io/ingress-nginx/controller:v1.15.1").
+	//
+	// HOWEVER, when a pod's spec.image carries BOTH a tag and a
+	// digest pin (e.g. "...controller:v1.15.1@sha256:594ce..."), the
+	// containerd/CRI implementation under kind sometimes normalises
+	// the rendered status.image down to the bare local digest
+	// ("sha256:895dd..."), discarding the registry path entirely.
+	// In that case ImageID still carries the canonical registry-
+	// prefixed digest reference (e.g.
+	// "registry.k8s.io/ingress-nginx/controller@sha256:594ce..."),
+	// so allowlist matching MUST fall back to ImageID when Image is
+	// a bare digest. See isAccepted for the fallback logic and
+	// SCR-2026-04-30-001 for the policy rationale.
 	Image                string `json:"image"`
+	ImageID              string `json:"imageID"`
 	RestartCount         int    `json:"restartCount"`
 	LastTerminationState struct {
 		Terminated *struct {
@@ -190,9 +207,13 @@ func collectImageViolations(pods *podList, allow []string) []string {
 	for _, p := range pods.Items {
 		all := append(append([]containerStatus{}, p.Status.ContainerStatuses...), p.Status.InitContainerStatuses...)
 		for _, cs := range all {
-			if isAccepted(cs.Image, allow) {
+			if isAccepted(cs.Image, cs.ImageID, allow) {
 				continue
 			}
+			// Diagnostic message uses Image (raw kubelet value) so
+			// the bare-digest case is still visible in CI logs;
+			// allowlist matching, however, has already consulted
+			// ImageID as a fallback above.
 			violations = append(violations, fmt.Sprintf(
 				"pod=%s/%s container=%s image=%s",
 				p.Metadata.Namespace, p.Metadata.Name, cs.Name, cs.Image,
@@ -202,7 +223,23 @@ func collectImageViolations(pods *podList, allow []string) []string {
 	return violations
 }
 
-func isAccepted(image string, allow []string) bool {
+// isAccepted returns true when the container is sourced from the
+// verity registry OR matches an allowlist prefix.
+//
+// Acceptance order:
+//
+//  1. verityRegistryPrefix short-circuit on `image`
+//  2. allowlist prefix match on `image`
+//  3. bare-digest fallback: if `image` looks like "sha256:..." (no
+//     registry path because kubelet/containerd normalised it), we
+//     re-run the verity short-circuit and allowlist match against
+//     `imageID`, which still carries the canonical registry-prefixed
+//     digest reference.
+//
+// imageID may be empty when the test calls isAccepted with synthetic
+// data; in that case the fallback degrades cleanly to the original
+// image-only behaviour.
+func isAccepted(image, imageID string, allow []string) bool {
 	if image == "" {
 		return false
 	}
@@ -212,6 +249,23 @@ func isAccepted(image string, allow []string) bool {
 	for _, prefix := range allow {
 		if strings.HasPrefix(image, prefix) {
 			return true
+		}
+	}
+	// Bare-digest fallback. kubelet sometimes records
+	// status.containerStatuses[].image as just "sha256:<hex>" when
+	// the pod spec pinned the image by tag+digest. In that case the
+	// allowlist prefixes (which are repository paths) cannot match,
+	// but imageID still carries "<repo>@sha256:<hex>" so the same
+	// prefix logic works against it. See containerStatus.Image
+	// docstring for the upstream cause.
+	if strings.HasPrefix(image, "sha256:") && imageID != "" {
+		if strings.HasPrefix(imageID, verityRegistryPrefix) {
+			return true
+		}
+		for _, prefix := range allow {
+			if strings.HasPrefix(imageID, prefix) {
+				return true
+			}
 		}
 	}
 	return false

--- a/test/chart-integration/assertions_test.go
+++ b/test/chart-integration/assertions_test.go
@@ -171,26 +171,58 @@ func TestIsAccepted(t *testing.T) {
 	allow := []string{
 		"quay.io/special/escape-hatch",
 		"registry.k8s.io/known-cant-rewrite",
+		"registry.k8s.io/ingress-nginx/controller@",
 	}
 	cases := []struct {
-		name  string
-		image string
-		want  bool
+		name    string
+		image   string
+		imageID string
+		want    bool
 	}{
-		{"verity registry", "ghcr.io/verity-org/prometheus/prometheus:v3.9.1", true},
-		{"verity registry verbose", "ghcr.io/verity-org/library/nginx:1.29.5-patched", true},
-		{"allowlist exact", "quay.io/special/escape-hatch:latest", true},
-		{"allowlist prefix", "registry.k8s.io/known-cant-rewrite/sub:v1", true},
-		{"upstream rejected", "quay.io/prometheus/prometheus:v3.9.1", false},
-		{"docker hub rejected", "docker.io/library/postgres:17", false},
-		{"empty rejected", "", false},
-		{"double-ghcr (chart-gen bug pattern) rejected", "ghcr.io/ghcr.io/verity-org/foo:tag", false},
+		{"verity registry", "ghcr.io/verity-org/prometheus/prometheus:v3.9.1", "", true},
+		{"verity registry verbose", "ghcr.io/verity-org/library/nginx:1.29.5-patched", "", true},
+		{"allowlist exact", "quay.io/special/escape-hatch:latest", "", true},
+		{"allowlist prefix", "registry.k8s.io/known-cant-rewrite/sub:v1", "", true},
+		{"upstream rejected", "quay.io/prometheus/prometheus:v3.9.1", "", false},
+		{"docker hub rejected", "docker.io/library/postgres:17", "", false},
+		{"empty rejected", "", "", false},
+		{"double-ghcr (chart-gen bug pattern) rejected", "ghcr.io/ghcr.io/verity-org/foo:tag", "", false},
+		// Bare-digest fallback: kubelet sometimes records the
+		// container status image as just "sha256:<hex>" (no registry
+		// path), with the canonical reference preserved in imageID.
+		// isAccepted MUST fall back to imageID for allowlist matching
+		// in that case. See SCR-2026-04-30-001 + assertions.go
+		// containerStatus.Image docstring for the underlying cause.
+		{
+			name:    "bare digest with allowlisted imageID accepted",
+			image:   "sha256:895ddb49053a9b80e1c97354a933f59cc94fba4b6f831615687151c9b178218d",
+			imageID: "registry.k8s.io/ingress-nginx/controller@sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1",
+			want:    true,
+		},
+		{
+			name:    "bare digest with verity-prefixed imageID accepted",
+			image:   "sha256:deadbeef",
+			imageID: "ghcr.io/verity-org/library/foo@sha256:deadbeef",
+			want:    true,
+		},
+		{
+			name:    "bare digest with non-allowlisted imageID rejected",
+			image:   "sha256:cafebabe",
+			imageID: "docker.io/library/postgres@sha256:cafebabe",
+			want:    false,
+		},
+		{
+			name:    "bare digest with empty imageID rejected (no fallback target)",
+			image:   "sha256:cafebabe",
+			imageID: "",
+			want:    false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := isAccepted(c.image, allow)
+			got := isAccepted(c.image, c.imageID, allow)
 			if got != c.want {
-				t.Fatalf("isAccepted(%q) = %v, want %v", c.image, got, c.want)
+				t.Fatalf("isAccepted(image=%q, imageID=%q) = %v, want %v", c.image, c.imageID, got, c.want)
 			}
 		})
 	}

--- a/test/chart-integration/values/cert-manager.allowlist.txt
+++ b/test/chart-integration/values/cert-manager.allowlist.txt
@@ -1,0 +1,38 @@
+# cert-manager upstream image allowlist (SCR-2026-04-30-001)
+#
+# The jetstack/cert-manager chart pulls three sibling images directly
+# from quay.io/jetstack at the chart's pinned version:
+#
+#   quay.io/jetstack/cert-manager-controller:v1.20.2  — main controller
+#                                                       (manages
+#                                                       Certificate /
+#                                                       Issuer
+#                                                       resources)
+#   quay.io/jetstack/cert-manager-cainjector:v1.20.2  — injects CA
+#                                                       bundles into
+#                                                       webhook
+#                                                       configs and
+#                                                       APIServices
+#   quay.io/jetstack/cert-manager-webhook:v1.20.2     — admission
+#                                                       webhook for
+#                                                       validating
+#                                                       cert-manager
+#                                                       CRDs
+#
+# verity.yaml has no `cert-manager/*` chart-wrapper replacement entry
+# (yet). Until the wrapper chart adds these three images to its
+# rebuild matrix and chart-gen learns to rewrite all three pod-spec
+# references, allowlist the upstreams so the chart-integration smoke
+# test can verify cert-manager still installs cleanly under the
+# verity-bundled Helm tooling.
+#
+# Format note: isAccepted (test/chart-integration/assertions.go:205)
+# uses strings.HasPrefix; the `:` and `@` separators ensure each
+# prefix only matches its intended image's tag or digest forms and
+# does not broaden to unrelated `quay.io/jetstack/*` repos.
+quay.io/jetstack/cert-manager-controller:
+quay.io/jetstack/cert-manager-controller@
+quay.io/jetstack/cert-manager-cainjector:
+quay.io/jetstack/cert-manager-cainjector@
+quay.io/jetstack/cert-manager-webhook:
+quay.io/jetstack/cert-manager-webhook@

--- a/test/chart-integration/values/cert-manager.allowlist.txt
+++ b/test/chart-integration/values/cert-manager.allowlist.txt
@@ -26,7 +26,7 @@
 # test can verify cert-manager still installs cleanly under the
 # verity-bundled Helm tooling.
 #
-# Format note: isAccepted (test/chart-integration/assertions.go:205)
+# Format note: the isAccepted helper in test/chart-integration/assertions.go
 # uses strings.HasPrefix; the `:` and `@` separators ensure each
 # prefix only matches its intended image's tag or digest forms and
 # does not broaden to unrelated `quay.io/jetstack/*` repos.

--- a/test/chart-integration/values/consul.allowlist.txt
+++ b/test/chart-integration/values/consul.allowlist.txt
@@ -17,6 +17,19 @@
 # without `:` / `@`, `hashicorp/consul` would also match
 # `hashicorp/consul-k8s-control-plane` (making the second entry redundant)
 # and could broaden allowance to any `hashicorp/consul*` repo.
+#
+# Registry-prefix note: the consul chart renders pod spec images
+# WITH the `docker.io/` prefix already attached (verified against
+# chart-integration run 25662716854: image field reported as
+# `docker.io/hashicorp/consul:1.22.7` etc.). The unprefixed
+# `hashicorp/consul:` forms are kept below for forward compatibility
+# in case a future kubelet/containerd combination strips the
+# `docker.io/` prefix, but the `docker.io/` variants are what
+# actually match today.
+docker.io/hashicorp/consul:
+docker.io/hashicorp/consul@
+docker.io/hashicorp/consul-k8s-control-plane:
+docker.io/hashicorp/consul-k8s-control-plane@
 hashicorp/consul:
 hashicorp/consul@
 hashicorp/consul-k8s-control-plane:

--- a/test/chart-integration/values/consul.allowlist.txt
+++ b/test/chart-integration/values/consul.allowlist.txt
@@ -10,7 +10,7 @@
 #                                          for connect-inject /
 #                                          partition-init / sync-catalog
 #
-# Format note: isAccepted (test/chart-integration/assertions.go:205) uses
+# Format note: the isAccepted helper in test/chart-integration/assertions.go uses
 # strings.HasPrefix, so we add separators (`:` for tag refs, `@` for
 # digest refs) to ensure each prefix only matches its intended repo and
 # not unrelated `hashicorp/consul*` repos. Per copilot review on PR #353:

--- a/test/chart-integration/values/ingress-nginx.allowlist.txt
+++ b/test/chart-integration/values/ingress-nginx.allowlist.txt
@@ -11,7 +11,7 @@
 # test while a separate chart-gen fix (similar to cilium's
 # useDigest: false chartValues in verity-org/verity#352) lands.
 #
-# Format note: isAccepted (test/chart-integration/assertions.go:205) uses
+# Format note: the isAccepted helper in test/chart-integration/assertions.go uses
 # strings.HasPrefix; using `:` and `@` separators ensures the prefix only
 # matches the controller image's tag/digest forms, not unrelated repos.
 registry.k8s.io/ingress-nginx/controller:

--- a/test/chart-integration/values/nats.allowlist.txt
+++ b/test/chart-integration/values/nats.allowlist.txt
@@ -14,7 +14,7 @@
 #                                                         configmap
 #                                                         changes
 #
-# Format note: isAccepted (test/chart-integration/assertions.go:205) uses
+# Format note: the isAccepted helper in test/chart-integration/assertions.go uses
 # strings.HasPrefix, and Docker Hub images may render in chart manifests
 # either with or without the `docker.io/` registry prefix depending on
 # how the chart constructs the image string. Adding both forms ensures

--- a/test/chart-integration/values/trivy-operator.allowlist.txt
+++ b/test/chart-integration/values/trivy-operator.allowlist.txt
@@ -21,3 +21,15 @@
 # matches this specific image's tag/digest forms.
 mirror.gcr.io/aquasec/trivy:
 mirror.gcr.io/aquasec/trivy@
+#
+# node-collector is a separate aquasecurity-published image launched
+# by trivy-operator as a DaemonSet to gather node-level facts (kernel
+# version, installed packages, etc.) that feed into vulnerability
+# reports. It is NOT covered by `mirror.gcr.io/aquasec/trivy` above
+# because it lives under a different aquasecurity-owned repository
+# (`ghcr.io/aquasecurity/node-collector`). Verified against
+# chart-integration run 25662716854:
+#   pod=trivy-operator/node-collector-6d54c6b6d7-4ft8p
+#   image=ghcr.io/aquasecurity/node-collector:0.3.1
+ghcr.io/aquasecurity/node-collector:
+ghcr.io/aquasecurity/node-collector@

--- a/test/chart-integration/values/trivy-operator.allowlist.txt
+++ b/test/chart-integration/values/trivy-operator.allowlist.txt
@@ -16,7 +16,7 @@
 # the upstream until either the operator config gets a verity-aware
 # scanner override OR chart-gen learns to walk operator ConfigMap data.
 #
-# Format note: isAccepted (test/chart-integration/assertions.go:205) uses
+# Format note: the isAccepted helper in test/chart-integration/assertions.go uses
 # strings.HasPrefix; using `:` and `@` separators ensures the prefix only
 # matches this specific image's tag/digest forms.
 mirror.gcr.io/aquasec/trivy:

--- a/test/chart-integration/values/vault.allowlist.txt
+++ b/test/chart-integration/values/vault.allowlist.txt
@@ -1,0 +1,41 @@
+# vault upstream image allowlist (SCR-2026-04-30-001)
+#
+# The hashicorp/vault chart pulls two upstream images directly from
+# Docker Hub:
+#
+#   docker.io/hashicorp/vault:1.21.2       — main vault server binary
+#                                            (KV / PKI / Transit /
+#                                            etc.)
+#   docker.io/hashicorp/vault-k8s:1.7.2    — kubernetes-native
+#                                            injector / agent
+#                                            sidecar controller
+#
+# verity.yaml has no `hashicorp/vault*` chart-wrapper replacement
+# entry. Until the wrapper chart adds vault to its rebuild matrix
+# and chart-gen learns to rewrite both pod-spec references,
+# allowlist the upstreams so the chart-integration smoke test can
+# verify vault still installs cleanly under the verity-bundled Helm
+# tooling.
+#
+# Registry-prefix note: the chart renders pod spec images WITH the
+# `docker.io/` prefix already attached (verified against
+# chart-integration run 25662716854: image field reported as
+# `docker.io/hashicorp/vault:1.21.2` etc.). Unprefixed
+# `hashicorp/vault:` forms are kept below for forward compatibility
+# in case a future kubelet/containerd combination strips the
+# `docker.io/` prefix.
+#
+# Format note: isAccepted (test/chart-integration/assertions.go:205)
+# uses strings.HasPrefix; the `:` and `@` separators ensure each
+# prefix only matches its intended image's tag or digest forms and
+# does not broaden to unrelated `hashicorp/vault*` repos (notably
+# `hashicorp/vault-k8s` would otherwise match `hashicorp/vault`
+# without the separators).
+docker.io/hashicorp/vault:
+docker.io/hashicorp/vault@
+docker.io/hashicorp/vault-k8s:
+docker.io/hashicorp/vault-k8s@
+hashicorp/vault:
+hashicorp/vault@
+hashicorp/vault-k8s:
+hashicorp/vault-k8s@

--- a/test/chart-integration/values/vault.allowlist.txt
+++ b/test/chart-integration/values/vault.allowlist.txt
@@ -25,7 +25,7 @@
 # in case a future kubelet/containerd combination strips the
 # `docker.io/` prefix.
 #
-# Format note: isAccepted (test/chart-integration/assertions.go:205)
+# Format note: the isAccepted helper in test/chart-integration/assertions.go
 # uses strings.HasPrefix; the `:` and `@` separators ensure each
 # prefix only matches its intended image's tag or digest forms and
 # does not broaden to unrelated `hashicorp/vault*` repos (notably


### PR DESCRIPTION
## Summary

Closes 5 image-origin gate failures observed in chart-integration run [25662716854](https://github.com/verity-org/verity/actions/runs/25662716854). Four are allowlist data updates; one is a real test-code gap shipped alongside its allowlist.

### Code fix — bare-digest fallback in `isAccepted`

Under kind/containerd, when a pod spec pins an image by **tag+digest** (e.g. `registry.k8s.io/ingress-nginx/controller:v1.15.1@sha256:594ce…`), kubelet sometimes records `status.containerStatuses[].image` as just the bare local content digest (`sha256:895dd…`) with no registry path, while `imageID` still carries the canonical `<repo>@sha256:…` reference. The prior code path matched only against `image` and therefore rejected ingress-nginx even though its `imageID` is allowlisted.

- `containerStatus` now decodes `imageID`.
- `isAccepted` falls back to `imageID` when `image` is a bare `sha256:` string (preserving both the verity short-circuit and allowlist semantics).
- 4 new `TestIsAccepted` subtests cover accepted + rejected variants of the bare-digest fallback. 12 cases total, all passing.

### Allowlist data updates

| File | Change | Reason (verified against run 25662716854) |
|---|---|---|
| `values/consul.allowlist.txt` | add `docker.io/`-prefixed forms | chart renders as `docker.io/hashicorp/consul:1.22.7` etc. — unprefixed entries from [#353](https://github.com/verity-org/verity/pull/353) don't match |
| `values/trivy-operator.allowlist.txt` | add `ghcr.io/aquasecurity/node-collector:` + `@` | DaemonSet image gathering node facts; separate from `mirror.gcr.io/aquasec/trivy` |
| `values/cert-manager.allowlist.txt` | **NEW** | jetstack triple at `v1.20.2` (controller, cainjector, webhook); no `cert-manager/*` wrapper entry in `verity.yaml` yet |
| `values/vault.allowlist.txt` | **NEW** | `docker.io/hashicorp/vault:1.21.2` + `vault-k8s:1.7.2`; no `hashicorp/vault*` wrapper entry in `verity.yaml` yet |

ingress-nginx allowlist itself was already correct — the bare-digest code fallback unblocks it.

## Validation

`go test -tags=integration -run 'TestIsAccepted|TestLoadAllowlist|TestClassify' ./test/chart-integration/...` → PASS.

Manual `chart-integration` re-run will follow once green.

## Related

- SCR-2026-04-30-001 (image-origin gate)
- Follows [#353](https://github.com/verity-org/verity/pull/353) (Category B allowlists)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five chart-integration image-origin gate failures by adding a bare-digest fallback in `isAccepted` and updating allowlists for `consul`, `trivy-operator`, `cert-manager`, and `vault`. Aligns with SCR-2026-04-30-001 and restores green runs under kind/containerd.

- **Bug Fixes**
  - `isAccepted(image, imageID)` now falls back to `imageID` when `image` is a bare `sha256:`; `containerStatus` decodes `imageID`; 4 new tests added.
  - Unblocks `ingress-nginx` where kubelet reports a bare digest; allowlist already covered it.
  - Allowlist updates: `consul` adds `docker.io/` forms; `trivy-operator` adds `ghcr.io/aquasecurity/node-collector`; new files for `cert-manager` (controller/cainjector/webhook v1.20.2) and `vault` (`hashicorp/vault`, `vault-k8s`).
  - Integration tests pass.

- **Refactors**
  - Removed hardcoded line numbers from allowlist header notes across related files to avoid stale references; no behavior change.

<sup>Written for commit f40681deeb7e8500a82187482b0b62636eea4c46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

