### PR TITLE
fix(charts): revert kyverno chart 3.8.0 → 3.7.2 (#355 regression)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -20,15 +20,22 @@ dependencies:
     version: "1.15.1"
     repository: "https://opensource.zalando.com/postgres-operator/charts/postgres-operator"
 
-  # Pinned at 3.7.2 — chart 3.8.0 (#314 bump) deployment passes
+  # Pinned at 3.7.2 — chart 3.8.0 (#314 + #355 bumps) deployment passes
   # `--apiCallTimeout=30s` to the kyverno binary, but Verity's wolfi-rebuilt
   # `kyverno-1.17` doesn't recognise that flag (added upstream in 1.18+).
   # Result: container CrashLoopBackOff with "flag provided but not defined:
-  # -apiCallTimeout". Bumping back to 3.7.2 restores yesterday's working
-  # state. The 3.8.0 bump is unblocked once the kyverno-1.18+ rebuild lands
-  # in `images/kyverno*.yaml`.
+  # -apiCallTimeout" (verified against chart-integration run 25662716854,
+  # admission-controller pod logs). Bumping back to 3.7.2 restores the
+  # working state. The 3.8.0 bump is unblocked once the kyverno-1.18+
+  # rebuild lands in `images/kyverno*.yaml`.
+  #
+  # Note: .github/renovate.json marks this dep `enabled: false` for the
+  # helmv3 manager, but Renovate re-bumped it anyway in #355. The follow-
+  # up automerge rule (matchUpdateTypes minor/patch) may be overriding
+  # `enabled: false`. Track separately; for now the revert is the
+  # immediate fix.
   - name: kyverno
-    version: "3.8.0"
+    version: "3.7.2"
     repository: "oci://ghcr.io/kyverno/charts"
 
   - name: argo-cd


### PR DESCRIPTION
## Summary

Reverts the kyverno chart from `3.8.0` back to `3.7.2`. The 3.8.0 chart was re-bumped by Renovate [#355](https://github.com/verity-org/verity/pull/355) even though `.github/renovate.json` marks the package as `enabled: false` for the `helmv3` manager — this is the second time we've taken this bump (first was [#314](https://github.com/verity-org/verity/pull/314), reverted in [#317](https://github.com/verity-org/verity/pull/317)).

## Root cause

The 3.8.0 chart passes `--apiCallTimeout=30s` to the kyverno binary, but Verity's wolfi-rebuilt `kyverno-1.17` doesn't recognise that flag (added upstream in 1.18+).

**Symptom** (chart-integration run [25662716854](https://github.com/verity-org/verity/actions/runs/25662716854), kyverno job):

```
pod=kyverno/kyverno-admission-controller-767b556954-lz566
container=kyverno
log: "flag provided but not defined: -apiCallTimeout"
→ CrashLoopBackOff
→ Deployment Available 0/1 for every kyverno controller
→ helm install --wait timeout at 10m
```

All four kyverno deployments (admission, background, cleanup, reports) hit the same flag-parse failure.

## Follow-up (separate PR)

The Renovate `enabled: false` rule for `kyverno`/`aws-load-balancer-controller` in `.github/renovate.json` is being defeated. The later `matchUpdateTypes: [minor, patch]` automerge rule may be overriding it; need to either reorder rules or use `matchPackageNames` exclusion on the automerge rule. Tracked as a follow-up — out of scope for this revert.

## Validation

- `helm dependency` resolves to `kyverno-3.7.2`.
- 3.7.2 was last green in pre-[#355](https://github.com/verity-org/verity/pull/355) chart-integration runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the `kyverno` Helm chart from 3.8.0 to 3.7.2 to fix controller CrashLoopBackOffs caused by an unsupported flag. Restores working installs until the `kyverno-1.18+` image is available.

- **Bug Fixes**
  - Pin `kyverno` chart to `3.7.2` in Chart.yaml (was `3.8.0`).
  - 3.8.0 passes `--apiCallTimeout=30s`, which `kyverno-1.17` doesn’t support, causing all controllers to crash and `helm install --wait` to time out.
  - Validation: dependencies resolve to `3.7.2`; this version was green in prior chart-integration runs.

<sup>Written for commit b670af3dc536cea342995cc2cb4e3497ddcade30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

