### PR TITLE
fix(images): grafana --homepath + meilisearch RO-safe DB paths

### DIFF
--- a/images/grafana.yaml
+++ b/images/grafana.yaml
@@ -7,7 +7,21 @@ types:
   default:
     base: wolfi-base
     packages: ["grafana-{{version}}"]
-    entrypoint: /usr/bin/grafana server
+    # grafana 12.x requires --homepath to locate conf/defaults.ini.
+    # The wolfi package installs defaults.ini at /usr/share/grafana/
+    # conf/defaults.ini. Without --homepath (or chdir to that dir),
+    # the server binary aborts at startup with:
+    #   "Grafana-server Init Failed: Could not find config defaults,
+    #    make sure homepath command line parameter is set or working
+    #    directory is homepath"
+    # Verified against chart-integration run 25662716854, grafana
+    # job pod logs: ghcr.io/verity-org/grafana:12.4 with chart-default
+    # pod spec (no command:/args:/workingDir:) hit the abort above
+    # because the official upstream image sets WORKDIR /usr/share/
+    # grafana but the wolfi rebuild does not. Embedding --homepath
+    # in the entrypoint matches what the upstream image's launcher
+    # script does and unblocks chart-integration.
+    entrypoint: /usr/bin/grafana server --homepath /usr/share/grafana
     environment:
       GF_PATHS_CONFIG: /etc/grafana/grafana.ini
       GF_PATHS_DATA: /var/lib/grafana

--- a/images/meilisearch.yaml
+++ b/images/meilisearch.yaml
@@ -7,7 +7,22 @@ types:
   default:
     base: wolfi-base
     packages: ["meilisearch"]
+    # meilisearch defaults to writing its DB to `./data.ms` and dumps
+    # to `./dumps/`, both relative to the process cwd. Under the
+    # meilisearch chart's default pod spec the container runs with
+    # securityContext.readOnlyRootFilesystem: true, which makes any
+    # write outside an explicit volume mount fail with `Read-only
+    # file system (os error 30)` — verified against chart-integration
+    # run 25662716854, meilisearch-0 pod logs.
+    #
+    # Pin both paths to /meili_data via env vars so the binary
+    # always writes inside the chart's data volume regardless of
+    # cwd or RO-root settings. /meili_data already exists from
+    # `paths:` below.
     entrypoint: /usr/bin/meilisearch
+    environment:
+      MEILI_DB_PATH: /meili_data
+      MEILI_DUMP_DIR: /meili_data/dumps
     paths:
       - {path: /meili_data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 


### PR DESCRIPTION
## Summary

Two wolfi image-config fixes to unblock chart-integration smoke tests for `grafana` and `meilisearch` (manual run [25662716854](https://github.com/verity-org/verity/actions/runs/25662716854)).

### images/grafana.yaml — `--homepath` in entrypoint

The wolfi grafana package installs `conf/defaults.ini` at `/usr/share/grafana/conf/defaults.ini`. Grafana 12.x's `server` subcommand needs either `--homepath` pointing at that directory or cwd set to it (the upstream docker image relies on `WORKDIR /usr/share/grafana`; the wolfi rebuild does not set workdir). Without it the server aborts at startup:

```
Grafana-server Init Failed: Could not find config defaults,
make sure homepath command line parameter is set or working
directory is homepath
```

**Manually verified:** `docker run … grafana server --homepath /usr/share/grafana` succeeds with `Config loaded from /usr/share/grafana/conf/defaults.ini`. Same invocation without `--homepath` reproduces the chart-integration abort.

### images/meilisearch.yaml — pin `MEILI_DB_PATH` + `MEILI_DUMP_DIR`

Meilisearch defaults to `--db-path ./data.ms` and `--dump-dir dumps/`, both relative to cwd. Under the meilisearch chart's default pod spec the container runs with `readOnlyRootFilesystem: true`, so any write outside the chart's data volume fails with `Read-only file system (os error 30)` — verified against `meilisearch-0` pod logs.

The chart's data volume is already mounted at `/meili_data`, and apko `paths:` already creates that directory with the right ownership, so pointing both env vars there is the minimal change.

## Follow-up

Both changes require a wolfi image rebuild via Integer Orchestrator. Once this PR lands, PMA will trigger `images-rebuild` for `grafana` and `meilisearch`, then re-run chart-integration to verify both come back green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `grafana` startup and `meilisearch` write paths in Wolfi image configs to unblock chart-integration smoke tests. Grafana now loads defaults without relying on WORKDIR, and Meilisearch writes to the mounted data volume under RO root.

- **Bug Fixes**
  - `grafana`: add `--homepath /usr/share/grafana` to the entrypoint so the server finds `/usr/share/grafana/conf/defaults.ini`.
  - `meilisearch`: set `MEILI_DB_PATH=/meili_data` and `MEILI_DUMP_DIR=/meili_data/dumps` to keep writes inside the chart’s data volume with `readOnlyRootFilesystem: true`.

- **Migration**
  - Rebuild the Wolfi images for `grafana` and `meilisearch`, then re-run chart-integration.

<sup>Written for commit 188611f5c1f33dec79fd0e47eccf38718ad195bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

