### PR TITLE
fix(chartgen): merge image-override leaf into existing chartValues siblings

### DIFF
--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -3,6 +3,7 @@ package chartgen
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -263,16 +264,12 @@ func mergeMapValue(root map[string]any, path string, value map[string]any) {
 				// Either no existing entry, or a non-map scalar
 				// occupies the slot. Fall back to the setScalarValue
 				// shape: drop a fresh map containing `value`.
-				next := make(map[string]any)
-				for k, v := range value {
-					next[k] = v
-				}
+				next := make(map[string]any, len(value))
+				maps.Copy(next, value)
 				current[part] = next
 				return
 			}
-			for k, v := range value {
-				existing[k] = v
-			}
+			maps.Copy(existing, value)
 			return
 		}
 

--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -190,9 +190,9 @@ func buildValuesTree(chartName string, chartValues map[string]any, overrides []V
 		// `image.registry` written by the image-override pass. The
 		// previous setScalarValue call replaced the entire subtree at
 		// override.Path with `leaf`, silently dropping the chartValues
-		// sibling and triggering the gitea `:1-rootless` ImagePullBack
-		// off + the missing-rootless-flag pattern documented in
-		// verity-org/verity#326.
+		// sibling and triggering the gitea `:1-rootless`
+		// ImagePullBackOff + missing-rootless-flag pattern documented
+		// in verity-org/verity#326.
 		mergeMapValue(chartRoot, override.Path, leaf)
 	}
 
@@ -244,7 +244,7 @@ func setScalarValue(root map[string]any, path string, value any) {
 // image-override pass's `image.repository` / `image.tag`). Replacing
 // the whole subtree silently drops the chartValues sibling and was
 // the root cause of the gitea `:1-rootless` ImagePullBackOff
-// regression diagnosed against chart-integration run 25662716854.
+// regression tracked under verity-org/verity#326.
 //
 // Entries in `value` win over any same-key entries already present at
 // the leaf; siblings present at the leaf but absent from `value` are

--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -181,7 +181,18 @@ func buildValuesTree(chartName string, chartValues map[string]any, overrides []V
 			leaf["defaultRegistry"] = override.SetDefaultRegistry
 		}
 
-		setScalarValue(chartRoot, override.Path, leaf)
+		// mergeMapValue (not setScalarValue) so any sibling fields
+		// already populated under override.Path by an earlier
+		// chartValues entry survive — e.g. gitea's `image.rootless:
+		// false` written by buildValuesTree's chartValues pass MUST
+		// remain a sibling of `image.repository` / `image.tag` /
+		// `image.registry` written by the image-override pass. The
+		// previous setScalarValue call replaced the entire subtree at
+		// override.Path with `leaf`, silently dropping the chartValues
+		// sibling and triggering the gitea `:1-rootless` ImagePullBack
+		// off + the missing-rootless-flag pattern documented in
+		// verity-org/verity#326.
+		mergeMapValue(chartRoot, override.Path, leaf)
 	}
 
 	return root
@@ -198,6 +209,70 @@ func setScalarValue(root map[string]any, path string, value any) {
 
 		if i == len(parts)-1 {
 			current[part] = value
+			return
+		}
+
+		next, ok := current[part]
+		if !ok {
+			nextMap := make(map[string]any)
+			current[part] = nextMap
+			current = nextMap
+			continue
+		}
+
+		nextMap, ok := next.(map[string]any)
+		if !ok {
+			nextMap = make(map[string]any)
+			current[part] = nextMap
+		}
+		current = nextMap
+	}
+}
+
+// mergeMapValue walks `root` along `path` and merges `value` into the
+// existing leaf map at `path`. If no map exists at the leaf, it is
+// created and `value`'s entries copied in. If the leaf is a non-map
+// scalar, it is replaced with `value` (same fallback shape as
+// setScalarValue handles when an intermediate non-map node is found).
+//
+// Difference from setScalarValue: setScalarValue REPLACES the leaf at
+// `path` outright. That is correct for scalar overrides (a single
+// string/bool/int) but wrong for map-shaped image overrides, because
+// an earlier chartValues pass may have already written sibling keys
+// at the same path (e.g. gitea's `image.rootless: false` next to the
+// image-override pass's `image.repository` / `image.tag`). Replacing
+// the whole subtree silently drops the chartValues sibling and was
+// the root cause of the gitea `:1-rootless` ImagePullBackOff
+// regression diagnosed against chart-integration run 25662716854.
+//
+// Entries in `value` win over any same-key entries already present at
+// the leaf; siblings present at the leaf but absent from `value` are
+// preserved.
+func mergeMapValue(root map[string]any, path string, value map[string]any) {
+	parts := splitOverridePath(path)
+	current := root
+
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		if i == len(parts)-1 {
+			existing, ok := current[part].(map[string]any)
+			if !ok {
+				// Either no existing entry, or a non-map scalar
+				// occupies the slot. Fall back to the setScalarValue
+				// shape: drop a fresh map containing `value`.
+				next := make(map[string]any)
+				for k, v := range value {
+					next[k] = v
+				}
+				current[part] = next
+				return
+			}
+			for k, v := range value {
+				existing[k] = v
+			}
 			return
 		}
 

--- a/internal/chartgen/chart_test.go
+++ b/internal/chartgen/chart_test.go
@@ -194,6 +194,113 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Regression for verity-org/verity#326 — gitea's
+			// `image.rootless: false` (a chartValues sibling of
+			// `image.repository` / `image.tag`) was being silently
+			// dropped because the image-override pass replaced the
+			// entire `image:` subtree with `{repository, tag}`,
+			// losing the rootless sibling. mergeMapValue must
+			// preserve unrelated chart-value keys that land at the
+			// same dotted path as a map-shaped image override.
+			name: "chart values siblings under image path preserved through image override",
+			chartValues: map[string]any{
+				"image.rootless": false,
+			},
+			overrides: []ValueOverride{{
+				Path:       "image",
+				Repository: testPromRepo,
+				Tag:        "v3",
+			}},
+			assert: func(t *testing.T, values map[string]any) {
+				prom, ok := values["prometheus"].(map[string]any)
+				if !ok {
+					t.Fatal("prometheus root missing")
+				}
+				image, ok := prom["image"].(map[string]any)
+				if !ok {
+					t.Fatalf("image missing: %#v", prom)
+				}
+				if !reflect.DeepEqual(image["rootless"], false) {
+					t.Fatalf("image.rootless dropped by override merge: %#v", image)
+				}
+				if image["repository"] != testPromRepo || image["tag"] != "v3" {
+					t.Fatalf("image override fields missing: %#v", image)
+				}
+			},
+		},
+		{
+			// Nested-path variant: chartValues sibling deep under an
+			// image override (`server.image.rootless: true`) must
+			// survive the override pass at the same path.
+			name: "chart values siblings under nested image path preserved",
+			chartValues: map[string]any{
+				"server.image.rootless": true,
+				"server.image.pullPolicy": "Always",
+			},
+			overrides: []ValueOverride{{
+				Path:       "server.image",
+				Repository: "ghcr.io/verity-org/prometheus",
+				Tag:        "v3.2.1",
+			}},
+			assert: func(t *testing.T, values map[string]any) {
+				prom, ok := values["prometheus"].(map[string]any)
+				if !ok {
+					t.Fatal("prometheus root missing")
+				}
+				server, ok := prom["server"].(map[string]any)
+				if !ok {
+					t.Fatal("server missing")
+				}
+				image, ok := server["image"].(map[string]any)
+				if !ok {
+					t.Fatalf("server.image missing: %#v", server)
+				}
+				if !reflect.DeepEqual(image["rootless"], true) {
+					t.Fatalf("server.image.rootless dropped: %#v", image)
+				}
+				if image["pullPolicy"] != "Always" {
+					t.Fatalf("server.image.pullPolicy dropped: %#v", image)
+				}
+				if image["repository"] != "ghcr.io/verity-org/prometheus" || image["tag"] != "v3.2.1" {
+					t.Fatalf("server.image override fields missing: %#v", image)
+				}
+			},
+		},
+		{
+			// Override at a path with no prior chartValues sibling
+			// must still produce the full {repository, tag} leaf —
+			// preserves backwards compatibility with the single-image
+			// override path.
+			name: "override at unoccupied image path writes fresh leaf",
+			chartValues: map[string]any{
+				"unrelated.flag": true,
+			},
+			overrides: []ValueOverride{{
+				Path:       "image",
+				Repository: testPromRepo,
+				Tag:        "v3",
+			}},
+			assert: func(t *testing.T, values map[string]any) {
+				prom, ok := values["prometheus"].(map[string]any)
+				if !ok {
+					t.Fatal("prometheus root missing")
+				}
+				image, ok := prom["image"].(map[string]any)
+				if !ok {
+					t.Fatalf("image missing: %#v", prom)
+				}
+				if image["repository"] != testPromRepo || image["tag"] != "v3" {
+					t.Fatalf("image override fields missing: %#v", image)
+				}
+				if _, present := image["rootless"]; present {
+					t.Fatalf("image.rootless leaked from elsewhere: %#v", image)
+				}
+				if !reflect.DeepEqual(prom["unrelated"].(map[string]any)["flag"], true) {
+					t.Fatalf("unrelated.flag chart value lost: %#v", prom["unrelated"])
+				}
+			},
+		},
 	}
 
 	original := config.ChartSpec{Name: "prometheus", Version: "28.9.1", Repository: "oci://repo/charts"}

--- a/internal/chartgen/chart_test.go
+++ b/internal/chartgen/chart_test.go
@@ -12,7 +12,11 @@ import (
 	"github.com/verity-org/verity/internal/config"
 )
 
-const testPromRepo = "ghcr.io/verity-org/prom"
+const (
+	testPromRepo       = "ghcr.io/verity-org/prom"
+	testPromServerRepo = "ghcr.io/verity-org/prometheus"
+	testPromServerTag  = "v3.2.1"
+)
 
 func TestBuildWrapperChart(t *testing.T) {
 	original := config.ChartSpec{
@@ -108,8 +112,8 @@ func TestBuildWrapperChartValues(t *testing.T) {
 			chartValues: nil,
 			overrides: []ValueOverride{{
 				Path:       "server.image",
-				Repository: "ghcr.io/verity-org/prometheus",
-				Tag:        "v3.2.1",
+				Repository: testPromServerRepo,
+				Tag:        testPromServerTag,
 			}},
 			assert: func(t *testing.T, values map[string]any) {
 				prom, ok := values["prometheus"].(map[string]any)
@@ -124,7 +128,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				if !ok {
 					t.Fatal("image missing")
 				}
-				if image["repository"] != "ghcr.io/verity-org/prometheus" || image["tag"] != "v3.2.1" {
+				if image["repository"] != testPromServerRepo || image["tag"] != testPromServerTag {
 					t.Fatalf("prometheus.server.image = %#v, want repository/tag override", image)
 				}
 			},
@@ -134,7 +138,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 			chartValues: nil,
 			overrides: []ValueOverride{
 				{Path: "image", Repository: testPromRepo, Tag: "v3"},
-				{Path: "server.image", Repository: "ghcr.io/verity-org/prometheus", Tag: "v3.2.1"},
+				{Path: "server.image", Repository: testPromServerRepo, Tag: testPromServerTag},
 			},
 			assert: func(t *testing.T, values map[string]any) {
 				prom, ok := values["prometheus"].(map[string]any)
@@ -156,7 +160,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				if img["repository"] != testPromRepo || img["tag"] != "v3" {
 					t.Fatalf("prometheus.image = %#v, want override", img)
 				}
-				if serverImg["repository"] != "ghcr.io/verity-org/prometheus" || serverImg["tag"] != "v3.2.1" {
+				if serverImg["repository"] != testPromServerRepo || serverImg["tag"] != testPromServerTag {
 					t.Fatalf("prometheus.server.image = %#v, want override", serverImg)
 				}
 			},
@@ -194,6 +198,39 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				}
 			},
 		},
+	}
+
+	original := config.ChartSpec{Name: "prometheus", Version: "28.9.1", Repository: "oci://repo/charts"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chart, err := BuildWrapperChart(original, tt.chartValues, tt.overrides)
+			if err != nil {
+				t.Fatalf("BuildWrapperChart() error = %v", err)
+			}
+
+			var values map[string]any
+			if err := yaml.Unmarshal(chart.ValuesYAML, &values); err != nil {
+				t.Fatalf("yaml.Unmarshal(ValuesYAML) error = %v", err)
+			}
+
+			tt.assert(t, values)
+		})
+	}
+}
+
+// TestBuildWrapperChartValuesMergeMapValue covers the mergeMapValue
+// path that buildValuesTree uses when applying map-shaped image
+// overrides on top of chartValues entries living at the same dotted
+// path. Split out from TestBuildWrapperChartValues to keep the
+// per-function cyclomatic complexity within the maintidx threshold.
+func TestBuildWrapperChartValuesMergeMapValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		chartValues map[string]any
+		overrides   []ValueOverride
+		assert      func(t *testing.T, values map[string]any)
+	}{
 		{
 			// Regression for verity-org/verity#326 — gitea's
 			// `image.rootless: false` (a chartValues sibling of
@@ -235,13 +272,13 @@ func TestBuildWrapperChartValues(t *testing.T) {
 			// survive the override pass at the same path.
 			name: "chart values siblings under nested image path preserved",
 			chartValues: map[string]any{
-				"server.image.rootless": true,
+				"server.image.rootless":   true,
 				"server.image.pullPolicy": "Always",
 			},
 			overrides: []ValueOverride{{
 				Path:       "server.image",
-				Repository: "ghcr.io/verity-org/prometheus",
-				Tag:        "v3.2.1",
+				Repository: testPromServerRepo,
+				Tag:        testPromServerTag,
 			}},
 			assert: func(t *testing.T, values map[string]any) {
 				prom, ok := values["prometheus"].(map[string]any)
@@ -262,7 +299,7 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				if image["pullPolicy"] != "Always" {
 					t.Fatalf("server.image.pullPolicy dropped: %#v", image)
 				}
-				if image["repository"] != "ghcr.io/verity-org/prometheus" || image["tag"] != "v3.2.1" {
+				if image["repository"] != testPromServerRepo || image["tag"] != testPromServerTag {
 					t.Fatalf("server.image override fields missing: %#v", image)
 				}
 			},
@@ -296,8 +333,12 @@ func TestBuildWrapperChartValues(t *testing.T) {
 				if _, present := image["rootless"]; present {
 					t.Fatalf("image.rootless leaked from elsewhere: %#v", image)
 				}
-				if !reflect.DeepEqual(prom["unrelated"].(map[string]any)["flag"], true) {
-					t.Fatalf("unrelated.flag chart value lost: %#v", prom["unrelated"])
+				unrelated, ok := prom["unrelated"].(map[string]any)
+				if !ok {
+					t.Fatalf("unrelated subtree missing: %#v", prom)
+				}
+				if !reflect.DeepEqual(unrelated["flag"], true) {
+					t.Fatalf("unrelated.flag chart value lost: %#v", unrelated)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

Fixes a chartgen bug that silently dropped any `chartValues` entry living at the same dotted path as a map-shaped image override. Most visibly: gitea's `image.rootless: false` was being lost, causing the wrapper chart to install `ghcr.io/verity-org/gitea:1-rootless` (a tag verity does not publish).

## Symptom (chart-integration run [25662716854](https://github.com/verity-org/verity/actions/runs/25662716854), gitea job)

```
Failed to pull image \"ghcr.io/verity-org/gitea:1-rootless\":
  rpc error: code = NotFound … not found
→ init container ImagePullBackOff
→ gitea Deployment Available 0/1
→ helm install --wait timeout at 10m
```

## Root cause

`buildValuesTree`'s image-override pass called `setScalarValue(chartRoot, override.Path, leaf)`, which REPLACED the entire subtree at `override.Path` with a fresh map containing only `{repository, tag, [registry], [defaultRegistry]}`. Any chart-values entry written earlier under the same path (e.g. `gitea.image.rootless: false`) was discarded.

Verified with an isolated Go reproduction against the exact `setScalarValue` logic — chartValues correctly writes `chartRoot[\"image\"] = {\"rootless\": false}`, then the override pass overwrites it.

## Fix

Introduce `mergeMapValue` that walks the same dotted path and merges the override's leaf map INTO the existing leaf:
- chartValues siblings at the override path survive
- override keys win over same-key collisions
- when no existing leaf is present, behaves identically to the old `setScalarValue` shape (fresh leaf written)

## Tests

3 new subtests under `TestBuildWrapperChartValues`:
- chart values siblings under image path preserved through image override (direct gitea regression)
- chart values siblings under nested image path preserved (`server.image.rootless` / `pullPolicy`)
- override at unoccupied image path writes fresh leaf (backward-compat guard)

All existing chartgen tests still pass.

## Follow-up

Once this lands, the next Chart Generation run will republish wrapper charts that have image-path chartValues siblings. The gitea wrapper is the only verified regression today; other charts may benefit silently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `chartgen` to merge image override maps into existing `chartValues` instead of replacing them. This preserves siblings like `image.rootless` and avoids bad tags such as `ghcr.io/verity-org/gitea:1-rootless`.

- **Bug Fixes**
  - Added `mergeMapValue` to merge image override maps; override keys win.
  - Keeps siblings under `image.*`; writes a fresh leaf if missing or non-map.
  - Tests cover the gitea regression, nested `server.image.*`, and fresh-leaf behavior.

- **Refactors**
  - Switched to `maps.Copy` and split tests/extracted consts to satisfy linters; minor docstring cleanup (fix ImagePullBackOff split, drop transient run ID).

<sup>Written for commit 4fcbb58a71aca84025fb18df557156c715fc8e94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

