### PR TITLE
fix(images): add openjdk-21-default-jvm to jenkins (missing JVM runtime)

### DIFF
--- a/images/jenkins.yaml
+++ b/images/jenkins.yaml
@@ -11,7 +11,19 @@ types:
     # process starts. Without it the init container fails at runc exec with
     # `sh: executable file not found`. Same shape as the valkey fix in
     # verity-org/verity#327. See verity-org/verity#318 (A.1 shell-missing cluster).
-    packages: ["jenkins-{{version}}", "busybox"]
+    #
+    # openjdk-21-default-jvm provides the JVM runtime + `/usr/bin/java`
+    # symlink + `/usr/lib/jvm/default-jvm` alias path that the entrypoint
+    # and JAVA_HOME below reference. The wolfi `jenkins` package itself
+    # does NOT declare a JVM dependency, so without an explicit JDK pull
+    # the container crashes immediately at runc exec with:
+    #   exec: "/usr/bin/java": stat /usr/bin/java: no such file or directory
+    # → StatefulSet Ready 0/1, helm install --wait timeouts at 10m.
+    # Verified against chart-integration run 25662716854, jenkins-0
+    # status.lastState.terminated.message. Jenkins LTS 2.x requires Java
+    # 17+; we choose 21 for parity with cassandra.yaml + maven.yaml +
+    # openjdk.yaml versioning.
+    packages: ["jenkins-{{version}}", "busybox", "openjdk-21-default-jvm"]
     entrypoint: /usr/bin/java -jar /usr/share/java/jenkins/jenkins.war
     environment:
       JENKINS_HOME: /var/jenkins_home


### PR DESCRIPTION
## Summary

The wolfi `jenkins` package does not declare a JVM dependency, so the container shipped from `images/jenkins.yaml` has no `/usr/bin/java` — and the entrypoint is `/usr/bin/java -jar /usr/share/java/jenkins/jenkins.war`.

## Symptom (chart-integration run [25662716854](https://github.com/verity-org/verity/actions/runs/25662716854), jenkins job)

`jenkins-0` `status.containerStatuses[0].lastState.terminated.message`:

```
exec: "/usr/bin/java": stat /usr/bin/java: no such file or directory
```

→ container `StartError` (exitCode 128)
→ jenkins-0 StatefulSet Ready 0/1
→ helm install --wait timeout at 10m

## Fix

Add `openjdk-21-default-jvm` to the apko packages list. This provides:

1. The JVM runtime
2. `/usr/bin/java` symlink (referenced by entrypoint)
3. `/usr/lib/jvm/default-jvm` alias path (referenced by `JAVA_HOME`)

Java 21 matches the version selection used by `cassandra.yaml`, `maven.yaml`, and `openjdk.yaml`, and exceeds Jenkins LTS 2.x's Java 17+ minimum.

## Follow-up

Requires Integer Orchestrator image rebuild for `jenkins:2`. PMA will trigger after this lands, then re-run chart-integration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `openjdk-21-default-jvm` to the Jenkins image to provide the JVM runtime and `/usr/bin/java`, fixing the startup crash. Aligns on Java 21 (>= Jenkins LTS requirement) and matches `cassandra`, `maven`, and `openjdk` images.

- **Bug Fixes**
  - Included `openjdk-21-default-jvm` in `images/jenkins.yaml` to supply the JVM, `/usr/bin/java`, and `/usr/lib/jvm/default-jvm`.
  - Resolves the Jenkins pod StartError and Helm install timeouts caused by the missing JVM.

- **Migration**
  - Rebuild and publish `jenkins:2`, then re-run chart-integration.

<sup>Written for commit 60dd545c7a23eebfef80fde375c154e0b4e52418. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

