### PR TITLE
fix(ci): avoid E2BIG in integer orchestrator dispatch step

### DIFF
--- a/.github/workflows/integer-orchestrator.yaml
+++ b/.github/workflows/integer-orchestrator.yaml
@@ -156,9 +156,15 @@ jobs:
       - name: Dispatch integer-build-image.yaml for each image
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGES: ${{ needs.discover.outputs.images }}
         run: |
-          echo "$IMAGES" | jq -c '.[]' | while IFS= read -r image; do
+          # Write images JSON to a temp file instead of an env var to avoid
+          # E2BIG (argv+env > ~2MB / per-string > 128KB) when the matrix is large.
+          # Heredoc with quoted delimiter disables shell expansion of the body,
+          # tolerating any JSON content (including apostrophes) safely.
+          cat > "$RUNNER_TEMP/images.json" <<'__IMAGES_JSON_EOF__'
+          ${{ needs.discover.outputs.images }}
+          __IMAGES_JSON_EOF__
+          jq -c '.[]' "$RUNNER_TEMP/images.json" | while IFS= read -r image; do
             NAME=$(echo "$image" | jq -r '.name')
             VERSION=$(echo "$image" | jq -r '.version')
             TYPE=$(echo "$image" | jq -r '.type')


### PR DESCRIPTION
## Summary

The dispatch step in `integer-orchestrator.yaml` was passing the full discovered-images JSON (~150KB for 736 image+version+type combos) into a bash `run:` block via an `IMAGES` environment variable. The process failed to start with `Argument list too long` (E2BIG) because Linux enforces a 128KB **per-string** limit on `execve` args+env (`MAX_ARG_STRLEN`), independent of the ~2MB total `argv+envp` cap.

**Failing run:** https://github.com/verity-org/verity/actions/runs/25717117143/job/75509532717

## Fix

Move the JSON payload out of the process environment and into a file inside `$RUNNER_TEMP`, written via a **quoted-delimiter heredoc** in the `run:` body. GitHub Actions writes the `run:` script itself to a tempfile and invokes bash on it, so the script body is never subject to `execve` arg/env limits.

```yaml
run: |
  cat > "$RUNNER_TEMP/images.json" <<'__IMAGES_JSON_EOF__'
  ${{ needs.discover.outputs.images }}
  __IMAGES_JSON_EOF__
  jq -c '.[]' "$RUNNER_TEMP/images.json" | while IFS= read -r image; do
    ...
```

The quoted heredoc delimiter (`<<'__IMAGES_JSON_EOF__'`) disables shell expansion of the body, so any JSON content — including apostrophes or backslashes — is preserved verbatim.

## Test plan

- [x] `actionlint` clean on both workflow files
- [x] YAML parses; heredoc + delimiter render at column 0 in the resulting shell script
- [x] Local heredoc round-trip with JSON containing apostrophes verified
- [ ] Post-merge: trigger orchestrator via `workflow_dispatch` and confirm "Dispatch builds" job no longer fails with E2BIG
- [ ] Confirm child `integer-build-image.yaml` runs are dispatched

## Notes on takeover

Original PR by @ckiee — thank you for the diagnosis and initial fix. This revision keeps her commit (authorship preserved) with one small hardening change: replaces the inline `printf '%s' '${{ ... }}'` with a quoted-delimiter heredoc so the dispatch step tolerates any JSON content (the previous form would break if any field ever contained a literal `'`).

The PR-trigger / `workflow_call` scaffolding from the earlier `DO NOT MERGE` commits was used to validate the fix on a fork (https://github.com/descope-dev/verity/pull/1/checks) and has been dropped from the final landing diff. Fork-CI support, if desired, can be tracked separately.
