### PR TITLE
fix(charts): prometheus allowlist + etcd replicaCount=1 for kind

### DIFF
--- a/test/chart-integration/values/prometheus.allowlist.txt
+++ b/test/chart-integration/values/prometheus.allowlist.txt
@@ -1,0 +1,42 @@
+# prometheus upstream image allowlist (SCR-2026-04-30-001)
+#
+# The prometheus chart (29.6.0 from prometheus-community) pulls three
+# upstream images that chart-gen intentionally skips because the
+# images are in the `--exclude-names` list in the Chart Generation
+# workflow (`prometheus`, `prometheus-operator`, `alertmanager`):
+#
+#   quay.io/prometheus/prometheus:v3.11.3           — main prometheus
+#                                                     server
+#   quay.io/prometheus/alertmanager:v0.32.1         — alertmanager
+#                                                     bundled with the
+#                                                     stack
+#   quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0
+#                                                   — config-reloader
+#                                                     sidecar that
+#                                                     reloads
+#                                                     prometheus.yml on
+#                                                     ConfigMap update
+#
+# These images do not have verity-org rebuilds (see verity.yaml
+# comment near `replacements:` about the prometheus chart being
+# dropped from the wave that adds verity coverage for prometheus-
+# operator and kube-webhook-certgen). chart-gen logs each as
+# `warning: skipping excluded image "prometheus/<image>"` and the
+# pod-spec reference stays at the upstream quay.io path.
+#
+# Allowlist these three until verity adds rebuilds for the
+# prometheus-stack ancillary images and the chart can be removed
+# from the chart-gen exclude list. Each prefix uses both `:` (tag
+# refs) and `@` (digest refs) so the rendered pod-spec image string
+# only matches its intended repo and never broadens to unrelated
+# `prometheus/<sibling>` repos.
+#
+# Format note: the isAccepted helper in test/chart-integration/
+# assertions.go uses strings.HasPrefix; `:` and `@` separators
+# ensure each prefix is scoped to one image.
+quay.io/prometheus/prometheus:
+quay.io/prometheus/prometheus@
+quay.io/prometheus/alertmanager:
+quay.io/prometheus/alertmanager@
+quay.io/prometheus-operator/prometheus-config-reloader:
+quay.io/prometheus-operator/prometheus-config-reloader@

--- a/verity.yaml
+++ b/verity.yaml
@@ -173,6 +173,21 @@ chartValues:
     envoy.image.useDigest: false
     operator.replicas: 1
 
+  # etcd chart (cloudpirates-io 0.7.1) defaults to a 3-replica
+  # StatefulSet for quorum. Single-node kind can only place 1; the
+  # other 2 pods sit Pending forever (no anti-affinity required
+  # — there literally isn't a second node). The 10-minute helm
+  # install --wait budget then expires with:
+  #   resource StatefulSet/etcd/etcd not ready.
+  #   status: InProgress, message: Ready: 0/3
+  # Drop to 1 replica for CI smoke. Same kind-sizing pattern as
+  # loki / minio / cilium operator above. Trade-off: a 1-node etcd
+  # has no quorum redundancy (any restart loses the cluster), but
+  # the smoke test only verifies install + pod readiness, not HA.
+  # See verity-org/verity#322 for the kind-sizing methodology.
+  etcd:
+    replicaCount: 1
+
   # airflow chart bundles a `postgresql` sub-chart with image
   # `bitnamilegacy/postgresql:16.1.0-debian-11-r15`. chart-gen rewrites
   # the repository (`bitnamilegacy/postgresql` →


### PR DESCRIPTION
## Summary

Two follow-up fixes for chart-integration regressions observed in [run 25667649162](https://github.com/verity-org/verity/actions/runs/25667649162) (post the 5-PR session that landed [#358](https://github.com/verity-org/verity/pull/358)/[#359](https://github.com/verity-org/verity/pull/359)/[#360](https://github.com/verity-org/verity/pull/360)/[#361](https://github.com/verity-org/verity/pull/361)/[#362](https://github.com/verity-org/verity/pull/362)).

### prometheus.allowlist.txt (new)

Renovate [#355](https://github.com/verity-org/verity/pull/355) bumped the prometheus chart 29.5.0 → 29.6.0. The new chart now renders three upstream images that chart-gen intentionally skips (workflow `--exclude-names` includes `prometheus`, `prometheus-operator`, `alertmanager`):

| Image | Source |
|---|---|
| `quay.io/prometheus/prometheus:v3.11.3` | main server |
| `quay.io/prometheus/alertmanager:v0.32.1` | bundled alertmanager |
| `quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0` | config-reloader sidecar |

verity has no rebuilds for these yet (per verity.yaml comment near `replacements:` about the prometheus chart being dropped from the wave that adds kube-prometheus-stack coverage). Allowlist them with both `:` and `@` separator forms.

### verity.yaml `chartValues.etcd.replicaCount: 1`

CloudPirates-io etcd 0.7.1 defaults to `replicaCount: 3` (must be odd for quorum). Single-node kind can only place 1 pod; the other 2 sit Pending and `helm install --wait` times out at 10m with `StatefulSet/etcd/etcd not ready. status: InProgress, message: Ready: 0/3`. Drop to 1 for CI smoke. Same pattern as loki/minio/cilium-operator single-replica fixes.

## Validation

- prometheus allowlist matches the 3 violation images via `strings.HasPrefix`
- etcd `replicaCount` is the canonical key per [CloudPirates-io/helm-charts etcd-0.7.1 values.yaml](https://github.com/CloudPirates-io/helm-charts/blob/etcd-0.7.1/charts/etcd/values.yaml)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI chart-integration failures by allowlisting Prometheus upstream images and forcing etcd to 1 replica on single-node kind. Stabilizes smoke tests after the Prometheus chart 29.6.0 bump.

- **Bug Fixes**
  - Added `test/chart-integration/values/prometheus.allowlist.txt` for the Prometheus chart (29.6.0). Allows the three upstream images (`prometheus`, `alertmanager`, `prometheus-config-reloader`) that `chart-gen` excludes, using `:` and `@` prefixes for tag/digest.
  - Set `chartValues.etcd.replicaCount: 1` in `verity.yaml` so single-node kind can schedule etcd and `helm install --wait` doesn’t time out.

<sup>Written for commit 3e88456a829f473b59c7794fcdd50a90519aa1d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

