### PR TITLE
fix(images): meilisearch — bind to 0.0.0.0 so chart readiness probe works

### DIFF
--- a/images/meilisearch.yaml
+++ b/images/meilisearch.yaml
@@ -23,6 +23,24 @@ types:
     environment:
       MEILI_DB_PATH: /meili_data
       MEILI_DUMP_DIR: /meili_data/dumps
+      # meilisearch binds to 127.0.0.1:7700 by default (verified
+      # against `meilisearch --help`: `--http-addr [env:
+      # MEILI_HTTP_ADDR=] [default: 127.0.0.1:7700]`). With the
+      # default, the pod's readiness probe from kubelet over the pod
+      # IP cannot reach the listener and the StatefulSet never
+      # becomes Ready — meilisearch logs show "starting service:
+      # actix-web-service-127.0.0.1:7700" and the smoke harness
+      # times out at 10m with `StatefulSet/meilisearch/meilisearch
+      # not ready. status: InProgress, message: Ready: 0/1`
+      # (chart-integration run 25934367685, meilisearch-0 pod logs).
+      #
+      # The upstream getmeili/meilisearch image sets
+      # `MEILI_HTTP_ADDR=0.0.0.0:7700` in its docker `ENV` so the
+      # chart's default readiness probe works out of the box. The
+      # wolfi rebuild was missing that override. Mirror upstream's
+      # default so the chart works without per-installation
+      # chartValues tuning.
+      MEILI_HTTP_ADDR: 0.0.0.0:7700
     paths:
       - {path: /meili_data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 


### PR DESCRIPTION
## Summary

Final fix for the chronic meilisearch nightly failure tracked under [#324](https://github.com/verity-org/verity/issues/324).

## Root cause

The wolfi `meilisearch` rebuild inherits the binary's default listen address of `127.0.0.1:7700` (verified via `meilisearch --help`: `--http-addr [env: MEILI_HTTP_ADDR=] [default: 127.0.0.1:7700]`). With the default, the chart's readiness probe — sent from kubelet via the pod IP — cannot reach the listener.

The upstream `getmeili/meilisearch` Docker image sets `MEILI_HTTP_ADDR=0.0.0.0:7700` in its `ENV` so the chart's default readiness probe works out of the box. The wolfi rebuild was missing that override.

## Symptom (chart-integration run [25934367685](https://github.com/verity-org/verity/actions/runs/25934367685), meilisearch job)

```
StatefulSet/meilisearch/meilisearch not ready.
status: InProgress, message: Ready: 0/1
```

meilisearch-0 container log:
```
starting service: "actix-web-service-[::1]:7700"
starting service: "actix-web-service-127.0.0.1:7700"
```
(no listener on 0.0.0.0.)

## Fix

Add `MEILI_HTTP_ADDR: 0.0.0.0:7700` to the apko `environment:` block in `images/meilisearch.yaml`. Mirrors upstream's `ENV` default — no chart-side change needed once the rebuilt image lands via Integer Orchestrator + chart-gen.

## Verification

The upstream getmeili/meilisearch image was inspected and confirmed to set this env var; the wolfi rebuild now matches.

## Closes

[#324](https://github.com/verity-org/verity/issues/324) (probe-race: cert-manager + meilisearch — cert-manager was already fixed in [#347](https://github.com/verity-org/verity/pull/347)).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `MEILI_HTTP_ADDR=0.0.0.0:7700` in the Wolfi `meilisearch` image so the chart readiness probe can reach the service and the StatefulSet becomes Ready. Fixes the nightly failures tracked in #324.

- **Bug Fixes**
  - Added `MEILI_HTTP_ADDR=0.0.0.0:7700` in `images/meilisearch.yaml` to match upstream `getmeili/meilisearch`.
  - No chart changes needed; readiness probe now works via the pod IP.

<sup>Written for commit b208c558b450adb73a1f066a43bcae6d3d7e094b. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/377?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

