### PR TITLE
fix(charts): falco driver.enabled=false → un-skip in chart-integration (closes #325)

### DIFF
--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -12,19 +12,19 @@
 # issue, an exit criterion, and a peer review. Prefer chartValues tuning,
 # image fixes, or harness retries (subtask 5) before adding here.
 #
-# Slot accounting: 5 of 5 slots used (full). Loader's MaxSkippedCharts=5
+# Slot accounting: 4 of 5 slots used. Loader's MaxSkippedCharts=5
 # invariant will reject any 6th entry. Adding another skip requires either
 # (a) removing an existing entry whose exit_criteria has been met, or
 # (b) a new SCR raising the cap.
+#
+# Recent slot reclaims:
+#   - falco (#325): closed via `chartValues.falco.driver.enabled: false`
+#     in verity.yaml — option (b) of the falco exit_criteria. The chart
+#     still installs cleanly without a kernel driver; container-engine
+#     plugin remains the event source. Verified in the same PR that
+#     removed this row.
 
 skips:
-  - chart: falco
-    reason: kernel-incompat
-    tracking_issue: https://github.com/verity-org/verity/issues/325
-    exit_criteria: "falco's modern_ebpf driver fails to load (`libpman: ring buffer map type is not supported`) under the Azure GHA runner because the BPF capability is denied at runc create time, not because the kernel is too old (failing runs are on 6.17.0-1010-azure). Revisit when (a) the GHA runner image grants CAP_BPF / CAP_PERFMON to docker-in-docker kind nodes, OR (b) the chart exposes a `driver.kind: legacy_ebpf` / `driver.enabled: false` knob the wrapper can wire from chartValues without requiring a tools install in the image."
-    added: 2026-05-14
-    added_by: SCR-2026-05-14-001
-
   - chart: nfs-subdir-external-provisioner
     reason: needs-external-infra
     tracking_issue: https://github.com/verity-org/verity/issues/373

--- a/verity.yaml
+++ b/verity.yaml
@@ -430,6 +430,30 @@ chartValues:
     readinessProbe.initialDelaySeconds: 60
     readinessProbe.failureThreshold: 12
 
+  # falco 8.0.3 — Bucket H (kernel-driver init blocked in CI).
+  # Per verity-org/verity#325: falco's main container exits at boot
+  # with `libpman: ring buffer map type is not supported
+  # (errno: 1 | message: Operation not permitted)` because the BPF
+  # capability (CAP_BPF / CAP_PERFMON) is denied at runc-create time
+  # on the Azure GHA runner, regardless of kernel version. The
+  # `falco-driver-loader` init container completes fine; only the
+  # subsequent BPF map load fails.
+  #
+  # The chart exposes `driver.enabled: false` for exactly this
+  # scenario (per chart values comment: "Set it to false if you
+  # want to deploy Falco without the drivers"). With the driver
+  # disabled, falco still starts and exposes its metrics/gRPC
+  # endpoint via the container engine + k8s plugin paths, which is
+  # all the smoke test needs (we verify install + Ready, not event
+  # detection). Real users who need syscall monitoring deploy with
+  # the default `driver.enabled: true` on a non-locked-down kernel.
+  #
+  # The chart's collectors.containerEngine.enabled default is true,
+  # so falco still has an event source after this flip — it just
+  # comes from the container plugin instead of the kernel probe.
+  falco:
+    driver.enabled: false
+
   # opensearch 3.6.0 — Bucket G (JVM gc log path is unwritable in the
   # rebuilt image).
   # bucket-confirmation.md opensearch row: container exits with exit=1 and


### PR DESCRIPTION
## Summary

Closes [#325](https://github.com/verity-org/verity/issues/325) by taking option (b) of the falco SKIPS.yaml exit criterion: the chart already exposes `driver.enabled: false` for exactly this scenario.

## Background

falco's main container exits at boot with:
```
libpman: ring buffer map type is not supported (errno: 1 | message: Operation not permitted)
```

BPF map creation is denied at runc-create time on the Azure GHA runner — regardless of kernel version. The `falco-driver-loader` init container completes; only the subsequent BPF map load fails.

## Fix

`chartValues.falco.driver.enabled: false` skips the kernel probe entirely. falco still starts and exposes its metrics/gRPC endpoint via the container-engine plugin path (`collectors.containerEngine.enabled` defaults to true, so falco has an event source after the flip — it just comes from the container plugin instead of the kernel probe).

That's all the smoke test needs: install + Ready, not event detection.

## Trade-off

Real users who need syscall monitoring deploy with the default `driver.enabled: true` on a non-locked-down kernel; this chartValues override is scoped to the verity wrapper chart and documented in a comment block above the entry so the trade-off is visible.

## SKIPS.yaml slot accounting

5/5 → 4/5 slots used. Header gets a new "recent slot reclaims" stanza recording the closure for future maintainers.

## Closes

[#325](https://github.com/verity-org/verity/issues/325)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `falco` `driver.enabled: false` in `verity.yaml` so the chart installs and becomes Ready in CI without BPF. Un-skipped `falco` in chart-integration and updated `SKIPS.yaml` slot accounting to 4/5. Closes #325.

<sup>Written for commit 9076af1025ebc213d69a2e5f5bfbbff5c03878c5. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

