### PR TITLE
fix(charts): workload-identity-webhook replicaCount=1 — un-skip (closes #375)

### DIFF
--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -50,5 +50,3 @@ skips:
     exit_criteria: "chart hardcodes livenessProbe initialDelaySeconds with no values knob; smoke harness \"helm install --wait\" hits the probe before driver registers with cert-manager (which the harness also doesn't pre-install). Revisit when chart exposes app.livenessProbe knobs OR when harness pre-installs cert-manager CRDs."
     added: 2026-05-14
     added_by: SCR-2026-05-14-001
-
-

--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -12,7 +12,7 @@
 # issue, an exit criterion, and a peer review. Prefer chartValues tuning,
 # image fixes, or harness retries (subtask 5) before adding here.
 #
-# Slot accounting: 4 of 5 slots used. Loader's MaxSkippedCharts=5
+# Slot accounting: 3 of 5 slots used. Loader's MaxSkippedCharts=5
 # invariant will reject any 6th entry. Adding another skip requires either
 # (a) removing an existing entry whose exit_criteria has been met, or
 # (b) a new SCR raising the cap.
@@ -23,6 +23,11 @@
 #     still installs cleanly without a kernel driver; container-engine
 #     plugin remains the event source. Verified in the same PR that
 #     removed this row.
+#   - workload-identity-webhook (#375): closed via
+#     `chartValues.workload-identity-webhook.replicaCount: 1` in
+#     verity.yaml. The chart's cert-rotator races between replicas on
+#     single-node kind; single replica converges fast enough to fit
+#     the helm `--wait` 10-minute budget.
 
 skips:
   - chart: nfs-subdir-external-provisioner
@@ -46,9 +51,4 @@ skips:
     added: 2026-05-14
     added_by: SCR-2026-05-14-001
 
-  - chart: workload-identity-webhook
-    reason: chart-template-blocked
-    tracking_issue: https://github.com/verity-org/verity/issues/375
-    exit_criteria: "chart hardcodes readinessProbe periodSeconds; pod self-heals after cert rotation but smoke harness times out first. Revisit when chart exposes startupProbe or readinessProbe.periodSeconds values knob."
-    added: 2026-05-14
-    added_by: SCR-2026-05-14-001
+

--- a/verity.yaml
+++ b/verity.yaml
@@ -132,8 +132,20 @@ chartValues:
 
   # workload-identity-webhook requires azureTenantID to render templates.
   # The wrapper chart consumers MUST override this to their actual tenant ID.
+  #
+  # replicaCount: 1 — chart default is 2 replicas. On the single-node
+  # kind cluster used by chart-integration, both pods race the
+  # controller-runtime cert-rotator state machine on first install
+  # (both write to the same Secret, both restart on rotation), and
+  # `/readyz` returns HTTP 500 until the rotator converges. With two
+  # replicas the race extends past the helm `--wait` 10-minute
+  # budget; single replica converges in ~30s (verified on a local
+  # kind run, see verity-org/verity#375). Production deployments
+  # should keep the default 2 replicas; this override is scoped to
+  # the verity wrapper chart for CI smoke.
   workload-identity-webhook:
     azureTenantID: verity-placeholder
+    replicaCount: 1
 
   # nfs-subdir-external-provisioner chart's Deployment requires `nfs.server`
   # to render — without it, helm install aborts with:


### PR DESCRIPTION
## Summary

Closes [#375](https://github.com/verity-org/verity/issues/375). The Azure workload-identity-webhook chart defaults to `replicaCount: 2`. On single-node kind, both replicas race the controller-runtime cert-rotator state machine on first install: both write to the same webhook-cert Secret, both restart on rotation, and `/readyz` returns HTTP 500 until the rotator converges. With two replicas the race extends past the helm `--wait` 10-minute budget.

## Fix

`chartValues.workload-identity-webhook.replicaCount: 1` — single replica converges in ~30s, fitting comfortably inside the helm install --wait budget.

## Trade-off

CI-scoped only. Production deployments should keep the default 2 replicas for HA. The comment block above the chartValues entry documents this so future readers don't accidentally roll the override into a production-tier values file.

## SKIPS.yaml slot accounting

4/5 → 3/5 slots used. Slot-reclaim history stanza in the file header records the closure.

## Closes

[#375](https://github.com/verity-org/verity/issues/375)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes readiness timeouts for the `workload-identity-webhook` in CI by forcing `replicaCount: 1` in `verity.yaml`, avoiding the cert-rotator race on single-node kind; re-enables the chart in smoke tests. Closes #375.

- **Bug Fixes**
  - Set `chartValues.workload-identity-webhook.replicaCount` to 1 for CI only; keep default 2 for production (documented in comments).
  - Removed the skip in `test/chart-integration/SKIPS.yaml` and updated slot accounting (4/5 → 3/5).
  - Trimmed trailing blank lines in `test/chart-integration/SKIPS.yaml` to satisfy `yamllint` empty-lines.

<sup>Written for commit 871edae3bd6258625f8063c2f212db119089a32c. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/379?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

