### PR TITLE
fix(images,charts): nightly-may16 follow-ups — re-skip falco, allowlists, etcd tag, apko chmod-symlink quirk

### DIFF
--- a/images/etcd.yaml
+++ b/images/etcd.yaml
@@ -10,17 +10,28 @@ types:
     entrypoint: /usr/bin/etcd
     paths:
       - {path: /var/lib/etcd, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
+      # bitnami/etcd helm chart hardcodes /usr/local/bin/etcd in the StatefulSet
+      # command — verity's wolfi rebuild ships at /usr/bin/etcd (FHS).
+      # Symlink keeps both layouts working. See verity-org/verity#318 (A.2).
+      #
+      # ORDERING IS LOAD-BEARING: the symlink entry MUST come BEFORE the
+      # `permissions` mutation on /usr/bin/etcd below. apko's mutatePaths
+      # (pkg/build/paths.go:146) calls mutatePermissions on every non-
+      # permissions entry AFTER its type-specific mutator, using the
+      # mutation's `permissions:` field — and the symlink entry has no
+      # `permissions:` set, so it falls back to mode 0. The Chmod follows
+      # the symlink (Linux symlink chmod semantics) and resets the target
+      # /usr/bin/etcd to mode 0o000, undoing the explicit chmod above.
+      # Reordering symlink-before-permissions sidesteps the apko quirk
+      # without needing an upstream patch.
+      - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
       # Published `ghcr.io/verity-org/etcd:latest` ships /usr/bin/etcd with
       # mode 0o000; runc aborts with `exec: "/usr/local/bin/etcd": permission
-      # denied` after resolving the symlink below. The prior #318 (A.2) FHS
+      # denied` after resolving the symlink above. The prior #318 (A.2) FHS
       # symlink IS landing in the image, but the target binary lacks +x.
       # apko `type: permissions` is the canonical chmod-on-existing-file
       # mutation. See SCR-2026-05-14-001 Bucket H + image-mode-audit.md.
       - {path: /usr/bin/etcd, type: permissions, uid: 0, gid: 0, permissions: 0o755}
-      # bitnami/etcd helm chart hardcodes /usr/local/bin/etcd in the StatefulSet
-      # command — verity's wolfi rebuild ships at /usr/bin/etcd (FHS).
-      # Symlink keeps both layouts working. See verity-org/verity#318 (A.2).
-      - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
 
   fips:
     base: wolfi-fips
@@ -28,8 +39,10 @@ types:
     entrypoint: /usr/bin/etcd
     paths:
       - {path: /var/lib/etcd, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
-      - {path: /usr/bin/etcd, type: permissions, uid: 0, gid: 0, permissions: 0o755}
+      # See the `default` types block above for the rationale on symlink-
+      # before-permissions ordering (apko chmod-via-symlink quirk).
       - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
+      - {path: /usr/bin/etcd, type: permissions, uid: 0, gid: 0, permissions: 0o755}
 
 versions:
   "3.5":

--- a/images/fluent-bit.yaml
+++ b/images/fluent-bit.yaml
@@ -10,17 +10,27 @@ types:
     entrypoint: /usr/bin/fluent-bit
     paths:
       - {path: /etc/fluent-bit, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+      # fluent/fluent-bit helm chart hardcodes /fluent-bit/bin/fluent-bit in the
+      # DaemonSet command — verity's wolfi rebuild ships at /usr/bin/fluent-bit
+      # (FHS). Need parent directory entry first, then the symlink itself.
+      # See verity-org/verity#318 (A.2).
+      #
+      # ORDERING IS LOAD-BEARING — the symlink entry MUST come BEFORE the
+      # `permissions` mutation on /usr/bin/fluent-bit below. apko's
+      # mutatePaths calls mutatePermissions on every non-permissions
+      # mutation AFTER its type-specific mutator, using the mutation's
+      # `permissions:` field — the symlink entry has no `permissions:` set
+      # (defaults to 0). The Chmod(0) follows the symlink (Linux symlink-
+      # chmod semantics) and resets the TARGET /usr/bin/fluent-bit to mode
+      # 0o000 — undoing the explicit chmod below. See SCR-2026-05-14-001
+      # Bucket H + the corresponding ordering note in images/etcd.yaml.
+      - {path: /fluent-bit/bin, type: directory, uid: 0, gid: 0, permissions: 0o755}
+      - {path: /fluent-bit/bin/fluent-bit, type: symlink, source: /usr/bin/fluent-bit, uid: 0, gid: 0}
       # Published `ghcr.io/verity-org/fluent-bit:latest` ships
       # `/usr/bin/fluent-bit` with mode 0o000 — `runc` aborts with
       # `exec: permission denied`. apko `type: permissions` forces +x on
       # layer assembly. See SCR-2026-05-14-001 Bucket H.
       - {path: /usr/bin/fluent-bit, type: permissions, uid: 0, gid: 0, permissions: 0o755}
-      # fluent/fluent-bit helm chart hardcodes /fluent-bit/bin/fluent-bit in the
-      # DaemonSet command — verity's wolfi rebuild ships at /usr/bin/fluent-bit
-      # (FHS). Need parent directory entry first, then the symlink itself.
-      # See verity-org/verity#318 (A.2).
-      - {path: /fluent-bit/bin, type: directory, uid: 0, gid: 0, permissions: 0o755}
-      - {path: /fluent-bit/bin/fluent-bit, type: symlink, source: /usr/bin/fluent-bit, uid: 0, gid: 0}
 
 versions:
   # Wolfi dropped fluent-bit-3.x entirely; previously declared "3.2" had no

--- a/images/velero.yaml
+++ b/images/velero.yaml
@@ -9,17 +9,26 @@ types:
     packages: ["velero"]
     entrypoint: /usr/bin/velero
     paths:
-      # Published `ghcr.io/verity-org/velero:latest` ships /usr/bin/velero with
-      # mode 0o000 — `runc` aborts with `exec: "/velero": permission denied`
-      # (chart resolves /velero via the symlink below to /usr/bin/velero, but
-      # the target lacks +x). apko `type: permissions` forces +x on layer
-      # assembly. See SCR-2026-05-14-001 Bucket H.
-      - {path: /usr/bin/velero, type: permissions, uid: 0, gid: 0, permissions: 0o755}
+      # ORDERING IS LOAD-BEARING — symlink entry comes BEFORE the permissions
+      # mutation on /usr/bin/velero. apko's mutatePaths calls
+      # mutatePermissions on every non-permissions mutation AFTER its
+      # type-specific mutator, and the symlink entry has no `permissions:`
+      # set (defaults to 0). The Chmod(0) follows the symlink (Linux
+      # symlink-chmod semantics) and resets the TARGET /usr/bin/velero to
+      # mode 0o000 — undoing the explicit chmod below. See SCR-2026-05-14-001
+      # Bucket H + the corresponding ordering note in images/etcd.yaml.
+      #
       # vmware-tanzu/velero helm chart's upgrade-crds Job runs `/velero install`
       # — chart hardcodes /velero in the Job command. Verity's wolfi rebuild
       # ships at /usr/bin/velero (FHS). Symlink keeps both layouts working.
       # See verity-org/verity#318 (A.2 FHS-path mismatch sub-cluster).
       - {path: /velero, type: symlink, source: /usr/bin/velero, uid: 0, gid: 0}
+      # Published `ghcr.io/verity-org/velero:latest` ships /usr/bin/velero with
+      # mode 0o000 — `runc` aborts with `exec: "/velero": permission denied`
+      # (chart resolves /velero via the symlink above to /usr/bin/velero, but
+      # the target lacks +x). apko `type: permissions` forces +x on layer
+      # assembly. See SCR-2026-05-14-001 Bucket H.
+      - {path: /usr/bin/velero, type: permissions, uid: 0, gid: 0, permissions: 0o755}
 
 versions:
   "1": {}

--- a/internal/integer/render/render.go
+++ b/internal/integer/render/render.go
@@ -125,6 +125,24 @@ func Config(tmpl *config.TypeTemplate, version, basePath string) ([]byte, error)
 //   - type=symlink requires Source (apko rejects symlinks without a target)
 //   - Source set on any non-symlink type is invalid (apko rejects it)
 //
+// It also REORDERS entries to defend against an apko quirk: apko's
+// mutatePaths (chainguard-dev/apko pkg/build/paths.go:146) runs
+// mutatePermissions on every non-permissions mutation AFTER its type-
+// specific mutator, using the mutation's `permissions:` field. A symlink
+// mutation with no explicit `permissions:` defaults to 0, so apko ends up
+// calling Chmod(0) on the SYMLINK PATH — and under Linux symlink-chmod
+// semantics that follows the link and resets the TARGET file's mode.
+// Concretely: if `/usr/bin/etcd` has a `permissions: 0o755` mutation and
+// `/usr/local/bin/etcd → /usr/bin/etcd` is mutated AFTER it, the symlink's
+// implicit Chmod(0) wipes the binary's executable bit and `runc exec`
+// aborts with permission denied at chart-integration time.
+//
+// To make this safe regardless of YAML ordering in images/*.yaml, we
+// reorder so every `symlink` entry comes BEFORE every `permissions`
+// entry whose `path:` is the symlink's `source:` (the link target). The
+// reorder is stable within each group — relative ordering of entries
+// that don't trigger the rule is preserved.
+//
 // Failing fast at render keeps misconfigured YAML errors close to their YAML
 // source instead of surfacing as opaque apko/melange build failures.
 func convertPaths(in []config.PathDef, version string) ([]apkoPath, error) {
@@ -153,7 +171,44 @@ func convertPaths(in []config.PathDef, version string) ([]apkoPath, error) {
 			Permissions: perms,
 		}
 	}
-	return out, nil
+	return reorderForApkoChmodQuirk(out), nil
+}
+
+// reorderForApkoChmodQuirk moves every `symlink` entry to come BEFORE every
+// `permissions` entry whose path equals the symlink's source. See the
+// convertPaths docstring for the underlying apko behaviour. Pure-data
+// reorder; no semantic change beyond mutation order.
+func reorderForApkoChmodQuirk(in []apkoPath) []apkoPath {
+	// Build a set of "symlink sources that will collide with permissions
+	// entries already past this point" so we know which symlinks to lift.
+	permsBefore := make(map[string]struct{})
+	for _, p := range in {
+		if p.Type == "permissions" {
+			permsBefore[p.Path] = struct{}{}
+		}
+	}
+	// Two-pass stable rebuild: first emit symlinks whose source matches
+	// a permissions entry's path (in their original relative order),
+	// then emit everything else (including any unrelated symlinks)
+	// in original order. This is the smallest reorder that satisfies
+	// the apko quirk.
+	out := make([]apkoPath, 0, len(in))
+	for _, p := range in {
+		if p.Type == "symlink" {
+			if _, hit := permsBefore[p.Source]; hit {
+				out = append(out, p)
+			}
+		}
+	}
+	for _, p := range in {
+		if p.Type == "symlink" {
+			if _, hit := permsBefore[p.Source]; hit {
+				continue
+			}
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // sub replaces all occurrences of {{version}} in s with version.

--- a/internal/integer/render/render_test.go
+++ b/internal/integer/render/render_test.go
@@ -307,17 +307,20 @@ func TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk(t *testing.T) {
 
 	// The symlink whose source matches the permissions entry must come
 	// FIRST in the emitted order (rewritten from its source position).
-	first, _ := paths[0].(map[string]any)
+	first, ok := paths[0].(map[string]any)
+	require.True(t, ok, "paths[0] is map[string]any")
 	assert.Equal(t, "symlink", first["type"], "symlink that targets a permissions-mutated path must be emitted first")
 	assert.Equal(t, "/usr/local/bin/etcd", first["path"])
 	assert.Equal(t, "/usr/bin/etcd", first["source"])
 
 	// Other entries retain their relative ordering.
-	second, _ := paths[1].(map[string]any)
+	second, ok := paths[1].(map[string]any)
+	require.True(t, ok, "paths[1] is map[string]any")
 	assert.Equal(t, "directory", second["type"])
 	assert.Equal(t, "/var/lib/etcd", second["path"])
 
-	third, _ := paths[2].(map[string]any)
+	third, ok := paths[2].(map[string]any)
+	require.True(t, ok, "paths[2] is map[string]any")
 	assert.Equal(t, "permissions", third["type"])
 	assert.Equal(t, "/usr/bin/etcd", third["path"])
 }
@@ -346,10 +349,13 @@ func TestConfig_UnrelatedSymlinkOrderPreserved(t *testing.T) {
 	require.Len(t, paths, 3)
 
 	// Order is unchanged because no symlink target matches a permissions path.
-	first, _ := paths[0].(map[string]any)
+	first, ok := paths[0].(map[string]any)
+	require.True(t, ok, "paths[0] is map[string]any")
 	assert.Equal(t, "/var/lib/foo", first["path"])
-	second, _ := paths[1].(map[string]any)
+	second, ok := paths[1].(map[string]any)
+	require.True(t, ok, "paths[1] is map[string]any")
 	assert.Equal(t, "/usr/bin/foo", second["path"])
-	third, _ := paths[2].(map[string]any)
+	third, ok := paths[2].(map[string]any)
+	require.True(t, ok, "paths[2] is map[string]any")
 	assert.Equal(t, "/usr/local/bin/bar", third["path"])
 }

--- a/internal/integer/render/render_test.go
+++ b/internal/integer/render/render_test.go
@@ -272,3 +272,84 @@ func TestConfig_PathSourceOnNonSymlink_Errors(t *testing.T) {
 	assert.Contains(t, err.Error(), "/usr/local/bin/etcd")
 	assert.Contains(t, err.Error(), `type="directory"`) // ensure the actual type is reported
 }
+
+// TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk regression-tests the
+// reorder in `convertPaths` for the apko `mutatePermissions on every
+// non-permissions entry` quirk (see the convertPaths docstring). When a
+// permissions mutation on `/usr/bin/X` is declared BEFORE a symlink
+// mutation pointing at `/usr/bin/X`, the rendered apko config MUST emit
+// the symlink first so apko's implicit Chmod(0) on the symlink doesn't
+// follow the link and reset the target's mode to 0o000.
+//
+// This protects the etcd / velero / fluent-bit FHS-symlink images from
+// silently regressing if a maintainer reorders entries in images/*.yaml
+// to read more naturally.
+func TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk(t *testing.T) {
+	tmpl := config.TypeTemplate{
+		Base: "wolfi-base",
+		// Source ORDER intentionally puts permissions before symlink —
+		// the test asserts the renderer rewrites it.
+		Paths: []config.PathDef{
+			{Path: "/var/lib/etcd", Type: "directory", UID: 65532, GID: 65532, Permissions: "0o700"},
+			{Path: "/usr/bin/etcd", Type: "permissions", UID: 0, GID: 0, Permissions: "0o755"},
+			{Path: "/usr/local/bin/etcd", Type: "symlink", Source: "/usr/bin/etcd", UID: 0, GID: 0},
+		},
+	}
+	out, err := render.Config(&tmpl, "latest", "_base")
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &cfg))
+
+	paths, ok := cfg["paths"].([]any)
+	require.True(t, ok)
+	require.Len(t, paths, 3)
+
+	// The symlink whose source matches the permissions entry must come
+	// FIRST in the emitted order (rewritten from its source position).
+	first, _ := paths[0].(map[string]any)
+	assert.Equal(t, "symlink", first["type"], "symlink that targets a permissions-mutated path must be emitted first")
+	assert.Equal(t, "/usr/local/bin/etcd", first["path"])
+	assert.Equal(t, "/usr/bin/etcd", first["source"])
+
+	// Other entries retain their relative ordering.
+	second, _ := paths[1].(map[string]any)
+	assert.Equal(t, "directory", second["type"])
+	assert.Equal(t, "/var/lib/etcd", second["path"])
+
+	third, _ := paths[2].(map[string]any)
+	assert.Equal(t, "permissions", third["type"])
+	assert.Equal(t, "/usr/bin/etcd", third["path"])
+}
+
+// TestConfig_UnrelatedSymlinkOrderPreserved confirms the reorder only
+// touches symlinks whose source matches a permissions entry. A symlink
+// pointing at an unrelated path keeps its original position.
+func TestConfig_UnrelatedSymlinkOrderPreserved(t *testing.T) {
+	tmpl := config.TypeTemplate{
+		Base: "wolfi-base",
+		Paths: []config.PathDef{
+			{Path: "/var/lib/foo", Type: "directory", UID: 65532, GID: 65532, Permissions: "0o755"},
+			{Path: "/usr/bin/foo", Type: "permissions", UID: 0, GID: 0, Permissions: "0o755"},
+			// Symlink pointing at /usr/bin/bar — NOT matching any permissions entry.
+			{Path: "/usr/local/bin/bar", Type: "symlink", Source: "/usr/bin/bar", UID: 0, GID: 0},
+		},
+	}
+	out, err := render.Config(&tmpl, "latest", "_base")
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &cfg))
+
+	paths, ok := cfg["paths"].([]any)
+	require.True(t, ok)
+	require.Len(t, paths, 3)
+
+	// Order is unchanged because no symlink target matches a permissions path.
+	first, _ := paths[0].(map[string]any)
+	assert.Equal(t, "/var/lib/foo", first["path"])
+	second, _ := paths[1].(map[string]any)
+	assert.Equal(t, "/usr/bin/foo", second["path"])
+	third, _ := paths[2].(map[string]any)
+	assert.Equal(t, "/usr/local/bin/bar", third["path"])
+}

--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -12,24 +12,36 @@
 # issue, an exit criterion, and a peer review. Prefer chartValues tuning,
 # image fixes, or harness retries (subtask 5) before adding here.
 #
-# Slot accounting: 3 of 5 slots used. Loader's MaxSkippedCharts=5
+# Slot accounting: 4 of 5 slots used. Loader's MaxSkippedCharts=5
 # invariant will reject any 6th entry. Adding another skip requires either
 # (a) removing an existing entry whose exit_criteria has been met, or
 # (b) a new SCR raising the cap.
 #
 # Recent slot reclaims:
-#   - falco (#325): closed via `chartValues.falco.driver.enabled: false`
-#     in verity.yaml — option (b) of the falco exit_criteria. The chart
-#     still installs cleanly without a kernel driver; container-engine
-#     plugin remains the event source. Verified in the same PR that
-#     removed this row.
 #   - workload-identity-webhook (#375): closed via
 #     `chartValues.workload-identity-webhook.replicaCount: 1` in
 #     verity.yaml. The chart's cert-rotator races between replicas on
 #     single-node kind; single replica converges fast enough to fit
 #     the helm `--wait` 10-minute budget.
+#
+# Re-skips after failed un-skip attempts:
+#   - falco (#325, re-added 2026-05-16): `chartValues.falco.driver.enabled:
+#     false` was attempted in #378 but is insufficient — the chart's
+#     auto-injection of the `container` plugin into falco.load_plugins
+#     is gated by `driver.enabled` in _helpers.tpl:477. With the driver
+#     disabled AND no plugin auto-added, falco starts with no event
+#     source and exits with `Error: Must enable at least one event
+#     source`. Fix requires the deeper chartValues plumbing described
+#     in the falco entry's exit_criteria below.
 
 skips:
+  - chart: falco
+    reason: kernel-incompat
+    tracking_issue: https://github.com/verity-org/verity/issues/325
+    exit_criteria: "falco's modern_ebpf driver fails to load (`libpman: ring buffer map type is not supported`) under the Azure GHA runner because the BPF capability is denied at runc create time. Bypassing via `driver.enabled: false` alone is NOT sufficient: the chart's auto-inject of the `container` plugin (_helpers.tpl:477 falco.containerPlugin) is gated by `driver.enabled` AND `collectors.enabled`, so disabling the driver also disables the only event source. Un-skipping requires either (a) GHA runner image grants CAP_BPF/CAP_PERFMON to docker-in-docker kind nodes, OR (b) chartValues wires the container plugin manually (set `falco.plugins`, `falco.load_plugins`, and `falcoctl.config.artifact.install.refs` to include the plugin artifact), OR (c) chart upstream provides a `driver.enabled: false` mode that does NOT also strip the container plugin."
+    added: 2026-05-14
+    added_by: SCR-2026-05-14-001
+
   - chart: nfs-subdir-external-provisioner
     reason: needs-external-infra
     tracking_issue: https://github.com/verity-org/verity/issues/373

--- a/test/chart-integration/values/meilisearch.allowlist.txt
+++ b/test/chart-integration/values/meilisearch.allowlist.txt
@@ -1,0 +1,23 @@
+# meilisearch upstream image allowlist (SCR-2026-04-30-001)
+#
+# The meilisearch chart 0.32.0 launches a `docker.io/library/busybox:latest`
+# pod (chart-template-driven, used to chmod/initialize the data volume
+# before the main meilisearch container starts). chart-gen has
+# `busybox` in its `--exclude-names` list (the wolfi busybox is its
+# own integer rebuild that's intentionally NOT chart-rewritten —
+# many charts use `:latest` busybox refs that would not survive
+# rewrite without per-chart wiring), so the upstream Docker Hub
+# reference renders into the wrapper verbatim.
+#
+# Without this allowlist, the image-origin gate fails with
+#   `image-origin gate: meilisearch has 1 non-verity image(s) but
+#    no allowlist file at ...meilisearch.allowlist.txt`
+# (verified against chart-integration run 25954862160, the run that
+# first exercised the meilisearch un-skip after #377 fixed the
+# HTTP-listen-address bug that was causing readiness-probe timeouts).
+#
+# Format note: the isAccepted helper in test/chart-integration/
+# assertions.go uses strings.HasPrefix; `:` and `@` separator forms
+# scope the prefix to busybox's library tag/digest refs.
+docker.io/library/busybox:
+docker.io/library/busybox@

--- a/test/chart-integration/values/workload-identity-webhook.allowlist.txt
+++ b/test/chart-integration/values/workload-identity-webhook.allowlist.txt
@@ -1,0 +1,34 @@
+# workload-identity-webhook upstream image allowlist (SCR-2026-04-30-001)
+#
+# The Azure workload-identity-webhook chart 1.5.1 pulls one image
+# directly from MCR (Microsoft Container Registry):
+#
+#   mcr.microsoft.com/oss/azure/workload-identity/webhook:v1.5.1
+#                                                         — the
+#                                                           mutating
+#                                                           admission
+#                                                           webhook
+#                                                           binary
+#
+# verity has no rebuild for this image (chart-gen exclude-names
+# includes `azure-workload-identity-webhook`; the upstream image is
+# Azure-specific and CGO-free, low risk for Debian-CVE accumulation
+# that the wolfi-rebuild program targets). The chart's wrapper
+# therefore renders the upstream MCR path verbatim, so the
+# image-origin gate needs an allowlist row.
+#
+# This allowlist landed alongside `chartValues.workload-identity-
+# webhook.replicaCount: 1` in #379 which un-skipped the chart from
+# SKIPS.yaml — without an allowlist file, the freshly-un-skipped
+# chart would have failed the next nightly with
+#   `image-origin gate: workload-identity-webhook has 1 non-verity
+#    image(s) but no allowlist file`
+# (verified against chart-integration run 25954862160).
+#
+# Format note: the isAccepted helper in test/chart-integration/
+# assertions.go uses strings.HasPrefix; `:` and `@` separator
+# forms scope the prefix to one image's tag/digest refs without
+# bleeding to unrelated `mcr.microsoft.com/oss/azure/workload-
+# identity/*` repos.
+mcr.microsoft.com/oss/azure/workload-identity/webhook:
+mcr.microsoft.com/oss/azure/workload-identity/webhook@

--- a/verity.yaml
+++ b/verity.yaml
@@ -442,29 +442,24 @@ chartValues:
     readinessProbe.initialDelaySeconds: 60
     readinessProbe.failureThreshold: 12
 
-  # falco 8.0.3 — Bucket H (kernel-driver init blocked in CI).
-  # Per verity-org/verity#325: falco's main container exits at boot
-  # with `libpman: ring buffer map type is not supported
-  # (errno: 1 | message: Operation not permitted)` because the BPF
-  # capability (CAP_BPF / CAP_PERFMON) is denied at runc-create time
-  # on the Azure GHA runner, regardless of kernel version. The
-  # `falco-driver-loader` init container completes fine; only the
-  # subsequent BPF map load fails.
+  # falco: NO chartValue tuning here — `driver.enabled: false`
+  # was attempted in #378 to bypass the BPF-capability denial on
+  # Azure GHA runners (verity-org/verity#325), but the May 16
+  # nightly (run 25954862160, falco pod log) revealed the chart's
+  # auto-injection of the `container` plugin into `falco.plugins`
+  # and `falco.load_plugins` is gated by `driver.enabled` in
+  # `_helpers.tpl:477` (`{{ if and .Values.driver.enabled
+  # .Values.collectors.enabled }}`). With the driver disabled
+  # AND no plugin auto-added, falco starts with no event source
+  # and exits with `Error: Must enable at least one event source`.
   #
-  # The chart exposes `driver.enabled: false` for exactly this
-  # scenario (per chart values comment: "Set it to false if you
-  # want to deploy Falco without the drivers"). With the driver
-  # disabled, falco still starts and exposes its metrics/gRPC
-  # endpoint via the container engine + k8s plugin paths, which is
-  # all the smoke test needs (we verify install + Ready, not event
-  # detection). Real users who need syscall monitoring deploy with
-  # the default `driver.enabled: true` on a non-locked-down kernel.
-  #
-  # The chart's collectors.containerEngine.enabled default is true,
-  # so falco still has an event source after this flip — it just
-  # comes from the container plugin instead of the kernel probe.
-  falco:
-    driver.enabled: false
+  # Properly fixing this requires explicitly wiring the container
+  # plugin via chartValues — both `falco.plugins[<dict>]` AND
+  # `falco.load_plugins: [container]` — and also overriding
+  # `falcoctl.config.artifact.install.refs` so the plugin artifact
+  # is pulled at install time. That's a much larger chart-config
+  # surface; deferred. falco re-skipped in test/chart-integration/
+  # SKIPS.yaml under #325 until the deeper wiring lands.
 
   # opensearch 3.6.0 — Bucket G (JVM gc log path is unwritable in the
   # rebuilt image).
@@ -700,10 +695,23 @@ replacements:
     registry: "ghcr.io/verity-org"
     image: "valkey"
     tag: "9.0"
+  # etcd: pin to the floating major.minor tag (`3.6`) instead of the
+  # specific patch (`3.6.10`). The Integer Orchestrator rebuilds the
+  # major.minor tag on every CI cycle, but only rebuilds the patch
+  # tag when the wolfi `etcd-3.6` package's version actually changes
+  # — which makes the patch tag "sticky" to whatever content was
+  # last published when the package version changed (currently
+  # commit 94ed8f9e, pre-#365 era). The chart-integration on
+  # 2026-05-16 was pulling `ghcr.io/verity-org/etcd:3.6.10` which
+  # still lacks the FHS symlink to `/usr/local/bin/etcd` added in
+  # `images/etcd.yaml` post-#365. The floating `:3.6` tag has the
+  # current build and the symlink. See verity-org/verity#318 (A.2)
+  # for the underlying chart-vs-image FHS-path mismatch the symlink
+  # exists to bridge.
   "etcd-development/etcd":
     registry: "ghcr.io/verity-org"
     image: "etcd"
-    tag: "3.6.10"
+    tag: "3.6"
   "velero/velero":
     registry: "ghcr.io/verity-org"
     image: "velero"


### PR DESCRIPTION
## Summary

Five follow-ups based on the May 16 nightly chart-integration ([run 25954862160](https://github.com/verity-org/verity/actions/runs/25954862160)). One of them is the **root-cause fix for chronic etcd / velero / fluent-bit FHS-symlink regressions** — an apko quirk that's been silently wiping binary execute bits since PR [#365](https://github.com/verity-org/verity/pull/365).

## 1. Falco re-skip + #325 reopened

[#378](https://github.com/verity-org/verity/pull/378)'s `driver.enabled: false` was insufficient. The chart's auto-injection of the `container` plugin into `falco.load_plugins` is gated by `driver.enabled` in `_helpers.tpl:477`, so disabling the driver also strips the only event source. Pod log:
```
Error: Must enable at least one event source
```
Restore the SKIPS.yaml entry with updated exit_criteria documenting the deeper plumbing needed.

## 2. workload-identity-webhook + meilisearch allowlists

[#379](https://github.com/verity-org/verity/pull/379) un-skipped wid via `replicaCount: 1` but didn't author an allowlist for `mcr.microsoft.com/oss/azure/workload-identity/webhook:v1.5.1`. [#377](https://github.com/verity-org/verity/pull/377) fixed meilisearch listen-address but the chart's data-volume init pod uses `docker.io/library/busybox:latest`. Both excluded from chart-gen rewrite, both need allowlist files.

## 3. etcd tag pin 3.6.10 → 3.6 (floating)

The Integer Orchestrator only rebuilds the patch tag when the wolfi package version changes. Wolfi etcd-3.6 has been version 3.6.10/3.6.11; the `:3.6.10` tag has been "sticky" to pre-[#365](https://github.com/verity-org/verity/pull/365) content (revision 94ed8f9e) since the package bumped to 3.6.11. The floating `:3.6` tag has the latest build.

## 4. **apko chmod-via-symlink quirk — root cause fix for etcd/velero/fluent-bit**

apko's `mutatePaths` (chainguard-dev/apko pkg/build/paths.go:146) runs `mutatePermissions` on every non-`permissions` mutation AFTER its type-specific mutator, using the mutation's `permissions:` field. A symlink with no explicit `permissions:` defaults to 0, so apko calls `Chmod(0)` on the SYMLINK — which follows the link (Linux symlink-chmod semantics) and chmods the TARGET to mode 0o000.

```
paths:
  - {path: /usr/bin/etcd,        type: permissions, ...0o755}      # ↰  
  - {path: /usr/local/bin/etcd,  type: symlink, source: /usr/bin/etcd}  # ↑
                                                                   # apko's implicit
                                                                   # Chmod(0) on this
                                                                   # symlink follows
                                                                   # the link and
                                                                   # resets the target
                                                                   # to 0o000
```

**Verified locally** with apko 1.2.9: the binary is 0o000 in the built layer with the bad order, 0o755 with the symlink-first order.

**Two-layer fix:**
1. Reorder the 3 affected `images/*.yaml` files (etcd, velero, fluent-bit) so symlinks come before permissions. Each file has a long-form "ORDERING IS LOAD-BEARING" comment block.
2. `internal/integer/render/render.go`: new `reorderForApkoChmodQuirk` helper that walks paths twice (stable rebuild), emitting any symlink whose `source:` matches a `permissions` entry's `path:` first. Pure-data reorder.

Tests: `TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk` (asserts the reorder happens on the bad pattern) + `TestConfig_UnrelatedSymlinkOrderPreserved` (asserts the renderer doesn't reorder unrelated symlinks).

## Verification target

Next chart-integration nightly:
- meilisearch + workload-identity-webhook + etcd back to green
- falco passes via skip
- velero + fluent-bit unblocked at the binary-mode level (other issues may remain but the chmod chain is fixed)