### PR TITLE
fix(render,skips): narrow apko-quirk reorder + #380 review nits

### DIFF
--- a/internal/integer/render/render.go
+++ b/internal/integer/render/render.go
@@ -174,39 +174,37 @@ func convertPaths(in []config.PathDef, version string) ([]apkoPath, error) {
 	return reorderForApkoChmodQuirk(out), nil
 }
 
-// reorderForApkoChmodQuirk moves every `symlink` entry to come BEFORE every
-// `permissions` entry whose path equals the symlink's source. See the
-// convertPaths docstring for the underlying apko behaviour. Pure-data
-// reorder; no semantic change beyond mutation order.
+// reorderForApkoChmodQuirk rewrites only the symlink ↔ permissions pairs
+// that would trigger the apko Chmod-via-symlink quirk, leaving every other
+// entry untouched. See the convertPaths docstring for the underlying apko
+// behaviour.
+//
+// The implementation does a single in-place pass: for each `symlink` entry
+// whose `Source` equals the `Path` of an earlier `permissions` entry, swap
+// the symlink with that earlier permissions entry so the symlink runs
+// first at apko mutate time. Unrelated entries (directories, other
+// symlinks, other permissions mutations) keep their absolute positions —
+// this matters because fluent-bit's `/fluent-bit/bin` parent directory
+// MUST be created before the `/fluent-bit/bin/fluent-bit` symlink it
+// hosts, and a "lift symlinks to the front" reorder would invert that.
 func reorderForApkoChmodQuirk(in []apkoPath) []apkoPath {
-	// Build a set of "symlink sources that will collide with permissions
-	// entries already past this point" so we know which symlinks to lift.
-	permsBefore := make(map[string]struct{})
-	for _, p := range in {
-		if p.Type == "permissions" {
-			permsBefore[p.Path] = struct{}{}
+	out := append([]apkoPath(nil), in...)
+	for i := range out {
+		if out[i].Type != "permissions" {
+			continue
 		}
-	}
-	// Two-pass stable rebuild: first emit symlinks whose source matches
-	// a permissions entry's path (in their original relative order),
-	// then emit everything else (including any unrelated symlinks)
-	// in original order. This is the smallest reorder that satisfies
-	// the apko quirk.
-	out := make([]apkoPath, 0, len(in))
-	for _, p := range in {
-		if p.Type == "symlink" {
-			if _, hit := permsBefore[p.Source]; hit {
-				out = append(out, p)
+		// Scan forward for a symlink whose Source is this permissions
+		// entry's Path. If found, swap them so the symlink runs first.
+		for j := i + 1; j < len(out); j++ {
+			if out[j].Type == "symlink" && out[j].Source == out[i].Path {
+				out[i], out[j] = out[j], out[i]
+				// Don't break — there could be more permissions
+				// entries later in the slice that need the same
+				// treatment. Continue the outer loop from the
+				// current index, which now holds the symlink.
+				break
 			}
 		}
-	}
-	for _, p := range in {
-		if p.Type == "symlink" {
-			if _, hit := permsBefore[p.Source]; hit {
-				continue
-			}
-		}
-		out = append(out, p)
 	}
 	return out
 }

--- a/internal/integer/render/render_test.go
+++ b/internal/integer/render/render_test.go
@@ -277,18 +277,21 @@ func TestConfig_PathSourceOnNonSymlink_Errors(t *testing.T) {
 // reorder in `convertPaths` for the apko `mutatePermissions on every
 // non-permissions entry` quirk (see the convertPaths docstring). When a
 // permissions mutation on `/usr/bin/X` is declared BEFORE a symlink
-// mutation pointing at `/usr/bin/X`, the rendered apko config MUST emit
-// the symlink first so apko's implicit Chmod(0) on the symlink doesn't
-// follow the link and reset the target's mode to 0o000.
+// mutation pointing at `/usr/bin/X`, the rendered apko config MUST swap
+// them so apko's implicit Chmod(0) on the symlink doesn't follow the link
+// and reset the target's mode to 0o000.
 //
-// This protects the etcd / velero / fluent-bit FHS-symlink images from
-// silently regressing if a maintainer reorders entries in images/*.yaml
-// to read more naturally.
+// The reorder is MINIMAL — only the offending permissions↔symlink pair is
+// swapped. Other entries (directories, other permissions mutations,
+// unrelated symlinks) keep their absolute positions. This matters because
+// charts like fluent-bit require a parent-directory entry to be created
+// before the symlink it hosts, and any "lift symlinks to the front"
+// strategy would invert that ordering.
 func TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk(t *testing.T) {
 	tmpl := config.TypeTemplate{
 		Base: "wolfi-base",
 		// Source ORDER intentionally puts permissions before symlink —
-		// the test asserts the renderer rewrites it.
+		// the test asserts the renderer swaps just those two entries.
 		Paths: []config.PathDef{
 			{Path: "/var/lib/etcd", Type: "directory", UID: 65532, GID: 65532, Permissions: "0o700"},
 			{Path: "/usr/bin/etcd", Type: "permissions", UID: 0, GID: 0, Permissions: "0o755"},
@@ -305,24 +308,78 @@ func TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, paths, 3)
 
-	// The symlink whose source matches the permissions entry must come
-	// FIRST in the emitted order (rewritten from its source position).
+	// First entry stays as the unrelated directory — proving the
+	// reorder is local (no global "lift to front").
 	first, ok := paths[0].(map[string]any)
 	require.True(t, ok, "paths[0] is map[string]any")
-	assert.Equal(t, "symlink", first["type"], "symlink that targets a permissions-mutated path must be emitted first")
-	assert.Equal(t, "/usr/local/bin/etcd", first["path"])
-	assert.Equal(t, "/usr/bin/etcd", first["source"])
+	assert.Equal(t, "directory", first["type"], "unrelated directory entry stays at its original position 0")
+	assert.Equal(t, "/var/lib/etcd", first["path"])
 
-	// Other entries retain their relative ordering.
+	// The symlink (originally at index 2) and the permissions entry
+	// (originally at index 1) get swapped — symlink now at the
+	// permissions entry's old position, permissions at the symlink's
+	// old position.
 	second, ok := paths[1].(map[string]any)
 	require.True(t, ok, "paths[1] is map[string]any")
-	assert.Equal(t, "directory", second["type"])
-	assert.Equal(t, "/var/lib/etcd", second["path"])
+	assert.Equal(t, "symlink", second["type"], "symlink slot now holds the swapped symlink entry")
+	assert.Equal(t, "/usr/local/bin/etcd", second["path"])
+	assert.Equal(t, "/usr/bin/etcd", second["source"])
 
 	third, ok := paths[2].(map[string]any)
 	require.True(t, ok, "paths[2] is map[string]any")
-	assert.Equal(t, "permissions", third["type"])
+	assert.Equal(t, "permissions", third["type"], "permissions slot now holds the swapped permissions entry")
 	assert.Equal(t, "/usr/bin/etcd", third["path"])
+}
+
+// TestConfig_ParentDirBeforeSymlink_StillRespected guards the fluent-bit
+// invariant: a parent-directory entry created right before a symlink
+// hosted in that directory must keep its position-before-symlink ordering
+// even when the symlink targets a permissions-mutated path. The reorder
+// only swaps the permissions↔symlink pair, never lifts the symlink past
+// an earlier directory entry.
+func TestConfig_ParentDirBeforeSymlink_StillRespected(t *testing.T) {
+	tmpl := config.TypeTemplate{
+		Base: "wolfi-base",
+		// Shape mirrors images/fluent-bit.yaml: parent dir is created
+		// FIRST, then permissions, then symlink hosted in that parent.
+		Paths: []config.PathDef{
+			{Path: "/etc/fluent-bit", Type: "directory", UID: 65532, GID: 65532, Permissions: "0o755"},
+			{Path: "/fluent-bit/bin", Type: "directory", UID: 0, GID: 0, Permissions: "0o755"},
+			{Path: "/usr/bin/fluent-bit", Type: "permissions", UID: 0, GID: 0, Permissions: "0o755"},
+			{Path: "/fluent-bit/bin/fluent-bit", Type: "symlink", Source: "/usr/bin/fluent-bit", UID: 0, GID: 0},
+		},
+	}
+	out, err := render.Config(&tmpl, "latest", "_base")
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &cfg))
+
+	paths, ok := cfg["paths"].([]any)
+	require.True(t, ok)
+	require.Len(t, paths, 4)
+
+	// Directories keep their absolute positions 0 and 1.
+	p0, ok := paths[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "directory", p0["type"])
+	assert.Equal(t, "/etc/fluent-bit", p0["path"])
+
+	p1, ok := paths[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "directory", p1["type"], "parent /fluent-bit/bin dir must still come before its child symlink")
+	assert.Equal(t, "/fluent-bit/bin", p1["path"])
+
+	// Position 2 was permissions, position 3 was symlink — swap.
+	p2, ok := paths[2].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "symlink", p2["type"], "symlink swapped into the permissions slot")
+	assert.Equal(t, "/fluent-bit/bin/fluent-bit", p2["path"])
+
+	p3, ok := paths[3].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "permissions", p3["type"], "permissions swapped into the symlink slot")
+	assert.Equal(t, "/usr/bin/fluent-bit", p3["path"])
 }
 
 // TestConfig_UnrelatedSymlinkOrderPreserved confirms the reorder only

--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -38,9 +38,27 @@ skips:
   - chart: falco
     reason: kernel-incompat
     tracking_issue: https://github.com/verity-org/verity/issues/325
-    exit_criteria: "falco's modern_ebpf driver fails to load (`libpman: ring buffer map type is not supported`) under the Azure GHA runner because the BPF capability is denied at runc create time. Bypassing via `driver.enabled: false` alone is NOT sufficient: the chart's auto-inject of the `container` plugin (_helpers.tpl:477 falco.containerPlugin) is gated by `driver.enabled` AND `collectors.enabled`, so disabling the driver also disables the only event source. Un-skipping requires either (a) GHA runner image grants CAP_BPF/CAP_PERFMON to docker-in-docker kind nodes, OR (b) chartValues wires the container plugin manually (set `falco.plugins`, `falco.load_plugins`, and `falcoctl.config.artifact.install.refs` to include the plugin artifact), OR (c) chart upstream provides a `driver.enabled: false` mode that does NOT also strip the container plugin."
-    added: 2026-05-14
-    added_by: SCR-2026-05-14-001
+    exit_criteria: |
+      falco's modern_ebpf driver fails to load (`libpman: ring buffer
+      map type is not supported`) under the Azure GHA runner because
+      the BPF capability is denied at runc create time. Bypassing via
+      `driver.enabled: false` alone is NOT sufficient: the chart's
+      auto-inject of the `container` plugin (_helpers.tpl:477
+      falco.containerPlugin) is gated by `driver.enabled` AND
+      `collectors.enabled`, so disabling the driver also disables the
+      only event source.
+
+      Un-skipping requires one of:
+      (a) GHA runner image grants CAP_BPF/CAP_PERFMON to
+          docker-in-docker kind nodes.
+      (b) chartValues wires the container plugin manually — set
+          `falco.plugins`, `falco.load_plugins`, AND
+          `falcoctl.config.artifact.install.refs` to include the
+          plugin artifact.
+      (c) chart upstream provides a `driver.enabled: false` mode that
+          does NOT also strip the container plugin.
+    added: 2026-05-16
+    added_by: SCR-2026-05-14-001 (re-added after #378 + #380 follow-up)
 
   - chart: nfs-subdir-external-provisioner
     reason: needs-external-infra

--- a/test/chart-integration/values/meilisearch.allowlist.txt
+++ b/test/chart-integration/values/meilisearch.allowlist.txt
@@ -4,7 +4,7 @@
 # pod (chart-template-driven, used to chmod/initialize the data volume
 # before the main meilisearch container starts). chart-gen has
 # `busybox` in its `--exclude-names` list (the wolfi busybox is its
-# own integer rebuild that's intentionally NOT chart-rewritten —
+# own Integer-Orchestrator rebuild that's intentionally NOT chart-rewritten —
 # many charts use `:latest` busybox refs that would not survive
 # rewrite without per-chart wiring), so the upstream Docker Hub
 # reference renders into the wrapper verbatim.


### PR DESCRIPTION
## Summary

Three follow-ups from review of [#380](https://github.com/verity-org/verity/pull/380).

### 1. P1 from cubic-dev-ai — narrow the apko-quirk reorder

The original `reorderForApkoChmodQuirk` lifted matching symlinks to the front of `paths`, which can break parent-directory-before-symlink ordering. Concretely, fluent-bit needs `/fluent-bit/bin` directory created BEFORE `/fluent-bit/bin/fluent-bit` symlink, but the lift would invert that.

Replaced with a minimal in-place swap: for each `permissions` entry, scan forward for a `symlink` whose `Source` matches the permissions entry's `Path`; swap that pair in place. Unrelated entries (directories, other permissions, unrelated symlinks) keep their absolute positions.

New test `TestConfig_ParentDirBeforeSymlink_StillRespected` feeds the exact fluent-bit shape and asserts the parent directory stays at its original index while the permissions/symlink pair swaps.

### 2. SKIPS.yaml falco entry hygiene (Copilot threads on #380)

- `added:` corrected `2026-05-14` → `2026-05-16` (re-added in [#380](https://github.com/verity-org/verity/pull/380) after the [#378](https://github.com/verity-org/verity/pull/378) un-skip didn't work).
- `added_by:` annotation calls out the re-addition context.
- `exit_criteria` switched from a 300+ char single-line string to a YAML block scalar (`|`) so options (a/b/c) read as a structured list.

### 3. meilisearch.allowlist.txt wording (Copilot)

`integer rebuild` → `Integer-Orchestrator rebuild` (the Verity component is named "Integer Orchestrator"; lowercase "integer rebuild" reads like a Go language reference).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the symlink/permissions reorder in the renderer to a minimal in-place swap so parent directories stay before their child symlinks, preventing the `apko` chmod-via-symlink issue. Also cleans up the Falco skip entry and a Meilisearch allowlist note.

- Bug Fixes
  - Replace “lift symlinks to front” with a local swap between a `permissions` entry and its matching `symlink`, preserving all other positions; adds a regression test to keep parent-dir-before-symlink ordering.

- Refactors
  - Falco `SKIPS.yaml`: fix `added` date, add re-addition context in `added_by`, and convert `exit_criteria` to a block scalar.
  - `meilisearch.allowlist.txt`: clarify wording to “Integer-Orchestrator rebuild.”

<sup>Written for commit b039b8e2cc827a3a569306f524a222ad5cf2596a. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/381?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

