### PR TITLE
fix(render): propagate target perms onto symlinks (replaces #381 swap)

### DIFF
--- a/images/etcd.yaml
+++ b/images/etcd.yaml
@@ -10,28 +10,23 @@ types:
     entrypoint: /usr/bin/etcd
     paths:
       - {path: /var/lib/etcd, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
-      # bitnami/etcd helm chart hardcodes /usr/local/bin/etcd in the StatefulSet
-      # command — verity's wolfi rebuild ships at /usr/bin/etcd (FHS).
-      # Symlink keeps both layouts working. See verity-org/verity#318 (A.2).
-      #
-      # ORDERING IS LOAD-BEARING: the symlink entry MUST come BEFORE the
-      # `permissions` mutation on /usr/bin/etcd below. apko's mutatePaths
-      # (pkg/build/paths.go:146) calls mutatePermissions on every non-
-      # permissions entry AFTER its type-specific mutator, using the
-      # mutation's `permissions:` field — and the symlink entry has no
-      # `permissions:` set, so it falls back to mode 0. The Chmod follows
-      # the symlink (Linux symlink chmod semantics) and resets the target
-      # /usr/bin/etcd to mode 0o000, undoing the explicit chmod above.
-      # Reordering symlink-before-permissions sidesteps the apko quirk
-      # without needing an upstream patch.
-      - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
       # Published `ghcr.io/verity-org/etcd:latest` ships /usr/bin/etcd with
       # mode 0o000; runc aborts with `exec: "/usr/local/bin/etcd": permission
-      # denied` after resolving the symlink above. The prior #318 (A.2) FHS
+      # denied` after resolving the symlink below. The prior #318 (A.2) FHS
       # symlink IS landing in the image, but the target binary lacks +x.
       # apko `type: permissions` is the canonical chmod-on-existing-file
       # mutation. See SCR-2026-05-14-001 Bucket H + image-mode-audit.md.
       - {path: /usr/bin/etcd, type: permissions, uid: 0, gid: 0, permissions: 0o755}
+      # bitnami/etcd helm chart hardcodes /usr/local/bin/etcd in the StatefulSet
+      # command — verity's wolfi rebuild ships at /usr/bin/etcd (FHS).
+      # Symlink keeps both layouts working. See verity-org/verity#318 (A.2).
+      #
+      # The verity render layer propagates the target's permissions onto
+      # this symlink at convertPaths time so apko's implicit
+      # Chmod-via-symlink doesn't reset /usr/bin/etcd back to mode 0;
+      # see `propagateSymlinkPermsForApkoChmodQuirk` in
+      # internal/integer/render/render.go.
+      - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
 
   fips:
     base: wolfi-fips
@@ -39,10 +34,8 @@ types:
     entrypoint: /usr/bin/etcd
     paths:
       - {path: /var/lib/etcd, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
-      # See the `default` types block above for the rationale on symlink-
-      # before-permissions ordering (apko chmod-via-symlink quirk).
-      - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
       - {path: /usr/bin/etcd, type: permissions, uid: 0, gid: 0, permissions: 0o755}
+      - {path: /usr/local/bin/etcd, type: symlink, source: /usr/bin/etcd, uid: 0, gid: 0}
 
 versions:
   "3.5":

--- a/images/fluent-bit.yaml
+++ b/images/fluent-bit.yaml
@@ -10,27 +10,23 @@ types:
     entrypoint: /usr/bin/fluent-bit
     paths:
       - {path: /etc/fluent-bit, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
-      # fluent/fluent-bit helm chart hardcodes /fluent-bit/bin/fluent-bit in the
-      # DaemonSet command — verity's wolfi rebuild ships at /usr/bin/fluent-bit
-      # (FHS). Need parent directory entry first, then the symlink itself.
-      # See verity-org/verity#318 (A.2).
-      #
-      # ORDERING IS LOAD-BEARING — the symlink entry MUST come BEFORE the
-      # `permissions` mutation on /usr/bin/fluent-bit below. apko's
-      # mutatePaths calls mutatePermissions on every non-permissions
-      # mutation AFTER its type-specific mutator, using the mutation's
-      # `permissions:` field — the symlink entry has no `permissions:` set
-      # (defaults to 0). The Chmod(0) follows the symlink (Linux symlink-
-      # chmod semantics) and resets the TARGET /usr/bin/fluent-bit to mode
-      # 0o000 — undoing the explicit chmod below. See SCR-2026-05-14-001
-      # Bucket H + the corresponding ordering note in images/etcd.yaml.
-      - {path: /fluent-bit/bin, type: directory, uid: 0, gid: 0, permissions: 0o755}
-      - {path: /fluent-bit/bin/fluent-bit, type: symlink, source: /usr/bin/fluent-bit, uid: 0, gid: 0}
       # Published `ghcr.io/verity-org/fluent-bit:latest` ships
       # `/usr/bin/fluent-bit` with mode 0o000 — `runc` aborts with
       # `exec: permission denied`. apko `type: permissions` forces +x on
       # layer assembly. See SCR-2026-05-14-001 Bucket H.
       - {path: /usr/bin/fluent-bit, type: permissions, uid: 0, gid: 0, permissions: 0o755}
+      # fluent/fluent-bit helm chart hardcodes /fluent-bit/bin/fluent-bit in the
+      # DaemonSet command — verity's wolfi rebuild ships at /usr/bin/fluent-bit
+      # (FHS). Need parent directory entry first, then the symlink itself.
+      # See verity-org/verity#318 (A.2).
+      #
+      # The verity render layer propagates the target's permissions onto
+      # the symlink at convertPaths time so apko's implicit
+      # Chmod-via-symlink doesn't reset /usr/bin/fluent-bit back to
+      # mode 0; see `propagateSymlinkPermsForApkoChmodQuirk` in
+      # internal/integer/render/render.go.
+      - {path: /fluent-bit/bin, type: directory, uid: 0, gid: 0, permissions: 0o755}
+      - {path: /fluent-bit/bin/fluent-bit, type: symlink, source: /usr/bin/fluent-bit, uid: 0, gid: 0}
 
 versions:
   # Wolfi dropped fluent-bit-3.x entirely; previously declared "3.2" had no

--- a/images/velero.yaml
+++ b/images/velero.yaml
@@ -9,26 +9,23 @@ types:
     packages: ["velero"]
     entrypoint: /usr/bin/velero
     paths:
-      # ORDERING IS LOAD-BEARING — symlink entry comes BEFORE the permissions
-      # mutation on /usr/bin/velero. apko's mutatePaths calls
-      # mutatePermissions on every non-permissions mutation AFTER its
-      # type-specific mutator, and the symlink entry has no `permissions:`
-      # set (defaults to 0). The Chmod(0) follows the symlink (Linux
-      # symlink-chmod semantics) and resets the TARGET /usr/bin/velero to
-      # mode 0o000 — undoing the explicit chmod below. See SCR-2026-05-14-001
-      # Bucket H + the corresponding ordering note in images/etcd.yaml.
-      #
+      # Published `ghcr.io/verity-org/velero:latest` ships /usr/bin/velero with
+      # mode 0o000 — `runc` aborts with `exec: "/velero": permission denied`
+      # (chart resolves /velero via the symlink below to /usr/bin/velero, but
+      # the target lacks +x). apko `type: permissions` forces +x on layer
+      # assembly. See SCR-2026-05-14-001 Bucket H.
+      - {path: /usr/bin/velero, type: permissions, uid: 0, gid: 0, permissions: 0o755}
       # vmware-tanzu/velero helm chart's upgrade-crds Job runs `/velero install`
       # — chart hardcodes /velero in the Job command. Verity's wolfi rebuild
       # ships at /usr/bin/velero (FHS). Symlink keeps both layouts working.
       # See verity-org/verity#318 (A.2 FHS-path mismatch sub-cluster).
+      #
+      # The verity render layer propagates the target's permissions onto
+      # this symlink at convertPaths time so apko's implicit
+      # Chmod-via-symlink doesn't reset /usr/bin/velero back to mode 0;
+      # see `propagateSymlinkPermsForApkoChmodQuirk` in
+      # internal/integer/render/render.go.
       - {path: /velero, type: symlink, source: /usr/bin/velero, uid: 0, gid: 0}
-      # Published `ghcr.io/verity-org/velero:latest` ships /usr/bin/velero with
-      # mode 0o000 — `runc` aborts with `exec: "/velero": permission denied`
-      # (chart resolves /velero via the symlink above to /usr/bin/velero, but
-      # the target lacks +x). apko `type: permissions` forces +x on layer
-      # assembly. See SCR-2026-05-14-001 Bucket H.
-      - {path: /usr/bin/velero, type: permissions, uid: 0, gid: 0, permissions: 0o755}
 
 versions:
   "1": {}

--- a/internal/integer/render/render.go
+++ b/internal/integer/render/render.go
@@ -125,23 +125,32 @@ func Config(tmpl *config.TypeTemplate, version, basePath string) ([]byte, error)
 //   - type=symlink requires Source (apko rejects symlinks without a target)
 //   - Source set on any non-symlink type is invalid (apko rejects it)
 //
-// It also REORDERS entries to defend against an apko quirk: apko's
-// mutatePaths (chainguard-dev/apko pkg/build/paths.go:146) runs
-// mutatePermissions on every non-permissions mutation AFTER its type-
-// specific mutator, using the mutation's `permissions:` field. A symlink
-// mutation with no explicit `permissions:` defaults to 0, so apko ends up
-// calling Chmod(0) on the SYMLINK PATH — and under Linux symlink-chmod
-// semantics that follows the link and resets the TARGET file's mode.
-// Concretely: if `/usr/bin/etcd` has a `permissions: 0o755` mutation and
-// `/usr/local/bin/etcd → /usr/bin/etcd` is mutated AFTER it, the symlink's
-// implicit Chmod(0) wipes the binary's executable bit and `runc exec`
-// aborts with permission denied at chart-integration time.
+// It also PROPAGATES permissions from a target-permissions entry onto a
+// matching symlink to defend against an apko quirk: apko's mutatePaths
+// (chainguard-dev/apko pkg/build/paths.go:146) runs mutatePermissions on
+// every non-permissions mutation AFTER its type-specific mutator, using
+// the mutation's `permissions:` field. A symlink mutation with no
+// explicit `permissions:` defaults to 0, so apko ends up calling
+// Chmod(0) on the SYMLINK PATH — and under Linux symlink-chmod semantics
+// that follows the link and resets the TARGET file's mode. Concretely:
+// if `/usr/bin/etcd` has a `permissions: 0o755` mutation and
+// `/usr/local/bin/etcd → /usr/bin/etcd` is mutated AFTER it, the
+// symlink's implicit Chmod(0) wipes the binary's executable bit and
+// `runc exec` aborts with permission denied at chart-integration time.
 //
-// To make this safe regardless of YAML ordering in images/*.yaml, we
-// reorder so every `symlink` entry comes BEFORE every `permissions`
-// entry whose `path:` is the symlink's `source:` (the link target). The
-// reorder is stable within each group — relative ordering of entries
-// that don't trigger the rule is preserved.
+// Defense: for each `symlink` entry whose `Source` equals the `Path` of
+// any `permissions` entry, COPY the permissions value (and the
+// permissions entry's UID/GID for consistency) onto the symlink. apko's
+// implicit Chmod still runs against the symlink, still follows the
+// link, but now writes the SAME mode the explicit permissions entry
+// asked for instead of wiping it to 0. This avoids reordering entries
+// entirely, so:
+//
+//   - parent-directory-before-symlink ordering (fluent-bit's
+//     /fluent-bit/bin before /fluent-bit/bin/fluent-bit) is preserved
+//   - multiple same-target permissions entries keep their declaration
+//     order (the last-write-wins semantics they already had under apko
+//     are unchanged)
 //
 // Failing fast at render keeps misconfigured YAML errors close to their YAML
 // source instead of surfacing as opaque apko/melange build failures.
@@ -171,42 +180,50 @@ func convertPaths(in []config.PathDef, version string) ([]apkoPath, error) {
 			Permissions: perms,
 		}
 	}
-	return reorderForApkoChmodQuirk(out), nil
+	propagateSymlinkPermsForApkoChmodQuirk(out)
+	return out, nil
 }
 
-// reorderForApkoChmodQuirk rewrites only the symlink ↔ permissions pairs
-// that would trigger the apko Chmod-via-symlink quirk, leaving every other
-// entry untouched. See the convertPaths docstring for the underlying apko
-// behaviour.
+// propagateSymlinkPermsForApkoChmodQuirk copies the permissions / uid /
+// gid from each `permissions` entry onto every `symlink` entry whose
+// `Source` matches that permissions entry's `Path`. See the convertPaths
+// docstring for the apko Chmod-via-symlink behaviour this works around.
 //
-// The implementation does a single in-place pass: for each `symlink` entry
-// whose `Source` equals the `Path` of an earlier `permissions` entry, swap
-// the symlink with that earlier permissions entry so the symlink runs
-// first at apko mutate time. Unrelated entries (directories, other
-// symlinks, other permissions mutations) keep their absolute positions —
-// this matters because fluent-bit's `/fluent-bit/bin` parent directory
-// MUST be created before the `/fluent-bit/bin/fluent-bit` symlink it
-// hosts, and a "lift symlinks to the front" reorder would invert that.
-func reorderForApkoChmodQuirk(in []apkoPath) []apkoPath {
-	out := append([]apkoPath(nil), in...)
-	for i := range out {
-		if out[i].Type != "permissions" {
-			continue
-		}
-		// Scan forward for a symlink whose Source is this permissions
-		// entry's Path. If found, swap them so the symlink runs first.
-		for j := i + 1; j < len(out); j++ {
-			if out[j].Type == "symlink" && out[j].Source == out[i].Path {
-				out[i], out[j] = out[j], out[i]
-				// Don't break — there could be more permissions
-				// entries later in the slice that need the same
-				// treatment. Continue the outer loop from the
-				// current index, which now holds the symlink.
-				break
-			}
+// Mutates `paths` in place. A symlink that already has a non-zero
+// Permissions is NOT overridden — the explicit value from the YAML wins.
+// If multiple permissions entries target the same path, the LAST-DECLARED
+// one is propagated (mirroring apko's last-write-wins semantics for
+// repeated permissions mutations).
+func propagateSymlinkPermsForApkoChmodQuirk(paths []apkoPath) {
+	// Build a `target Path → (perms, uid, gid)` map from permissions
+	// entries. Iterate in declared order so later entries overwrite
+	// earlier ones (matches apko's apply order).
+	type permsRecord struct {
+		perms    uint32
+		uid, gid int
+	}
+	byTarget := make(map[string]permsRecord)
+	for _, p := range paths {
+		if p.Type == "permissions" {
+			byTarget[p.Path] = permsRecord{p.Permissions, p.UID, p.GID}
 		}
 	}
-	return out
+	for i := range paths {
+		if paths[i].Type != "symlink" {
+			continue
+		}
+		if paths[i].Permissions != 0 {
+			// Explicit YAML value — respect it.
+			continue
+		}
+		rec, ok := byTarget[paths[i].Source]
+		if !ok {
+			continue
+		}
+		paths[i].Permissions = rec.perms
+		paths[i].UID = rec.uid
+		paths[i].GID = rec.gid
+	}
 }
 
 // sub replaces all occurrences of {{version}} in s with version.

--- a/internal/integer/render/render_test.go
+++ b/internal/integer/render/render_test.go
@@ -273,25 +273,21 @@ func TestConfig_PathSourceOnNonSymlink_Errors(t *testing.T) {
 	assert.Contains(t, err.Error(), `type="directory"`) // ensure the actual type is reported
 }
 
-// TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk regression-tests the
-// reorder in `convertPaths` for the apko `mutatePermissions on every
-// non-permissions entry` quirk (see the convertPaths docstring). When a
-// permissions mutation on `/usr/bin/X` is declared BEFORE a symlink
-// mutation pointing at `/usr/bin/X`, the rendered apko config MUST swap
-// them so apko's implicit Chmod(0) on the symlink doesn't follow the link
-// and reset the target's mode to 0o000.
+// TestConfig_SymlinkInheritsTargetPerms_ApkoChmodQuirk regression-tests
+// the permissions-propagation in `convertPaths` for the apko
+// `mutatePermissions on every non-permissions entry` quirk (see the
+// convertPaths docstring). When a permissions mutation on `/usr/bin/X`
+// declares mode 0o755 and a symlink points at `/usr/bin/X`, the rendered
+// apko config MUST copy that 0o755 onto the symlink entry so apko's
+// implicit Chmod on the symlink (which follows the link) writes 0o755
+// to the target instead of 0.
 //
-// The reorder is MINIMAL — only the offending permissions↔symlink pair is
-// swapped. Other entries (directories, other permissions mutations,
-// unrelated symlinks) keep their absolute positions. This matters because
-// charts like fluent-bit require a parent-directory entry to be created
-// before the symlink it hosts, and any "lift symlinks to the front"
-// strategy would invert that ordering.
-func TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk(t *testing.T) {
+// This approach has zero ordering impact — parent-directory-before-
+// symlink invariants and same-target-permissions declaration order are
+// both preserved.
+func TestConfig_SymlinkInheritsTargetPerms_ApkoChmodQuirk(t *testing.T) {
 	tmpl := config.TypeTemplate{
 		Base: "wolfi-base",
-		// Source ORDER intentionally puts permissions before symlink —
-		// the test asserts the renderer swaps just those two entries.
 		Paths: []config.PathDef{
 			{Path: "/var/lib/etcd", Type: "directory", UID: 65532, GID: 65532, Permissions: "0o700"},
 			{Path: "/usr/bin/etcd", Type: "permissions", UID: 0, GID: 0, Permissions: "0o755"},
@@ -308,40 +304,39 @@ func TestConfig_SymlinkBeforePermissions_ApkoChmodQuirk(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, paths, 3)
 
-	// First entry stays as the unrelated directory — proving the
-	// reorder is local (no global "lift to front").
-	first, ok := paths[0].(map[string]any)
-	require.True(t, ok, "paths[0] is map[string]any")
-	assert.Equal(t, "directory", first["type"], "unrelated directory entry stays at its original position 0")
-	assert.Equal(t, "/var/lib/etcd", first["path"])
+	// Order is COMPLETELY UNCHANGED — every entry stays at its
+	// original index. The fix is permissions-propagation, not
+	// reordering.
+	p0, ok := paths[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "directory", p0["type"])
+	assert.Equal(t, "/var/lib/etcd", p0["path"])
 
-	// The symlink (originally at index 2) and the permissions entry
-	// (originally at index 1) get swapped — symlink now at the
-	// permissions entry's old position, permissions at the symlink's
-	// old position.
-	second, ok := paths[1].(map[string]any)
-	require.True(t, ok, "paths[1] is map[string]any")
-	assert.Equal(t, "symlink", second["type"], "symlink slot now holds the swapped symlink entry")
-	assert.Equal(t, "/usr/local/bin/etcd", second["path"])
-	assert.Equal(t, "/usr/bin/etcd", second["source"])
+	p1, ok := paths[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "permissions", p1["type"])
+	assert.Equal(t, "/usr/bin/etcd", p1["path"])
 
-	third, ok := paths[2].(map[string]any)
-	require.True(t, ok, "paths[2] is map[string]any")
-	assert.Equal(t, "permissions", third["type"], "permissions slot now holds the swapped permissions entry")
-	assert.Equal(t, "/usr/bin/etcd", third["path"])
+	p2, ok := paths[2].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "symlink", p2["type"])
+	assert.Equal(t, "/usr/local/bin/etcd", p2["path"])
+	assert.Equal(t, "/usr/bin/etcd", p2["source"])
+	// The symlink inherited the target's permissions 0o755 = 493
+	// decimal. apko's implicit Chmod on the symlink now writes 0o755
+	// to the target instead of 0.
+	assert.Equal(t, 493, p2["permissions"], "symlink inherits its target's permissions mutation value")
 }
 
-// TestConfig_ParentDirBeforeSymlink_StillRespected guards the fluent-bit
-// invariant: a parent-directory entry created right before a symlink
-// hosted in that directory must keep its position-before-symlink ordering
-// even when the symlink targets a permissions-mutated path. The reorder
-// only swaps the permissions↔symlink pair, never lifts the symlink past
-// an earlier directory entry.
-func TestConfig_ParentDirBeforeSymlink_StillRespected(t *testing.T) {
+// TestConfig_SymlinkParentDirAndPermsOrderingPreserved guards the
+// fluent-bit invariant: a parent-directory entry created before a
+// symlink hosted in that directory keeps its position-before-symlink
+// ordering. Since the fix is propagation (not reorder), all 4 entries
+// stay at their declared indices.
+func TestConfig_SymlinkParentDirAndPermsOrderingPreserved(t *testing.T) {
 	tmpl := config.TypeTemplate{
 		Base: "wolfi-base",
-		// Shape mirrors images/fluent-bit.yaml: parent dir is created
-		// FIRST, then permissions, then symlink hosted in that parent.
+		// Shape mirrors images/fluent-bit.yaml.
 		Paths: []config.PathDef{
 			{Path: "/etc/fluent-bit", Type: "directory", UID: 65532, GID: 65532, Permissions: "0o755"},
 			{Path: "/fluent-bit/bin", Type: "directory", UID: 0, GID: 0, Permissions: "0o755"},
@@ -359,33 +354,62 @@ func TestConfig_ParentDirBeforeSymlink_StillRespected(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, paths, 4)
 
-	// Directories keep their absolute positions 0 and 1.
-	p0, ok := paths[0].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "directory", p0["type"])
-	assert.Equal(t, "/etc/fluent-bit", p0["path"])
+	// Indices unchanged.
+	for i, want := range []struct {
+		ptype string
+		path  string
+	}{
+		{"directory", "/etc/fluent-bit"},
+		{"directory", "/fluent-bit/bin"},
+		{"permissions", "/usr/bin/fluent-bit"},
+		{"symlink", "/fluent-bit/bin/fluent-bit"},
+	} {
+		p, ok := paths[i].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, want.ptype, p["type"], "paths[%d].type", i)
+		assert.Equal(t, want.path, p["path"], "paths[%d].path", i)
+	}
 
-	p1, ok := paths[1].(map[string]any)
+	// Symlink inherited the target's perms.
+	sym, ok := paths[3].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "directory", p1["type"], "parent /fluent-bit/bin dir must still come before its child symlink")
-	assert.Equal(t, "/fluent-bit/bin", p1["path"])
-
-	// Position 2 was permissions, position 3 was symlink — swap.
-	p2, ok := paths[2].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "symlink", p2["type"], "symlink swapped into the permissions slot")
-	assert.Equal(t, "/fluent-bit/bin/fluent-bit", p2["path"])
-
-	p3, ok := paths[3].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "permissions", p3["type"], "permissions swapped into the symlink slot")
-	assert.Equal(t, "/usr/bin/fluent-bit", p3["path"])
+	assert.Equal(t, 493, sym["permissions"])
 }
 
-// TestConfig_UnrelatedSymlinkOrderPreserved confirms the reorder only
-// touches symlinks whose source matches a permissions entry. A symlink
-// pointing at an unrelated path keeps its original position.
-func TestConfig_UnrelatedSymlinkOrderPreserved(t *testing.T) {
+// TestConfig_ExplicitSymlinkPermsRespected confirms the propagation only
+// fires when the symlink's own permissions are unset (mode 0). If a YAML
+// author explicitly set the symlink's permissions, that wins.
+func TestConfig_ExplicitSymlinkPermsRespected(t *testing.T) {
+	tmpl := config.TypeTemplate{
+		Base: "wolfi-base",
+		Paths: []config.PathDef{
+			{Path: "/usr/bin/foo", Type: "permissions", UID: 0, GID: 0, Permissions: "0o755"},
+			// Author explicitly set 0o700 on the symlink.
+			{Path: "/usr/local/bin/foo", Type: "symlink", Source: "/usr/bin/foo", UID: 0, GID: 0, Permissions: "0o700"},
+		},
+	}
+	out, err := render.Config(&tmpl, "latest", "_base")
+	require.NoError(t, err)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &cfg))
+
+	paths, ok := cfg["paths"].([]any)
+	require.True(t, ok)
+	require.Len(t, paths, 2)
+
+	sym, ok := paths[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "symlink", sym["type"])
+	// 0o700 = 448 decimal. Author's explicit value wins over the
+	// propagation (which would have written 0o755 = 493).
+	assert.Equal(t, 448, sym["permissions"], "explicit symlink permissions are not overwritten by propagation")
+}
+
+// TestConfig_UnrelatedSymlinkPermsZero confirms a symlink that doesn't
+// target any permissions-mutated path stays at permissions: 0. This is
+// the prior behaviour for the common case (most symlinks).
+func TestConfig_UnrelatedSymlinkPermsZero(t *testing.T) {
 	tmpl := config.TypeTemplate{
 		Base: "wolfi-base",
 		Paths: []config.PathDef{
@@ -405,14 +429,14 @@ func TestConfig_UnrelatedSymlinkOrderPreserved(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, paths, 3)
 
-	// Order is unchanged because no symlink target matches a permissions path.
-	first, ok := paths[0].(map[string]any)
-	require.True(t, ok, "paths[0] is map[string]any")
-	assert.Equal(t, "/var/lib/foo", first["path"])
-	second, ok := paths[1].(map[string]any)
-	require.True(t, ok, "paths[1] is map[string]any")
-	assert.Equal(t, "/usr/bin/foo", second["path"])
-	third, ok := paths[2].(map[string]any)
-	require.True(t, ok, "paths[2] is map[string]any")
-	assert.Equal(t, "/usr/local/bin/bar", third["path"])
+	// Order unchanged.
+	p0, ok := paths[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "/var/lib/foo", p0["path"])
+	p2, ok := paths[2].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "/usr/local/bin/bar", p2["path"])
+	// Unrelated symlink keeps its zero permissions (no propagation
+	// source).
+	assert.NotContains(t, p2, "permissions", "unrelated symlink omits permissions key (zero value, omitempty)")
 }


### PR DESCRIPTION
## Summary

Addresses cubic-dev-ai's P2 on [#381](https://github.com/verity-org/verity/pull/381): the pairwise-swap fix for the apko Chmod-via-symlink quirk can reverse the apply order of two `permissions` entries targeting the same path.

Replace the swap with **permissions propagation**: copy the target's `permissions/uid/gid` onto any symlink whose `Source` matches a `permissions` entry's `Path`. apko's implicit Chmod-via-symlink then writes the SAME mode the target wanted, instead of 0.

## Benefits

- **Zero reordering** — `paths:` declaration order is preserved exactly.
- Parent-directory-before-symlink invariants (fluent-bit) hold unconditionally.
- Same-target permissions declaration order preserved; last-write-wins semantics intact.
- Explicit YAML `permissions:` on a symlink is NOT overridden by the propagation.

## Image YAMLs

Revert the load-bearing-ordering hack from [#380](https://github.com/verity-org/verity/pull/380) for `images/etcd.yaml`, `velero.yaml`, `fluent-bit.yaml`. Symlinks can now sit AFTER permissions entries (the natural reading order). New comments point to the render-layer fix.

## Tests

4 new render tests covering: propagation happens, fluent-bit-style ordering preserved, explicit symlink perms respected, unrelated symlinks unchanged.

## Local verification

Built etcd:3.6 via apko 1.2.9 against the rendered config; extracted layer shows `/usr/bin/etcd` at 0o755 (was 0o000 with the unfixed config). Same chain holds for velero and fluent-bit.

Closes the P2 thread on [#381](https://github.com/verity-org/verity/pull/381).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates target `permissions/uid/gid` onto matching symlinks during render so `apko`’s implicit chmod writes the intended mode instead of 0. Replaces the swap-based workaround from #381 and restores natural YAML ordering in etcd, velero, and fluent-bit images.

- **Bug Fixes**
  - Copy `permissions/uid/gid` from each `permissions` entry to any `symlink` whose `source` matches that path, only if the symlink has no permissions set.
  - No reordering: preserves `paths:` order, keeps parent-dir-before-symlink, and maintains last-write-wins for multiple `permissions`; explicit symlink perms are not overridden.
  - Updated `images/etcd.yaml`, `images/velero.yaml`, and `images/fluent-bit.yaml` to remove ordering hacks; added render tests for propagation, ordering, and explicit-perms cases.

<sup>Written for commit 8b18b412233cb51398ef2752ba086a8a684d9516. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/382?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

