### PR TITLE
fix(charts,images): nightly-may16 batch2 — allowlists + chartValues + busybox

### DIFF
--- a/images/opensearch-dashboards.yaml
+++ b/images/opensearch-dashboards.yaml
@@ -6,7 +6,15 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["opensearch-dashboards-{{version}}"]
+    # busybox supplies `/bin/sh` plus basic coreutils. The apk-shipped
+    # `bin/opensearch-dashboards` is itself a POSIX shell script
+    # (`#!/bin/sh ...`) — without `/bin/sh` in the image, runc aborts
+    # at exec time with `exec /usr/share/opensearch-dashboards/bin/
+    # opensearch-dashboards: no such file or directory` (the missing
+    # file is the script's interpreter, not the script itself —
+    # verified against chart-integration run 25961993442). Same
+    # wolfi-baselayout shape as jenkins.yaml.
+    packages: ["opensearch-dashboards-{{version}}", "busybox"]
     # The apk does not ship `opensearch-dashboards-docker-entrypoint.sh`
     # (that script is a Docker-build artifact upstream, not an apk payload).
     # Published image's entrypoint failed with `exec: no such file or

--- a/test/chart-integration/values/openbao.allowlist.txt
+++ b/test/chart-integration/values/openbao.allowlist.txt
@@ -1,0 +1,25 @@
+# openbao upstream image allowlist (SCR-2026-04-30-001)
+#
+# The openbao chart pulls two upstream images directly:
+#
+#   quay.io/openbao/openbao:2.5.3       — the openbao server binary
+#                                         (HashiCorp Vault fork by the
+#                                         OpenBao maintainers)
+#   docker.io/hashicorp/vault-k8s:1.7.2 — agent injector sidecar
+#                                         controller (chart reuses
+#                                         hashicorp/vault-k8s since
+#                                         openbao didn't fork it)
+#
+# verity has no rebuilds for these (no `openbao/*` or `hashicorp/vault-k8s`
+# entries in verity.yaml replacements). Chart-gen leaves the upstream
+# references verbatim. Allowlist the upstreams so the image-origin
+# gate can pass.
+#
+# Format note: the isAccepted helper in test/chart-integration/
+# assertions.go uses strings.HasPrefix; the `:` and `@` separator
+# forms ensure each prefix only matches its intended image's
+# tag or digest forms.
+quay.io/openbao/openbao:
+quay.io/openbao/openbao@
+docker.io/hashicorp/vault-k8s:
+docker.io/hashicorp/vault-k8s@

--- a/test/chart-integration/values/victoria-logs-single.allowlist.txt
+++ b/test/chart-integration/values/victoria-logs-single.allowlist.txt
@@ -1,0 +1,21 @@
+# victoria-logs-single upstream image allowlist (SCR-2026-04-30-001)
+#
+# The victoria-logs-single chart pulls `victoriametrics/victoria-logs:
+# v1.50.0` — a statically-linked Go binary in a FROM-SCRATCH base
+# image. verity has no rebuild for it; chart-gen would route it
+# through Copa, but `victoriametrics/victoria-logs` is now listed in
+# verity.yaml `unpatchableImages` (Copa was substituting a dynamically-
+# linked binary against a missing dynamic-linker on the scratch base,
+# breaking `runc exec` — see the unpatchableImages comment in
+# verity.yaml).
+#
+# With the chart's image pinned to `docker.io/victoriametrics/
+# victoria-logs:v1.50.0` (unpatched), the chart-integration image-
+# origin gate needs this allowlist row.
+#
+# Format note: the isAccepted helper in test/chart-integration/
+# assertions.go uses strings.HasPrefix; the `:` and `@` separator
+# forms scope each prefix to the image's tag/digest refs without
+# leaking to unrelated `victoriametrics/*` repos.
+docker.io/victoriametrics/victoria-logs:
+docker.io/victoriametrics/victoria-logs@

--- a/test/chart-integration/values/weaviate.allowlist.txt
+++ b/test/chart-integration/values/weaviate.allowlist.txt
@@ -1,0 +1,26 @@
+# weaviate upstream image allowlist (SCR-2026-04-30-001)
+#
+# The weaviate chart pulls two upstream images:
+#
+#   cr.weaviate.io/semitechnologies/weaviate:1.37.0
+#                                       — main weaviate server binary
+#   docker.io/library/alpine:latest    — used as the init/utility
+#                                         pod for permission setup on
+#                                         the data volume (similar
+#                                         pattern to meilisearch's
+#                                         busybox init)
+#
+# verity has no rebuild for cr.weaviate.io/semitechnologies/weaviate
+# (the registry uses a custom hostname; no verity `weaviate` image
+# config exists). Chart-gen leaves both references verbatim.
+# `alpine` is intentionally excluded from chart-gen rewrite for the
+# same reason as `busybox` — short utility images that many charts
+# pull as `:latest` would not survive a tag rewrite.
+#
+# Format note: the isAccepted helper in test/chart-integration/
+# assertions.go uses strings.HasPrefix; `:` and `@` separator forms
+# scope each prefix to its image's tag/digest refs.
+cr.weaviate.io/semitechnologies/weaviate:
+cr.weaviate.io/semitechnologies/weaviate@
+docker.io/library/alpine:
+docker.io/library/alpine@

--- a/verity.yaml
+++ b/verity.yaml
@@ -82,11 +82,21 @@ chartValues:
 
   # mimir-distributed 6.0.6 can render as a single-image runtime if we turn off
   # optional bundled infra components (MinIO, Kafka, nginx gateway, rollout-operator).
+  #
+  # Additionally: with `kafka.enabled: false`, the chart's hardcoded
+  # `ingest_storage.enabled: true` template still tries to validate a
+  # Kafka address and aborts mimir components at startup with
+  # `invalid ingest storage config: the Kafka address has not been
+  # configured` (verified against chart-integration run 25961993442
+  # mimir-distributed-* pod logs). Override `ingest_storage.enabled:
+  # false` via `mimir.structuredConfig` — the chart's documented hook
+  # for overriding the rendered text-config.
   mimir-distributed:
     gateway.enabled: false
     kafka.enabled: false
     minio.enabled: false
     rollout_operator.enabled: false
+    mimir.structuredConfig.ingest_storage.enabled: false
 
   # tempo-distributed 1.61.3 defaults to a separate Memcached statefulset;
   # the minimal CI-friendly wrapper just runs the Tempo microservices
@@ -454,21 +464,6 @@ chartValues:
   dex:
     config.issuer: "http://dex.dex.svc.cluster.local:5556/dex"
     config.storage.type: "memory"
-
-  # mimir-distributed 6.0.6 — chart defaults `kafka.enabled: true` AND
-  # the mimir.config template hardcodes `ingest_storage.enabled: true`
-  # whether or not Kafka is actually deployed. With Kafka disabled the
-  # mimir components abort at startup:
-  #   error validating config: invalid ingest storage config: the Kafka
-  #   address has not been configured
-  # (chart-integration run 25961993442 mimir-distributed-* pod logs).
-  # Override ingest_storage via mimir.structuredConfig (the chart's
-  # documented override mechanism for the rendered text-config). Keep
-  # kafka.enabled: false to avoid deploying the bundled Kafka image,
-  # which would also need an allowlist entry.
-  mimir-distributed:
-    kafka.enabled: false
-    mimir.structuredConfig.ingest_storage.enabled: false
 
   # velero 12.0.1 — chart's default `configuration.backupStorageLocation`
   # is a one-element list with `provider: ""`. helm install then issues

--- a/verity.yaml
+++ b/verity.yaml
@@ -442,6 +442,48 @@ chartValues:
     readinessProbe.initialDelaySeconds: 60
     readinessProbe.failureThreshold: 12
 
+  # dex 0.24.0 — chart has empty `config: {}` default, but the dex
+  # binary refuses to start without `issuer` and `storage` set:
+  #   invalid Config:
+  #     - no issuer specified in config file
+  #     - no storage supplied in config file
+  # (verified against chart-integration run 25961993442 dex pod log).
+  # Provide a minimal CI-only config: a localhost issuer URL and an
+  # in-memory storage driver. Production deployments are expected to
+  # override both via their own values.yaml.
+  dex:
+    config.issuer: "http://dex.dex.svc.cluster.local:5556/dex"
+    config.storage.type: "memory"
+
+  # mimir-distributed 6.0.6 — chart defaults `kafka.enabled: true` AND
+  # the mimir.config template hardcodes `ingest_storage.enabled: true`
+  # whether or not Kafka is actually deployed. With Kafka disabled the
+  # mimir components abort at startup:
+  #   error validating config: invalid ingest storage config: the Kafka
+  #   address has not been configured
+  # (chart-integration run 25961993442 mimir-distributed-* pod logs).
+  # Override ingest_storage via mimir.structuredConfig (the chart's
+  # documented override mechanism for the rendered text-config). Keep
+  # kafka.enabled: false to avoid deploying the bundled Kafka image,
+  # which would also need an allowlist entry.
+  mimir-distributed:
+    kafka.enabled: false
+    mimir.structuredConfig.ingest_storage.enabled: false
+
+  # velero 12.0.1 — chart's default `configuration.backupStorageLocation`
+  # is a one-element list with `provider: ""`. helm install then issues
+  # a server-side apply on a `BackupStorageLocation` CR which fails
+  # validation:
+  #   BackupStorageLocation.velero.io "default" is invalid:
+  #     spec.provider in body must be of type string: "null"
+  #     spec.credential in body must be of type object: "null"
+  # (chart-integration run 25961993442 velero install log). Empty the
+  # BSL list so the chart skips the resource entirely. The smoke test
+  # only validates that the controller pod becomes Ready; real users
+  # provide their own provider/bucket via values.yaml.
+  velero:
+    configuration.backupStorageLocation: []
+
   # falco: NO chartValue tuning here — `driver.enabled: false`
   # was attempted in #378 to bypass the BPF-capability denial on
   # Azure GHA runners (verity-org/verity#325), but the May 16
@@ -998,3 +1040,17 @@ unpatchableImages:
   # #227 but argo-cd still references redis upstream. Skipping the patch
   # is correct — chart-gen handles wrapper-chart routing separately.
   - "docker/library/redis"
+  # victoriametrics/victoria-logs is a statically-linked Go binary in a
+  # FROM-SCRATCH base image. Copa's "patch" step (sh.copa.image.patched
+  # annotation) replaces the binary with one that's dynamically linked
+  # against /lib64/ld-linux-x86-64.so.2 — which doesn't exist in the
+  # scratch base, so runc aborts with `exec /victoria-logs-prod: no
+  # such file or directory` (the missing file is actually the dynamic
+  # linker, not the binary). The upstream `docker.io/victoriametrics/
+  # victoria-logs:v1.50.0` works directly because the binary is
+  # statically linked. Skipping the patch keeps the chart pointed at
+  # the working upstream image. Verified via crane export of both
+  # the verity-patched and upstream images:
+  #   - upstream: /victoria-logs-prod, 23076128 bytes, statically linked
+  #   - patched: /victoria-logs-prod, 22168512 bytes, dynamically linked
+  - "victoriametrics/victoria-logs"


### PR DESCRIPTION
## Summary

Six fixes from chart-integration run [25961993442](https://github.com/verity-org/verity/actions/runs/25961993442) diagnostic dive.

### Allowlists (3 new files)
- **openbao**: chart pulls `quay.io/openbao/openbao` + `docker.io/hashicorp/vault-k8s`
- **weaviate**: `cr.weaviate.io/semitechnologies/weaviate` + `docker.io/library/alpine`
- **victoria-logs-single**: `docker.io/victoriametrics/victoria-logs`

### verity.yaml unpatchableImages — victoriametrics/victoria-logs

Copa's patched verity image replaces the upstream statically-linked Go binary with a dynamically-linked one whose interpreter `/lib64/ld-linux-x86-64.so.2` doesn't exist in the FROM-SCRATCH base. runc aborts at exec. Skipping the patch keeps the chart pointed at the working upstream image.

### verity.yaml chartValues

- **dex**: `config.issuer` + `config.storage.type: memory` (chart's empty default refuses to start)
- **mimir-distributed**: `kafka.enabled: false` + `mimir.structuredConfig.ingest_storage.enabled: false` (ingest-storage hardcoded in template)
- **velero**: `configuration.backupStorageLocation: []` (default has invalid `provider: ""`)

### images/opensearch-dashboards.yaml — busybox

The apk-shipped `bin/opensearch-dashboards` is a POSIX shell script. Without `/bin/sh`, runc aborts at exec. Add `busybox` package, same shape as `images/jenkins.yaml`.

## Remaining nightly failures (not in this PR — need deeper investigation)

- argo-cd: pre-install redis-secret-init Job fails (pod logs unavailable in diag)
- opensearch: JVM gc.log path is read-only (existing chartValue `-Xlog:disable` doesn't override prior `-Xlog:` flags from chart's jvm.options file)
- cluster-autoscaler: AWS SDK requires region, no region in chart (chronic — chart fundamentally needs cloud creds)
- crossplane: waits for CRDs that don't install (chart bug or template ordering)
- gitea: PodInitializing stuck (init container)
- airflow: migrations >111s (chart timeout or postgres init slow)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly chart-integration failures by adding upstream image allowlists, minimal chart values, and making the `opensearch-dashboards` image runnable with `/bin/sh`. This unblocks installs and prevents runc and validation errors.

- **Bug Fixes**
  - Allowlists: add upstream prefixes for `openbao`, `weaviate`, and `victoria-logs-single`.
  - Unpatchable images: mark `victoriametrics/victoria-logs` to keep the working static upstream image.
  - Chart values:
    - `dex`: set `config.issuer` and `config.storage.type: memory`.
    - `mimir-distributed`: set `kafka.enabled: false` and `mimir.structuredConfig.ingest_storage.enabled: false`.
    - `velero`: set `configuration.backupStorageLocation: []`.
  - Images: add `busybox` to `images/opensearch-dashboards.yaml` to provide `/bin/sh` for the launcher script.
  - Lint: merge duplicate `mimir-distributed` values in `verity.yaml` to satisfy yamllint.

<sup>Written for commit b7973e1e27349a6df579c69002570a842e49206c. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/383?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

