### PR TITLE
fix(chartgen,charts,skips): nightly-may16 batch3 — close 5 more failures

### DIFF
--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -68,6 +68,29 @@ func Run(cfg *Config) (*DryRunResult, error) {
 		return nil, fmt.Errorf("load verity config: %w", err)
 	}
 
+	// Treat verity.yaml's `unpatchableImages` list as additional
+	// exclude-names so chart-gen does NOT generate a verity-org
+	// mapping for these chart-discovered images. Without this,
+	// chart-gen would crane-mirror an upstream image into
+	// `ghcr.io/verity-org/<repo>` even though the Copa pipeline
+	// also patches that image and may break it (notably:
+	// `victoriametrics/victoria-logs`, a statically-linked Go
+	// binary in a FROM-SCRATCH base that Copa converts to
+	// dynamically-linked, leaving runc unable to load the missing
+	// `/lib64/ld-linux-x86-64.so.2`). The chart's wrapper now keeps
+	// the upstream image reference intact, and the chart-integration
+	// allowlist files admit it explicitly.
+	//
+	// This mirrors the discovery package's semantics: an image in
+	// `unpatchableImages` is skipped in both the standalone-image
+	// pipeline and the chart-discovered-image pipeline.
+	if cfg.ExcludeNames == nil {
+		cfg.ExcludeNames = make(map[string]struct{})
+	}
+	for _, n := range vc.UnpatchableImages {
+		cfg.ExcludeNames[n] = struct{}{}
+	}
+
 	result := &DryRunResult{
 		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
 		ChartRegistry: cfg.ChartRegistry,

--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -12,7 +12,7 @@
 # issue, an exit criterion, and a peer review. Prefer chartValues tuning,
 # image fixes, or harness retries (subtask 5) before adding here.
 #
-# Slot accounting: 4 of 5 slots used. Loader's MaxSkippedCharts=5
+# Slot accounting: 5 of 5 slots used. Loader's MaxSkippedCharts=5
 # invariant will reject any 6th entry. Adding another skip requires either
 # (a) removing an existing entry whose exit_criteria has been met, or
 # (b) a new SCR raising the cap.
@@ -80,3 +80,25 @@ skips:
     exit_criteria: "chart hardcodes livenessProbe initialDelaySeconds with no values knob; smoke harness \"helm install --wait\" hits the probe before driver registers with cert-manager (which the harness also doesn't pre-install). Revisit when chart exposes app.livenessProbe knobs OR when harness pre-installs cert-manager CRDs."
     added: 2026-05-14
     added_by: SCR-2026-05-14-001
+
+  - chart: cluster-autoscaler
+    reason: needs-cloud-credentials
+    tracking_issue: https://github.com/verity-org/verity/issues/384
+    exit_criteria: |
+      cluster-autoscaler's binary requires a real AWS region + creds
+      to call DescribeAutoScalingGroups. Without them it crashes with
+      `Failed to regenerate ASG cache: ... an AWS region is required`
+      and trips the no-restart-during-settle gate. Smoke testing in
+      single-node kind cannot provide real cloud creds.
+
+      Un-skipping requires one of:
+      (a) chart exposes a no-op cloud-provider mode that doesn't need
+          real cloud creds (`cloudProvider: externalgrpc` with a
+          stub backend, or similar).
+      (b) smoke harness provisions an in-cluster Cluster-API mock the
+          chart can target with `cloudProvider: clusterapi`.
+      (c) chart-integration smoke gate is relaxed to accept the
+          no-restart-during-settle failure mode for cloud-provider-
+          requiring charts.
+    added: 2026-05-16
+    added_by: SCR-2026-05-14-001 (added after #383 confirmed chronic)

--- a/verity.yaml
+++ b/verity.yaml
@@ -97,6 +97,16 @@ chartValues:
     minio.enabled: false
     rollout_operator.enabled: false
     mimir.structuredConfig.ingest_storage.enabled: false
+    # mimir's usage-stats module is enabled by default and creates an
+    # S3 client at startup to upload anonymous installation telemetry.
+    # The chart's mimir.config template configures the storage backend
+    # as `s3` with no `endpoint:` value, so the binary aborts at init
+    # with:
+    #   error running application err="no s3 endpoint in config file"
+    # (chart-integration run 25964060759 mimir-distributed-* pod
+    # logs). Disabling usage_stats removes the S3 client and lets the
+    # binary boot.
+    mimir.structuredConfig.usage_stats.enabled: false
 
   # tempo-distributed 1.61.3 defaults to a separate Memcached statefulset;
   # the minimal CI-friendly wrapper just runs the Tempo microservices
@@ -464,6 +474,17 @@ chartValues:
   dex:
     config.issuer: "http://dex.dex.svc.cluster.local:5556/dex"
     config.storage.type: "memory"
+    # dex aborts at startup with `failed to initialize server: no
+    # connectors specified` when its `connectors` array is empty.
+    # Provide a minimal mock connector for CI — it doesn't actually
+    # do authentication, just satisfies the chart's startup
+    # validation. Real users override this with their actual OIDC /
+    # SAML / OAuth2 provider config. Verified against chart-
+    # integration run 25964060759 dex pod log.
+    config.connectors:
+      - type: mockCallback
+        id: mock
+        name: Mock
 
   # velero 12.0.1 — chart's default `configuration.backupStorageLocation`
   # is a one-element list with `provider: ""`. helm install then issues
@@ -478,6 +499,14 @@ chartValues:
   # provide their own provider/bucket via values.yaml.
   velero:
     configuration.backupStorageLocation: []
+    # velero's `configuration.volumeSnapshotLocation` has the same
+    # `provider: ""` / `credential: null` default as the BSL above
+    # and trips the same Kubernetes server-side-apply validation:
+    #   VolumeSnapshotLocation.velero.io "default" is invalid:
+    #     spec.provider in body must be of type string: "null"
+    # (chart-integration run 25964060759 velero install log).
+    # Empty the VSL list so the chart skips that resource too.
+    configuration.volumeSnapshotLocation: []
 
   # falco: NO chartValue tuning here — `driver.enabled: false`
   # was attempted in #378 to bypass the BPF-capability denial on
@@ -522,6 +551,21 @@ chartValues:
   # here; setting `opensearchJavaOpts` directly is the only viable lever.
   opensearch:
     opensearchJavaOpts: "-Xmx512M -Xms512M -Xlog:disable"
+
+  # opensearch-dashboards 3.6.0 — chart defaults `securityContext.
+  # runAsUser: 1000` (matching the upstream `opensearchproject/
+  # opensearch-dashboards` image's `dashboards` user uid). Verity's
+  # wolfi rebuild creates `/usr/share/opensearch-dashboards/{data,
+  # config}` owned by uid 65532 (the wolfi `nonroot` user). With
+  # chart's uid 1000 running, the dashboards binary cannot write its
+  # `data/uuid` file:
+  #   FATAL Error: Unable to write OpenSearch Dashboards UUID file ...
+  #         Error was: EACCES
+  # (chart-integration run 25964060759 dashboards pod log). Override
+  # the chart's runAsUser to verity's `nonroot` uid so the writable
+  # paths match.
+  opensearch-dashboards:
+    securityContext.runAsUser: 65532
 
   # kyverno 3.7.2: disable the post-upgrade `crds.migration` hook. It runs
   # `kubectl` from `registry.k8s.io/kubectl:v1.34.3`. Verity rebuilds kubectl


### PR DESCRIPTION
## Summary

Five more fixes from chart-integration [run 25964060759](https://github.com/verity-org/verity/actions/runs/25964060759).

### chartgen — extend ExcludeNames with unpatchableImages

Previously chart-gen ignored \`unpatchableImages\` — it only affected the Copa pipeline. As a result, chart-gen still generated \`ghcr.io/verity-org/<repo>\` mappings for unpatchable images, pointing wrappers at the Copa-patched (broken) verity image.

Visible case: \`victoriametrics/victoria-logs\` — Copa converts the static Go binary to dynamically-linked against missing \`/lib64/ld-linux-x86-64.so.2\`. Chart wrapper still pointed at it, runc aborted at exec.

The fix merges \`unpatchableImages\` entries into chart-gen's \`ExcludeNames\` set so wrappers keep the upstream reference.

### chartValues

- **dex**: \`config.connectors\` with a \`mockCallback\` entry (chart aborts with \`no connectors specified\`)
- **mimir-distributed**: \`mimir.structuredConfig.usage_stats.enabled: false\` (usage-stats S3 client errors on empty endpoint)
- **velero**: \`configuration.volumeSnapshotLocation: []\` matching the prior BSL fix in [#383](https://github.com/verity-org/verity/pull/383)
- **opensearch-dashboards**: \`securityContext.runAsUser: 65532\` (chart's uid 1000 can't write to verity's uid-65532-owned data dir)

### SKIPS.yaml — cluster-autoscaler

Chart fundamentally requires real AWS region + creds. New tracking issue [#384](https://github.com/verity-org/verity/issues/384). SKIPS slot accounting → 5/5 (cap reached).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five nightly chart-integration failures by making `chartgen` honor `unpatchableImages`, tightening chart values to avoid startup errors, and skipping `cluster-autoscaler` that needs real AWS creds.

- **Bug Fixes**
  - `chartgen`: merge `unpatchableImages` into `ExcludeNames` so wrappers keep upstream refs; avoids bad `ghcr.io/verity-org/<repo>` mappings (e.g., `victoriametrics/victoria-logs`).
  - `dex`: add `config.connectors` with `mockCallback` to satisfy startup.
  - `mimir-distributed`: disable `mimir.structuredConfig.usage_stats` to prevent S3 client init errors.
  - `velero`: set `configuration.volumeSnapshotLocation: []` to avoid invalid CRs.
  - `opensearch-dashboards`: set `securityContext.runAsUser: 65532` to match file ownership.
  - `SKIPS.yaml`: add `cluster-autoscaler` (needs real AWS creds; tracking issue #384). Slots now 5/5.

<sup>Written for commit 076a42ea068c2bb49a7c3d232d925480acd9bec6. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/385?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

