### PR TITLE
fix(chartgen,charts): keep wrappers for chartValues-only charts (gitea unblock)

### DIFF
--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -158,9 +158,22 @@ func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) 
 	allMappings = append(allMappings, replacementMappings...)
 	allMappings = append(allMappings, mappings...)
 
-	if len(allMappings) == 0 {
-		fmt.Fprintf(os.Stderr, "warning: no patched image mappings for chart %s@%s; skipping\n", chart.Name, chart.Version)
+	// Skip the chart only when there's NOTHING for the wrapper to
+	// carry — no image mappings AND no verity.yaml chartValues for
+	// the chart. The latter check matters for charts whose only
+	// reason to have a verity wrapper is a chartValues override
+	// (e.g., gitea pins `image.repository: bitnami/gitea` to switch
+	// off the verity-rebuild path because the wolfi rebuild lacks
+	// the Bitnami init scripts; the chart has no images to replace
+	// and yet still needs the wrapper to carry the chartValues
+	// override). Without this check, strict mode aborts chart-gen
+	// because gitea produces zero mappings.
+	if len(allMappings) == 0 && len(vc.ChartValues[chart.Name]) == 0 {
+		fmt.Fprintf(os.Stderr, "warning: no patched image mappings and no chartValues for chart %s@%s; skipping\n", chart.Name, chart.Version)
 		return ChartResult{}, false, nil
+	}
+	if len(allMappings) == 0 {
+		fmt.Fprintf(os.Stderr, "info: no patched image mappings for chart %s@%s; emitting chartValues-only wrapper\n", chart.Name, chart.Version)
 	}
 
 	valuesYAML, err := GetChartValues(chart)

--- a/test/chart-integration/values/gitea.allowlist.txt
+++ b/test/chart-integration/values/gitea.allowlist.txt
@@ -1,0 +1,18 @@
+# gitea upstream image allowlist (SCR-2026-04-30-001)
+#
+# The gitea chart's `chartValues.gitea.image.repository: bitnami/gitea`
+# (verity.yaml, PO Option A from verity-org/verity#326) routes the
+# chart at Bitnami's gitea image. chart-gen now leaves the upstream
+# reference intact (via the `bitnami/gitea` entry in verity.yaml's
+# `unpatchableImages` list) instead of trying to mirror it into the
+# non-existent `ghcr.io/verity-org/bitnami/gitea` repo.
+#
+# The chart-integration image-origin gate therefore needs to admit
+# `docker.io/bitnami/gitea:1` (plus any sibling Bitnami image the
+# chart pulls — e.g., `bitnami/git` for repo init).
+#
+# Format note: the isAccepted helper in test/chart-integration/
+# assertions.go uses strings.HasPrefix; the `:` and `@` separators
+# scope each prefix to its image's tag/digest refs.
+docker.io/bitnami/gitea:
+docker.io/bitnami/gitea@

--- a/verity.yaml
+++ b/verity.yaml
@@ -1093,3 +1093,16 @@ unpatchableImages:
   #   - upstream: /victoria-logs-prod, 23076128 bytes, statically linked
   #   - patched: /victoria-logs-prod, 22168512 bytes, dynamically linked
   - "victoriametrics/victoria-logs"
+  # bitnami/gitea — chart's `chartValues.gitea.image.repository:
+  # bitnami/gitea` switches the gitea chart off the verity-rebuilt
+  # gitea (whose wolfi base lacks Bitnami's
+  # `/usr/sbinx/init_directory_structure.sh` init script) and onto
+  # Bitnami's gitea image. chart-gen would otherwise try to mirror
+  # `bitnami/gitea` to `ghcr.io/verity-org/bitnami/gitea` — a repo
+  # that doesn't exist (verity has no Bitnami fork) — and fail at
+  # the `crane ls` tag-listing step. With this entry, chart-gen
+  # leaves the upstream `docker.io/bitnami/gitea` reference intact
+  # and the chart's chartValues block carries the override.
+  # See verity-org/verity#326 (PO Option A) for the Bitnami switch
+  # rationale.
+  - "bitnami/gitea"


### PR DESCRIPTION
## Summary

Unblocks the nightly Chart Generation pipeline after [#385](https://github.com/verity-org/verity/pull/385). Adding `unpatchableImages → ExcludeNames` to chart-gen made gitea hit strict-mode failure (zero mappings), but gitea NEEDS a wrapper to carry its chartValues override.

## Changes

### `internal/chartgen/chartgen.go`

Change zero-mappings skip to zero-mappings-AND-zero-chartValues skip. Charts with chartValues but no image mappings now emit a chartValues-only wrapper instead of being silently dropped.

### `verity.yaml`

Add `bitnami/gitea` to `unpatchableImages`. Without this, chart-gen tried `crane ls ghcr.io/verity-org/bitnami/gitea` (fails — verity has no Bitnami fork) and aborted the nightly.

### `test/chart-integration/values/gitea.allowlist.txt` (new)

Admit `docker.io/bitnami/gitea` in the image-origin gate.

## Validation

`go test ./internal/chartgen/...` passes; lint is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep wrappers for charts that only have `chartValues` (no image mappings) to unblock the nightly Chart Generation pipeline and restore `gitea` support.

- **Bug Fixes**
  - Only skip a chart when it has zero image mappings and zero `chartValues`; otherwise emit a `chartValues`-only wrapper (logs an info line).
  - Add `bitnami/gitea` to `unpatchableImages` to keep the upstream image and avoid mirroring to `ghcr.io/verity-org/bitnami/gitea`.
  - Add `test/chart-integration/values/gitea.allowlist.txt` to allow `docker.io/bitnami/gitea` in image-origin checks.

<sup>Written for commit 92979ba1433ea1b239f4ab3c049c30baad7e7e91. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/386?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

