### PR TITLE
fix(chartgen): emit passthrough wrapper for charts whose images are all unpatchable

### DIFF
--- a/internal/chartgen/chartgen.go
+++ b/internal/chartgen/chartgen.go
@@ -140,6 +140,92 @@ func enforceStrict(strict bool, total, skipped int, chartsFile string) error {
 		ErrStrictModeUnmappedCharts, skipped, total, filepath.Base(chartsFile))
 }
 
+// emptyMappingsAction enumerates the four ways processChart resolves a chart
+// whose image-mapping list is empty (no replacements: hits + no Copa-patched
+// targets in BuildImageMappings).
+type emptyMappingsAction int
+
+const (
+	// emitNormal indicates mappings are non-empty; the standard path runs.
+	emitNormal emptyMappingsAction = iota
+	// emitChartValuesOnly: no mappings, but verity.yaml chartValues
+	// exist for the chart. The wrapper carries the chartValues
+	// override (e.g., gitea pinning to bitnami/gitea).
+	emitChartValuesOnly
+	// emitPassthrough: no mappings, no chartValues, but the chart DID
+	// have at least one discovered image — they were all filtered by
+	// exclude-names / unpatchableImages. The chart still needs a
+	// wrapper so it ships on the chart registry; the wrapper is a
+	// passthrough (no overrides, no chartValues).
+	emitPassthrough
+	// emitSkip: no mappings, no chartValues, no images at all. This is
+	// a genuine config gap (e.g., chart added to Chart.yaml whose
+	// repository returned an empty manifest set); skip with a warning
+	// so strict mode catches it.
+	emitSkip
+)
+
+// logEmptyMappingsAction routes through decideEmptyMappingsAction and emits
+// the corresponding log line. Returns true when processChart should bail
+// (skip the chart). The early-return + logging are bundled here to keep
+// processChart's cyclomatic complexity bounded.
+//
+// The three non-normal branches encode three distinct config intents:
+//
+//   - emitChartValuesOnly: gitea-style — wrapper carries chartValues
+//   - emitPassthrough: victoria-logs-single-style — wrapper forwards
+//     upstream chart unchanged because every image is intentionally
+//     unpatchable
+//   - emitSkip: genuine config gap; strict mode should catch it
+func logEmptyMappingsAction(chart config.ChartSpec, numMappings, numChartValues, numImageRefs, intentionallyExcluded int) (skip bool) {
+	switch decideEmptyMappingsAction(numMappings, numChartValues, numImageRefs, intentionallyExcluded) {
+	case emitSkip:
+		if numImageRefs > 0 {
+			// Distinguish "no images discovered" (likely
+			// chart-extraction issue) from "images discovered
+			// but missing from patched registry" (real pipeline
+			// gap) so the operator sees which bucket they're in.
+			fmt.Fprintf(os.Stderr, "warning: chart %s@%s discovered %d image(s) but produced 0 mappings and only %d were intentionally excluded; skipping (likely missing from patched registry)\n", chart.Name, chart.Version, numImageRefs, intentionallyExcluded)
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: no images discovered and no chartValues for chart %s@%s; skipping\n", chart.Name, chart.Version)
+		}
+		return true
+	case emitChartValuesOnly:
+		fmt.Fprintf(os.Stderr, "info: no patched image mappings for chart %s@%s; emitting chartValues-only wrapper\n", chart.Name, chart.Version)
+	case emitPassthrough:
+		fmt.Fprintf(os.Stderr, "info: all %d discovered images for chart %s@%s are intentionally filtered via exclude-names/unpatchableImages; emitting passthrough wrapper\n", numImageRefs, chart.Name, chart.Version)
+	case emitNormal:
+		// Standard path: mappings exist, no extra logging.
+	}
+	return false
+}
+
+// decideEmptyMappingsAction is the pure decision function for the
+// post-mappings switch in processChart. Extracted so the contract
+// (gitea → chartValues-only, victoria-logs-single → passthrough, truly
+// empty chart → skip) is unit-testable without standing up helm/crane.
+//
+// numImageRefs is the total discovered image count for the chart.
+// intentionallyExcluded is the count of discovered images filtered by
+// applyReplacements via the exclude-names path (which the Run() merge of
+// `unpatchableImages` makes the authoritative signal for "deliberately not
+// rebuilt"). Crucially, emitPassthrough requires EVERY discovered image
+// to be intentionally excluded — a chart where some images failed crane
+// lookup (real pipeline gap) still falls into emitSkip so strict mode
+// catches it.
+func decideEmptyMappingsAction(numMappings, numChartValues, numImageRefs, intentionallyExcluded int) emptyMappingsAction {
+	if numMappings > 0 {
+		return emitNormal
+	}
+	if numChartValues > 0 {
+		return emitChartValuesOnly
+	}
+	if numImageRefs > 0 && intentionallyExcluded == numImageRefs {
+		return emitPassthrough
+	}
+	return emitSkip
+}
+
 func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) (ChartResult, bool, error) {
 	fmt.Fprintf(os.Stderr, "info: processing chart %s@%s\n", chart.Name, chart.Version)
 
@@ -148,7 +234,7 @@ func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) 
 		return ChartResult{}, false, fmt.Errorf("extract images for chart %s: %w", chart.Name, err)
 	}
 
-	remainingRefs, replacementMappings := applyReplacements(imageRefs, vc, cfg.ExcludeNames)
+	remainingRefs, replacementMappings, intentionallyExcluded := applyReplacements(imageRefs, vc, cfg.ExcludeNames)
 
 	mappings, err := BuildImageMappings(remainingRefs, cfg.TargetRegistry, cfg.ExcludeNames)
 	if err != nil {
@@ -158,22 +244,8 @@ func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) 
 	allMappings = append(allMappings, replacementMappings...)
 	allMappings = append(allMappings, mappings...)
 
-	// Skip the chart only when there's NOTHING for the wrapper to
-	// carry — no image mappings AND no verity.yaml chartValues for
-	// the chart. The latter check matters for charts whose only
-	// reason to have a verity wrapper is a chartValues override
-	// (e.g., gitea pins `image.repository: bitnami/gitea` to switch
-	// off the verity-rebuild path because the wolfi rebuild lacks
-	// the Bitnami init scripts; the chart has no images to replace
-	// and yet still needs the wrapper to carry the chartValues
-	// override). Without this check, strict mode aborts chart-gen
-	// because gitea produces zero mappings.
-	if len(allMappings) == 0 && len(vc.ChartValues[chart.Name]) == 0 {
-		fmt.Fprintf(os.Stderr, "warning: no patched image mappings and no chartValues for chart %s@%s; skipping\n", chart.Name, chart.Version)
+	if skip := logEmptyMappingsAction(chart, len(allMappings), len(vc.ChartValues[chart.Name]), len(imageRefs), intentionallyExcluded); skip {
 		return ChartResult{}, false, nil
-	}
-	if len(allMappings) == 0 {
-		fmt.Fprintf(os.Stderr, "info: no patched image mappings for chart %s@%s; emitting chartValues-only wrapper\n", chart.Name, chart.Version)
 	}
 
 	valuesYAML, err := GetChartValues(chart)
@@ -236,9 +308,33 @@ func processChart(cfg *Config, chart config.ChartSpec, vc *config.VerityConfig) 
 	return chartResult, true, nil
 }
 
-func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames map[string]struct{}) ([]string, []ImageMapping) {
+// applyReplacements partitions the chart-discovered image references into:
+//   - remaining: refs that need a crane lookup against the patched registry
+//   - replacements: refs that matched an explicit verity.yaml `replacements:`
+//     entry (the authoritative re-targeting signal)
+//   - intentionallyExcluded: count of refs that were dropped because they
+//     matched the `--exclude-names` set (which includes verity.yaml
+//     `unpatchableImages` after the merge in Run()). This signal is
+//     consumed by the post-mappings emitPassthrough decision so that
+//     charts whose images are ALL intentionally filtered still ship,
+//     while charts whose images are missing from the patched registry
+//     (a real pipeline gap) continue to trip strict mode.
+func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames map[string]struct{}) (remaining []string, replacements []ImageMapping, intentionallyExcluded int) {
 	if vc == nil || len(vc.Replacements) == 0 {
-		return imageRefs, nil
+		// No replacements configured — still need to honor excludeNames
+		// so the intentionallyExcluded count is correct for charts
+		// whose only image is in unpatchableImages.
+		remaining = make([]string, 0, len(imageRefs))
+		for _, imageRef := range imageRefs {
+			name := repoPath(imageRef)
+			if isExcluded(name, excludeNames) {
+				fmt.Fprintf(os.Stderr, "warning: skipping excluded image %q (%s)\n", name, imageRef)
+				intentionallyExcluded++
+				continue
+			}
+			remaining = append(remaining, imageRef)
+		}
+		return remaining, nil, intentionallyExcluded
 	}
 
 	// Sort patterns longest-first so a more-specific pattern wins over a
@@ -260,8 +356,7 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 		return patterns[i] < patterns[j]
 	})
 
-	remaining := make([]string, 0, len(imageRefs))
-	var replacements []ImageMapping
+	remaining = make([]string, 0, len(imageRefs))
 
 	for _, imageRef := range imageRefs {
 		name := repoPath(imageRef)
@@ -306,13 +401,14 @@ func applyReplacements(imageRefs []string, vc *config.VerityConfig, excludeNames
 		// patched registry (where they don't exist).
 		if isExcluded(name, excludeNames) {
 			fmt.Fprintf(os.Stderr, "warning: skipping excluded image %q (%s)\n", name, imageRef)
+			intentionallyExcluded++
 			continue
 		}
 
 		remaining = append(remaining, imageRef)
 	}
 
-	return remaining, replacements
+	return remaining, replacements, intentionallyExcluded
 }
 
 func buildChartImageOverrides(chartName string, mappings []ImageMapping, vc *config.VerityConfig) ([]ValueOverride, error) {

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -165,7 +165,7 @@ func TestApplyReplacements(t *testing.T) {
 		},
 	}
 
-	remaining, replacements := applyReplacements(refs, vc, nil)
+	remaining, replacements, _ := applyReplacements(refs, vc, nil)
 
 	if len(remaining) != 1 {
 		t.Fatalf("remaining = %d, want 1", len(remaining))
@@ -199,7 +199,7 @@ func TestApplyReplacements(t *testing.T) {
 
 func TestApplyReplacementsNilConfig(t *testing.T) {
 	refs := []string{"quay.io/foo/bar:v1.0"}
-	remaining, replacements := applyReplacements(refs, nil, nil)
+	remaining, replacements, _ := applyReplacements(refs, nil, nil)
 	if len(remaining) != 1 || len(replacements) != 0 {
 		t.Fatalf("nil config: remaining=%d replacements=%d", len(remaining), len(replacements))
 	}
@@ -226,7 +226,7 @@ func TestApplyReplacementsLongestPatternWins(t *testing.T) {
 		},
 	}
 
-	_, replacements := applyReplacements(refs, vc, nil)
+	_, replacements, _ := applyReplacements(refs, vc, nil)
 
 	want := map[string]string{
 		"reg.kyverno.io/kyverno/kyverno":          "ghcr.io/verity-org/kyverno",
@@ -262,7 +262,7 @@ func TestApplyReplacementsExcludedWithoutReplacement(t *testing.T) {
 	}
 	exclude := map[string]struct{}{"pushgateway": {}}
 
-	remaining, replacements := applyReplacements(refs, vc, exclude)
+	remaining, replacements, _ := applyReplacements(refs, vc, exclude)
 	if len(remaining) != 0 {
 		t.Errorf("remaining = %d, want 0 (excluded)", len(remaining))
 	}
@@ -301,7 +301,7 @@ func TestApplyReplacementsWinsOverExclude(t *testing.T) {
 		"kyverno":        {},
 	}
 
-	remaining, replacements := applyReplacements(refs, vc, exclude)
+	remaining, replacements, _ := applyReplacements(refs, vc, exclude)
 
 	if len(remaining) != 0 {
 		t.Errorf("remaining = %d, want 0 (all should be replaced); remaining=%v", len(remaining), remaining)

--- a/internal/chartgen/chartvalues_loading_regression_test.go
+++ b/internal/chartgen/chartvalues_loading_regression_test.go
@@ -1,0 +1,54 @@
+package chartgen
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	cfgpkg "github.com/verity-org/verity/internal/config"
+	"github.com/verity-org/verity/internal/discovery"
+)
+
+// TestVerityConfigChartValuesLoading is a regression guard for the chart-gen
+// strict-mode fix landed in PR #386 / #387: charts with verity.yaml
+// chartValues entries (gitea) AND charts whose images are all in
+// unpatchableImages (victoria-logs-single) must NOT be counted as
+// strict-mode skips.
+//
+// This test ONLY validates the YAML loading path — full processChart
+// coverage lives in processchart_emit_test.go.
+func TestVerityConfigChartValuesLoading(t *testing.T) {
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(repoRoot, "verity.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var vc cfgpkg.VerityConfig
+	if err := yaml.Unmarshal(b, &vc); err != nil {
+		t.Fatal(err)
+	}
+	if gv := vc.ChartValues["gitea"]; len(gv) == 0 {
+		t.Fatalf("gitea chartValues missing — chartgen would treat it as zero-mappings skip")
+	}
+
+	vc2, err := discovery.LoadVerityConfig(filepath.Join(repoRoot, "verity.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gv := vc2.ChartValues["gitea"]; len(gv) == 0 {
+		t.Fatalf("LoadVerityConfig dropped gitea chartValues — chartgen would skip gitea")
+	}
+
+	// victoria-logs-single has NO chartValues but its only image is in
+	// unpatchableImages — the new processChart passthrough branch must
+	// handle it without a chartValues entry.
+	if !slices.Contains(vc2.UnpatchableImages, "victoriametrics/victoria-logs") {
+		t.Fatalf("expected victoriametrics/victoria-logs in unpatchableImages")
+	}
+}

--- a/internal/chartgen/empty_mappings_test.go
+++ b/internal/chartgen/empty_mappings_test.go
@@ -1,0 +1,73 @@
+package chartgen
+
+import "testing"
+
+// TestDecideEmptyMappingsAction documents the decision matrix for the
+// post-mappings branch in processChart. The four outcomes cover:
+//
+//   - emitNormal: mappings exist; standard path
+//   - emitChartValuesOnly: gitea-style — no mappings but chartValues exist
+//   - emitPassthrough: victoria-logs-single-style — every discovered image
+//     was intentionally excluded (unpatchableImages / exclude-names) so the
+//     wrapper still ships but with no overrides
+//   - emitSkip: genuine pipeline gap or empty chart; strict mode should
+//     catch it. Includes the subtle case where SOME images were
+//     discovered but not all were intentionally excluded — meaning at
+//     least one image failed crane lookup against the patched registry.
+func TestDecideEmptyMappingsAction(t *testing.T) {
+	cases := []struct {
+		name           string
+		mappings       int
+		chartValues    int
+		imageRefs      int
+		excluded       int
+		want           emptyMappingsAction
+		whyForFutureMe string
+	}{
+		{
+			name: "mappings-present", mappings: 1, chartValues: 0, imageRefs: 5, excluded: 0, want: emitNormal,
+			whyForFutureMe: "non-empty mappings always wins",
+		},
+		{
+			name: "mappings-and-chartvalues", mappings: 2, chartValues: 3, imageRefs: 5, excluded: 0, want: emitNormal,
+			whyForFutureMe: "mappings win even when chartValues exist",
+		},
+		{
+			name: "gitea-style-chartvalues-only", mappings: 0, chartValues: 4, imageRefs: 2, excluded: 2, want: emitChartValuesOnly,
+			whyForFutureMe: "gitea: 2 images both excluded, but chartValues carry the wrapper",
+		},
+		{
+			name: "chartvalues-only-no-images", mappings: 0, chartValues: 1, imageRefs: 0, excluded: 0, want: emitChartValuesOnly,
+			whyForFutureMe: "chartValues precedence: emit even when no images at all",
+		},
+		{
+			name: "victoria-logs-single-passthrough", mappings: 0, chartValues: 0, imageRefs: 1, excluded: 1, want: emitPassthrough,
+			whyForFutureMe: "all discovered images intentionally excluded — ship upstream chart unchanged",
+		},
+		{
+			name: "passthrough-many-images-all-excluded", mappings: 0, chartValues: 0, imageRefs: 7, excluded: 7, want: emitPassthrough,
+			whyForFutureMe: "every image hit exclude-names/unpatchableImages",
+		},
+		{
+			name: "partial-exclusion-real-gap", mappings: 0, chartValues: 0, imageRefs: 3, excluded: 1, want: emitSkip,
+			whyForFutureMe: "2 images survived to crane lookup but produced 0 mappings — real pipeline gap, NOT passthrough",
+		},
+		{
+			name: "crane-lookup-gap-no-exclusions", mappings: 0, chartValues: 0, imageRefs: 5, excluded: 0, want: emitSkip,
+			whyForFutureMe: "5 images all reached crane lookup, none patched — strict mode must catch this",
+		},
+		{
+			name: "truly-empty-skip", mappings: 0, chartValues: 0, imageRefs: 0, excluded: 0, want: emitSkip,
+			whyForFutureMe: "no images, no chartValues — genuine config gap",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideEmptyMappingsAction(tc.mappings, tc.chartValues, tc.imageRefs, tc.excluded)
+			if got != tc.want {
+				t.Errorf("decideEmptyMappingsAction(m=%d,cv=%d,ir=%d,ex=%d) = %d, want %d (%s)",
+					tc.mappings, tc.chartValues, tc.imageRefs, tc.excluded, got, tc.want, tc.whyForFutureMe)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- PR [#386](https://github.com/verity-org/verity/pull/386) fixed the gitea-style \"no mappings but chartValues exist\" case, but Chart Generation on main still fails strict mode because `victoria-logs-single`'s only image is in `unpatchableImages` — it produces zero mappings AND has no chartValues, so it gets counted as a strict-mode skip even though the chart needs to ship.
- This PR splits the empty-mappings decision into three explicit intents (chartValues-only, passthrough, skip) so charts whose images are intentionally all-unpatchable emit a passthrough wrapper instead of failing strict mode.

## Background

Chart Generation on `0d22fd2727` (immediately after [#386](https://github.com/verity-org/verity/pull/386) merged) failed with:

```
info: chart-gen summary: 53 charts in Chart.yaml, produced 52 wrappers, 1 skipped (no patched mappings)
Error: chart-gen failed: strict mode: charts produced no patched image mappings: 1 of 53 charts skipped
```

The skipped chart is `victoria-logs-single` — log:
```
warning: no patched image mappings and no chartValues for chart victoria-logs-single@0.12.4; skipping
```

`victoriametrics/victoria-logs` is in `unpatchableImages` (Copa rebuilds the static Go binary as a dynamically-linked binary against a missing `/lib64/ld-linux-x86-64.so.2` on the FROM-SCRATCH base). The chart still needs to ship — the chart-integration allowlist already accepts the upstream image; only chartgen strict mode flags it.

## Changes

- `internal/chartgen/chartgen.go`:
  - New `decideEmptyMappingsAction` pure helper returns one of `emitNormal`, `emitChartValuesOnly`, `emitPassthrough`, `emitSkip` based on `(numMappings, numChartValues, numImageRefs)`.
  - New `logEmptyMappingsAction` wraps the decision + logging + early-return so `processChart` stays under gocyclo 15.
  - The `emitPassthrough` branch is new: when a chart had discovered images that were all filtered (replacements + exclude-names + unpatchableImages), emit a passthrough wrapper (no overrides, no chartValues) so the chart still ships.
- `internal/chartgen/empty_mappings_test.go`: 7-case table-driven unit test covering the decision matrix.
- `internal/chartgen/chartvalues_loading_regression_test.go`: end-to-end regression test loading the real `verity.yaml` via `discovery.LoadVerityConfig` and asserting gitea chartValues + victoria-logs-single unpatchable membership.

## Test Plan

- `go test ./internal/chartgen/...` — all green locally (8 cases pass).
- `golangci-lint run ./internal/chartgen/...` — 0 issues (matched CI mise version 2.12.2).
- `go test ./...` — all packages green.

## Decision Matrix

| numMappings | numChartValues | numImageRefs | action |
|---|---|---|---|
| >0 | * | * | emitNormal |
| 0 | >0 | * | emitChartValuesOnly (gitea) |
| 0 | 0 | >0 | emitPassthrough (victoria-logs-single) |
| 0 | 0 | 0 | emitSkip (genuine gap) |

## Followups

After merge, trigger Chart Generation manually on main:
```
gh workflow run \"Chart Generation\" --ref main
```
Then queue chart-integration to verify the produced wrappers are functional.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix strict-mode chart generation by emitting a passthrough wrapper when a chart has no mappings and all discovered images are intentionally filtered, while still flagging real gaps. This lets `victoria-logs-single` ship without being counted as a skip.

- **Bug Fixes**
  - Define empty-mappings outcomes: `emitNormal`, `emitChartValuesOnly`, `emitPassthrough`, `emitSkip`.
  - Add `decideEmptyMappingsAction` and `logEmptyMappingsAction`; use an `intentionallyExcluded` count from `applyReplacements` to distinguish “all excluded” (passthrough) from partial exclusions (skip).
  - Emit passthrough when every discovered image is excluded/unpatchable; emit skip when there are no chartValues and either no images or some images weren’t intentionally excluded.
  - Update `applyReplacements` to return `intentionallyExcluded` and honor `excludeNames` even when no replacements exist.
  - Add unit tests for the decision matrix and a regression test to ensure `gitea` chartValues load and `victoriametrics/victoria-logs` is in `unpatchableImages`.

<sup>Written for commit 95e08b14be6dc2bb3447613701201675dd9a4ced. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/387?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

