### PR TITLE
fix(gitea): switch to single-node postgresql + valkey subcharts for CI

### DIFF
--- a/test/chart-integration/values/gitea.allowlist.txt
+++ b/test/chart-integration/values/gitea.allowlist.txt
@@ -24,3 +24,12 @@ docker.io/bitnamilegacy/postgresql:
 docker.io/bitnamilegacy/postgresql@
 docker.io/bitnamilegacy/valkey:
 docker.io/bitnamilegacy/valkey@
+# The gitea chart's `init-directories` initContainer uses `busybox:
+# latest` (bare ref; kubelet resolves to `docker.io/library/busybox:
+# latest`). chart-gen excludes it from the patched pipeline via the
+# global busybox entry in exclude-names (images/busybox.yaml), so
+# the wrapper leaves the upstream reference intact and the image-
+# origin gate needs the allowlist row — same shape as the
+# meilisearch chart's busybox helper.
+docker.io/library/busybox:
+docker.io/library/busybox@

--- a/test/chart-integration/values/gitea.allowlist.txt
+++ b/test/chart-integration/values/gitea.allowlist.txt
@@ -7,12 +7,20 @@
 # `unpatchableImages` list) instead of trying to mirror it into the
 # non-existent `ghcr.io/verity-org/bitnami/gitea` repo.
 #
-# The chart-integration image-origin gate therefore needs to admit
-# `docker.io/bitnami/gitea:1` (plus any sibling Bitnami image the
-# chart pulls — e.g., `bitnami/git` for repo init).
+# The Bitnami subcharts pulled in by gitea (postgresql + valkey,
+# enabled via verity.yaml chartValues; we disable the much heavier
+# postgresql-ha/valkey-cluster HA variants so kind-based CI can
+# converge inside the 10-minute helm-install budget) ship images
+# under `docker.io/bitnamilegacy/*`. These aren't in verity's rebuild
+# pipeline and are intentionally left upstream. Add allowlist rows
+# for the postgresql and valkey single-node images.
 #
 # Format note: the isAccepted helper in test/chart-integration/
 # assertions.go uses strings.HasPrefix; the `:` and `@` separators
 # scope each prefix to its image's tag/digest refs.
 docker.io/bitnami/gitea:
 docker.io/bitnami/gitea@
+docker.io/bitnamilegacy/postgresql:
+docker.io/bitnamilegacy/postgresql@
+docker.io/bitnamilegacy/valkey:
+docker.io/bitnamilegacy/valkey@

--- a/verity.yaml
+++ b/verity.yaml
@@ -1127,14 +1127,20 @@ unpatchableImages:
   # rationale.
   - "bitnami/gitea"
 
-  # The Bitnami gitea chart's single-node postgresql and valkey
-  # subcharts (enabled via verity.yaml chartValues to replace the
-  # default HA postgresql-ha + valkey-cluster which never converge
-  # in kind-based CI) ship images under `docker.io/bitnamilegacy/*`.
-  # verity has no rebuild for these — they're Bitnami's repackaged
-  # images. Keep them upstream (the chart-integration allowlist row
-  # in test/chart-integration/values/gitea.allowlist.txt admits
-  # them; this list keeps chart-gen from attempting to mirror them
-  # into the non-existent `ghcr.io/verity-org/bitnamilegacy/*` repos).
-  - "bitnamilegacy/postgresql"
-  - "bitnamilegacy/valkey"
+  # NOTE: `bitnamilegacy/postgresql` is intentionally NOT in this list,
+  # even though gitea's single-node postgresql subchart pulls
+  # `docker.io/bitnamilegacy/postgresql:17.6.0-debian-12-r4` (verity
+  # has no rebuild for that tag). The airflow chart already depends
+  # on chart-gen rewriting its `bitnamilegacy/postgresql:16.1.0-
+  # debian-11-r15` to `ghcr.io/verity-org/bitnamilegacy/postgresql:
+  # 16.1.0-debian-11-r15` (see the airflow chartValues block above
+  # at lines 223-265). Globally excluding `bitnamilegacy/postgresql`
+  # would break airflow. The gitea-specific tag will fall through
+  # chart-gen's per-tag crane lookup (the tag does not exist in
+  # ghcr.io/verity-org/bitnamilegacy/postgresql, only the airflow
+  # tag does), producing a "tag not found" warning but leaving the
+  # upstream reference intact — which is admitted by the gitea
+  # allowlist row at test/chart-integration/values/gitea.allowlist.txt.
+  # Same reasoning applies to `bitnamilegacy/valkey` (currently
+  # unused by any other chart, but listed only in the gitea
+  # allowlist so a future airflow-style rewrite remains possible).

--- a/verity.yaml
+++ b/verity.yaml
@@ -383,6 +383,26 @@ chartValues:
     image.registry: docker.io
     image.repository: bitnami/gitea
     image.tag: "1"
+    # The Bitnami gitea chart 12.5.3 defaults
+    # `postgresql-ha.enabled: true` (3-replica HA postgres + repmgr) and
+    # `valkey-cluster.enabled: true` (3-replica valkey cluster). On the
+    # kind-based chart-integration runners these subcharts pull in 6
+    # stateful pods (postgresql-ha-0/1/2, valkey-cluster-0/1/2) whose
+    # peer-discovery DNS resolves on a slow schedule — the helm
+    # `--wait --timeout 10m0s` blocks waiting for the postgresql-ha
+    # statefulset to converge, repeating "unable to resolve domain
+    # gitea-postgresql-ha-postgresql-N.gitea-postgresql-ha-postgresql-
+    # headless.gitea.svc.cluster.local" until the smoke harness's
+    # 10-minute install budget is exhausted three times in a row.
+    # Switch to the chart's single-node subchart variants for CI: the
+    # single `postgresql` subchart deploys one postgres pod and the
+    # single `valkey` subchart (architecture: standalone) deploys one
+    # valkey pod. The gitea workload pod can reach both via the simple
+    # ClusterIP service and helm install converges well within 10m.
+    postgresql-ha.enabled: false
+    valkey-cluster.enabled: false
+    postgresql.enabled: true
+    valkey.enabled: true
 
   # cert-manager startupapicheck Job runs `cert-manager check api --wait=1m`
   # to verify webhook readiness post-install. The default 1-minute timeout
@@ -1106,3 +1126,15 @@ unpatchableImages:
   # See verity-org/verity#326 (PO Option A) for the Bitnami switch
   # rationale.
   - "bitnami/gitea"
+
+  # The Bitnami gitea chart's single-node postgresql and valkey
+  # subcharts (enabled via verity.yaml chartValues to replace the
+  # default HA postgresql-ha + valkey-cluster which never converge
+  # in kind-based CI) ship images under `docker.io/bitnamilegacy/*`.
+  # verity has no rebuild for these — they're Bitnami's repackaged
+  # images. Keep them upstream (the chart-integration allowlist row
+  # in test/chart-integration/values/gitea.allowlist.txt admits
+  # them; this list keeps chart-gen from attempting to mirror them
+  # into the non-existent `ghcr.io/verity-org/bitnamilegacy/*` repos).
+  - "bitnamilegacy/postgresql"
+  - "bitnamilegacy/valkey"


### PR DESCRIPTION
## Summary

The Bitnami `gitea` chart 12.5.3 defaults to HA subcharts (3-replica `postgresql-ha` + 3-replica `valkey-cluster`). On kind-based chart-integration runners the StatefulSet peer-discovery DNS never converges inside the 10-minute helm-install budget; the harness times out 3 attempts in a row.

Switch to single-node `postgresql` + `valkey` subcharts. Allowlist the new `bitnamilegacy/postgresql` + `bitnamilegacy/valkey` upstream images (per-tag fall-through; not added to global `unpatchableImages` because airflow depends on rewriting the same repo for a different tag — see review thread resolution).

## Diagnosis from chart-integration run [25969781886](https://github.com/verity-org/verity/actions/runs/25969781886)

```
unable to resolve domain gitea-postgresql-ha-postgresql-0.gitea-postgresql-ha-postgresql-headless.gitea.svc.cluster.local
... (repeating until 25-minute timeout)
install (attempt 3/3, classification=unknown): helm install ... signal: killed
```

## Final Changes (after review thread resolution)

- `verity.yaml`:
  - gitea chartValues: `postgresql-ha.enabled: false`, `valkey-cluster.enabled: false`, `postgresql.enabled: true`, `valkey.enabled: true`
  - `unpatchableImages`: NO new entries (an early version added `bitnamilegacy/postgresql` + `bitnamilegacy/valkey` but that broke airflow's existing rewrite at `verity.yaml:223-265`; reverted in fb942a9135). Per-tag crane lookup will skip the gitea tag (not in our mirror) while preserving airflow's working rewrite for the airflow tag.
- `test/chart-integration/values/gitea.allowlist.txt`: admit `docker.io/bitnamilegacy/postgresql:`, `docker.io/bitnamilegacy/valkey:`, `docker.io/library/busybox:` (plus `@` digest variants).

## Test Plan

- `helm template gitea --set postgresql-ha.enabled=false ...` locally confirms 4 images total: `bitnami/gitea`, `busybox`, `bitnamilegacy/postgresql:17.6.0-debian-12-r4`, `bitnamilegacy/valkey:8.1.3-debian-12-r3`.
- Unit tests: `go test ./internal/chartgen/...` + `go test -tags integration ./test/chart-integration/...` all green.

## Followups

Pre-existing failures in chart-integration run [25969781886](https://github.com/verity-org/verity/actions/runs/25969781886) (6 more shards beyond gitea):
- `argo-cd`: redis-secret-init Job
- `opensearch`: JVM gc.log path
- `opensearch-dashboards`: crash-class
- `mimir-distributed`: crash-class
- `airflow`: migration timeout
- `crossplane`: settle-window restart / CRD ordering

These are tracked under SCR-2026-05-14-001 chart-integration recovery and will land in separate per-chart PRs.