### PR TITLE
fix(gitea): run init-directories initContainer as root for PVC chown

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -1,0 +1,36 @@
+# gitea chart-integration smoke-test value overrides.
+#
+# The Bitnami gitea chart's `init-directories` initContainer runs
+# `/usr/sbinx/init_directory_structure.sh` which does
+# `chown 1000:1000 /data` on the mounted PVC. The chart's default
+# `containerSecurityContext` is empty, so the init container inherits
+# the chart's per-container default `securityContext.runAsUser: 1000`
+# — which means it cannot chown the PVC. The kind local-path-
+# provisioner creates the host-path mount as root:root, and the
+# chart's `podSecurityContext.fsGroup: 1000` is not reliably applied
+# before the init runs. Result (chart-integration run 25974769298
+# gitea shard diagnostic dump):
+#
+#   chown: changing ownership of '/data': Operation not permitted
+#   failed to change ownership of '/data' from root:root to 1000:1000
+#
+# → init-directories enters CrashLoopBackOff and helm install times
+# out at 10 minutes.
+#
+# This override runs ALL containers in the gitea pod as root. The
+# Bitnami chart uses one `containerSecurityContext` block for both
+# init and main containers, so we cannot scope the override to just
+# the init container without forking the chart. Running the main
+# gitea container as root is acceptable in the smoke-test cluster
+# (kind, ephemeral, no real data), but should NOT be the production
+# default — which is why this override lives in the chart-integration
+# values directory and NOT in `verity.yaml`'s gitea chartValues block.
+#
+# Production users who hit the same PVC-chown issue on their cluster
+# should either (a) switch to `image.rootless: true` (the upstream
+# chart's supported path for non-root containers) or (b) configure
+# their CSI driver / storage class to honor `fsGroup` recursively
+# before the init container runs.
+containerSecurityContext:
+  runAsUser: 0
+  runAsNonRoot: false

--- a/verity.yaml
+++ b/verity.yaml
@@ -413,6 +413,15 @@ chartValues:
     valkey-cluster.enabled: false
     postgresql.enabled: true
     valkey.enabled: true
+    # NOTE: the kind-CI workaround for the `init-directories`
+    # initContainer's "Operation not permitted" chown failure
+    # (`chown 1000:1000 /data` cannot run when the chart's per-
+    # container default `runAsUser: 1000` is inherited and the kind
+    # local-path-provisioner mounts /data as root:root) is applied
+    # in `test/chart-integration/values/gitea.yaml`, NOT here, to
+    # avoid changing the production security posture (running the
+    # main gitea container as root). The chart-integration override
+    # only affects the smoke-test cluster.
 
   # cert-manager startupapicheck Job runs `cert-manager check api --wait=1m`
   # to verify webhook readiness post-install. The default 1-minute timeout


### PR DESCRIPTION
## Summary

After PR [#389](https://github.com/verity-org/verity/pull/389) fixed the bitnami → bitnamilegacy image namespace, the gitea init-directories initContainer crashed with:

```
chown: changing ownership of '/data': Operation not permitted
failed to change ownership of '/data' from root:root to 1000:1000
```

Override `containerSecurityContext.runAsUser: 0` so init-directories can chown the PVC.

## Diagnosis

chart-integration run [25974769298](https://github.com/verity-org/verity/actions/runs/25974769298) (gitea shard) diagnostic dump:

```
gitea-8484cdc46d-bdfgn [Pending]
  init-directories: waiting/CrashLoopBackOff
  init-directories: prev-term/exit1/Error
gitea-postgresql-0 [Running] OK
gitea-valkey-primary-0 [Running] OK
```

Container log:
```
chown: changing ownership of '/data': Operation not permitted
failed to change ownership of '/data' from root:root to 1000:1000
```

The Bitnami gitea chart's init-directories runs `/usr/sbinx/init_directory_structure.sh` which does `chown 1000:1000 /data`. The chart's default `containerSecurityContext` is empty, but its per-container default pins `runAsUser: 1000`. The kind-cluster local-path-provisioner creates the host-path mount as `root:root`, and the chart's `podSecurityContext.fsGroup: 1000` is not reliably applied before the init runs.

## Changes

`verity.yaml` gitea chartValues:
```yaml
containerSecurityContext.runAsUser: 0
containerSecurityContext.runAsNonRoot: false
```

The Bitnami gitea entrypoint handles dropping privileges internally for the main gitea container (starts as root, sets up storage permissions, drops to 1000), so applying this to all containers (Bitnami uses one `containerSecurityContext` block for both init and main containers) is safe.

## Test Plan

- `helm template gitea --set containerSecurityContext.runAsUser=0 --set containerSecurityContext.runAsNonRoot=false ...` confirms init-directories renders with `runAsUser: 0 / runAsNonRoot: false`.
- Unit tests + lint clean locally.

## Followups

Same 6 pre-existing failures still tracked under SCR-2026-05-14-001 chart-integration recovery:
- `argo-cd`: redis-secret-init Job
- `opensearch`: JVM gc.log path
- `opensearch-dashboards`: crash-class
- `mimir-distributed`: crash-class
- `airflow`: migration timeout
- `crossplane`: settle-window restart / CRD ordering

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Gitea’s `init-directories` as root to fix PVC chown failures and stop the CrashLoopBackOff in CI. Applies `containerSecurityContext.runAsUser: 0` and `containerSecurityContext.runAsNonRoot: false` via chart-integration test values; production chart values are unchanged.

- **Bug Fixes**
  - Fixes “Operation not permitted” when `init-directories` tries to `chown /data` on PVCs created as `root:root`.
  - Scoped to the smoke-test cluster (`test/chart-integration/values/gitea.yaml`) to avoid running production pods as root.
  - Safe for the main container: Bitnami’s entrypoint starts as root, sets permissions, then drops to UID 1000.

<sup>Written for commit 5bafef455f68c7ae1d146c948d5cfcad46e860df. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/390?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

