### PR TITLE
fix(chart-mimir): push_grpc + filesystem storage for CI smoke

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -107,6 +107,36 @@ chartValues:
     # logs). Disabling usage_stats removes the S3 client and lets the
     # binary boot.
     mimir.structuredConfig.usage_stats.enabled: false
+    # The chart's `mimir.config` template hardcodes
+    # `ingester.push_grpc_method_enabled: false` (values.yaml L249,
+    # mimir-distributed 6.0.6) because the upstream architecture
+    # routes writes via Kafka under ingest_storage. With
+    # `ingest_storage.enabled: false`, the ingester binary validates
+    # the combination at startup and aborts with:
+    #   error validating config: cannot disable Push gRPC method in
+    #   ingester, while ingest storage (-ingest-storage.enabled) is
+    #   not enabled
+    # (chart-integration run 25974769298 mimir-distributed-ingester-*
+    # pod logs). Re-enable the Push gRPC method via structuredConfig.
+    mimir.structuredConfig.ingester.push_grpc_method_enabled: true
+    # With `minio.enabled: false`, the chart's `mimir.config` template
+    # still hardcodes `backend: s3` for blocks_storage,
+    # alertmanager_storage, and ruler_storage but emits NO `s3:`
+    # endpoint block (values.yaml L138-147, L180-187, L302-311 are
+    # `{{- if .Values.minio.enabled }}` gated). The mimir binary then
+    # aborts the store-gateway / querier / compactor / ruler with:
+    #   error running application err="no s3 endpoint in config file"
+    # (chart-integration run 25974769298 store-gateway, querier,
+    # compactor pod logs). Switch all three storage subsystems to
+    # `filesystem` — CI smoke just needs the binaries to boot; it
+    # doesn't exercise persistence across pods. Real users override
+    # to s3/gcs/azure via their own structuredConfig.
+    mimir.structuredConfig.blocks_storage.backend: filesystem
+    mimir.structuredConfig.blocks_storage.filesystem.dir: /data/blocks
+    mimir.structuredConfig.alertmanager_storage.backend: filesystem
+    mimir.structuredConfig.alertmanager_storage.filesystem.dir: /data/alertmanager
+    mimir.structuredConfig.ruler_storage.backend: filesystem
+    mimir.structuredConfig.ruler_storage.filesystem.dir: /data/ruler
 
   # tempo-distributed 1.61.3 defaults to a separate Memcached statefulset;
   # the minimal CI-friendly wrapper just runs the Tempo microservices


### PR DESCRIPTION
## Summary

Get the `mimir-distributed` chart-integration shard to pass.

Two new failure modes surfaced after the previous fixes (`kafka.enabled=false`, `ingest_storage.enabled=false`, `usage_stats.enabled=false`):

### 1. Ingesters CrashLoopBackOff — push_grpc

The chart's hardcoded `mimir.config` template sets `ingester.push_grpc_method_enabled: false` ([values.yaml L249](https://github.com/grafana/helm-charts) of mimir-distributed 6.0.6) because the upstream architecture routes writes via Kafka under `ingest_storage.enabled: true`. With `ingest_storage.enabled: false`, mimir's startup validator aborts ingester pods:

> error validating config: cannot disable Push gRPC method in ingester, while ingest storage (-ingest-storage.enabled) is not enabled

Pod log: [`mimir-distributed-ingester-zone-a-0` from run 25974769298](https://github.com/verity-org/verity/actions/runs/25974769298) (diagnostics-mimir-distributed artifact).

Fix: `mimir.structuredConfig.ingester.push_grpc_method_enabled: true`.

### 2. store-gateway / querier / compactor / ruler CrashLoopBackOff — no s3 endpoint

With `minio.enabled: false`, the chart's `mimir.config` template still hardcodes `backend: s3` for `blocks_storage`, `alertmanager_storage`, and `ruler_storage` but emits NO `s3:` endpoint block (the s3 sub-key is `{{- if .Values.minio.enabled }}` gated). mimir's bucket client validator aborts:

> no s3 endpoint in config file

Pod logs: `mimir-distributed-store-gateway-zone-a-0`, `mimir-distributed-querier-*`, `mimir-distributed-compactor-0`, `mimir-distributed-ruler-*` from the same run.

Fix: switch all three storage subsystems to `filesystem` for the CI wrapper. Production users override storage backend in their own structuredConfig.

## Validation

- `go test ./internal/chartgen/...` ✅
- `golangci-lint run ./internal/chartgen/...` clean ✅
- `helm template` of the chart with the new chartValues produces a valid `mimir.yaml` configmap with both fixes applied (verified locally).

## Root cause

mimir-distributed 6.0.6's `mimir.config` template is structured around the `kafka + minio + ingest_storage` happy path; turning off the infra subcharts leaves orphan `backend: s3` / `push_grpc_method_enabled: false` lines that crash the binary. The chart's documented escape hatch (`mimir.structuredConfig`) merges over the rendered text-config and gives us a surgical fix.

## Refs

- Failing run: [chart-integration #25974769298](https://github.com/verity-org/verity/actions/runs/25974769298), job 76352955977
- Previous mimir fixes: same `chartValues['mimir-distributed']` block in `verity.yaml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `mimir-distributed` CI smoke by enabling ingester Push gRPC and switching storage backends to filesystem when `kafka` and `minio` are off. This stops CrashLoopBackOffs and lets all pods boot.

- **Bug Fixes**
  - Set `mimir.structuredConfig.ingester.push_grpc_method_enabled: true` when `ingest_storage.enabled: false`.
  - Use `filesystem` for `blocks_storage`, `alertmanager_storage`, and `ruler_storage` with `/data/blocks`, `/data/alertmanager`, and `/data/ruler` dirs when `minio.enabled: false`.

<sup>Written for commit 7084814ea127437bbae40197336198b1540c9b1a. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/393?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

