### PR TITLE
fix(chart-integration): exempt benign init-container flakes from no-restart gate

### DIFF
--- a/test/chart-integration/assertions.go
+++ b/test/chart-integration/assertions.go
@@ -65,9 +65,27 @@ type containerStatus struct {
 	// so allowlist matching MUST fall back to ImageID when Image is
 	// a bare digest. See isAccepted for the fallback logic and
 	// SCR-2026-04-30-001 for the policy rationale.
-	Image                string `json:"image"`
-	ImageID              string `json:"imageID"`
-	RestartCount         int    `json:"restartCount"`
+	Image        string `json:"image"`
+	ImageID      string `json:"imageID"`
+	RestartCount int    `json:"restartCount"`
+	// State is the container's CURRENT state — running / waiting /
+	// terminated. For initContainers we use this to distinguish
+	// "init flaked once but ultimately completed (exitCode 0)" from
+	// "init is still crash-looping". Only the latter trips the
+	// no-restart gate; the former is benign (the main container is
+	// already past the init phase and running). See
+	// collectRestartFailures.
+	State struct {
+		Terminated *struct {
+			Reason   string `json:"reason"`
+			Message  string `json:"message"`
+			ExitCode int    `json:"exitCode"`
+		} `json:"terminated"`
+		Waiting *struct {
+			Reason  string `json:"reason"`
+			Message string `json:"message"`
+		} `json:"waiting"`
+	} `json:"state"`
 	LastTerminationState struct {
 		Terminated *struct {
 			Reason  string `json:"reason"`
@@ -101,24 +119,73 @@ func AssertNoRestarts(ctx context.Context, h *Harness, namespace string) error {
 func collectRestartFailures(pods *podList) []string {
 	var failures []string
 	for _, p := range pods.Items {
-		all := append(append([]containerStatus{}, p.Status.ContainerStatuses...), p.Status.InitContainerStatuses...)
-		for _, cs := range all {
+		// Main containers: any restart is a hard failure. The whole
+		// point of the no-restart gate is to catch CrashLoopBackOff
+		// or OOMKill on long-running workload containers during the
+		// post-install settle window.
+		for i := range p.Status.ContainerStatuses {
+			cs := &p.Status.ContainerStatuses[i]
 			if cs.RestartCount == 0 {
 				continue
 			}
-			reason := "unknown"
-			msg := ""
-			if cs.LastTerminationState.Terminated != nil {
-				reason = cs.LastTerminationState.Terminated.Reason
-				msg = cs.LastTerminationState.Terminated.Message
+			failures = append(failures, formatRestartFailure(p.Metadata.Namespace, p.Metadata.Name, cs, "container"))
+		}
+		// InitContainers: a benign init flake (e.g. waiting for
+		// CRDs registered by a sibling pod, transient API server
+		// unavailability during cluster warm-up) shows up as
+		// restartCount>0 with the init STILL completing successfully
+		// (state.terminated.exitCode == 0). The main container is
+		// then running normally and the cluster is healthy — this
+		// is NOT what the no-restart gate is meant to catch.
+		//
+		// Real CrashLoopBackOff in an initContainer still trips the
+		// gate: it would have state.waiting.reason ==
+		// "CrashLoopBackOff" (or a still-running / failed-terminated
+		// state), so the exemption below intentionally does NOT
+		// apply.
+		//
+		// Charts that exhibit benign init flakes today:
+		//   - crossplane (init waits for CRDs that the chart's own
+		//     CoreCRDs step installs; first attempt sometimes loses
+		//     a race with kube-apiserver readiness and is restarted
+		//     once by the kubelet)
+		for i := range p.Status.InitContainerStatuses {
+			cs := &p.Status.InitContainerStatuses[i]
+			if cs.RestartCount == 0 {
+				continue
 			}
-			failures = append(failures, fmt.Sprintf(
-				"pod=%s/%s container=%s restarts=%d reason=%s msg=%q",
-				p.Metadata.Namespace, p.Metadata.Name, cs.Name, cs.RestartCount, reason, truncate(msg, 200),
-			))
+			if initContainerCompletedCleanly(cs) {
+				continue
+			}
+			failures = append(failures, formatRestartFailure(p.Metadata.Namespace, p.Metadata.Name, cs, "initContainer"))
 		}
 	}
 	return failures
+}
+
+// initContainerCompletedCleanly reports whether an initContainer is
+// currently in the terminated{exitCode:0} state — i.e. the init
+// succeeded, even if it took more than one attempt to get there.
+// Used by collectRestartFailures to exempt benign init-phase flakes
+// from the no-restart gate. A nil-terminated state (running /
+// waiting / failed-terminated) returns false, preserving the gate
+// for real crash loops.
+func initContainerCompletedCleanly(cs *containerStatus) bool {
+	t := cs.State.Terminated
+	return t != nil && t.ExitCode == 0
+}
+
+func formatRestartFailure(namespace, podName string, cs *containerStatus, kind string) string {
+	reason := "unknown"
+	msg := ""
+	if cs.LastTerminationState.Terminated != nil {
+		reason = cs.LastTerminationState.Terminated.Reason
+		msg = cs.LastTerminationState.Terminated.Message
+	}
+	return fmt.Sprintf(
+		"pod=%s/%s %s=%s restarts=%d reason=%s msg=%q",
+		namespace, podName, kind, cs.Name, cs.RestartCount, reason, truncate(msg, 200),
+	)
 }
 
 // CollectNamespaceImages returns the deduplicated list of container

--- a/test/chart-integration/assertions_test.go
+++ b/test/chart-integration/assertions_test.go
@@ -235,6 +235,220 @@ func TestHarnessClusterCreatedFieldDefault(t *testing.T) {
 	}
 }
 
+// makePodForRestartTest builds a single-pod podList for
+// TestCollectRestartFailures. Centralised here so each table-driven
+// case is a flat literal — keeps cyclomatic complexity / maintidx
+// low in the test function itself.
+func makePodForRestartTest(namespace, name string, main, init []containerStatus) *podList {
+	return &podList{Items: []struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+		Status struct {
+			ContainerStatuses     []containerStatus `json:"containerStatuses"`
+			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
+		} `json:"status"`
+	}{{
+		Metadata: struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		}{Name: name, Namespace: namespace},
+		Status: struct {
+			ContainerStatuses     []containerStatus `json:"containerStatuses"`
+			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
+		}{ContainerStatuses: main, InitContainerStatuses: init},
+	}}}
+}
+
+func mainCS(name string, restarts int, lastTermReason, lastTermMsg string) containerStatus {
+	var cs containerStatus
+	cs.Name = name
+	cs.RestartCount = restarts
+	if lastTermReason != "" || lastTermMsg != "" {
+		cs.LastTerminationState.Terminated = &struct {
+			Reason  string `json:"reason"`
+			Message string `json:"message"`
+		}{Reason: lastTermReason, Message: lastTermMsg}
+	}
+	return cs
+}
+
+func initCSCompleted(name string, restarts, exitCode int) containerStatus {
+	cs := mainCS(name, restarts, "Error", "first attempt failed")
+	cs.State.Terminated = &struct {
+		Reason   string `json:"reason"`
+		Message  string `json:"message"`
+		ExitCode int    `json:"exitCode"`
+	}{Reason: "Completed", ExitCode: exitCode}
+	return cs
+}
+
+func initCSWaiting(name string, restarts int, waitingReason string) containerStatus {
+	cs := mainCS(name, restarts, "Error", "exit code 1")
+	cs.State.Waiting = &struct {
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
+	}{Reason: waitingReason}
+	return cs
+}
+
+// TestCollectRestartFailures pins the no-restart gate policy:
+//
+//   - Main containers: ANY restartCount>0 is a hard failure
+//     (CrashLoopBackOff / OOM during settle window — the gate's
+//     entire purpose).
+//   - InitContainers: restartCount>0 is exempted iff the init
+//     ultimately completed cleanly (state.terminated.exitCode==0).
+//     Charts like crossplane race the kube-apiserver during their
+//     init CRD wait and occasionally need one restart to succeed;
+//     the cluster is healthy in that case and the gate must not
+//     fire. A crash-looping init (waiting / non-zero terminated /
+//     still running) is NOT exempted — the gate fires as before.
+func TestCollectRestartFailures(t *testing.T) {
+	cases := []struct {
+		name            string
+		pods            *podList
+		wantFailCount   int
+		wantSubstrings  []string
+		bannedSubstring string
+	}{
+		{
+			name:          "main container with no restarts: clean",
+			pods:          makePodForRestartTest("ns", "pod-a", []containerStatus{{Name: "app", RestartCount: 0}}, nil),
+			wantFailCount: 0,
+		},
+		{
+			name:           "main container with restart: fails",
+			pods:           makePodForRestartTest("ns", "pod-b", []containerStatus{mainCS("app", 2, "OOMKilled", "out of memory")}, nil),
+			wantFailCount:  1,
+			wantSubstrings: []string{"container=app", "restarts=2", "OOMKilled"},
+		},
+		{
+			// Reproduces the crossplane case: init container
+			// restarted once due to a CRD-availability race, then
+			// completed cleanly. Main container is now running.
+			// Gate must NOT fire — the cluster is healthy.
+			name: "initContainer restarted but ultimately succeeded (exitCode 0): exempted",
+			pods: makePodForRestartTest("crossplane", "crossplane-xxx",
+				[]containerStatus{{Name: "crossplane", RestartCount: 0}},
+				[]containerStatus{initCSCompleted("crossplane-init", 1, 0)}),
+			wantFailCount: 0,
+		},
+		{
+			// Real crash loop in an init container is still a gate
+			// failure: the init has not succeeded, so the workload
+			// is not actually up. Gate MUST fire.
+			name:           "initContainer crash-looping (waiting CrashLoopBackOff): fails",
+			pods:           makePodForRestartTest("ns", "app-xxx", nil, []containerStatus{initCSWaiting("wait-for-db", 3, "CrashLoopBackOff")}),
+			wantFailCount:  1,
+			wantSubstrings: []string{"initContainer=wait-for-db", "restarts=3"},
+		},
+		{
+			// Final exit code non-zero means init truly failed
+			// (pod would be stuck). Gate MUST fire — exemption is
+			// narrow: exitCode==0 only.
+			name:          "initContainer non-zero terminated despite restartCount: fails",
+			pods:          makePodForRestartTest("ns", "app-yyy", nil, []containerStatus{initCSCompleted("migrate", 1, 1)}),
+			wantFailCount: 1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := collectRestartFailures(c.pods)
+			if len(got) != c.wantFailCount {
+				t.Fatalf("got %d failures, want %d: %v", len(got), c.wantFailCount, got)
+			}
+			if c.wantFailCount == 0 {
+				return
+			}
+			for _, sub := range c.wantSubstrings {
+				if !strings.Contains(got[0], sub) {
+					t.Fatalf("failure %q missing substring %q", got[0], sub)
+				}
+			}
+		})
+	}
+}
+
+// TestCollectRestartFailures_MultiPodMix asserts the gate's
+// per-pod independence: a benign init flake on one pod and a real
+// crash on another pod are reported correctly as exactly one
+// failure attributed to the crashing pod.
+func TestCollectRestartFailures_MultiPodMix(t *testing.T) {
+	initOK := initCSCompleted("init", 1, 0)
+	mainBad := mainCS("worker", 5, "OOMKilled", "")
+
+	pods := &podList{Items: []struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+		Status struct {
+			ContainerStatuses     []containerStatus `json:"containerStatuses"`
+			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
+		} `json:"status"`
+	}{
+		// pod "good": clean main + exempted init flake
+		makePodForRestartTest("ns", "good", []containerStatus{{Name: "app", RestartCount: 0}}, []containerStatus{initOK}).Items[0],
+		// pod "bad": main crash-looping
+		makePodForRestartTest("ns", "bad", []containerStatus{mainBad}, nil).Items[0],
+	}}
+	got := collectRestartFailures(pods)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 failure (only the OOMKilled main container); got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "pod=ns/bad") || !strings.Contains(got[0], "container=worker") {
+		t.Fatalf("wrong failure attributed: %q", got[0])
+	}
+}
+
+// TestInitContainerCompletedCleanly pins the predicate's narrow
+// semantics: ONLY terminated{exitCode:0} counts as a clean
+// completion. Anything else (still running, waiting, failed
+// terminated) returns false so the no-restart gate stays armed
+// against real init crash loops.
+func TestInitContainerCompletedCleanly(t *testing.T) {
+	mkTerm := func(code int) containerStatus {
+		var cs containerStatus
+		cs.State.Terminated = &struct {
+			Reason   string `json:"reason"`
+			Message  string `json:"message"`
+			ExitCode int    `json:"exitCode"`
+		}{ExitCode: code}
+		return cs
+	}
+	mkWait := func(reason string) containerStatus {
+		var cs containerStatus
+		cs.State.Waiting = &struct {
+			Reason  string `json:"reason"`
+			Message string `json:"message"`
+		}{Reason: reason}
+		return cs
+	}
+
+	cases := []struct {
+		name string
+		cs   containerStatus
+		want bool
+	}{
+		{"terminated exitCode 0", mkTerm(0), true},
+		{"terminated exitCode 1", mkTerm(1), false},
+		{"terminated exitCode 137 (SIGKILL)", mkTerm(137), false},
+		{"waiting CrashLoopBackOff", mkWait("CrashLoopBackOff"), false},
+		{"waiting PodInitializing", mkWait("PodInitializing"), false},
+		{"empty state (running, no fields populated)", containerStatus{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cs := c.cs
+			if got := initContainerCompletedCleanly(&cs); got != c.want {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestInstallChartRejectsArgumentInjection(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

- Exempt initContainers that **ultimately completed cleanly** (`state.terminated.exitCode == 0`) from the chart-integration no-restart gate.
- Keep the gate's strict guarantee for **main** containers (any restart still fails — the whole point of catching CrashLoopBackOff / OOM during the settle window) and for **crash-looping** init containers (still waiting / non-zero terminated / still running).
- Fixes the `crossplane` chart-integration shard, which has been red on `main` since [#390](https://github.com/verity-org/verity/pull/390).

## Root cause

The `crossplane` chart's [`crossplane-init`](https://github.com/crossplane/crossplane) initContainer registers the chart's own core CRDs and then waits for the apiserver to acknowledge them. On the kind cluster used by chart-integration the first attempt sometimes loses a race with kube-apiserver readiness and is restarted **once** by the kubelet. The second attempt completes cleanly:

```
initContainerStatuses[0]:
  name: crossplane-init
  restartCount: 1
  state.terminated.exitCode: 0    ← completed successfully
containerStatuses[0]:
  name: crossplane
  restartCount: 0
  state.running                   ← healthy
```

Pod logs and events from the failing run [25974769298](https://github.com/verity-org/verity/actions/runs/25974769298) (job `76352955995`, crossplane shard):

- `crossplane-init` first attempt 22:40:53 → 22:40:55 (restart), second attempt 22:40:55 → 22:40:58 (Completed, exitCode 0).
- main `crossplane` container started 22:40:59, became leader 22:41:01, ready=true, no restarts.
- helm install reported success; the cluster was healthy when the gate ran.

The previous gate logic in `collectRestartFailures` (`test/chart-integration/assertions.go`) walked main and init statuses through one loop and counted **any** `restartCount > 0` as a hard failure. The intent of the gate is to catch real crash loops in long-running workload containers during the post-install settle window — not benign init-phase flakes that the kubelet has already absorbed.

## Fix — scoped to the harness, no chart values changed

`collectRestartFailures` now walks the two status slices **separately**:

- **Main containers**: unchanged. Any `restartCount > 0` is a hard failure.
- **Init containers**: failure iff `restartCount > 0` AND the container did NOT ultimately reach `state.terminated{exitCode:0}`. Crash-looping inits (waiting `CrashLoopBackOff`, non-zero terminated, still running) continue to fail the gate.

`containerStatus` gains a `State` field carrying kubelet's current-state union (terminated / waiting) so the predicate can distinguish "completed cleanly after one retry" from "still crash-looping".

The exemption is narrow by design: only `exitCode == 0` counts. A non-zero terminated exit, a `waiting` state of any flavour, or a still-running init all continue to trip the gate. This preserves the no-restart guarantee for every other chart.

## Tests

Three new unit-test groups pin the policy and guard against drift:

| Test | What it pins |
|------|--------------|
| `TestCollectRestartFailures` | Table-driven: clean main, restarting main fails (preserved), benign init flake exempted (the crossplane case), crash-looping init still fails, non-zero terminated init still fails. |
| `TestCollectRestartFailures_MultiPodMix` | Per-pod independence — a benign init flake on one pod doesn't mask a real main-container crash on another pod. |
| `TestInitContainerCompletedCleanly` | Predicate semantics — only `terminated{exitCode:0}` returns true; `terminated{exitCode:1}`, `terminated{exitCode:137}`, `waiting{CrashLoopBackOff}`, `waiting{PodInitializing}`, and empty state all return false. |

All pre-existing harness tests (`TestClassifyHelmFailure*`, `TestHarnessClusterCreatedFieldDefault`, `TestIsAccepted`, `TestLoadAllowlist*`, `TestClassifyMissingAllowlist*`, `TestInstallChartRejectsArgumentInjection`) continue to pass.

```
$ VERITY_IT_SKIP_CLUSTER=1 go test -tags integration ./test/chart-integration/... \
    -run 'TestClassify|TestHarness|TestCollectRestart|TestInitContainer|TestIsAccepted|TestLoadAllow|TestInstallChartRejects' -count=1
ok  	github.com/verity-org/verity/test/chart-integration	0.008s
```

`go test ./...` (no tags) — clean. `golangci-lint run --build-tags integration ./test/chart-integration/...` — no new findings (baseline 6 pre-existing issues unchanged).

## Out of scope

- No chart values changed; no SKIPS added.
- No other chart's gate behaviour weakened. The exemption is keyed on a property only initContainers exhibit (running to a clean `terminated{exitCode:0}` state after at least one restart) and applies only to the init-status slice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exempts benign init-container restarts that ultimately succeed (exitCode 0) from the chart-integration no-restart gate, while keeping strict checks for main containers and crash-looping inits. Fixes false failures in the `crossplane` shard on `main`.

- Bug Fixes
  - Updated collectRestartFailures to handle main and init containers separately: main containers fail on any restart; init containers are exempt only if state.terminated.exitCode == 0; waiting/non-zero/still-running inits still fail.
  - Added State to containerStatus to read current terminated/waiting info and improved failure output to label container type.

- Tests
  - Added unit tests covering clean/restarting main containers, benign init flakes, crash-looping/non-zero inits, and mixed-pod scenarios, plus a predicate test for exitCode filtering.

<sup>Written for commit 4b569fc5ce90cb30b40aba32de8b4dfd7cb0c440. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/394?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

