### PR TITLE
fix(airflow): disable migration job helm hooks to break install --wait deadlock

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -246,23 +246,47 @@ chartValues:
   #
   # Bucket E (probe-race) — bucket-confirmation.md (airflow row) shows
   # `wait-for-airflow-migrations` init container looping `Waiting for
-  # migrations... NN second(s)` because the bundled `airflow-postgresql-0`
-  # is slow to become reachable inside the 10-minute `helm install --wait`
-  # budget. The chart converges to healthy given more time, but
-  # `helm install` exits first.
+  # migrations... NN second(s)`. Root cause is NOT just probe race — the
+  # upstream chart ships `migrateDatabaseJob.useHelmHooks: true` (chart
+  # default), which annotates the migrations Job with
+  # `helm.sh/hook: post-install,post-upgrade`. Under `helm install --wait`
+  # this creates a deadlock:
   #
-  # Probe-race knobs:
-  # - `images.migrationsWaitTimeout` (default 60s) — wait budget for
-  #   `wait-for-airflow-migrations`. Raised 60s → 180s (3×) to give the
-  #   chained postgres init time to finish before the wait-job gives up.
-  # - `apiServer.startupProbe.failureThreshold` (default 6) — Airflow 3.x
-  #   chart renamed `webserver` → `apiServer`; 6 × 10s = 60s grace from
-  #   container start. Doubled to 12 (= 120s) so a freshly-migrated API
-  #   server isn't killed before it binds.
+  #   1. helm applies non-hook resources (api-server / scheduler /
+  #      worker Deployments + StatefulSets).
+  #   2. helm `--wait` blocks until those Deployments become Ready.
+  #   3. Each Deployment's pod has a `wait-for-airflow-migrations`
+  #      init container that polls the DB for an applied alembic
+  #      revision and never exits.
+  #   4. The migrations Job (post-install hook) only runs AFTER the
+  #      install step succeeds — which it never does, because step 2
+  #      times out first.
+  #
+  # Fix: flip `migrateDatabaseJob.useHelmHooks` AND
+  # `createUserJob.useHelmHooks` to `false`. The Jobs then render as
+  # regular resources that helm applies in the first pass, so the
+  # migrations Job runs in parallel with the Deployments and the
+  # init container exits as soon as alembic finishes.
+  #
+  # Supporting knobs:
+  # - `postgresql.image.registry: ghcr.io` — overrides the chart's
+  #   `image.registry: docker.io` default so the chart-gen-rewritten
+  #   `bitnamilegacy/postgresql` → `ghcr.io/verity-org/bitnamilegacy/postgresql`
+  #   reference doesn't collide with a stale `docker.io/` prefix. Same
+  #   shape as the tempo-distributed fix in verity-org/verity#318.
+  # - `images.migrationsWaitTimeout: 300` (default 60s) — wait budget
+  #   for `wait-for-airflow-migrations`. Kept generous so the init
+  #   container still has headroom while the migrations Job runs.
+  # - `apiServer.startupProbe.failureThreshold: 12` (default 6) —
+  #   Airflow 3.x chart renamed `webserver` → `apiServer`; 12 × 10s =
+  #   120s grace from container start so a freshly-migrated API server
+  #   isn't killed before it binds.
   airflow:
     postgresql.image.registry: ghcr.io
-    images.migrationsWaitTimeout: 180
+    images.migrationsWaitTimeout: 300
     apiServer.startupProbe.failureThreshold: 12
+    migrateDatabaseJob.useHelmHooks: false
+    createUserJob.useHelmHooks: false
 
   # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
   # default inbound agent image. Keep the wrapper focused on the controller and


### PR DESCRIPTION
## Summary

Airflow chart-integration shard has been failing because the upstream
chart's `migrateDatabaseJob.useHelmHooks: true` default creates a
deadlock with `helm install --wait`. This PR flips that to `false` so
the migrations Job runs as a regular resource in the install pass,
unblocking the `wait-for-airflow-migrations` init containers.

## Root cause

Upstream chart annotates the migrations Job with
`helm.sh/hook: post-install,post-upgrade`. That means:

1. `helm install` applies non-hook resources first
   (api-server / scheduler / worker / triggerer / dag-processor /
   create-user pods).
2. `helm install --wait` blocks until those Deployments / StatefulSets
   become Ready.
3. Each of those pods declares a `wait-for-airflow-migrations` init
   container that polls the metadata DB for an applied alembic
   revision and never exits.
4. The migrations Job (a post-install hook) only runs AFTER the
   install step succeeds — which it never does, because step 2 times
   out first.

## Diagnostic evidence (run [25974769298](https://github.com/verity-org/verity/actions/runs/25974769298), job [76352955976](https://github.com/verity-org/verity/actions/runs/25974769298/job/76352955976))

`diagnostics-airflow` artifact `_dump-airflow/airflow/pods.json` after
the 10-minute install timeout:

| Pod                               | Phase   | wait-for-migrations restartCount | wait-for-migrations state |
|-----------------------------------|---------|----------------------------------|---------------------------|
| airflow-api-server-…              | Pending | 3                                | running (looping)         |
| airflow-dag-processor-…           | Pending | 3                                | running (looping)         |
| airflow-scheduler-…               | Pending | 3                                | running (looping)         |
| airflow-triggerer-0               | Pending | 2                                | running (looping)         |
| airflow-worker-0                  | Pending | 3                                | running (looping)         |
| airflow-postgresql-0              | Running | n/a                              | (healthy)                 |
| airflow-redis-0                   | Running | n/a                              | (healthy)                 |
| airflow-statsd-…                  | Running | n/a                              | (healthy)                 |

Container log for any wait-for-migrations init:
```
Waiting for migrations... 0 second(s)
Waiting for migrations... 1 second(s)
...
Waiting for migrations... 51 second(s) (truncated at restart)
```

Crucially: **zero `airflow-run-airflow-migrations-*` pods are present in
the namespace and zero events reference one**. The Job never ran
because the install step never reached the `post-install` phase.

Failure surfaced as:
```
Error: INSTALLATION FAILED: resource Deployment/airflow/airflow-api-server not ready.
status: InProgress, message: Available: 0/1
```
classified as `crash-class`, NOT retrying.

## Fix

`verity.yaml` chartValues for `airflow`:

- `migrateDatabaseJob.useHelmHooks: false` — render the migrations
  Job as a regular resource so it's applied in the install pass.
- `createUserJob.useHelmHooks: false` — same treatment for the
  create-user Job (also a post-install hook by default; runs after
  migrations via its own `wait-for-airflow-migrations` init).
- `images.migrationsWaitTimeout: 180 → 300` — wider safety margin
  in case alembic is slow on the freshly-initialised postgres.
- Existing `postgresql.image.registry: ghcr.io` and
  `apiServer.startupProbe.failureThreshold: 12` kept unchanged.

## Verification

- `helm template airflow ./airflow-1.21.0` with the new values
  confirms the migrations and create-user Jobs no longer carry
  `helm.sh/hook` annotations (verified locally against the
  `oci://ghcr.io/verity-org/charts/airflow:1.21.0` wrapper).
- `go test ./...` green.
- `TestVerityConfigChartValuesLoading` green — dotted-key chartValues
  parse correctly.

## Refs

- Failing run: [25974769298](https://github.com/verity-org/verity/actions/runs/25974769298)
- Failing job: [76352955976](https://github.com/verity-org/verity/actions/runs/25974769298/job/76352955976)
- Bucket E (probe-race) classification baseline:
  `bucket-confirmation.md` (airflow row)
- Related chartValues fix shape: [#318](https://github.com/verity-org/verity/pull/318) (tempo-distributed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a deadlock during `helm install --wait` for the Airflow chart by running migrations and create-user jobs as regular resources. This lets `wait-for-airflow-migrations` exit and the release install cleanly.

- **Bug Fixes**
  - Set `migrateDatabaseJob.useHelmHooks: false` and `createUserJob.useHelmHooks: false` in `verity.yaml` to avoid post-install hook deadlock.
  - Increased `images.migrationsWaitTimeout` to 300s to give alembic more headroom.

<sup>Written for commit 67244d83fced7eba3e10d678d889bcb91b2a2ac9. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/395?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

