### PR TITLE
fix(chart-osd): override broken apk default opensearch_dashboards.yml

### DIFF
--- a/test/chart-integration/values/opensearch-dashboards.yaml
+++ b/test/chart-integration/values/opensearch-dashboards.yaml
@@ -1,0 +1,52 @@
+# Chart-integration override for opensearch-dashboards 3.6.0.
+#
+# The verity wolfi rebuild (images/opensearch-dashboards.yaml) installs the
+# upstream `opensearch-dashboards-3` apk, which ships
+# `/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml` with
+# four `opensearch_security.*` keys appended at the bottom:
+# multitenancy.enabled, multitenancy.tenants.preferred, readonly_mode.roles,
+# and cookie.secure. Those keys are owned by the `securityDashboards`
+# plugin — which is NOT in the apk and NOT in the rebuilt image
+# (`crane export ghcr.io/verity-org/opensearch-dashboards:3 | tar -tf - |
+# grep -i securityDashboards` returns nothing — `-f -` tells tar to read
+# the archive from stdin).
+#
+# OSD's bootstrap therefore aborts with
+#   FATAL InvalidConfigurationError: Unknown configuration key(s):
+#         "opensearch_security.multitenancy.enabled", ...
+#         processExitCode: 64
+# (chart-integration run 25974769298, dashboards pod log 5.log). The
+# container CrashLoopBackOff is observed by the harness as
+# classification=crash-class.
+#
+# This override replaces the rendered ConfigMap entry — the chart's
+# `templates/configmap.yaml` mounts `.Values.config.opensearch_dashboards.yml`
+# into `/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml`,
+# overlaying the broken apk default with a clean minimal config that points
+# at the in-cluster opensearch service but omits every `opensearch_security.*`
+# key.
+#
+# Long-term fix tracked under verity-org/verity#396: the image-build system
+# has no path-type for arbitrary file content (internal/integer/config/types.go
+# PathDef only models directory/symlink), so the apk-supplied yml cannot
+# currently be patched inside images/opensearch-dashboards.yaml. The follow-up
+# will either (a) extend PathDef with a `contents`/`source-file` field, or
+# (b) add a bespoke melange package that overwrites the file in the apk
+# install hook. Until then, every consumer of
+# ghcr.io/verity-org/opensearch-dashboards:3 must provide their own
+# `config.opensearch_dashboards.yml` override.
+
+config:
+  opensearch_dashboards.yml: |
+    server.host: "0.0.0.0"
+    server.name: dashboards
+    # The chart wires `opensearchHosts` (default
+    # https://opensearch-cluster-master:9200) into the OPENSEARCH_HOSTS env
+    # var on the dashboards container, which OSD reads in addition to this
+    # file. Setting the same value here keeps behaviour identical whether
+    # OSD reads the env var or the yml first.
+    opensearch.hosts: ["https://opensearch-cluster-master:9200"]
+    opensearch.ssl.verificationMode: none
+    opensearch.username: kibanaserver
+    opensearch.password: kibanaserver
+    opensearch.requestHeadersAllowlist: [authorization]


### PR DESCRIPTION
## Summary

Unblocks the `opensearch-dashboards` shard of the `chart-integration` workflow. Run [25974769298](https://github.com/verity-org/verity/actions/runs/25974769298) (job [76352955969](https://github.com/verity-org/verity/actions/runs/25974769298/job/76352955969)) showed the dashboards pod CrashLoopBackOff with classification=crash-class.

## Root cause

The wolfi rebuild ([`images/opensearch-dashboards.yaml`](https://github.com/verity-org/verity/blob/main/images/opensearch-dashboards.yaml)) installs the upstream `opensearch-dashboards-3` apk, which ships `/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml` with four `opensearch_security.*` keys at the bottom (multitenancy, readonly_mode, cookie.secure). Those keys belong to the `securityDashboards` plugin — which is **not** in the apk and **not** in the rebuilt image:

```
$ crane export ghcr.io/verity-org/opensearch-dashboards:3 \
  | tar -tf - | grep -i securityDashboards
(nothing)
```

OSD therefore aborts at boot with:

```
FATAL InvalidConfigurationError: Unknown configuration key(s):
      "opensearch_security.multitenancy.enabled",
      "opensearch_security.multitenancy.tenants.preferred",
      "opensearch_security.readonly_mode.roles",
      "opensearch_security.cookie.secure".
      Check for spelling errors and ensure that expected plugins are installed.
processExitCode: 64
```

(verbatim from `dashboards/5.log` in the failing run's diagnostics).

The kubelet sees exit 64 / CrashLoopBackOff, the harness classifies as `crash-class`, the shard fails.

## Fix

Add `test/chart-integration/values/opensearch-dashboards.yaml`, which the test harness ([`chart.go` `valuesFile`](https://github.com/verity-org/verity/blob/main/test/chart-integration/chart.go#L98)) auto-merges at `helm install` time. The override sets the chart's `config.opensearch_dashboards.yml` to a clean minimal yml that:

- points at the in-cluster `opensearch-cluster-master:9200` endpoint,
- carries the kibanaserver basic-auth defaults that the chart already expects, and
- omits every `opensearch_security.*` key.

The chart's `templates/configmap.yaml` materialises this string as a ConfigMap entry and the deployment mounts it at `/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml`, overlaying the broken apk default.

## Validation

Local reproduction on a fresh `kind` cluster:

```
helm install osd opensearch-dashboards \
  --repo https://opensearch-project.github.io/helm-charts --version 3.6.0 \
  -n osd --create-namespace \
  -f test/chart-integration/values/opensearch-dashboards.yaml \
  --set image.repository=ghcr.io/verity-org/opensearch-dashboards \
  --set image.tag=3 --set securityContext.runAsUser=65532
```

→ pod `osd-opensearch-dashboards-…` reaches `1/1 Running` within ~90s. Logs show `queryEnhancements: Setup complete` (no `InvalidConfigurationError`).

Other validation:

- `go test ./internal/chartgen/...` → `ok` (4.0s)
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid"` → `ok` (35.5s)
- `golangci-lint run ./...` → no new findings in this worktree
- `helm template … -f …` confirms ConfigMap renders the clean yml verbatim

## Follow-up

Image-side fix tracked under [#396](https://github.com/verity-org/verity/issues/396). [`PathDef`](https://github.com/verity-org/verity/blob/main/internal/integer/config/types.go) only models `directory`/`symlink`, so the apk-supplied yml cannot currently be patched inside `images/opensearch-dashboards.yaml`. Once that lands, the test-values override can be removed.

## Scope

- One new file: `test/chart-integration/values/opensearch-dashboards.yaml`
- No CI-defaults changes (`verity.yaml` untouched)
- No SKIPS additions
- No other chart affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `opensearch-dashboards` CrashLoopBackOff in chart-integration by overriding the apk’s default config that references a missing plugin. Unblocks the `opensearch-dashboards` shard.

- Bug Fixes
  - Added `test/chart-integration/values/opensearch-dashboards.yaml` to replace the chart’s rendered `opensearch_dashboards.yml` (3.6.0) with a minimal, valid config.
  - Removes `opensearch_security.*` keys tied to the missing `securityDashboards` plugin (not in `ghcr.io/verity-org/opensearch-dashboards:3`), preventing boot failure.
  - Points to `https://opensearch-cluster-master:9200` with `kibanaserver` defaults; no CI defaults changed. Follow-up image-side fix tracked in #396.

<sup>Written for commit df7547dafd18d36f86d9b1ce709d43ad16d2b53f. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/397?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

