### PR TITLE
fix(airflow): close postgres double-prefix + statsd + create-user race after #395

### DIFF
--- a/test/chart-integration/values/airflow.allowlist.txt
+++ b/test/chart-integration/values/airflow.allowlist.txt
@@ -1,0 +1,28 @@
+# airflow upstream image allowlist (SCR-2026-04-30-001)
+#
+# The Apache Airflow Helm chart 1.21.0 sources its main application
+# image (api-server, scheduler, worker, triggerer, dag-processor,
+# migrations, create-user) from the chart-level scalars
+# `defaultAirflowRepository: apache/airflow` and
+# `defaultAirflowTag: "3.2.0"`. chart-gen's image-mapping pass does
+# NOT rewrite these scalars today: the `apache/airflow` →
+# `ghcr.io/verity-org/airflow:3` replacement in verity.yaml depends
+# on a per-image value path (`image.repository` shape), which the
+# chart's top-level scalars don't expose.
+#
+# A verity wolfi rebuild of Airflow exists at
+# `ghcr.io/verity-org/airflow:3` (see `images/airflow.yaml`), but
+# it currently ships with `/opt/airflow/bin` outside `$PATH`, so
+# the chart's `bash -c "exec airflow ..."` Job commands cannot find
+# the binary. Routing the chart at the verity rebuild requires
+# coordinated changes to `images/airflow.yaml` (apko PATH or
+# symlink) AND verity.yaml chartValues
+# (`defaultAirflowRepository` + `defaultAirflowTag` overrides).
+#
+# Tracking issue: verity-org/verity#399
+#
+# Format note: the isAccepted helper in
+# test/chart-integration/assertions.go uses strings.HasPrefix;
+# the `:` and `@` separators scope each prefix to tag/digest refs.
+docker.io/apache/airflow:
+docker.io/apache/airflow@

--- a/verity.yaml
+++ b/verity.yaml
@@ -292,18 +292,31 @@ chartValues:
   #      install step succeeds — which it never does, because step 2
   #      times out first.
   #
-  # Fix: flip `migrateDatabaseJob.useHelmHooks` AND
-  # `createUserJob.useHelmHooks` to `false`. The Jobs then render as
-  # regular resources that helm applies in the first pass, so the
-  # migrations Job runs in parallel with the Deployments and the
-  # init container exits as soon as alembic finishes.
+  # Fix: flip `migrateDatabaseJob.useHelmHooks` to `false`. The Job
+  # renders as a regular resource that helm applies in the first pass,
+  # so the migrations Job runs in parallel with the Deployments and
+  # each Deployment's init container exits as soon as alembic finishes.
+  # `createUserJob.useHelmHooks` is LEFT at chart default `true`:
+  # post-install hooks run after `helm install --wait` has confirmed
+  # Deployments are ready (which already implies migrations finished),
+  # so create-user doesn't race the DB and the no-restart-during-settle
+  # gate stays clean.
   #
   # Supporting knobs:
-  # - `postgresql.image.registry: ghcr.io` — overrides the chart's
-  #   `image.registry: docker.io` default so the chart-gen-rewritten
-  #   `bitnamilegacy/postgresql` → `ghcr.io/verity-org/bitnamilegacy/postgresql`
-  #   reference doesn't collide with a stale `docker.io/` prefix. Same
-  #   shape as the tempo-distributed fix in verity-org/verity#318.
+  # - `postgresql.image.registry: ghcr.io` +
+  #   `postgresql.image.repository: verity-org/bitnamilegacy/postgresql`
+  #   — both siblings are set explicitly because the upstream airflow
+  #   chart's parent values.yaml pins the repository as a leaf scalar
+  #   (`postgresql.image.repository: bitnamilegacy/postgresql`). chart-gen
+  #   detects the override path at the parent scope, but the parent
+  #   path lacks a `registry` sibling so its `hasRegistry`-driven
+  #   stripping fallback leaves the repository unstripped. The
+  #   bundled postgresql subchart's template then renders
+  #   `{{ .Values.image.registry }}/{{ .Values.image.repository }}` →
+  #   the double-prefix `docker.io/ghcr.io/verity-org/bitnamilegacy/postgresql`.
+  #   Pinning BOTH siblings explicitly here side-steps that gap until
+  #   chart-gen learns to consult subchart values for registry-sibling
+  #   detection (verity-org/verity#318 covers the related tempo case).
   # - `images.migrationsWaitTimeout: 300` (default 60s) — wait budget
   #   for `wait-for-airflow-migrations`. Kept generous so the init
   #   container still has headroom while the migrations Job runs.
@@ -311,12 +324,20 @@ chartValues:
   #   Airflow 3.x chart renamed `webserver` → `apiServer`; 12 × 10s =
   #   120s grace from container start so a freshly-migrated API server
   #   isn't killed before it binds.
+  # - `statsd.enabled: false` — the chart bundles
+  #   `quay.io/prometheus/statsd-exporter:v0.29.0`, which has no
+  #   verity rebuild today. Disabling the optional StatsD sidecar
+  #   removes a non-verity image from the smoke namespace so the
+  #   image-origin gate stays clean WITHOUT an allowlist exception.
+  #   StatsD metrics are not required for the smoke test (which only
+  #   verifies install + pod readiness, not metric scraping).
   airflow:
     postgresql.image.registry: ghcr.io
+    postgresql.image.repository: verity-org/bitnamilegacy/postgresql
     images.migrationsWaitTimeout: 300
     apiServer.startupProbe.failureThreshold: 12
     migrateDatabaseJob.useHelmHooks: false
-    createUserJob.useHelmHooks: false
+    statsd.enabled: false
 
   # jenkins 5.9.18 otherwise renders an unpatched bats helm-test pod and a
   # default inbound agent image. Keep the wrapper focused on the controller and


### PR DESCRIPTION
## Summary

Follow-up to [#395](https://github.com/verity-org/verity/pull/395).
That PR unblocked the `helm install --wait` deadlock so the install
step actually completes; post-install assertion checks then surfaced
three latent issues the deadlock had been hiding. This PR closes
all of them so the chart-integration airflow shard goes green on
main.

## Root cause analysis (post-#395)

Run [25981181358](https://github.com/verity-org/verity/actions/runs/25981181358), job [76370194087](https://github.com/verity-org/verity/actions/runs/25981181358/job/76370194087). diagnostics-airflow:

- Every pod Running/Ready. Migrations Job + create-user Job both
  Succeeded.
- **no-restart gate**:
  `pod=airflow/airflow-create-user-rgsqq container=create-user restartCount=1 reason=Completed exit=0`
- **image-origin gate**: 3 non-verity images, no allowlist:
  - `docker.io/apache/airflow:3.2.0`
  - `ghcr.io/ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15` (**double-ghcr.io bug pattern**)
  - `quay.io/prometheus/statsd-exporter:v0.29.0`

### Issue 1 — Postgres double-prefix

`ghcr.io/ghcr.io/...` happens because chart-gen detects the override
path at the parent scope (the airflow chart's parent values.yaml
pins `postgresql.image.repository: bitnamilegacy/postgresql` as a
leaf scalar — no `registry` sibling). chart-gen's
`hasRegistry`-driven stripping fallback in
`buildValueOverride` leaves the repository unstripped. The Bitnami
subchart's template then renders
`{{ .Values.image.registry }}/{{ .Values.image.repository }}` →
`ghcr.io/ghcr.io/verity-org/bitnamilegacy/postgresql`.

The earlier verity.yaml chartValues only set
`postgresql.image.registry: ghcr.io`, which fixed the original
`docker.io/ghcr.io/...` shape but not the new
`ghcr.io/ghcr.io/...` shape.

**Fix**: pin BOTH siblings explicitly:
```yaml
postgresql.image.registry: ghcr.io
postgresql.image.repository: verity-org/bitnamilegacy/postgresql
```

Local `helm template` confirms the rendered ref is now the clean
`ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`.

(A proper chart-gen fix to consult subchart values for the
registry-sibling detection is the right strategic answer; it's
the same shape as the [#318](https://github.com/verity-org/verity/pull/318) tempo-distributed fix
generalisation and is out of scope here.)

### Issue 2 — Create-user race

[#395](https://github.com/verity-org/verity/pull/395) flipped BOTH
`migrateDatabaseJob.useHelmHooks` AND
`createUserJob.useHelmHooks` to `false`. With the create-user hook
off, the Job renders as a regular resource and races the migrations
Job + the DB. The Job's `restartPolicy: OnFailure` retries and
succeeds on attempt 2, but the no-restart-during-settle gate flags
`restartCount=1`.

**Fix**: REVERT `createUserJob.useHelmHooks` to chart default
(`true`). Post-install hooks run AFTER `helm install --wait` has
confirmed Deployments are ready (which already implies migrations
finished), so create-user can't race the DB. Leaving
`migrateDatabaseJob.useHelmHooks: false` intact — that's the
deadlock-breaker from [#395](https://github.com/verity-org/verity/pull/395).

### Issue 3 — StatsD image not in verity

`quay.io/prometheus/statsd-exporter:v0.29.0` has no verity rebuild
today. The smoke test only verifies install + pod readiness, not
metric scraping, so the StatsD sidecar is optional.

**Fix**: `statsd.enabled: false`. Removes the non-verity image from
the namespace entirely — no allowlist entry needed.

### Issue 4 — apache/airflow main image still upstream

chart-gen does NOT rewrite the chart's `defaultAirflowRepository:
apache/airflow` + `defaultAirflowTag: "3.2.0"` scalars. The
`apache/airflow` → `ghcr.io/verity-org/airflow:3` replacement in
verity.yaml depends on a per-image value-path (`image.repository`
shape) that the chart's top-level scalars don't expose.

A verity wolfi rebuild exists at `ghcr.io/verity-org/airflow:3`
(see `images/airflow.yaml`) but is NOT chart-compatible today
(`/opt/airflow/bin` is not on `$PATH`, so the chart's
`bash -c "exec airflow ..."` Job commands fail with `command not
found`). Closing that gap is a coordinated change across
`images/airflow.yaml` + chartValues plumbing.

**Fix (tactical)**: add a focused
`test/chart-integration/values/airflow.allowlist.txt` admitting
`docker.io/apache/airflow:` / `@` ONLY. Tracking issue
[#399](https://github.com/verity-org/verity/issues/399) for the
strategic wolfi-rebuild integration (the allowlist row goes away
when that lands).

## Verification

- `go test ./...` green.
- `go test -tags integration ./test/chart-integration/...
  -run 'TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid'`
  green — the new airflow allowlist parses correctly.
- Local `helm template airflow ./airflow-1.21.0
  -f /tmp/values.yaml` with the new chartValues:
  - postgres image renders `ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15` (no double prefix).
  - statsd-exporter no longer in the rendered output.
  - create-user Job once again carries
    `helm.sh/hook: post-install,post-upgrade`.

## Refs

- Predecessor: [#395](https://github.com/verity-org/verity/pull/395)
- Failure that surfaced after #395 merged:
  [run 25981181358](https://github.com/verity-org/verity/actions/runs/25981181358), [job 76370194087](https://github.com/verity-org/verity/actions/runs/25981181358/job/76370194087)
- Strategic tracking issue for apache/airflow → verity wolfi rebuild:
  [#399](https://github.com/verity-org/verity/issues/399)
- Related chartValues fix shape: [#318](https://github.com/verity-org/verity/pull/318) (tempo-distributed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Airflow chart issues after #395 so installs are stable: corrects the PostgreSQL image reference, prevents the create-user race, and removes the non-verity StatsD sidecar. Adds a strict allowlist for upstream `apache/airflow` until our image is chart-compatible.

- **Bug Fixes**
  - Postgres image: set `airflow.postgresql.image.registry: ghcr.io` and `airflow.postgresql.image.repository: verity-org/bitnamilegacy/postgresql` to remove the `ghcr.io/ghcr.io/...` double prefix.
  - Create-user race: keep `airflow.migrateDatabaseJob.useHelmHooks: false`; rely on default `airflow.createUserJob.useHelmHooks: true` so it runs post-install.
  - StatsD sidecar: set `airflow.statsd.enabled: false` to drop `quay.io/prometheus/statsd-exporter:v0.29.0`.
  - Airflow main image: add `test/chart-integration/values/airflow.allowlist.txt` allowing only `docker.io/apache/airflow:` and `docker.io/apache/airflow@` until `ghcr.io/verity-org/airflow:3` is chart-ready (see #399).

<sup>Written for commit 273d0418742cd6a107aa947426d1739f6cf6a470. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/400?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

