### PR TITLE
fix(opensearch): drop unsubstituted heap.dump.path/error.file placeholders from custom jvm.options

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -697,9 +697,18 @@ chartValues:
         -Djava.io.tmpdir=${OPENSEARCH_TMPDIR}
 
         ## heap dumps
+        ## Note: the upstream file ships `${heap.dump.path}` and
+        ## `${error.file}` placeholders here that the `opensearch-env`
+        ## shell wrapper substitutes at entrypoint time. Because we
+        ## replace the entire jvm.options via ConfigMap, those
+        ## placeholders are NOT expanded by the launcher (JvmOptions-
+        ## Parser only resolves `${ENVVAR}` references, not these
+        ## opensearch-env-specific tokens) and would cause
+        ##   improperly formatted JVM option in [.../jvm.options] ...
+        ## startup errors. The JVM falls back to its built-in defaults
+        ## (heap dump in CWD, no separate fatal-error log file), which
+        ## is acceptable for the CI smoke test.
         -XX:+HeapDumpOnOutOfMemoryError
-        ${heap.dump.path}
-        ${error.file}
 
         ## JDK 20+ Incubating Vector Module for SIMD optimizations
         20-:--add-modules=jdk.incubator.vector


### PR DESCRIPTION
## Summary

Follow-up to [#398](https://github.com/verity-org/verity/pull/398).

The earlier fix supplied a custom `jvm.options` via chartValues to replace the upstream copy that has the unwritable `-Xlog:gc*:file=logs/gc.log` directive. It shipped the upstream `${heap.dump.path}` and `${error.file}` lines verbatim — but those placeholders are expanded by the `opensearch-env` shell wrapper at entrypoint time, and ONLY when the launcher reads the upstream file. Because our ConfigMap-mounted jvm.options replaces the whole file, no shell wrapper processes those tokens; `JvmOptionsParser` (which only substitutes proper `${ENVVAR}` env references) then rejects them with

~~~
encountered [2] errors parsing [/usr/share/opensearch/config/jvm.options]
[1]: improperly formatted JVM option in [.../jvm.options] on line number [15]: [${heap.dump.path}]
[2]: improperly formatted JVM option in [.../jvm.options] on line number [16]: [${error.file}]
~~~

and the pods crash-loop on main ([chart-integration run 25982132035](https://github.com/verity-org/verity/actions/runs/25982132035) opensearch shard, [job 76372969285](https://github.com/verity-org/verity/actions/runs/25982132035/job/76372969285)).

## Why [#398](https://github.com/verity-org/verity/pull/398)'s CI did not catch this

`chart-integration` sets `continue-on-error: ${{ github.event_name == 'pull_request' }}` on the `Run chart smoke test` step (workflow line 144), so on PR events the shard's smoke step turned red but the `Record shard outcome` step still surfaced 'success' to the check overall. The earlier PR's opensearch shard log shows `--- FAIL: TestCharts/opensearch (604.60s)` but the check rolled up green. The hard-failure on `push:main` is what surfaced this gap.

## Fix

Drop the two unsubstituted lines outright. The JVM falls back to its built-in defaults (heap dump in CWD, no separate fatal-error log file), which is acceptable for the CI smoke test. The other env-style template (`-Djava.io.tmpdir=${OPENSEARCH_TMPDIR}`) is left in place because `OPENSEARCH_TMPDIR` is a real env var that `JvmOptionsParser` DOES substitute (verified: no parse error was logged against that line on the failing main run).

## Local validation

- `go test ./internal/chartgen/... ./internal/discovery/...` — pass
- `helm template` of the rebuilt wrapper shows the `jvm.options` ConfigMap without `${heap.dump.path}` / `${error.file}` lines and otherwise matches the upstream OpenSearch 3.x baseline minus the gc-file logging directive.

## Scope

`verity.yaml` only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `${heap.dump.path}` and `${error.file}` from the ConfigMap `jvm.options` for OpenSearch to stop `JvmOptionsParser` errors and crash loops. Pods start cleanly; CI smoke tests pass.

- **Bug Fixes**
  - Dropped placeholders that only `opensearch-env` expands; they were left literal after our full-file replacement and failed parsing.
  - Rely on JVM defaults for heap dumps and fatal error logs, which is fine for CI.
  - Kept `-Djava.io.tmpdir=${OPENSEARCH_TMPDIR}` since it’s a real env var and parses correctly.

<sup>Written for commit b7416847d134449a5ce0ef3a13f5b897556dd221. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/401?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

