### PR TITLE
fix(chart-osd): nest config override under wrapper sub-chart key

### DIFF
--- a/test/chart-integration/values/opensearch-dashboards.yaml
+++ b/test/chart-integration/values/opensearch-dashboards.yaml
@@ -36,17 +36,21 @@
 # ghcr.io/verity-org/opensearch-dashboards:3 must provide their own
 # `config.opensearch_dashboards.yml` override.
 
-config:
-  opensearch_dashboards.yml: |
-    server.host: "0.0.0.0"
-    server.name: dashboards
-    # The chart wires `opensearchHosts` (default
-    # https://opensearch-cluster-master:9200) into the OPENSEARCH_HOSTS env
-    # var on the dashboards container, which OSD reads in addition to this
-    # file. Setting the same value here keeps behaviour identical whether
-    # OSD reads the env var or the yml first.
-    opensearch.hosts: ["https://opensearch-cluster-master:9200"]
-    opensearch.ssl.verificationMode: none
-    opensearch.username: kibanaserver
-    opensearch.password: kibanaserver
-    opensearch.requestHeadersAllowlist: [authorization]
+# Must be nested under `opensearch-dashboards:` because the verity wrapper
+# chart makes the upstream chart a sub-dependency under that key. See PR #402
+# for the empirical confirmation (workflow run + dump artifact).
+opensearch-dashboards:
+  config:
+    opensearch_dashboards.yml: |
+      server.host: "0.0.0.0"
+      server.name: dashboards
+      # The chart wires `opensearchHosts` (default
+      # https://opensearch-cluster-master:9200) into the OPENSEARCH_HOSTS
+      # env var on the dashboards container, which OSD reads in addition
+      # to this file. Setting the same value here keeps behaviour
+      # identical whether OSD reads the env var or the yml first.
+      opensearch.hosts: ["https://opensearch-cluster-master:9200"]
+      opensearch.ssl.verificationMode: none
+      opensearch.username: kibanaserver
+      opensearch.password: kibanaserver
+      opensearch.requestHeadersAllowlist: [authorization]


### PR DESCRIPTION
## Summary

Follow-up to [#397](https://github.com/verity-org/verity/pull/397). The OSD shard regressed on main with the same exit-64 `InvalidConfigurationError` because the values override was at the wrapper top-level instead of nested under the sub-chart key.

## Root cause

The chart-integration harness installs the **verity wrapper chart** at `oci://ghcr.io/verity-org/charts/opensearch-dashboards`, not the upstream chart. Pulling the wrapper shows:

```yaml
opensearch-dashboards:
  image:
    repository: ghcr.io/verity-org/opensearch-dashboards
    tag: "3"
  securityContext:
    runAsUser: 65532
```

The upstream `opensearch-project/opensearch-dashboards` chart is a **sub-dependency** named `opensearch-dashboards`. Per Helm's dependency-overrides convention, values that target the sub-chart must be nested under that key.

[#397](https://github.com/verity-org/verity/pull/397) placed `config.opensearch_dashboards.yml: |…` at the top level, so the entry sat next to (not inside) the sub-chart values block, and the sub-chart's `templates/configmap.yaml` never saw it.

Confirmed empirically by [run 25982132035](https://github.com/verity-org/verity/actions/runs/25982132035) (workflow_dispatch on main after [#397](https://github.com/verity-org/verity/pull/397) merged):

- `_dump-opensearch-dashboards/opensearch-dashboards/deployments.json` → `volumes[].configMap` is null (no ConfigMap mounted)
- `_kind-logs.../dashboards/5.log` → same `Unknown configuration key(s): "opensearch_security.multitenancy.enabled" …`, `processExitCode: 64`, classification=crash-class

## Fix

Wrap the config block under the sub-chart key:

```yaml
opensearch-dashboards:
  config:
    opensearch_dashboards.yml: |
      …
```

## Validation

Rendering the actual wrapper (3.6.0 pulled from GHCR) with this override now emits the ConfigMap and the yml body verbatim:

```
$ helm pull oci://ghcr.io/verity-org/charts/opensearch-dashboards --version 3.6.0 -d /tmp/wrap
$ helm template osd /tmp/wrap/opensearch-dashboards-3.6.0.tgz \
    -f test/chart-integration/values/opensearch-dashboards.yaml \
  | grep -A 5 ConfigMap
kind: ConfigMap
  name: osd-opensearch-dashboards-config
…
  opensearch_dashboards.yml: |
    server.host: "0.0.0.0"
    server.name: dashboards
    …
    opensearch.hosts: ["https://opensearch-cluster-master:9200"]
```

Diff vs. [#397](https://github.com/verity-org/verity/pull/397) is purely an indentation change + an explanatory comment block; no behaviour changes for any other chart.

## Scope

- One file: `test/chart-integration/values/opensearch-dashboards.yaml`
- No `verity.yaml` / `Chart.yaml` / `images/` changes
- No SKIPS
- No other charts affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Nest the OpenSearch Dashboards config under the `opensearch-dashboards` sub-chart key in the wrapper Helm values. This renders the ConfigMap and fixes the chart-integration OSD crash (exit 64).

- **Bug Fixes**
  - Move `config.opensearch_dashboards.yml` from wrapper top level to `opensearch-dashboards.config` per Helm dependency overrides for `oci://ghcr.io/verity-org/charts/opensearch-dashboards`.
  - Add an inline comment explaining the wrapper/sub-chart nesting. Only `test/chart-integration/values/opensearch-dashboards.yaml` changed.

<sup>Written for commit fa74f10949bef7ba1f2c9a9f56806a8ad50473f5. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/402?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

