### PR TITLE
fix(chart-integration): exempt Job-owned pods with successful retries from no-restart gate

### DIFF
--- a/test/chart-integration/assertions.go
+++ b/test/chart-integration/assertions.go
@@ -39,8 +39,25 @@ type podList struct {
 		Metadata struct {
 			Name      string `json:"name"`
 			Namespace string `json:"namespace"`
+			// OwnerReferences lets the no-restart gate distinguish
+			// Job-owned pods (one-shot workloads that legitimately
+			// rerun a failed container in-place when restartPolicy
+			// is OnFailure) from Deployment / StatefulSet pods
+			// (long-running workloads where any restart is a hard
+			// signal). See collectRestartFailures for the
+			// Job-owned-pod exemption rationale.
+			OwnerReferences []struct {
+				Kind string `json:"kind"`
+				Name string `json:"name"`
+			} `json:"ownerReferences"`
 		} `json:"metadata"`
 		Status struct {
+			// Phase is the pod's lifecycle phase. For Job-owned
+			// pods we accept Succeeded as the terminal state when
+			// admitting a Job-pod main-container-restart exemption
+			// (the Job ran, the container retried, the final
+			// attempt exited 0, k8s marked the pod Succeeded).
+			Phase                 string            `json:"phase"`
 			ContainerStatuses     []containerStatus `json:"containerStatuses"`
 			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
 		} `json:"status"`
@@ -119,6 +136,32 @@ func AssertNoRestarts(ctx context.Context, h *Harness, namespace string) error {
 func collectRestartFailures(pods *podList) []string {
 	var failures []string
 	for _, p := range pods.Items {
+		// Job-owned pods are one-shot workloads. A Job with the
+		// default `restartPolicy: OnFailure` retries the container
+		// in-place when its first attempt exits non-zero (transient
+		// DB unavailability while the postgres subchart is still
+		// starting is a common cause). The final attempt exits 0,
+		// the pod transitions to Succeeded, and the Job is
+		// Complete — that's the success state. The no-restart gate
+		// is meant to catch CrashLoopBackOff / OOMKill on
+		// long-running workload containers, NOT a benign Job retry
+		// that ultimately succeeded.
+		//
+		// Real Job failures (backoff limit exhausted, pod
+		// Failed) are still caught: the pod phase would be Failed
+		// (not Succeeded) and the container's current state would
+		// not be terminated{exitCode:0}.
+		//
+		// Charts that exhibit benign Job retries today:
+		//   - airflow (run-airflow-migrations races postgres
+		//     readiness when rendered as a regular resource via
+		//     `migrateDatabaseJob.useHelmHooks: false`; first
+		//     attempt fails with a transient connection error,
+		//     restartPolicy:OnFailure retries, alembic completes,
+		//     exit 0). See verity-org/verity#400.
+		jobOwned := isOwnedByJob(p.Metadata.OwnerReferences)
+		podSucceeded := p.Status.Phase == "Succeeded"
+
 		// Main containers: any restart is a hard failure. The whole
 		// point of the no-restart gate is to catch CrashLoopBackOff
 		// or OOMKill on long-running workload containers during the
@@ -126,6 +169,9 @@ func collectRestartFailures(pods *podList) []string {
 		for i := range p.Status.ContainerStatuses {
 			cs := &p.Status.ContainerStatuses[i]
 			if cs.RestartCount == 0 {
+				continue
+			}
+			if jobOwned && podSucceeded && initContainerCompletedCleanly(cs) {
 				continue
 			}
 			failures = append(failures, formatRestartFailure(p.Metadata.Namespace, p.Metadata.Name, cs, "container"))
@@ -170,9 +216,33 @@ func collectRestartFailures(pods *podList) []string {
 // from the no-restart gate. A nil-terminated state (running /
 // waiting / failed-terminated) returns false, preserving the gate
 // for real crash loops.
+//
+// Also reused by collectRestartFailures for the Job-owned-pod
+// main-container exemption: the function's contract — "terminated
+// cleanly with exitCode 0" — applies equally to a main container
+// in a Succeeded Job pod whose first attempt failed and second
+// attempt succeeded.
 func initContainerCompletedCleanly(cs *containerStatus) bool {
 	t := cs.State.Terminated
 	return t != nil && t.ExitCode == 0
+}
+
+// isOwnedByJob reports whether a pod has a controller owner-reference
+// of kind "Job". Used by collectRestartFailures to admit
+// main-container restartCount>0 on one-shot Job pods that ultimately
+// succeeded. We intentionally do NOT match "CronJob" here — that
+// would be the CronJob controller, NOT the per-execution Job; pods
+// created by CronJob runs still have a direct `Kind: Job` owner.
+func isOwnedByJob(refs []struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}) bool {
+	for _, ref := range refs {
+		if ref.Kind == "Job" {
+			return true
+		}
+	}
+	return false
 }
 
 func formatRestartFailure(namespace, podName string, cs *containerStatus, kind string) string {

--- a/test/chart-integration/assertions_test.go
+++ b/test/chart-integration/assertions_test.go
@@ -240,24 +240,52 @@ func TestHarnessClusterCreatedFieldDefault(t *testing.T) {
 // case is a flat literal — keeps cyclomatic complexity / maintidx
 // low in the test function itself.
 func makePodForRestartTest(namespace, name string, main, init []containerStatus) *podList {
+	return makePodWithOwnerForRestartTest(namespace, name, "", "", main, init)
+}
+
+// makePodWithOwnerForRestartTest builds a single-pod podList with
+// optional ownerReferences[0].kind + status.phase. Used by the
+// Job-owned-pod main-container exemption tests; passing empty
+// strings reduces to the default makePodForRestartTest shape.
+func makePodWithOwnerForRestartTest(namespace, name, ownerKind, phase string, main, init []containerStatus) *podList {
+	var owners []struct {
+		Kind string `json:"kind"`
+		Name string `json:"name"`
+	}
+	if ownerKind != "" {
+		owners = []struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		}{{Kind: ownerKind, Name: name + "-owner"}}
+	}
 	return &podList{Items: []struct {
 		Metadata struct {
-			Name      string `json:"name"`
-			Namespace string `json:"namespace"`
+			Name            string `json:"name"`
+			Namespace       string `json:"namespace"`
+			OwnerReferences []struct {
+				Kind string `json:"kind"`
+				Name string `json:"name"`
+			} `json:"ownerReferences"`
 		} `json:"metadata"`
 		Status struct {
+			Phase                 string            `json:"phase"`
 			ContainerStatuses     []containerStatus `json:"containerStatuses"`
 			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
 		} `json:"status"`
 	}{{
 		Metadata: struct {
-			Name      string `json:"name"`
-			Namespace string `json:"namespace"`
-		}{Name: name, Namespace: namespace},
+			Name            string `json:"name"`
+			Namespace       string `json:"namespace"`
+			OwnerReferences []struct {
+				Kind string `json:"kind"`
+				Name string `json:"name"`
+			} `json:"ownerReferences"`
+		}{Name: name, Namespace: namespace, OwnerReferences: owners},
 		Status: struct {
+			Phase                 string            `json:"phase"`
 			ContainerStatuses     []containerStatus `json:"containerStatuses"`
 			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
-		}{ContainerStatuses: main, InitContainerStatuses: init},
+		}{Phase: phase, ContainerStatuses: main, InitContainerStatuses: init},
 	}}}
 }
 
@@ -381,10 +409,15 @@ func TestCollectRestartFailures_MultiPodMix(t *testing.T) {
 
 	pods := &podList{Items: []struct {
 		Metadata struct {
-			Name      string `json:"name"`
-			Namespace string `json:"namespace"`
+			Name            string `json:"name"`
+			Namespace       string `json:"namespace"`
+			OwnerReferences []struct {
+				Kind string `json:"kind"`
+				Name string `json:"name"`
+			} `json:"ownerReferences"`
 		} `json:"metadata"`
 		Status struct {
+			Phase                 string            `json:"phase"`
 			ContainerStatuses     []containerStatus `json:"containerStatuses"`
 			InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
 		} `json:"status"`
@@ -400,6 +433,148 @@ func TestCollectRestartFailures_MultiPodMix(t *testing.T) {
 	}
 	if !strings.Contains(got[0], "pod=ns/bad") || !strings.Contains(got[0], "container=worker") {
 		t.Fatalf("wrong failure attributed: %q", got[0])
+	}
+}
+
+// jobCompletedMainCS builds a main containerStatus that mimics the
+// terminal state of a Job pod whose first container attempt failed
+// and second attempt succeeded: restartCount>0, current state is
+// terminated with exitCode 0.
+func jobCompletedMainCS(name string, restarts int) containerStatus {
+	cs := mainCS(name, restarts, "Error", "first attempt: connection refused")
+	cs.State.Terminated = &struct {
+		Reason   string `json:"reason"`
+		Message  string `json:"message"`
+		ExitCode int    `json:"exitCode"`
+	}{Reason: "Completed", ExitCode: 0}
+	return cs
+}
+
+// TestCollectRestartFailures_JobOwnedPodExemption pins the
+// Job-owned-pod main-container exemption: a one-shot Job pod whose
+// first container attempt failed and second attempt succeeded
+// (final exitCode 0, pod phase Succeeded) MUST NOT trip the
+// no-restart gate. The gate's purpose is to catch CrashLoopBackOff
+// / OOMKill on long-running workloads, not benign Job retries that
+// ultimately completed cleanly.
+//
+// Negative cases (Job pod where the final state is still Failed,
+// or non-Job pod with the same restart pattern) still trip the
+// gate — the exemption is narrow: kind=Job AND phase=Succeeded AND
+// terminated{exitCode:0}.
+func TestCollectRestartFailures_JobOwnedPodExemption(t *testing.T) {
+	cases := []struct {
+		name          string
+		ownerKind     string
+		phase         string
+		main          []containerStatus
+		wantFailCount int
+	}{
+		{
+			// The airflow run-airflow-migrations case: Job pod,
+			// first attempt failed (transient DB unavailability),
+			// second attempt succeeded, phase Succeeded.
+			name:          "Job-owned pod main container retried then succeeded: exempted",
+			ownerKind:     "Job",
+			phase:         "Succeeded",
+			main:          []containerStatus{jobCompletedMainCS("run-airflow-migrations", 1)},
+			wantFailCount: 0,
+		},
+		{
+			// Deployment-owned pod with the same restart pattern
+			// is NOT exempted — long-running workloads should not
+			// have any restarts during settle window.
+			name:          "Deployment-owned pod main container retried then succeeded: NOT exempted",
+			ownerKind:     "ReplicaSet",
+			phase:         "Running",
+			main:          []containerStatus{jobCompletedMainCS("api-server", 1)},
+			wantFailCount: 1,
+		},
+		{
+			// Job-owned pod still running / pod phase Failed is
+			// NOT exempted — the exemption is narrow: the Job
+			// must have reached Succeeded.
+			name:          "Job-owned pod main container crash-looping (phase Failed): NOT exempted",
+			ownerKind:     "Job",
+			phase:         "Failed",
+			main:          []containerStatus{mainCS("flaky", 3, "Error", "exit code 1")},
+			wantFailCount: 1,
+		},
+		{
+			// Job-owned pod, phase Succeeded, but the container's
+			// final state is non-zero exit — should NOT happen in
+			// practice (k8s would mark the pod Failed) but pin the
+			// narrowness of the exemption: terminated{exitCode:0}
+			// is REQUIRED.
+			name:      "Job-owned pod phase Succeeded but final exit non-zero: NOT exempted",
+			ownerKind: "Job",
+			phase:     "Succeeded",
+			main: []containerStatus{func() containerStatus {
+				cs := mainCS("weird", 1, "Error", "")
+				cs.State.Terminated = &struct {
+					Reason   string `json:"reason"`
+					Message  string `json:"message"`
+					ExitCode int    `json:"exitCode"`
+				}{Reason: "Error", ExitCode: 1}
+				return cs
+			}()},
+			wantFailCount: 1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pods := makePodWithOwnerForRestartTest("ns", "pod-x", c.ownerKind, c.phase, c.main, nil)
+			got := collectRestartFailures(pods)
+			if len(got) != c.wantFailCount {
+				t.Fatalf("got %d failures, want %d: %v", len(got), c.wantFailCount, got)
+			}
+		})
+	}
+}
+
+// TestIsOwnedByJob pins the predicate: only an ownerReference of
+// kind "Job" returns true; everything else (ReplicaSet, StatefulSet,
+// CronJob, nil) returns false. CronJob does NOT pass because pods
+// created by a CronJob run have a direct `Kind: Job` owner — the
+// CronJob is one level removed from the pod.
+func TestIsOwnedByJob(t *testing.T) {
+	mk := func(kinds ...string) []struct {
+		Kind string `json:"kind"`
+		Name string `json:"name"`
+	} {
+		out := make([]struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		}, 0, len(kinds))
+		for _, k := range kinds {
+			out = append(out, struct {
+				Kind string `json:"kind"`
+				Name string `json:"name"`
+			}{Kind: k})
+		}
+		return out
+	}
+	cases := []struct {
+		name string
+		refs []struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		}
+		want bool
+	}{
+		{"empty owners", nil, false},
+		{"single Job owner", mk("Job"), true},
+		{"single ReplicaSet owner", mk("ReplicaSet"), false},
+		{"CronJob owner (does NOT match — pods have direct Job owner)", mk("CronJob"), false},
+		{"multiple owners, includes Job", mk("StatefulSet", "Job"), true},
+		{"multiple owners, no Job", mk("StatefulSet", "ReplicaSet"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isOwnedByJob(c.refs); got != c.want {
+				t.Fatalf("isOwnedByJob(%v) = %v, want %v", c.refs, got, c.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Followup to [#395](https://github.com/verity-org/verity/pull/395),
[#400](https://github.com/verity-org/verity/pull/400). Closes the
airflow chart-integration shard.

The no-restart-during-settle gate hard-fails on ANY main-container
`restartCount>0`. That works for long-running Deployment /
StatefulSet workloads (where a restart genuinely is a
CrashLoopBackOff signal) but is wrong for one-shot Job pods that
retry their main container in-place
(`restartPolicy: OnFailure`) on a transient first-attempt failure
and ultimately succeed.

## Concrete case: airflow run-airflow-migrations

With `migrateDatabaseJob.useHelmHooks: false` (the
[#395](https://github.com/verity-org/verity/pull/395)
deadlock-breaker), the migrations Job runs as a regular resource
in the install pass. It races postgres readiness — the first
container attempt sometimes fails with a connection error,
`restartPolicy: OnFailure` restarts the container in-place,
alembic completes, exit 0, pod transitions to Succeeded.

From the workload's perspective this is a clean success; the Job
is Complete and migrations are applied. But the no-restart gate
sees `restartCount=1` on the main container and trips.

## Diagnostic evidence

chart-integration [run 25982848894](https://github.com/verity-org/verity/actions/runs/25982848894), [job 76375137451](https://github.com/verity-org/verity/actions/runs/25982848894/job/76375137451) (post-[#400](https://github.com/verity-org/verity/pull/400) attempt on main). `diagnostics-airflow`:

- All pods Running/Ready, helm install succeeded.
- `airflow-run-airflow-migrations-g2vz7` phase=Succeeded,
  container `run-airflow-migrations` restartCount=1
  terminated(Completed/exit=0).
- Gate fired:
  > no-restart gate: container restarted during settle window:
  > count=1 pod=airflow/airflow-run-airflow-migrations-g2vz7
  > container=run-airflow-migrations restarts=1 reason=unknown

## Fix

Narrow exemption in `collectRestartFailures`: a main container
is exempted iff ALL of:

1. The pod is owned by a `Kind: Job` ownerReference.
2. The pod's `status.phase == Succeeded`.
3. The container's current state is `terminated{exitCode:0}`.

Real Job failures (backoff limit exhausted → pod phase Failed)
and non-Job pods with the same restart pattern
(Deployment-owned pod where the workload is supposed to be
long-running) are NOT exempted — the gate fires as before.

## Tests

- `TestCollectRestartFailures_JobOwnedPodExemption`: pins all four
  branches of the new exemption:
  - `Job + Succeeded + exit0` → exempted ✓
  - `Deployment + Running + exit0` → NOT exempted (long-running
    workload shouldn't restart at all)
  - `Job + Failed` → NOT exempted (Job hit backoff limit)
  - `Job + Succeeded + exit non-zero` → NOT exempted (narrow
    exemption keyed on exit==0)
- `TestIsOwnedByJob`: pins the predicate's scope:
  `Kind == "Job"` direct match only — `CronJob` does NOT pass
  because pods created by a CronJob run still have a direct Job
  owner one level down.
- Existing `TestCollectRestartFailures` and `_MultiPodMix` updated
  to use the new podList shape (`OwnerReferences` + `Phase` added);
  `makePodForRestartTest` now delegates to a richer
  `makePodWithOwnerForRestartTest` so existing call sites stay
  one-line.

`go test ./...` + `go test -tags integration ./test/chart-integration/...`
both green.

## Refs

- Predecessors:
  - [#395](https://github.com/verity-org/verity/pull/395) — break
    the helm install --wait deadlock
  - [#400](https://github.com/verity-org/verity/pull/400) — postgres
    double-prefix, statsd, create-user race
- Failure that surfaced after #400 merged:
  [run 25982848894](https://github.com/verity-org/verity/actions/runs/25982848894), [job 76375137451](https://github.com/verity-org/verity/actions/runs/25982848894/job/76375137451)
- Strategic tracking issue (apache/airflow → verity wolfi rebuild):
  [#399](https://github.com/verity-org/verity/issues/399)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exempts Job-owned pods that successfully retry their main container from the no-restart gate to stop false failures on one-shot Jobs like Airflow migrations. Real crash loops and non-Job pods still fail the gate.

- **Bug Fixes**
  - Updated `collectRestartFailures` to skip main-container restarts only when the pod is owned by a `Job`, pod `phase` is `Succeeded`, and the container is `terminated` with `exitCode: 0`.
  - Extended test `podList` with `OwnerReferences` and `Phase`; added `isOwnedByJob`.
  - Added `TestCollectRestartFailures_JobOwnedPodExemption` and `TestIsOwnedByJob`; updated existing tests and helpers.

<sup>Written for commit f8e0b3314a6a5eaf7affa3b21e5a4c3156f02061. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/403?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

