### PR TITLE
fix(chart-mimir): non-overlapping data_dir + filesystem paths

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -131,12 +131,32 @@ chartValues:
     # `filesystem` — CI smoke just needs the binaries to boot; it
     # doesn't exercise persistence across pods. Real users override
     # to s3/gcs/azure via their own structuredConfig.
+    #
+    # `readOnlyRootFilesystem: true` is set on all mimir pods (chart
+    # `templates/*-statefulset.yaml`), so the ONLY writable path
+    # inside the container is the `storage` PVC mounted at `/data`.
+    # Both the filesystem storage dirs AND each component's data_dir
+    # must therefore live under `/data`, AND mimir's validator
+    # rejects any overlap between the two (e.g. `data_dir: /data`
+    # vs `filesystem.dir: /data/blocks` — chart-integration run
+    # 25982132035 alertmanager-0/compactor-0/ruler-* logs:
+    # "the configured ... data directory \"/data\" cannot overlap
+    # with the configured ... storage filesystem directory
+    # \"/data/blocks\""). Resolve by giving each component its own
+    # `/data/<component>` subdir AND putting filesystem storage in
+    # sibling `/data/storage-<kind>` subdirs that no component
+    # data_dir templates into.
+    mimir.structuredConfig.compactor.data_dir: /data/compactor
+    mimir.structuredConfig.alertmanager.data_dir: /data/alertmanager
+    mimir.structuredConfig.ruler.rule_path: /data/ruler
+    mimir.structuredConfig.blocks_storage.bucket_store.sync_dir: /data/tsdb-sync
+    mimir.structuredConfig.blocks_storage.tsdb.dir: /data/tsdb
     mimir.structuredConfig.blocks_storage.backend: filesystem
-    mimir.structuredConfig.blocks_storage.filesystem.dir: /data/blocks
+    mimir.structuredConfig.blocks_storage.filesystem.dir: /data/storage-blocks
     mimir.structuredConfig.alertmanager_storage.backend: filesystem
-    mimir.structuredConfig.alertmanager_storage.filesystem.dir: /data/alertmanager
+    mimir.structuredConfig.alertmanager_storage.filesystem.dir: /data/storage-alertmanager
     mimir.structuredConfig.ruler_storage.backend: filesystem
-    mimir.structuredConfig.ruler_storage.filesystem.dir: /data/ruler
+    mimir.structuredConfig.ruler_storage.filesystem.dir: /data/storage-ruler
 
   # tempo-distributed 1.61.3 defaults to a separate Memcached statefulset;
   # the minimal CI-friendly wrapper just runs the Tempo microservices


### PR DESCRIPTION
## Summary

Follow-up to [#393](https://github.com/verity-org/verity/pull/393). After enabling `filesystem` storage backends for mimir-distributed, three components still CrashLoopBackOff because mimir's startup validator rejects ANY overlap between a component's `data_dir` and that component's filesystem storage dir — and overlap includes the parent-of relationship.

## Symptom (chart-integration run [25982132035](https://github.com/verity-org/verity/actions/runs/25982132035) on main, post-[#393](https://github.com/verity-org/verity/pull/393))

```
alertmanager-0: the configured alertmanager data directory "/data" cannot
                overlap with the configured alertmanager storage filesystem
                directory "/data/alertmanager"
compactor-0:    the configured blocks storage filesystem directory
                "/data/blocks" cannot overlap with the configured compactor
                data directory "/data"
ruler-*:        the configured blocks storage filesystem directory
                "/data/blocks" cannot overlap with the configured ruler
                data directory "/data"
```

After [#393](https://github.com/verity-org/verity/pull/393), 12 of 15 mimir pod groups boot (ingesters, queriers, store-gateways, distributors, query-schedulers, query-frontends, overrides-exporter). Only alertmanager / compactor / ruler still fail on this last validator.

## Fix

`readOnlyRootFilesystem: true` is set on all mimir pods (chart `templates/*-statefulset.yaml`), so the PVC mount at `/data` is the only writable path. Both data_dirs AND filesystem dirs must therefore live under `/data`.

Give each component its own `/data/<component>` subdir AND put filesystem storage in sibling `/data/storage-<kind>` subdirs:

| component       | data_dir / rule_path | storage backend filesystem.dir |
|-----------------|----------------------|---------------------------------|
| compactor       | `/data/compactor`    | (blocks)                        |
| alertmanager    | `/data/alertmanager` | `/data/storage-alertmanager`    |
| ruler           | `/data/ruler`        | `/data/storage-ruler`           |
| blocks storage  | (tsdb at /data/tsdb) | `/data/storage-blocks`          |

## Validation

- `go test ./internal/chartgen/...` ✅
- `helm template` renders the expected `mimir.yaml` configmap with all `data_dir` and `filesystem.dir` paths as siblings.

## Refs

- Failing run: [chart-integration #25982132035](https://github.com/verity-org/verity/actions/runs/25982132035) (mimir-distributed shard, post-[#393](https://github.com/verity-org/verity/pull/393) state)
- Previous PR: [#393](https://github.com/verity-org/verity/pull/393)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `mimir` CrashLoopBackOff by making `data_dir` and filesystem storage dirs non-overlapping under `/data`. Each component gets its own `/data/<component>` and storage moves to sibling `/data/storage-*` paths to satisfy the startup validator with read-only root filesystems.

- **Bug Fixes**
  - Data dirs: compactor `/data/compactor`, alertmanager `/data/alertmanager`, ruler rule_path `/data/ruler`, blocks TSDB `/data/tsdb`, sync `/data/tsdb-sync`.
  - Filesystem storage dirs: blocks `/data/storage-blocks`, alertmanager `/data/storage-alertmanager`, ruler `/data/storage-ruler`.

<sup>Written for commit 5deca5d5ef21c737004653c94af20c6b02879f67. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/404?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

