### PR TITLE
fix(chart-gitea): nest smoke security override

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -17,20 +17,22 @@
 # → init-directories enters CrashLoopBackOff and helm install times
 # out at 10 minutes.
 #
-# This override runs ALL containers in the gitea pod as root. The
-# Bitnami chart uses one `containerSecurityContext` block for both
-# init and main containers, so we cannot scope the override to just
-# the init container without forking the chart. Running the main
-# gitea container as root is acceptable in the smoke-test cluster
-# (kind, ephemeral, no real data), but should NOT be the production
-# default — which is why this override lives in the chart-integration
-# values directory and NOT in `verity.yaml`'s gitea chartValues block.
+# This override runs the init-directories/init-app-ini containers and
+# the main gitea container as root. The Bitnami chart uses one
+# `containerSecurityContext` block for those containers, so we cannot
+# scope the override to just init-directories without forking the chart.
+# Running the main gitea container as root is acceptable in the smoke-
+# test cluster (kind, ephemeral, no real data), but should NOT be the
+# production default — which is why this override lives in the chart-
+# integration values directory and NOT in `verity.yaml`'s gitea
+# chartValues block.
 #
 # Production users who hit the same PVC-chown issue on their cluster
 # should either (a) switch to `image.rootless: true` (the upstream
 # chart's supported path for non-root containers) or (b) configure
 # their CSI driver / storage class to honor `fsGroup` recursively
 # before the init container runs.
-containerSecurityContext:
-  runAsUser: 0
-  runAsNonRoot: false
+gitea:
+  containerSecurityContext:
+    runAsUser: 0
+    runAsNonRoot: false


### PR DESCRIPTION
## Summary
- Fixes the gitea chart-integration smoke values so the `containerSecurityContext` override is nested under the wrapper dependency key.
- Keeps the root-running override scoped to `test/chart-integration/values/gitea.yaml`, avoiding production chartValues changes.

## Root Cause
The failed gitea run installed with `test/chart-integration/values/gitea.yaml`, but the fixture set `containerSecurityContext` at the wrapper chart top level. The rendered gitea Deployment therefore did not pass the override to the upstream subchart, leaving `init-directories` without `runAsUser: 0`. That init container then failed `chown /data` with `Operation not permitted`, so `Deployment/gitea/gitea` never became ready.

## Verification
- `helm template gitea oci://ghcr.io/verity-org/charts/gitea --version 12.5.3 --values test/chart-integration/values/gitea.yaml` now renders `runAsUser: 0` for `init-directories`, `init-app-ini`, `configure-gitea`, and the main `gitea` container.
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `gitea` smoke test by nesting the `containerSecurityContext` override under the `gitea` key so the Bitnami subchart receives it. This prevents init container permission errors and keeps the root override limited to test-only values.

- **Bug Fixes**
  - Move override to `gitea.containerSecurityContext` in `test/chart-integration/values/gitea.yaml`.
  - Ensures `runAsUser: 0` for init and main containers in smoke tests; no production `chartValues` changes.

<sup>Written for commit 6e6e1fc30c7fae2f922f46eb8283e493c5589856. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/405?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

