### PR TITLE
fix(chart-fluent-bit): delay liveness probe during startup

### DIFF
--- a/internal/chartgen/chartvalues_loading_regression_test.go
+++ b/internal/chartgen/chartvalues_loading_regression_test.go
@@ -44,6 +44,9 @@ func TestVerityConfigChartValuesLoading(t *testing.T) {
 	if gv := vc2.ChartValues["gitea"]; len(gv) == 0 {
 		t.Fatalf("LoadVerityConfig dropped gitea chartValues — chartgen would skip gitea")
 	}
+	if got := vc2.ChartValues["fluent-bit"]["livenessProbe.initialDelaySeconds"]; got != 45 {
+		t.Fatalf("fluent-bit livenessProbe.initialDelaySeconds = %#v, want 45", got)
+	}
 
 	// victoria-logs-single has NO chartValues but its only image is in
 	// unpatchableImages — the new processChart passthrough branch must

--- a/verity.yaml
+++ b/verity.yaml
@@ -654,6 +654,16 @@ chartValues:
   # surface; deferred. falco re-skipped in test/chart-integration/
   # SKIPS.yaml under #325 until the deeper wiring lands.
 
+  # fluent-bit 0.57.3 starts its Kubernetes filter by waiting 30s for
+  # cluster DNS before opening the HTTP server used by the chart's
+  # livenessProbe. The chart default has no liveness initial delay, so
+  # kubelet can hit the default 3 failures and SIGTERM fluent-bit just
+  # as it becomes healthy, producing a clean restart that fails the
+  # chart-integration no-restart gate (run 25987025840). Delay only
+  # liveness; readiness can still report startup progress normally.
+  fluent-bit:
+    livenessProbe.initialDelaySeconds: 45
+
   # opensearch 3.6.0 — Bucket G (JVM gc log path is unwritable in the
   # rebuilt image).
   #


### PR DESCRIPTION
## Summary
- Delays the fluent-bit chart liveness probe so kubelet does not restart the pod during the chart's 30s Kubernetes filter DNS/API startup wait.
- Adds a production `verity.yaml` regression guard for the fluent-bit liveness probe override.

## Validation
- `go test ./internal/chartgen ./internal/discovery`
- `VERITY_CHART=fluent-bit make chart-integration`
- `go test ./...`
- `golangci-lint run --timeout=5m`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delay the `fluent-bit` liveness probe to 45s to avoid restarts during the 30s Kubernetes filter DNS wait, preventing false failures in chart integration.

- **Bug Fixes**
  - Set `fluent-bit` `livenessProbe.initialDelaySeconds: 45` in production `verity.yaml` (readiness unchanged).
  - Added a regression test asserting the override in `TestVerityConfigChartValuesLoading`.

<sup>Written for commit a3c7449fab4eb94683b29a196aba91afb01ffc6a. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/406?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

