### PR TITLE
fix(chart-mimir): route smoke test around disabled gateway

### DIFF
--- a/test/chart-integration/mimir_values_test.go
+++ b/test/chart-integration/mimir_values_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestMimirDistributedSmokeTestEndpointsBypassDisabledGateway(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locating test file")
+	}
+	valuesPath := filepath.Join(filepath.Dir(file), "values", "mimir-distributed.yaml")
+	body, err := os.ReadFile(valuesPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", valuesPath, err)
+	}
+
+	var values struct {
+		MimirDistributed struct {
+			SmokeTest struct {
+				ExtraArgs map[string]string `yaml:"extraArgs"`
+				TenantID  string            `yaml:"tenantId"`
+			} `yaml:"smoke_test"`
+		} `yaml:"mimir-distributed"`
+	}
+	if err := yaml.Unmarshal(body, &values); err != nil {
+		t.Fatalf("parse %s: %v", valuesPath, err)
+	}
+	if values.MimirDistributed.SmokeTest.TenantID != "anonymous" {
+		t.Fatalf("smoke_test.tenantId=%q want anonymous", values.MimirDistributed.SmokeTest.TenantID)
+	}
+
+	want := map[string]string{
+		"tests.write-endpoint": "http://mimir-distributed-distributor.mimir-distributed.svc:8080",
+		"tests.read-endpoint":  "http://mimir-distributed-query-frontend.mimir-distributed.svc:8080/prometheus",
+	}
+	for key, wantValue := range want {
+		if got := values.MimirDistributed.SmokeTest.ExtraArgs[key]; got != wantValue {
+			t.Errorf("smoke_test.extraArgs[%q]=%q want %q", key, got, wantValue)
+		}
+	}
+}

--- a/test/chart-integration/values/mimir-distributed.yaml
+++ b/test/chart-integration/values/mimir-distributed.yaml
@@ -1,0 +1,14 @@
+# mimir-distributed chart-integration smoke-test value overrides.
+
+mimir-distributed:
+  smoke_test:
+    # The disabled gateway would normally inject the chart's default no-auth
+    # tenant when X-Scope-OrgID is absent. Direct service calls need the same
+    # tenant header explicitly.
+    tenantId: anonymous
+    extraArgs:
+      # The wrapper disables the chart's gateway, but the chart's smoke-test Job
+      # still defaults to the gateway URL. Route the test directly to the Mimir
+      # services that exist in the minimal CI topology.
+      tests.write-endpoint: http://mimir-distributed-distributor.mimir-distributed.svc:8080
+      tests.read-endpoint: http://mimir-distributed-query-frontend.mimir-distributed.svc:8080/prometheus


### PR DESCRIPTION
## Summary
- Add a mimir-distributed chart-integration values fixture that sends the Helm smoke test directly to distributor/query-frontend because the wrapper disables the gateway.
- Set the smoke-test tenant to `anonymous`, matching the gateway's default no-auth tenant injection.
- Add an integration regression test that locks the mimir smoke-test endpoint and tenant overrides.

## Validation
- `VERITY_IT_SKIP_CLUSTER=1 go test -tags integration ./test/chart-integration`
- `go test ./...`
- `PATH=\"$(go env GOPATH)/bin:$PATH\" make lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reroutes the `mimir-distributed` smoke test to call distributor and query-frontend directly when the gateway is disabled, and sets the tenant to `anonymous`. Adds an integration test and values fixture to lock this behavior.

- **Bug Fixes**
  - Override smoke_test.extraArgs: write-endpoint -> http://mimir-distributed-distributor.mimir-distributed.svc:8080, read-endpoint -> http://mimir-distributed-query-frontend.mimir-distributed.svc:8080/prometheus
  - Set smoke_test.tenantId to anonymous
  - Add integration regression test verifying the endpoints and tenant in `values/mimir-distributed.yaml`

<sup>Written for commit 116d981f36700665ca2b49c4b0c8f6cd05ae9d5b. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/407?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

