### PR TITLE
fix(airflow): keep postgresql source repo unprefixed

### DIFF
--- a/verity.yaml
+++ b/verity.yaml
@@ -323,20 +323,13 @@ chartValues:
   # gate stays clean.
   #
   # Supporting knobs:
-  # - `postgresql.image.registry: ghcr.io` +
-  #   `postgresql.image.repository: verity-org/bitnamilegacy/postgresql`
-  #   — both siblings are set explicitly because the upstream airflow
-  #   chart's parent values.yaml pins the repository as a leaf scalar
-  #   (`postgresql.image.repository: bitnamilegacy/postgresql`). chart-gen
-  #   detects the override path at the parent scope, but the parent
-  #   path lacks a `registry` sibling so its `hasRegistry`-driven
-  #   stripping fallback leaves the repository unstripped. The
-  #   bundled postgresql subchart's template then renders
-  #   `{{ .Values.image.registry }}/{{ .Values.image.repository }}` →
-  #   the double-prefix `docker.io/ghcr.io/verity-org/bitnamilegacy/postgresql`.
-  #   Pinning BOTH siblings explicitly here side-steps that gap until
-  #   chart-gen learns to consult subchart values for registry-sibling
-  #   detection (verity-org/verity#318 covers the related tempo case).
+  # - `postgresql.image.registry: ghcr.io` keeps the parent-level
+  #   postgresql image reference composable while image discovery still
+  #   sees the upstream repository path below. Do NOT pre-prefix the
+  #   repository with `verity-org/`: chart-gen derives the patched
+  #   target from discovered images, so pre-prefixing makes the source
+  #   name `verity-org/bitnamilegacy/postgresql` and renders the broken
+  #   `ghcr.io/verity-org/verity-org/bitnamilegacy/postgresql`.
   # - `images.migrationsWaitTimeout: 300` (default 60s) — wait budget
   #   for `wait-for-airflow-migrations`. Kept generous so the init
   #   container still has headroom while the migrations Job runs.
@@ -353,7 +346,7 @@ chartValues:
   #   verifies install + pod readiness, not metric scraping).
   airflow:
     postgresql.image.registry: ghcr.io
-    postgresql.image.repository: verity-org/bitnamilegacy/postgresql
+    postgresql.image.repository: bitnamilegacy/postgresql
     images.migrationsWaitTimeout: 300
     apiServer.startupProbe.failureThreshold: 12
     migrateDatabaseJob.useHelmHooks: false


### PR DESCRIPTION
## Summary
- Keep the airflow PostgreSQL chartValues repository as the upstream `bitnamilegacy/postgresql` source path so chart generation does not patch `verity-org/...` into `verity-org/verity-org/...`.
- Update the inline airflow chartValues note to document why the repository must not be pre-prefixed.

## Root Cause
The failing main chart-integration run [25987025840](https://github.com/verity-org/verity/actions/runs/25987025840) passed install, then failed the image-origin gate because PostgreSQL rendered as `ghcr.io/ghcr.io/verity-org/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`. The `postgresql.image.repository` chartValues override was already prefixed with `verity-org/`, and chartgen uses discovery output to derive patched target names, causing a second `verity-org/` prefix.

## Tests
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-prefixed PostgreSQL image in Airflow by keeping the upstream repo unprefixed. Prevents image-origin gate failures during chart generation.

- **Bug Fixes**
  - Set `airflow.postgresql.image.repository` to `bitnamilegacy/postgresql` (no `verity-org/` prefix); keep `airflow.postgresql.image.registry` as `ghcr.io`.
  - Stops `chart-gen` from double-prefixing discovered images that rendered as `ghcr.io/verity-org/verity-org/bitnamilegacy/postgresql`.
  - Updated the inline note in `verity.yaml` to explain why the repo must stay unprefixed.

<sup>Written for commit f5c2b5b893a71973f0fb8e56d05335531b7997b9. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/408?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

