### PR TITLE
fix(chart-opensearch): run pods as image nonroot user

### DIFF
--- a/test/chart-integration/values/opensearch.yaml
+++ b/test/chart-integration/values/opensearch.yaml
@@ -1,0 +1,23 @@
+# Chart-integration override for opensearch 3.6.0.
+#
+# The verity wolfi rebuild owns /usr/share/opensearch/config as uid/gid 65532.
+# The upstream chart defaults to uid/gid 1000, and OpenSearch 3.x attempts to
+# create /usr/share/opensearch/config/opensearch.keystore.tmp during bootstrap.
+# Running as the image's nonroot user keeps that config directory writable.
+opensearch:
+  # The chart's default init chown targets uid/gid 1000 and uses
+  # docker.io/library/busybox. With the pod running as 65532 and fsGroup set,
+  # kubelet volume ownership is sufficient for the smoke-test PVC.
+  persistence:
+    enableInitChown: false
+
+  podSecurityContext:
+    fsGroup: 65532
+    runAsUser: 65532
+
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    runAsUser: 65532

--- a/verity.yaml
+++ b/verity.yaml
@@ -698,6 +698,14 @@ chartValues:
   # entrypoint time, and we want explicit CI-sized heap regardless).
   opensearch:
     opensearchJavaOpts: "-Xmx512M -Xms512M"
+    # The chart defaults to uid/gid 1000, but the verity wolfi image owns
+    # /usr/share/opensearch/config as uid/gid 65532. OpenSearch creates a
+    # temporary keystore file in that directory during bootstrap, so the chart
+    # must run as the image's nonroot user.
+    persistence.enableInitChown: false
+    podSecurityContext.fsGroup: 65532
+    podSecurityContext.runAsUser: 65532
+    securityContext.runAsUser: 65532
     # jvm.options is the upstream 3.x baseline with the `9-:-Xlog:gc*`
     # gc-file logging directive removed. Keep this in sync with
     # https://github.com/opensearch-project/OpenSearch/blob/<version>/


### PR DESCRIPTION
## Summary
- Run the generated OpenSearch wrapper chart as the image-owned nonroot uid/gid so `/usr/share/opensearch/config` stays writable for keystore temp-file creation.
- Add the same chart-integration fixture for the currently published wrapper chart and disable the obsolete uid-1000 PVC chown init container.

## Validation
- `go test ./...`
- `go test -tags=integration -run 'TestLoadAllowlist|TestLoadAllowlistMissing|TestLoadAllowlistPresentRegression|TestIsAccepted|TestClassifyMissingAllowlist|TestClassifyMissingAllowlistDoesNotConsultAllowlist|TestHarnessClusterCreatedFieldDefault|TestInstallChartRejectsArgumentInjection|TestClassifyHelmFailure|TestClassifyHelmFailureStringer|TestClassifyHelmFailureParsesPodJSON|TestClassifyHelmFailureMalformedJSON|TestLoadSkips|TestIsSkipped|TestProductionSKIPSYAMLIsValid' ./test/chart-integration/...`
- `GOBIN=/tmp/opencode/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 && /tmp/opencode/bin/golangci-lint run --timeout=5m`
- `VERITY_CHART=opensearch make chart-integration`

Root cause: OpenSearch 3.x creates `/usr/share/opensearch/config/opensearch.keystore.tmp` during bootstrap. The verity wolfi image owns that directory as uid/gid 65532, while the upstream chart default runs as uid/gid 1000, causing bootstrap to crash before the StatefulSet becomes Ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the OpenSearch wrapper chart pods as the image-owned nonroot user (uid/gid 65532) so `/usr/share/opensearch/config` stays writable during bootstrap. This fixes the 3.x crash when creating the keystore temp file and lets the StatefulSet become Ready.

- **Bug Fixes**
  - Set `podSecurityContext.runAsUser`/`fsGroup` and `securityContext.runAsUser` to `65532`; keep `runAsNonRoot: true` in test override.
  - Disable `persistence.enableInitChown` (kubelet volume ownership covers the PVC; no `busybox` chown needed).
  - Add a chart-integration values override for `opensearch` 3.6.0 to validate these settings.

<sup>Written for commit 72b3f90ce0b175f43804a4419a899c91103f1a85. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/409?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

