### PR TITLE
fix(airflow): clear postgresql parent registry

### DIFF
--- a/internal/chartgen/chartvalues_loading_regression_test.go
+++ b/internal/chartgen/chartvalues_loading_regression_test.go
@@ -48,11 +48,11 @@ func TestVerityConfigChartValuesLoading(t *testing.T) {
 		t.Fatalf("fluent-bit livenessProbe.initialDelaySeconds = %#v, want 45", got)
 	}
 	airflow := vc2.ChartValues["airflow"]
-	if airflow["postgresql.image.registry"] != "ghcr.io" {
-		t.Fatalf("airflow postgresql.image.registry=%v, want ghcr.io", airflow["postgresql.image.registry"])
+	if airflow["postgresql.image.registry"] != "" {
+		t.Fatalf("airflow postgresql.image.registry=%v, want empty string", airflow["postgresql.image.registry"])
 	}
-	if repo, ok := airflow["postgresql.image.repository"]; ok {
-		t.Fatalf("airflow must not pin postgresql.image.repository=%v; chart-gen rewrites that chartValues input into a double ghcr.io prefix", repo)
+	if airflow["postgresql.image.repository"] != "bitnamilegacy/postgresql" {
+		t.Fatalf("airflow postgresql.image.repository=%v, want bitnamilegacy/postgresql", airflow["postgresql.image.repository"])
 	}
 
 	// victoria-logs-single has NO chartValues but its only image is in

--- a/verity.yaml
+++ b/verity.yaml
@@ -289,10 +289,11 @@ chartValues:
   # tag DOES exist in verity-org/ — the only thing wrong with the
   # generated wrapper is the extraneous `docker.io/` prefix.
   #
-  # Setting `postgresql.image.registry: ghcr.io` overrides the chart's
-  # `image.registry` default so the rendered reference becomes the
-  # clean `ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`.
-  # Same shape as the tempo-distributed fix. See verity-org/verity#318.
+  # Clearing `postgresql.image.registry` prevents the parent chart's
+  # registry scalar from being prepended to chartgen's generated FQDN
+  # repository override, yielding the clean
+  # `ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`.
+  # See verity-org/verity#318 for the related registry-composition class.
   #
   # Bucket E (probe-race) — bucket-confirmation.md (airflow row) shows
   # `wait-for-airflow-migrations` init container looping `Waiting for
@@ -323,13 +324,19 @@ chartValues:
   # gate stays clean.
   #
   # Supporting knobs:
-  # - `postgresql.image.registry: ghcr.io` keeps the parent-level
-  #   postgresql image reference composable while chart-gen uses the
-  #   bundled subchart values to rewrite the repository. Do NOT also
-  #   set `postgresql.image.repository` here: chart-gen treats chartValues
-  #   image repositories as override inputs and rewrites the manual value
-  #   to `ghcr.io/verity-org/...`, which renders the broken
+  # - `postgresql.image.registry: ""` prevents the parent-level
+  #   registry scalar from being prepended to the generated FQDN
+  #   repository override. Do NOT set it to `ghcr.io`: during chart
+  #   generation, chartgen overwrites
+  #   `airflow.postgresql.image.repository` with an FQDN repository for
+  #   this parent path, and a non-empty registry renders the broken
   #   `ghcr.io/ghcr.io/verity-org/bitnamilegacy/postgresql`.
+  # - `postgresql.image.repository: bitnamilegacy/postgresql` keeps
+  #   image discovery on the upstream source path. Do NOT pre-prefix
+  #   it with `verity-org/`: chartgen derives patched targets from
+  #   discovered images, so pre-prefixing makes the source name
+  #   `verity-org/bitnamilegacy/postgresql` and renders the broken
+  #   `ghcr.io/verity-org/verity-org/bitnamilegacy/postgresql`.
   # - `images.migrationsWaitTimeout: 300` (default 60s) — wait budget
   #   for `wait-for-airflow-migrations`. Kept generous so the init
   #   container still has headroom while the migrations Job runs.
@@ -345,7 +352,8 @@ chartValues:
   #   StatsD metrics are not required for the smoke test (which only
   #   verifies install + pod readiness, not metric scraping).
   airflow:
-    postgresql.image.registry: ghcr.io
+    postgresql.image.registry: ""
+    postgresql.image.repository: bitnamilegacy/postgresql
     images.migrationsWaitTimeout: 300
     apiServer.startupProbe.failureThreshold: 12
     migrateDatabaseJob.useHelmHooks: false


### PR DESCRIPTION
## Summary
- Clear the airflow parent `postgresql.image.registry` override so it does not prepend `ghcr.io/` in front of the generated FQDN PostgreSQL repository.
- Keep `postgresql.image.repository` as the upstream `bitnamilegacy/postgresql` source path to avoid double `verity-org/` patching.

## Root Cause
After [#408](https://github.com/verity-org/verity/pull/408), main chart-integration removed the double `verity-org/` prefix but still failed airflow with `ghcr.io/ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`. The parent chart registry scalar was composing in front of chartgen's generated FQDN repository override.

## Tests
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Airflow PostgreSQL image by clearing the parent registry, avoiding a double `ghcr.io` prefix and using the correct FQDN repo. Adds a regression test to lock the expected `airflow.postgresql` values.

- Bug Fixes
  - Set `airflow.postgresql.image.registry` to `""` so the parent registry isn’t prepended.
  - Keep `airflow.postgresql.image.repository` as `bitnamilegacy/postgresql` to use the upstream path.
  - Add a test to assert the registry is empty and the repository is `bitnamilegacy/postgresql`.

<sup>Written for commit 56069741093f082e06a4400f749f9dacec70691d. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/410?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

