### PR TITLE
fix(airflow): avoid double ghcr prefix for postgres

### DIFF
--- a/internal/chartgen/chartvalues_loading_regression_test.go
+++ b/internal/chartgen/chartvalues_loading_regression_test.go
@@ -47,6 +47,13 @@ func TestVerityConfigChartValuesLoading(t *testing.T) {
 	if got := vc2.ChartValues["fluent-bit"]["livenessProbe.initialDelaySeconds"]; got != 45 {
 		t.Fatalf("fluent-bit livenessProbe.initialDelaySeconds = %#v, want 45", got)
 	}
+	airflow := vc2.ChartValues["airflow"]
+	if airflow["postgresql.image.registry"] != "ghcr.io" {
+		t.Fatalf("airflow postgresql.image.registry=%v, want ghcr.io", airflow["postgresql.image.registry"])
+	}
+	if repo, ok := airflow["postgresql.image.repository"]; ok {
+		t.Fatalf("airflow must not pin postgresql.image.repository=%v; chart-gen rewrites that chartValues input into a double ghcr.io prefix", repo)
+	}
 
 	// victoria-logs-single has NO chartValues but its only image is in
 	// unpatchableImages — the new processChart passthrough branch must

--- a/verity.yaml
+++ b/verity.yaml
@@ -324,12 +324,12 @@ chartValues:
   #
   # Supporting knobs:
   # - `postgresql.image.registry: ghcr.io` keeps the parent-level
-  #   postgresql image reference composable while image discovery still
-  #   sees the upstream repository path below. Do NOT pre-prefix the
-  #   repository with `verity-org/`: chart-gen derives the patched
-  #   target from discovered images, so pre-prefixing makes the source
-  #   name `verity-org/bitnamilegacy/postgresql` and renders the broken
-  #   `ghcr.io/verity-org/verity-org/bitnamilegacy/postgresql`.
+  #   postgresql image reference composable while chart-gen uses the
+  #   bundled subchart values to rewrite the repository. Do NOT also
+  #   set `postgresql.image.repository` here: chart-gen treats chartValues
+  #   image repositories as override inputs and rewrites the manual value
+  #   to `ghcr.io/verity-org/...`, which renders the broken
+  #   `ghcr.io/ghcr.io/verity-org/bitnamilegacy/postgresql`.
   # - `images.migrationsWaitTimeout: 300` (default 60s) — wait budget
   #   for `wait-for-airflow-migrations`. Kept generous so the init
   #   container still has headroom while the migrations Job runs.
@@ -346,7 +346,6 @@ chartValues:
   #   verifies install + pod readiness, not metric scraping).
   airflow:
     postgresql.image.registry: ghcr.io
-    postgresql.image.repository: bitnamilegacy/postgresql
     images.migrationsWaitTimeout: 300
     apiServer.startupProbe.failureThreshold: 12
     migrateDatabaseJob.useHelmHooks: false


### PR DESCRIPTION
## Summary
- Remove the Airflow chartValues pin for `postgresql.image.repository` so chart-gen can apply its subchart repository rewrite once.
- Keep `postgresql.image.registry: ghcr.io`, which is the only manual Airflow value needed to render the PostgreSQL image under GHCR.
- Add a regression guard that rejects reintroducing the repository chartValues pin.

## Validation
- `go test ./internal/chartgen ./internal/discovery ./...`
- `PATH=\"$(go env GOPATH)/bin:$PATH\" make lint`

## Context
Main chart-integration after [#407](https://github.com/verity-org/verity/pull/407) verified `mimir-distributed` successfully, but the all-chart run failed on Airflow because the wrapper rendered `ghcr.io/ghcr.io/verity-org/bitnamilegacy/postgresql:16.1.0-debian-11-r15`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Airflow’s PostgreSQL image rendering by removing the manual repository pin that caused a double `ghcr.io` prefix. Keeps the registry override and adds a regression test to prevent this from breaking again.

- **Bug Fixes**
  - Removed `airflow.postgresql.image.repository` from `verity.yaml` so chart-gen rewrites the repository once.
  - Kept `airflow.postgresql.image.registry: ghcr.io` to serve the image from GHCR.
  - Added a regression test asserting the registry stays `ghcr.io` and the repository is not set.

<sup>Written for commit 75eab7fcd6b2a07a582c6c65fc7f0e06868f6531. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/411?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

