### PR TITLE
fix(chart-gitea): provide smoke env-to-ini helper

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -32,7 +32,92 @@
 # chart's supported path for non-root containers) or (b) configure
 # their CSI driver / storage class to honor `fsGroup` recursively
 # before the init container runs.
+#
+# The only published `bitnamilegacy/gitea` tag that matches the chart's
+# major-version reference is `:1`, but that legacy image does not ship
+# Gitea's newer `environment-to-ini` helper. The chart requires that
+# helper in `init-app-ini`; without it the init container exits 127.
+# Mount a smoke-only helper that implements the chart's env var encoding
+# for the generated app.ini.
 gitea:
   containerSecurityContext:
     runAsUser: 0
     runAsNonRoot: false
+  extraDeploy:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: gitea-env-to-ini
+      data:
+        environment-to-ini: |-
+          #!/usr/bin/env sh
+          set -eu
+
+          out=""
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              -o)
+                out="$2"
+                shift 2
+                ;;
+              *)
+                echo "unsupported argument: $1" >&2
+                exit 2
+                ;;
+            esac
+          done
+
+          if [ -z "$out" ]; then
+            echo "missing -o output path" >&2
+            exit 2
+          fi
+
+          tmp="$(mktemp)"
+          env | sort | awk -F= '
+            function decode(s) {
+              gsub(/_0X2E_/, ".", s)
+              gsub(/_0X2D_/, "-", s)
+              return tolower(s)
+            }
+            /^GITEA____/ {
+              key = substr($1, 10)
+              root[decode(key)] = substr($0, length($1) + 2)
+              next
+            }
+            /^GITEA__/ {
+              rest = substr($1, 8)
+              sep = index(rest, "__")
+              if (sep == 0) next
+              section = decode(substr(rest, 1, sep - 1))
+              key = decode(substr(rest, sep + 2))
+              value = substr($0, length($1) + 2)
+              sections[section] = 1
+              values[section SUBSEP key] = value
+              keys[section] = keys[section] key "\n"
+              next
+            }
+            END {
+              for (key in root) print key " = " root[key]
+              for (section in sections) {
+                print ""
+                print "[" section "]"
+                split(keys[section], sectionKeys, "\n")
+                for (i in sectionKeys) {
+                  key = sectionKeys[i]
+                  if (key != "") print key " = " values[section SUBSEP key]
+                }
+              }
+            }
+          ' > "$tmp"
+          mkdir -p "$(dirname "$out")"
+          mv "$tmp" "$out"
+  extraVolumes:
+    - name: env-to-ini
+      configMap:
+        name: gitea-env-to-ini
+        defaultMode: 365
+  extraInitVolumeMounts:
+    - name: env-to-ini
+      mountPath: /usr/local/bin/environment-to-ini
+      subPath: environment-to-ini
+      readOnly: true


### PR DESCRIPTION
## Summary
- Mounts a smoke-only `environment-to-ini` helper into Gitea init containers because the only published `bitnamilegacy/gitea:1` image lacks the helper required by chart 12.5.3.
- Keeps the workaround scoped to `test/chart-integration/values/gitea.yaml` alongside the existing smoke-only root security override.

## Root Cause
After [#405](https://github.com/verity-org/verity/pull/405), `init-directories` completed successfully on main, but `init-app-ini` failed with exit 127:

`/usr/sbinx/config_environment.sh: line 154: environment-to-ini: command not found`

The Gitea chart 12.5.3 expects newer Gitea images to provide `environment-to-ini`, but Docker Hub only publishes `docker.io/bitnamilegacy/gitea:1` for this legacy namespace/tag shape, and that image does not include the helper.

## Verification
- `helm template gitea oci://ghcr.io/verity-org/charts/gitea --version 12.5.3 --values test/chart-integration/values/gitea.yaml` renders the helper ConfigMap, init-container mount, and volume.
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a smoke-only `environment-to-ini` helper script for Gitea init containers to replace the missing binary in `docker.io/bitnamilegacy/gitea:1`. This lets chart `12.5.3` complete `init-app-ini` during smoke tests without touching production values.

- **Bug Fixes**
  - Injects the helper via ConfigMap, volume, and init mount in `test/chart-integration/values/gitea.yaml` at `/usr/local/bin/environment-to-ini` to prevent exit 127.
  - Scoped to smoke tests and keeps the existing root security override.

<sup>Written for commit 184cff0de9a67b889c1937503c8928f274012061. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/412?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

