### PR TITLE
fix(chartgen): prefer registry-aware image paths

### DIFF
--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -162,29 +162,48 @@ func resolveValuePathPairs(pairs []repoTagPair, globalRegistryPaths []string, ma
 		}
 	}
 
-	for _, pair := range pairs {
-		if !pair.HasTag {
+	for i, m := range mappings {
+		if matched[i] {
 			continue
 		}
-		for i, m := range mappings {
-			if matched[i] {
-				continue
-			}
-			if matchesRepo(pair.Repo, m.OriginalRepo) {
-				result = append(result, buildValueOverride(
-					pair.Path,
-					m.PatchedRepo,
-					m.PatchedTag,
-					pair.HasRegistry,
-					pair.HasDefaultRegistry,
-				))
-				matched[i] = true
-				break
-			}
+		best := bestRepoTagPair(pairs, m.OriginalRepo)
+		if best == nil {
+			continue
 		}
+		result = append(result, buildValueOverride(
+			best.Path,
+			m.PatchedRepo,
+			m.PatchedTag,
+			best.HasRegistry,
+			best.HasDefaultRegistry,
+		))
+		matched[i] = true
 	}
 
 	return appendGlobalRegistryNeutralisations(result, globalRegistryPaths)
+}
+
+func bestRepoTagPair(pairs []repoTagPair, originalRepo string) *repoTagPair {
+	var best *repoTagPair
+	for idx := range pairs {
+		pair := &pairs[idx]
+		if !pair.HasTag || !matchesRepo(pair.Repo, originalRepo) {
+			continue
+		}
+		if best == nil || preferRepoTagPair(pair, best) {
+			best = pair
+		}
+	}
+	return best
+}
+
+func preferRepoTagPair(candidate, current *repoTagPair) bool {
+	candidateHasRegistry := candidate.HasRegistry || candidate.HasDefaultRegistry
+	currentHasRegistry := current.HasRegistry || current.HasDefaultRegistry
+	if candidateHasRegistry != currentHasRegistry {
+		return candidateHasRegistry
+	}
+	return len(candidate.Path) > len(current.Path)
 }
 
 // appendGlobalRegistryNeutralisations appends an IsScalarOverride entry

--- a/internal/chartgen/values.go
+++ b/internal/chartgen/values.go
@@ -162,11 +162,12 @@ func resolveValuePathPairs(pairs []repoTagPair, globalRegistryPaths []string, ma
 		}
 	}
 
+	usedPairs := make(map[int]bool, len(mappings))
 	for i, m := range mappings {
 		if matched[i] {
 			continue
 		}
-		best := bestRepoTagPair(pairs, m.OriginalRepo)
+		best, bestIdx := bestRepoTagPair(pairs, m.OriginalRepo, usedPairs)
 		if best == nil {
 			continue
 		}
@@ -178,23 +179,28 @@ func resolveValuePathPairs(pairs []repoTagPair, globalRegistryPaths []string, ma
 			best.HasDefaultRegistry,
 		))
 		matched[i] = true
+		usedPairs[bestIdx] = true
 	}
 
 	return appendGlobalRegistryNeutralisations(result, globalRegistryPaths)
 }
 
-func bestRepoTagPair(pairs []repoTagPair, originalRepo string) *repoTagPair {
-	var best *repoTagPair
+func bestRepoTagPair(pairs []repoTagPair, originalRepo string, used map[int]bool) (best *repoTagPair, bestIdx int) {
+	bestIdx = -1
 	for idx := range pairs {
+		if used[idx] {
+			continue
+		}
 		pair := &pairs[idx]
 		if !pair.HasTag || !matchesRepo(pair.Repo, originalRepo) {
 			continue
 		}
 		if best == nil || preferRepoTagPair(pair, best) {
 			best = pair
+			bestIdx = idx
 		}
 	}
-	return best
+	return best, bestIdx
 }
 
 func preferRepoTagPair(candidate, current *repoTagPair) bool {
@@ -203,7 +209,17 @@ func preferRepoTagPair(candidate, current *repoTagPair) bool {
 	if candidateHasRegistry != currentHasRegistry {
 		return candidateHasRegistry
 	}
+	if candidateDepth, currentDepth := pathDepth(candidate.Path), pathDepth(current.Path); candidateDepth != currentDepth {
+		return candidateDepth > currentDepth
+	}
 	return len(candidate.Path) > len(current.Path)
+}
+
+func pathDepth(path string) int {
+	if path == "" {
+		return 0
+	}
+	return strings.Count(path, ".") + 1
 }
 
 // appendGlobalRegistryNeutralisations appends an IsScalarOverride entry

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -702,6 +702,45 @@ image:
 			},
 		},
 		{
+			// Airflow declares the same postgresql repository in parent
+			// values and in the bundled postgresql subchart. Prefer the
+			// subchart path because it declares image.registry, allowing
+			// chart-gen to split ghcr.io into the registry sibling instead
+			// of rendering ghcr.io/ghcr.io/... at template time.
+			name: "duplicate parent and subchart repo prefers registry sibling",
+			parentValues: `postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 16.1.0-debian-11-r15
+`,
+			subchartValues: map[string]string{
+				"postgresql": `global:
+  imageRegistry: ""
+image:
+  registry: docker.io
+  repository: bitnamilegacy/postgresql
+  tag: 16.1.0-debian-11-r15
+`,
+			},
+			mappings: []ImageMapping{{
+				OriginalRepo: "bitnamilegacy/postgresql",
+				PatchedRepo:  "ghcr.io/verity-org/bitnamilegacy/postgresql",
+				PatchedTag:   "16.1.0-debian-11-r15",
+			}},
+			want: []ValueOverride{
+				{
+					Path:        "postgresql.image",
+					Repository:  "verity-org/bitnamilegacy/postgresql",
+					Tag:         "16.1.0-debian-11-r15",
+					SetRegistry: "ghcr.io",
+				},
+				{
+					Path:             "postgresql.global.imageRegistry",
+					IsScalarOverride: true,
+				},
+			},
+		},
+		{
 			// Tempo-distributed shape variant lifted into a sub-chart.
 			// Verifies that `global.image.registry` (under a `global.image`
 			// map, not a top-level scalar) is detected and prefixed

--- a/internal/chartgen/values_test.go
+++ b/internal/chartgen/values_test.go
@@ -1602,6 +1602,26 @@ func TestResolveValuePathsComposeRegistryOnRegistryOnlyPath(t *testing.T) {
 	}
 }
 
+func TestResolveValuePathPairsConsumesDuplicateRepoPairs(t *testing.T) {
+	pairs := []repoTagPair{
+		{Path: "primary.image", Repo: "example/app", HasTag: true, HasRegistry: true, Registry: "docker.io"},
+		{Path: "sidecar.image", Repo: "example/app", HasTag: true, HasRegistry: true, Registry: "docker.io"},
+	}
+	mappings := []ImageMapping{
+		{OriginalRepo: "example/app", PatchedRepo: "ghcr.io/verity-org/example/app", PatchedTag: "1"},
+		{OriginalRepo: "example/app", PatchedRepo: "ghcr.io/verity-org/example/app", PatchedTag: "2"},
+	}
+
+	got := resolveValuePathPairs(pairs, nil, mappings, nil)
+	want := []ValueOverride{
+		{Path: "primary.image", Repository: "verity-org/example/app", Tag: "1", SetRegistry: "ghcr.io"},
+		{Path: "sidecar.image", Repository: "verity-org/example/app", Tag: "2", SetRegistry: "ghcr.io"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveValuePathPairs() = %#v, want %#v", got, want)
+	}
+}
+
 func TestResolveValuePathsWithSubchartsErrorIdentifiesFailingSubchart(t *testing.T) {
 	parent := []byte(`image:
   repository: nginx


### PR DESCRIPTION
## Summary
- Prefer image value paths that declare `registry`/`defaultRegistry` when duplicate parent/subchart paths match the same repository.
- Add a regression case for Airflow's parent PostgreSQL image values versus bundled Bitnami PostgreSQL subchart values.

## Validation
- `go test ./internal/chartgen ./internal/discovery`
- `go test ./...`
- `PATH=\"$(go env GOPATH)/bin:$PATH\" make lint`

## Context
After [#411](https://github.com/verity-org/verity/pull/411), main Chart Generation still produced an Airflow wrapper with `repository: ghcr.io/verity-org/bitnamilegacy/postgresql` and an empty registry because chart-gen selected the parent chart path before the registry-aware subchart path. Main chart-integration verified `mimir-distributed` successfully, but Airflow remained red until this path selection is corrected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer registry-aware image value paths and ensure each mapping uses a unique image path when duplicates exist. Fixes Airflow selecting the parent PostgreSQL path with an empty registry by choosing the subchart path that declares `image.registry`/`global.imageRegistry`.

- **Bug Fixes**
  - Select the best repo/tag pair per mapping and consume duplicates: prefer paths with `image.registry` or `global.imageRegistry`, then deeper, then longer.
  - Prevent empty or duplicated registries (e.g., avoid ghcr.io/ghcr.io).
  - Add regression tests for Airflow and duplicate repo pairs.

<sup>Written for commit 6039f079bb8142197bed17d3e02f4fa58d09e7d3. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/413?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

