### PR TITLE
fix(chart-gitea): keep smoke runtime nonroot

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -17,15 +17,10 @@
 # → init-directories enters CrashLoopBackOff and helm install times
 # out at 10 minutes.
 #
-# This override runs the init-directories/init-app-ini containers and
-# the main gitea container as root. The Bitnami chart uses one
-# `containerSecurityContext` block for those containers, so we cannot
-# scope the override to just init-directories without forking the chart.
-# Running the main gitea container as root is acceptable in the smoke-
-# test cluster (kind, ephemeral, no real data), but should NOT be the
-# production default — which is why this override lives in the chart-
-# integration values directory and NOT in `verity.yaml`'s gitea
-# chartValues block.
+# The chart's rootless mode skips the `chown` while keeping the Gitea
+# command/runtime containers non-root. Keep `image.fullOverride` pointed
+# at the only published legacy image tag (`bitnamilegacy/gitea:1`) so
+# `image.rootless: true` does not append an unavailable `-rootless` tag.
 #
 # Production users who hit the same PVC-chown issue on their cluster
 # should either (a) switch to `image.rootless: true` (the upstream
@@ -40,9 +35,9 @@
 # Mount a smoke-only helper that implements the chart's env var encoding
 # for the generated app.ini.
 gitea:
-  containerSecurityContext:
-    runAsUser: 0
-    runAsNonRoot: false
+  image:
+    rootless: true
+    fullOverride: docker.io/bitnamilegacy/gitea:1
   extraDeploy:
     - apiVersion: v1
       kind: ConfigMap


### PR DESCRIPTION
## Summary
- Switches the gitea smoke fixture to chart rootless mode so `init-directories` skips the PVC `chown` instead of forcing all Gitea containers to run as root.
- Keeps `image.fullOverride: docker.io/bitnamilegacy/gitea:1` so rootless mode does not append the unavailable `-rootless` tag.

## Root Cause
After [#412](https://github.com/verity-org/verity/pull/412), `init-app-ini` completed, exposing the next failure: `configure-gitea` ran the Gitea binary as root and Gitea refused startup with:

`Gitea is not supposed to be run as root. Sorry.`

The broad `containerSecurityContext.runAsUser: 0` workaround fixed the PVC chown but incorrectly forced Gitea command/runtime containers to root. Using chart rootless mode skips the chown while preserving non-root execution.

## Verification
- `helm template gitea oci://ghcr.io/verity-org/charts/gitea --version 12.5.3 --values test/chart-integration/values/gitea.yaml` renders `docker.io/bitnamilegacy/gitea:1`, omits the init chown, keeps `configure-gitea` at `runAsUser: 1000`, and mounts the smoke `environment-to-ini` helper.
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Gitea smoke fixture to chart rootless mode so containers run as non-root and startup no longer fails with “Gitea is not supposed to be run as root.” Pins the image to `docker.io/bitnamilegacy/gitea:1` to avoid the unavailable `-rootless` tag.

- **Bug Fixes**
  - Replaces the root override with `image.rootless: true` and `image.fullOverride: docker.io/bitnamilegacy/gitea:1`.
  - Skips the PVC `chown` init step while keeping runtime containers non-root (e.g., `configure-gitea` runs as 1000).

<sup>Written for commit 74933e3b04335ad68cc15339b0e09f307a72bf86. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/414?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

