### PR TITLE
fix(chart-gitea): relax smoke app ini mode

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -104,6 +104,7 @@ gitea:
               }
             }
           ' > "$tmp"
+          chmod 0644 "$tmp"
           mkdir -p "$(dirname "$out")"
           mv "$tmp" "$out"
   extraVolumes:


### PR DESCRIPTION
## Summary
- Makes the smoke-mounted `environment-to-ini` helper publish `app.ini` as mode `0644` so non-root Gitea init/runtime containers can read it.

## Root Cause
After [#414](https://github.com/verity-org/verity/pull/414), `init-directories` and `init-app-ini` completed, but `configure-gitea` failed reading the generated app.ini:

`failed to load config file "/data/gitea/conf/app.ini": open /data/gitea/conf/app.ini: permission denied`

The helper wrote through `mktemp`, producing a restrictive file mode. Gitea then runs as uid 1000 and could not read it.

## Verification
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the generated `app.ini` to mode 0644 in the smoke `environment-to-ini` helper so non-root Gitea containers can read it. Fixes the configure step failing with “permission denied”.

- **Bug Fixes**
  - Add `chmod 0644 "$tmp"` before moving to `/data/gitea/conf/app.ini` in `test/chart-integration/values/gitea.yaml`.

<sup>Written for commit 311e683460feae8bf1f450dee1356a4e248bd34f. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/416?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

