### PR TITLE
fix(chart-gitea): preserve generated ini keys

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -69,22 +69,27 @@ gitea:
 
           tmp="$(mktemp)"
           env | sort | awk -F= '
-            function decode(s) {
+            function decode_section(s) {
               gsub(/_0X2E_/, ".", s)
               gsub(/_0X2D_/, "-", s)
               return tolower(s)
             }
+            function decode_key(s) {
+              gsub(/_0X2E_/, ".", s)
+              gsub(/_0X2D_/, "-", s)
+              return s
+            }
             /^GITEA____/ {
               key = substr($1, 10)
-              root[decode(key)] = substr($0, length($1) + 2)
+              root[decode_key(key)] = substr($0, length($1) + 2)
               next
             }
             /^GITEA__/ {
               rest = substr($1, 8)
               sep = index(rest, "__")
               if (sep == 0) next
-              section = decode(substr(rest, 1, sep - 1))
-              key = decode(substr(rest, sep + 2))
+              section = decode_section(substr(rest, 1, sep - 1))
+              key = decode_key(substr(rest, sep + 2))
               value = substr($0, length($1) + 2)
               sections[section] = 1
               values[section SUBSEP key] = value


### PR DESCRIPTION
## Summary
- Preserves app.ini key casing in the smoke `environment-to-ini` helper while still decoding/lowercasing section names.

## Root Cause
After [#416](https://github.com/verity-org/verity/pull/416), Gitea could read app.ini but still treated the instance as uninstalled:

`Unable to load config file for a installed Gitea instance`

The helper lowercased keys, turning `INSTALL_LOCK=true` into `install_lock=true`. Preserve key casing so Gitea sees the chart-provided `INSTALL_LOCK` setting.

## Verification
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves INI key casing in the Gitea env-to-INI generator while still lowercasing section names. Fixes Gitea treating the instance as uninstalled by keeping `INSTALL_LOCK` as-is.

- **Bug Fixes**
  - Split decoding: lowercase only section names; leave key names unchanged.
  - Updated AWK helper to preserve keys like `INSTALL_LOCK`, restoring correct install state.

<sup>Written for commit c3f8a0eec90285062cffb065966da6cf6e5f0c11. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/417?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

