### PR TITLE
fix(chart-gitea): add smoke nc shim

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -117,15 +117,18 @@ gitea:
           set -euo pipefail
 
           args=()
+          timeout_seconds=2
           while [ "$#" -gt 0 ]; do
             case "$1" in
-              -v|-z)
+              -v|-z|-vz|-zv)
                 shift
                 ;;
               -w)
+                timeout_seconds="$2"
                 shift 2
                 ;;
               -w*)
+                timeout_seconds="${1#-w}"
                 shift
                 ;;
               *)
@@ -142,9 +145,7 @@ gitea:
 
           host="${args[0]}"
           port="${args[1]}"
-          exec 3<>"/dev/tcp/${host}/${port}"
-          exec 3>&-
-          exec 3<&-
+          timeout "${timeout_seconds}" bash -c 'exec 3<>"/dev/tcp/${1}/${2}"; exec 3>&-; exec 3<&-' _ "${host}" "${port}"
   extraVolumes:
     - name: env-to-ini
       configMap:

--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -112,6 +112,39 @@ gitea:
           chmod 0644 "$tmp"
           mkdir -p "$(dirname "$out")"
           mv "$tmp" "$out"
+        nc: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          args=()
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              -v|-z)
+                shift
+                ;;
+              -w)
+                shift 2
+                ;;
+              -w*)
+                shift
+                ;;
+              *)
+                args+=("$1")
+                shift
+                ;;
+            esac
+          done
+
+          if [ "${#args[@]}" -lt 2 ]; then
+            echo "usage: nc [-vz] [-wN] host port" >&2
+            exit 2
+          fi
+
+          host="${args[0]}"
+          port="${args[1]}"
+          exec 3<>"/dev/tcp/${host}/${port}"
+          exec 3>&-
+          exec 3<&-
   extraVolumes:
     - name: env-to-ini
       configMap:
@@ -121,4 +154,8 @@ gitea:
     - name: env-to-ini
       mountPath: /usr/local/bin/environment-to-ini
       subPath: environment-to-ini
+      readOnly: true
+    - name: env-to-ini
+      mountPath: /usr/local/bin/nc
+      subPath: nc
       readOnly: true


### PR DESCRIPTION
## Summary
- Adds a smoke-only `nc` shim mounted into Gitea init containers so the chart's Valkey connectivity check can run with the legacy `bitnamilegacy/gitea:1` image.

## Root Cause
After [#417](https://github.com/verity-org/verity/pull/417), Gitea migrated the database and reached the Valkey readiness check, but the legacy image lacks `nc`:

`/usr/sbinx/configure_gitea.sh: line 19: nc: command not found`

The chart uses `nc -vz -w2 <valkey-service> <port>` in `configure_gitea.sh`; the shim implements that smoke-test usage through bash `/dev/tcp`.

## Verification
- `helm template gitea oci://ghcr.io/verity-org/charts/gitea --version 12.5.3 --values test/chart-integration/values/gitea.yaml` renders both helper mounts.
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a smoke-only `nc` shim to Gitea init containers so the Valkey connectivity check works with the legacy `bitnamilegacy/gitea:1` image. Fixes the startup error "nc: command not found".

- **Bug Fixes**
  - Provide a tiny bash `nc` script (uses /dev/tcp) that handles `-v`, `-z`, and `-w` flags, including `-wN` and `-w N`.
  - Mount the script via ConfigMap to `/usr/local/bin/nc` in init containers.

<sup>Written for commit 54b9d4918d212ee6093a4da12d00e02d2187d4d1. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/418?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

