### PR TITLE
fix(chart-gitea): point smoke entrypoint at postgres

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -38,6 +38,12 @@ gitea:
   image:
     rootless: true
     fullOverride: docker.io/bitnamilegacy/gitea:1
+  deployment:
+    env:
+      - name: GITEA_DATABASE_HOST
+        value: gitea-postgresql
+      - name: GITEA_DATABASE_PORT_NUMBER
+        value: "5432"
   extraDeploy:
     - apiVersion: v1
       kind: ConfigMap


### PR DESCRIPTION
## Summary
- Sets Bitnami Gitea startup env vars in the smoke fixture so the main container waits on `gitea-postgresql:5432`, matching the chart's single-node PostgreSQL service.

## Root Cause
After [#418](https://github.com/verity-org/verity/pull/418), all init containers completed and the main Gitea container started, but Bitnami's entrypoint waited on its default `postgresql:5432` host:

`Could not connect to the postgresql:5432`

The chart-rendered app.ini points Gitea at the right database, but the legacy Bitnami entrypoint does its own preflight from env defaults before launching Gitea.

## Verification
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Gitea smoke fixture so the Bitnami entrypoint waits on the correct Postgres service (`gitea-postgresql:5432`). Prevents startup failures caused by the default `postgresql` host.

- **Bug Fixes**
  - Set `GITEA_DATABASE_HOST=gitea-postgresql` and `GITEA_DATABASE_PORT_NUMBER=5432` in `test/chart-integration/values/gitea.yaml`.
  - Aligns the entrypoint preflight with the chart’s single-node PostgreSQL service.

<sup>Written for commit 78093594abb0c2e9ced44179b5c469ae78601ea7. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/419?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

