### PR TITLE
fix(chart-gitea): align smoke database credentials

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -44,6 +44,12 @@ gitea:
         value: gitea-postgresql
       - name: GITEA_DATABASE_PORT_NUMBER
         value: "5432"
+      - name: GITEA_DATABASE_NAME
+        value: gitea
+      - name: GITEA_DATABASE_USER
+        value: gitea
+      - name: GITEA_DATABASE_PASSWORD
+        value: gitea
   extraDeploy:
     - apiVersion: v1
       kind: ConfigMap


### PR DESCRIPTION
## Summary
- Sets Bitnami Gitea startup database name/user/password in the smoke fixture to match the chart-created PostgreSQL database.

## Root Cause
After [#419](https://github.com/verity-org/verity/pull/419), the main container reached PostgreSQL but used Bitnami defaults (`bn_gitea`) instead of the chart's `gitea` database/user/password:

`password authentication failed for user "bn_gitea"`

The chart app.ini already contains `NAME/USER/PASSWD=gitea`; these env vars align the legacy Bitnami entrypoint preflight with that configuration.

## Verification
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned Gitea smoke test database credentials with the chart’s PostgreSQL setup to use the `gitea` DB, user, and password. This fixes startup auth failures caused by Bitnami defaults (`bn_gitea`).

<sup>Written for commit 244d08b2ea1aa41280c63aae67cc27e0ea3c115d. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/420?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

