### PR TITLE
fix(chart-gitea): set bitnami database username

### DIFF
--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -48,6 +48,8 @@ gitea:
         value: gitea
       - name: GITEA_DATABASE_USER
         value: gitea
+      - name: GITEA_DATABASE_USERNAME
+        value: gitea
       - name: GITEA_DATABASE_PASSWORD
         value: gitea
   extraDeploy:


### PR DESCRIPTION
## Summary
- Adds `GITEA_DATABASE_USERNAME=gitea` for the legacy Bitnami Gitea entrypoint preflight, alongside the chart/app.ini database credentials.

## Root Cause
After [#420](https://github.com/verity-org/verity/pull/420), the main Gitea container still attempted PostgreSQL auth as `bn_gitea`. The legacy Bitnami entrypoint uses `GITEA_DATABASE_USERNAME`, not only `GITEA_DATABASE_USER`.

## Verification
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Gitea DB username env var used by the legacy Bitnami entrypoint. Ensures the container authenticates to PostgreSQL as gitea, not bn_gitea.

- **Bug Fixes**
  - The Bitnami entrypoint reads GITEA_DATABASE_USERNAME, not GITEA_DATABASE_USER.
  - Added GITEA_DATABASE_USERNAME=gitea in test/chart-integration/values/gitea.yaml.

<sup>Written for commit b3dc76be6790df3461776be69fd809134e29b726. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/421?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

