### PR TITLE
fix(valkey): override digest-pinned chart image to verity rebuild

### DIFF
--- a/internal/chartgen/chartvalues_loading_regression_test.go
+++ b/internal/chartgen/chartvalues_loading_regression_test.go
@@ -54,6 +54,16 @@ func TestVerityConfigChartValuesLoading(t *testing.T) {
 	if airflow["postgresql.image.repository"] != "bitnamilegacy/postgresql" {
 		t.Fatalf("airflow postgresql.image.repository=%v, want bitnamilegacy/postgresql", airflow["postgresql.image.repository"])
 	}
+	valkey := vc2.ChartValues["valkey"]
+	if valkey["image.registry"] != "ghcr.io" {
+		t.Fatalf("valkey image.registry=%v, want ghcr.io", valkey["image.registry"])
+	}
+	if valkey["image.repository"] != "verity-org/valkey" {
+		t.Fatalf("valkey image.repository=%v, want verity-org/valkey", valkey["image.repository"])
+	}
+	if valkey["image.tag"] != "9.0" {
+		t.Fatalf("valkey image.tag=%v, want 9.0", valkey["image.tag"])
+	}
 
 	// victoria-logs-single has NO chartValues but its only image is in
 	// unpatchableImages — the new processChart passthrough branch must

--- a/verity.yaml
+++ b/verity.yaml
@@ -270,6 +270,18 @@ chartValues:
   etcd:
     replicaCount: 1
 
+  # valkey 0.20.2 (cloudpirates chart) pins its default image tag to
+  # `9.0.0-alpine3.22@sha256:...`. chart-gen's replacement maps
+  # `valkey/valkey` to `ghcr.io/verity-org/valkey:9.0`, but the
+  # digest suffix can survive the wrapper render and force kubelet
+  # back to the upstream docker.io image, tripping the image-origin
+  # gate. Explicitly set the chart's image tuple to the Integer-backed
+  # rebuild tag so the wrapper renders only verity-org/valkey.
+  valkey:
+    image.registry: ghcr.io
+    image.repository: verity-org/valkey
+    image.tag: "9.0"
+
   # airflow chart bundles a `postgresql` sub-chart with image
   # `bitnamilegacy/postgresql:16.1.0-debian-11-r15`. chart-gen rewrites
   # the repository (`bitnamilegacy/postgresql` →


### PR DESCRIPTION
## Summary

The final full main chart-integration run [25999278729](https://github.com/verity-org/verity/actions/runs/25999278729) had 53 green shards and one failing shard: `valkey`.

`valkey` installed successfully, but failed the image-origin gate because the pod still used the upstream digest-pinned image:

```text
spec valkey docker.io/valkey/valkey:9.0.0-alpine3.22@sha256:bef37d06d4856710973ee31dd1eac1482e4c8e6e7b847f999ad25433e646587b
status valkey sha256:cf08f5e72fc968773547bd4052062474a7993b01791699569df1361763331629 docker.io/valkey/valkey@sha256:bef37d06d4856710973ee31dd1eac1482e4c8e6e7b847f999ad25433e646587b
```

The chart has no allowlist because valkey is intended to use the Integer-backed rebuild (`ghcr.io/verity-org/valkey:9.0`).

## Root Cause

The cloudpirates `valkey` chart pins its default image tag to:

```yaml
image:
  registry: docker.io
  repository: valkey/valkey
  tag: "9.0.0-alpine3.22@sha256:bef37d06..."
```

Chart-gen has a `replacements:` entry for `valkey/valkey`, but the chart's digest-pinned tag survived the generated wrapper render and forced kubelet back to the upstream digest.

## Changes

Add explicit valkey chartValues in `verity.yaml`:

```yaml
valkey:
  image.registry: ghcr.io
  image.repository: verity-org/valkey
  image.tag: "9.0"
```

Add regression coverage in `internal/chartgen/chartvalues_loading_regression_test.go` so the image tuple remains pinned to the verity rebuild.

## Test Plan

- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`
- `/tmp/opencode/gobin/golangci-lint run ./internal/chartgen/`

Note: `golangci-lint run --build-tags integration ./test/chart-integration/` currently reports unrelated pre-existing integration-lint issues in harness files touched by earlier PRs; this PR changes only `verity.yaml` and a chartgen regression test.

## Final Verification Plan

After merge:

1. Trigger `Chart Generation` on `main` and wait for success.
2. Trigger full `chart-integration` on `main` with no `chart` input.
3. Confirm all shards pass, especially `valkey`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forces the `valkey` chart to use our rebuilt image by overriding its digest-pinned upstream tag, fixing the image-origin gate failure in CI. Adds a regression test to ensure this override stays in place.

- Bug Fixes
  - Set `valkey` chart values in `verity.yaml`: `image.registry=ghcr.io`, `image.repository=verity-org/valkey`, `image.tag="9.0"`, preventing fallback to `docker.io/valkey/valkey@sha256:...`.
  - Added regression checks in `internal/chartgen/chartvalues_loading_regression_test.go` to verify the `valkey` image tuple.

<sup>Written for commit 6a6876009eed1fbdc334fbaff88bcea5765c9b30. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/422?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

