### PR TITLE
fix(ci): retry Integer Orchestrator dispatches

### DIFF
--- a/.github/workflows/integer-orchestrator.yaml
+++ b/.github/workflows/integer-orchestrator.yaml
@@ -164,7 +164,46 @@ jobs:
           cat > "$RUNNER_TEMP/images.json" <<'__IMAGES_JSON_EOF__'
           ${{ needs.discover.outputs.images }}
           __IMAGES_JSON_EOF__
-          jq -c '.[]' "$RUNNER_TEMP/images.json" | while IFS= read -r image; do
+          dispatch_build() {
+            local name="$1"
+            local version="$2"
+            local type="$3"
+            local tags="$4"
+            local registry="$5"
+
+            local attempt
+            for attempt in 1 2 3 4 5; do
+              if gh workflow run integer-build-image.yaml \
+                --repo "${{ github.repository }}" \
+                --ref "${{ github.ref_name }}" \
+                --field "image=${name}" \
+                --field "version=${version}" \
+                --field "type=${type}" \
+                --field "tags=${tags}" \
+                --field "registry=${registry}"; then
+                return 0
+              fi
+
+              # GitHub can return secondary-rate-limit or transient
+              # 5xx/transport failures when hundreds of workflow_dispatch
+              # calls are made in one job. Retry with bounded backoff so
+              # one transient dispatch does not fail the entire nightly.
+              if [ "$attempt" -lt 5 ]; then
+                local sleep_seconds=$((attempt * 10))
+                echo "Dispatch failed for ${name}:${version}-${type} (attempt ${attempt}/5); retrying in ${sleep_seconds}s" >&2
+                sleep "${sleep_seconds}"
+              fi
+            done
+
+            echo "Failed to dispatch ${name}:${version}-${type} after 5 attempts" >&2
+            return 1
+          }
+
+          jq -c '.[]' "$RUNNER_TEMP/images.json" > "$RUNNER_TEMP/images.ndjson"
+
+          expected_count="${{ needs.discover.outputs.count }}"
+          dispatched=0
+          while IFS= read -r image; do
             NAME=$(echo "$image" | jq -r '.name')
             VERSION=$(echo "$image" | jq -r '.version')
             TYPE=$(echo "$image" | jq -r '.type')
@@ -184,16 +223,15 @@ jobs:
             fi
 
             echo "Dispatching build for ${NAME}:${VERSION}-${TYPE}..."
-            gh workflow run integer-build-image.yaml \
-              --repo "${{ github.repository }}" \
-              --ref "${{ github.ref_name }}" \
-              --field "image=${NAME}" \
-              --field "version=${VERSION}" \
-              --field "type=${TYPE}" \
-              --field "tags=${TAGS}" \
-              --field "registry=${REGISTRY}"
+            dispatch_build "$NAME" "$VERSION" "$TYPE" "$TAGS" "$REGISTRY"
+            dispatched=$((dispatched + 1))
 
             # Throttle to avoid GitHub API rate limits
-            sleep 1
-          done
-          echo "✓ Dispatched ${{ needs.discover.outputs.count }} build runs"
+            sleep 2
+          done < "$RUNNER_TEMP/images.ndjson"
+
+          if [ "$dispatched" -ne "$expected_count" ]; then
+            echo "Dispatched ${dispatched}/${expected_count} build runs; expected all discovered images to dispatch" >&2
+            exit 1
+          fi
+          echo "✓ Dispatched ${dispatched}/${expected_count} build runs"


### PR DESCRIPTION
## Summary

Nightly `Integer Orchestrator` failed in the `Dispatch builds` step after dispatching several hundred `integer-build-image.yaml` workflow runs. The visible terminal error was:

```text
jq: error: writing output failed: Broken pipe
Process completed with exit code 1
```

Run: [26018490708](https://github.com/verity-org/verity/actions/runs/26018490708)

## Root Cause

The dispatch step streamed `jq -c '.[]' images.json | while ... gh workflow run ...`. If any `gh workflow run` call exits non-zero (secondary rate limit, transient GitHub API/transport failure, etc.), `set -euo pipefail` exits the `while` loop while `jq` is still writing, producing the misleading `Broken pipe` error.

The job was making hundreds of workflow_dispatch API calls in a single run and had reached around the `haproxy:3.0` entries when it exited, consistent with an intermittent dispatch/API failure rather than invalid image metadata.

## Changes

- Wrap `gh workflow run integer-build-image.yaml` in `dispatch_build()` with 5 attempts and bounded backoff.
- Switch the `jq` producer from a pipe to process substitution: `while ... done < <(jq -c '.[]' ...)` so a loop failure is not reported as a jq pipe failure.
- Track and print the successful dispatch count.
- Increase the throttle from 1s to 2s to reduce secondary-rate-limit pressure during the full nightly matrix.

## Test Plan

- `git diff --check`
- `actionlint .github/workflows/integer-orchestrator.yaml` using the mise-installed actionlint 1.7.12 binary

## Follow-up Verification

After merge, run `Integer Orchestrator` manually on `main` and verify the `Dispatch builds` step completes instead of exiting with `jq: Broken pipe`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly `Integer Orchestrator` dispatch failures by retrying `gh workflow run` and reading images from a temp NDJSON file to avoid the misleading `jq: Broken pipe` error. Improves reliability of the “Dispatch builds” step.

- **Bug Fixes**
  - Retry `gh workflow run integer-build-image.yaml` up to 5 times with incremental backoff.
  - Write `jq` output to `images.ndjson` and read from it to prevent pipefail masking real errors.
  - Track successful dispatches and fail the job if the count doesn’t match the discovered total.
  - Increase per-dispatch throttle from 1s to 2s to reduce secondary-rate-limit hits.

<sup>Written for commit f645c320c07a23759591617ff01abbdae5135e66. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/425?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

