### PR TITLE
fix(charts): restore nightly kyverno and gitea compatibility

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -93,7 +93,7 @@
     {
       "description": "Hold kyverno + aws-load-balancer-controller helm bumps until #318 verity-rebuild incompatibilities clear (the kyverno 3.7.2 → 3.8.0 automerge in #314 broke nightly because the chart expects binary >=1.18 while verity ships 1.17; reverted in #317. aws-load-balancer-controller is in #318's suspected (A) cluster and a v3 major is queued in #68.)",
       "matchManagers": ["helmv3"],
-      "matchPackageNames": ["kyverno", "aws-load-balancer-controller"],
+      "matchPackageNames": ["kyverno", "ghcr.io/kyverno/charts/kyverno", "aws-load-balancer-controller"],
       "enabled": false
     }
   ],

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
   # `enabled: false`. Track separately; for now the revert is the
   # immediate fix.
   - name: kyverno
-    version: "3.8.0"
+    version: "3.7.2"
     repository: "oci://ghcr.io/kyverno/charts"
 
   - name: argo-cd

--- a/test/chart-integration/values/gitea.allowlist.txt
+++ b/test/chart-integration/values/gitea.allowlist.txt
@@ -24,6 +24,8 @@
 # scope each prefix to its image's tag/digest refs.
 docker.io/bitnamilegacy/gitea:
 docker.io/bitnamilegacy/gitea@
+docker.gitea.com/gitea:
+docker.gitea.com/gitea@
 docker.io/bitnamilegacy/postgresql:
 docker.io/bitnamilegacy/postgresql@
 docker.io/bitnamilegacy/valkey:

--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -18,9 +18,11 @@
 # out at 10 minutes.
 #
 # The chart's rootless mode skips the `chown` while keeping the Gitea
-# command/runtime containers non-root. Keep `image.fullOverride` pointed
-# at the only published legacy image tag (`bitnamilegacy/gitea:1`) so
-# `image.rootless: true` does not append an unavailable `-rootless` tag.
+# command/runtime containers non-root. For gitea chart 12.6.x, use the
+# chart's upstream `docker.gitea.com/gitea:1.26.1-rootless` image in
+# smoke tests because the legacy `bitnamilegacy/gitea:1` binary lacks
+# the newer `gitea config edit-ini` subcommand that the chart's
+# `init-app-ini` script now calls.
 #
 # Production users who hit the same PVC-chown issue on their cluster
 # should either (a) switch to `image.rootless: true` (the upstream
@@ -37,7 +39,7 @@
 gitea:
   image:
     rootless: true
-    fullOverride: docker.io/bitnamilegacy/gitea:1
+    fullOverride: docker.gitea.com/gitea:1.26.1-rootless
   deployment:
     env:
       - name: GITEA_DATABASE_HOST


### PR DESCRIPTION
## Summary

The current-main chart-integration run after the Renovate chart bump failed 2 shards:

- `kyverno` 3.8.0: every controller crashes on `flag provided but not defined: -apiCallTimeout`
- `gitea` 12.6.0: `init-app-ini` crashes with `No help topic for 'config'`

Run: [26020010014](https://github.com/verity-org/verity/actions/runs/26020010014)

## Root Cause

`kyverno` 3.8.0 expects Kyverno controller binaries with the new `-apiCallTimeout` flag. Verity currently publishes Kyverno 1.17 controller images, which do not support that flag. This is the same incompatibility documented in `.github/renovate.json`, but Renovate matched the package as `ghcr.io/kyverno/charts/kyverno`, so the existing hold on `kyverno` did not apply.

`gitea` 12.6.0 changed `init-app-ini` to call `gitea config edit-ini`. Our smoke override still forced `docker.io/bitnamilegacy/gitea:1`, which lacks the `config` subcommand. The 12.6.0 chart default image `docker.gitea.com/gitea:1.26.1-rootless` has the expected command.

## Changes

- Revert `Chart.yaml` kyverno from `3.8.0` to `3.7.2` until Verity ships Kyverno 1.18 controller images.
- Extend the Renovate hold rule to include `ghcr.io/kyverno/charts/kyverno` so the bypass does not recur.
- Update `test/chart-integration/values/gitea.yaml` smoke override to use `docker.gitea.com/gitea:1.26.1-rootless`.
- Add `docker.gitea.com/gitea:` and `@` to `gitea.allowlist.txt`.

## Test Plan

- `jq empty .github/renovate.json`
- `git diff --check`
- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid|TestClassify|TestHarness"`

## Verification Plan

After merge:
1. Trigger `Chart Generation` on `main`.
2. Trigger full `chart-integration` on `main`.
3. Confirm `kyverno` and `gitea` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly chart-integration failures by reverting `kyverno` to 3.7.2 and switching the `gitea` smoke image to the upstream rootless build. Prevents Renovate from re-bumping `kyverno` until 1.18 controllers are available.

- **Bug Fixes**
  - Revert `kyverno` Helm dep from 3.8.0 to 3.7.2 to avoid the `-apiCallTimeout` flag mismatch with 1.17 controllers.
  - Extend Renovate hold to include `ghcr.io/kyverno/charts/kyverno`.
  - Use `docker.gitea.com/gitea:1.26.1-rootless` in smoke tests so `init-app-ini` can run `gitea config edit-ini`.
  - Allowlist `docker.gitea.com/gitea:` and `@` for the chart-integration gate.

<sup>Written for commit 401264e0a8cb8a3e0e6039a42ed8a4567cc372ea. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/426?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

