### PR TITLE
fix(copa): retry unresolved Go source refs

### DIFF
--- a/.github/scripts/patch-image.sh
+++ b/.github/scripts/patch-image.sh
@@ -106,7 +106,12 @@ _is_go_rebuild_failure() {
   #   - "no binaries were successfully rebuilt" → missing source repo per binary (mongodb tools)
   #   - "copa_discover_build.sh ... did not complete successfully" → go build crash (prom-config-reloader)
   #   - 'exec: "sh": executable file not found' → distroless image with no shell
-  grep -qE 'go package upgrade operation failed|no go\.mod files detected|no Go binaries detected|no binaries were successfully rebuilt|copa_discover_build\.sh.*did not complete successfully|exec: "sh": executable file not found' "$PATCH_LOG"
+  #   - "repository does not contain ref" / "Not a valid object name" →
+  #     BuildKit cannot resolve the Go source ref Copa chose for a binary
+  #     rebuild. Seen with consul, consul-k8s-control-plane, and
+  #     ingress-nginx/kube-webhook-certgen, where the image tag does not map
+  #     to a source repository tag (or the binary VCS commit is unavailable).
+  grep -qE 'go package upgrade operation failed|no go\.mod files detected|no Go binaries detected|no binaries were successfully rebuilt|copa_discover_build\.sh.*did not complete successfully|exec: "sh": executable file not found|repository does not contain ref|Not a valid object name' "$PATCH_LOG"
 }
 
 if [ "$PATCH_EXIT" -ne 0 ]; then


### PR DESCRIPTION
## Summary
- retry Copa patching with OS-only packages when Go binary rebuild source refs cannot be resolved
- covers BuildKit errors seen in consul, consul-k8s-control-plane, and kube-webhook-certgen Patch Image jobs

## Root cause
Failed main Patch Image runs showed Copa finding Go binaries that needed stdlib rebuilds, then BuildKit tried to clone source refs derived from image tags or embedded VCS metadata. Those refs were not resolvable for the affected repositories, causing errors like `repository does not contain ref` and `Not a valid object name`. Existing retry logic only handled other Go rebuild terminal states, so these runs failed instead of falling back to OS-only patching.

## Validation
- `go test ./...`
- `MISE_TRUSTED_CONFIG_PATHS="/tmp/opencode/verity-copa-cache-ref/mise.toml" mise x shellcheck@0.11.0 -- shellcheck .github/scripts/patch-image.sh`
- PR checks green: Unit Tests, Go Lint, Static Analysis, CodeQL, Discover Images, and PR Copa Patch smoke jobs
- Review threads: 0 unresolved, pagination complete (`hasNextPage=false`)
