### PR TITLE
fix(ci): retry GHCR login in patch finalize

### DIFF
--- a/.github/scripts/retry-docker-login.sh
+++ b/.github/scripts/retry-docker-login.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Retry registry login to absorb transient GHCR token endpoint timeouts.
+# Required env: DOCKER_REGISTRY, DOCKER_USERNAME, DOCKER_PASSWORD
+
+: "${DOCKER_REGISTRY:?DOCKER_REGISTRY is required}"
+: "${DOCKER_USERNAME:?DOCKER_USERNAME is required}"
+: "${DOCKER_PASSWORD:?DOCKER_PASSWORD is required}"
+
+MAX_ATTEMPTS="${DOCKER_LOGIN_ATTEMPTS:-4}"
+TIMEOUT_SECONDS="${DOCKER_LOGIN_TIMEOUT_SECONDS:-45}"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  echo "Logging into ${DOCKER_REGISTRY} (attempt ${attempt}/${MAX_ATTEMPTS})..."
+  if printf '%s' "$DOCKER_PASSWORD" \
+    | timeout "${TIMEOUT_SECONDS}s" docker login "$DOCKER_REGISTRY" \
+        --username "$DOCKER_USERNAME" \
+        --password-stdin; then
+    echo "✓ Logged into ${DOCKER_REGISTRY}"
+    exit 0
+  fi
+
+  rc=$?
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "::error::Docker login to ${DOCKER_REGISTRY} failed after ${MAX_ATTEMPTS} attempts (exit ${rc})"
+    exit "$rc"
+  fi
+
+  wait_seconds=$(( attempt * 10 + RANDOM % 10 ))
+  echo "Docker login failed (exit ${rc}); retrying in ${wait_seconds}s..."
+  sleep "$wait_seconds"
+done

--- a/.github/scripts/retry-docker-login.sh
+++ b/.github/scripts/retry-docker-login.sh
@@ -13,15 +13,17 @@ TIMEOUT_SECONDS="${DOCKER_LOGIN_TIMEOUT_SECONDS:-45}"
 
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   echo "Logging into ${DOCKER_REGISTRY} (attempt ${attempt}/${MAX_ATTEMPTS})..."
+  rc=0
   if printf '%s' "$DOCKER_PASSWORD" \
     | timeout "${TIMEOUT_SECONDS}s" docker login "$DOCKER_REGISTRY" \
         --username "$DOCKER_USERNAME" \
         --password-stdin; then
     echo "✓ Logged into ${DOCKER_REGISTRY}"
     exit 0
+  else
+    rc=$?
   fi
 
-  rc=$?
   if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
     echo "::error::Docker login to ${DOCKER_REGISTRY} failed after ${MAX_ATTEMPTS} attempts (exit ${rc})"
     exit "$rc"

--- a/.github/scripts/retry-docker-login.sh
+++ b/.github/scripts/retry-docker-login.sh
@@ -11,6 +11,20 @@ set -euo pipefail
 MAX_ATTEMPTS="${DOCKER_LOGIN_ATTEMPTS:-4}"
 TIMEOUT_SECONDS="${DOCKER_LOGIN_TIMEOUT_SECONDS:-45}"
 
+case "$MAX_ATTEMPTS" in
+  ''|*[!0-9]*|0)
+    echo "::error::DOCKER_LOGIN_ATTEMPTS must be a positive integer"
+    exit 2
+    ;;
+esac
+
+case "$TIMEOUT_SECONDS" in
+  ''|*[!0-9]*|0)
+    echo "::error::DOCKER_LOGIN_TIMEOUT_SECONDS must be a positive integer"
+    exit 2
+    ;;
+esac
+
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   echo "Logging into ${DOCKER_REGISTRY} (attempt ${attempt}/${MAX_ATTEMPTS})..."
   rc=0

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -14,6 +14,23 @@ def require(condition: bool, message: str) -> None:
         sys.exit(1)
 
 
+def job_body(text: str, job: str) -> str:
+    lines = text.splitlines()
+    start = next(
+        (idx for idx, line in enumerate(lines) if line == f"  {job}:"),
+        None,
+    )
+    require(start is not None, f"missing {job} job")
+
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        line = lines[idx]
+        if line.startswith("  ") and not line.startswith("    ") and line.endswith(":"):
+            end = idx
+            break
+    return "\n".join(lines[start:end])
+
+
 def main() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     uncommented = "\n".join(
@@ -24,9 +41,18 @@ def main() -> None:
         "docker/login-action" not in uncommented,
         "GHCR login must use retrying docker login, not one-shot docker/login-action",
     )
+    for job in ("scan", "patch", "finalize"):
+        body = job_body(uncommented, job)
+        require("- name: Login to GHCR" in body, f"{job} job must log in to GHCR")
+        require(
+            "bash .github/scripts/retry-docker-login.sh" in body,
+            f"{job} job must use retrying GHCR login helper",
+        )
+
+    finalize = job_body(uncommented, "finalize")
     require(
-        uncommented.count("bash .github/scripts/retry-docker-login.sh") >= 3,
-        "scan, patch, and finalize jobs must retry GHCR login",
+        ".github/scripts/retry-docker-login.sh" in finalize.split("- name: Install mise", 1)[0],
+        "finalize sparse checkout must include retry-docker-login.sh",
     )
     require(
         'LOGIN_OUTCOME: ${{ steps.ghcr-login.outcome }}' in uncommented,

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Guard patch-image workflow behavior that actionlint cannot express."""
+
+from pathlib import Path
+import sys
+
+
+WORKFLOW = Path(".github/workflows/patch-image.yaml")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        print(f"patch-image workflow check failed: {message}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    require(
+        "docker/login-action" not in text,
+        "GHCR login must use retrying docker login, not one-shot docker/login-action",
+    )
+    require(
+        text.count("bash .github/scripts/retry-docker-login.sh") >= 3,
+        "scan, patch, and finalize jobs must retry GHCR login",
+    )
+    require(
+        'LOGIN_OUTCOME: ${{ steps.ghcr-login.outcome }}' in text,
+        "finalize metrics must record failure when manifest/publish steps are skipped",
+    )
+    require(
+        'if [ "$outcome" = "failure" ]; then' in text,
+        "metrics JSON must derive failure from prior finalize step outcomes",
+    )
+    require(
+        '--arg conclusion "${FINALIZE_CONCLUSION}"' in text,
+        "metrics JSON must use resolved finalize conclusion",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -16,25 +16,32 @@ def require(condition: bool, message: str) -> None:
 
 def main() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
+    uncommented = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
 
     require(
-        "docker/login-action" not in text,
+        "docker/login-action" not in uncommented,
         "GHCR login must use retrying docker login, not one-shot docker/login-action",
     )
     require(
-        text.count("bash .github/scripts/retry-docker-login.sh") >= 3,
+        uncommented.count("bash .github/scripts/retry-docker-login.sh") >= 3,
         "scan, patch, and finalize jobs must retry GHCR login",
     )
     require(
-        'LOGIN_OUTCOME: ${{ steps.ghcr-login.outcome }}' in text,
+        'LOGIN_OUTCOME: ${{ steps.ghcr-login.outcome }}' in uncommented,
         "finalize metrics must record failure when manifest/publish steps are skipped",
     )
     require(
-        'if [ "$outcome" = "failure" ]; then' in text,
+        'PREFLIGHT_OUTCOME: ${{ steps.preflight-manifest.outcome }}' in uncommented,
+        "finalize metrics must include late publish/report step outcomes",
+    )
+    require(
+        'if [ "$outcome" = "failure" ]; then' in uncommented,
         "metrics JSON must derive failure from prior finalize step outcomes",
     )
     require(
-        '--arg conclusion "${FINALIZE_CONCLUSION}"' in text,
+        '--arg conclusion "${FINALIZE_CONCLUSION}"' in uncommented,
         "metrics JSON must use resolved finalize conclusion",
     )
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -56,6 +56,9 @@ jobs:
       - name: Run actionlint
         run: actionlint
 
+      - name: Validate patch-image workflow guards
+        run: python3 .github/scripts/validate-patch-image-workflow.py
+
       - name: Run yamllint
         run: yamllint -c .yamllint.yml .
 

--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -110,11 +110,12 @@ jobs:
           cache: true
 
       - name: Login to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        id: ghcr-login
+        env:
+          DOCKER_REGISTRY: ghcr.io
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/retry-docker-login.sh
 
       - name: Parse inputs
         id: parse
@@ -292,11 +293,11 @@ jobs:
 
       - name: Login to GHCR
         if: steps.platform-check.outputs.enabled == 'true'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          DOCKER_REGISTRY: ghcr.io
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/retry-docker-login.sh
 
       - name: Setup BuildKit
         if: steps.platform-check.outputs.enabled == 'true'
@@ -446,6 +447,7 @@ jobs:
             mise.toml
             mise.lock
             .github/scripts/push-reports.sh
+            .github/scripts/retry-docker-login.sh
           sparse-checkout-cone-mode: false
 
       - name: Install mise
@@ -455,11 +457,12 @@ jobs:
           cache: true
 
       - name: Login to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        id: ghcr-login
+        env:
+          DOCKER_REGISTRY: ghcr.io
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/retry-docker-login.sh
 
       - name: Download scan artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -755,10 +758,32 @@ jobs:
           SAFE_NAME: ${{ needs.scan.outputs.safe-name }}
           SOURCE_TAG: ${{ needs.scan.outputs.source-tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOGIN_OUTCOME: ${{ steps.ghcr-login.outcome }}
+          MANIFEST_OUTCOME: ${{ steps.manifest.outcome }}
+          POSTSCAN_OUTCOME: ${{ steps.postscan.outcome }}
+          COMPARE_OUTCOME: ${{ steps.compare.outcome }}
+          PUSH_OUTCOME: ${{ steps.push.outcome }}
+          COSIGN_OUTCOME: ${{ steps.cosign-sign.outcome }}
+          SBOM_OUTCOME: ${{ steps.sbom.outcome }}
+          ATTEST_OUTCOME: ${{ steps.attest.outcome }}
         run: |
           set -euo pipefail
           OUT="metrics-${SAFE_NAME}-${SOURCE_TAG}.json"
           STARTED_AT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq '.run_started_at' 2>/dev/null || true)
+          FINALIZE_CONCLUSION="success"
+          for outcome in \
+            "$LOGIN_OUTCOME" \
+            "$MANIFEST_OUTCOME" \
+            "$POSTSCAN_OUTCOME" \
+            "$COMPARE_OUTCOME" \
+            "$PUSH_OUTCOME" \
+            "$COSIGN_OUTCOME" \
+            "$SBOM_OUTCOME" \
+            "$ATTEST_OUTCOME"; do
+            if [ "$outcome" = "failure" ]; then
+              FINALIZE_CONCLUSION="failure"
+            fi
+          done
 
           SEVERITIES_BEFORE=$(jq -c '
             {CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0, UNKNOWN: 0} +
@@ -780,7 +805,7 @@ jobs:
             --arg run_attempt "${{ github.run_attempt }}" \
             --arg started_at "${STARTED_AT}" \
             --arg ended_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --arg conclusion "${{ needs.patch.result }}" \
+            --arg conclusion "${FINALIZE_CONCLUSION}" \
             --arg image_name "${{ inputs.image-name }}" \
             --arg source_tag "${SOURCE_TAG}" \
             --arg target_ref "${{ steps.push.outputs.final-tag }}" \

--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -437,11 +437,13 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
+        id: finalize-harden
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        id: finalize-checkout
         with:
           sparse-checkout: |
             mise.toml
@@ -451,6 +453,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install mise
+        id: finalize-mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -609,6 +612,7 @@ jobs:
           key: otel-cli-v${{ env.OTEL_CLI_VERSION }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install otel-cli
+        id: install-otel-finalize
         if: ${{ !cancelled() && vars.HONEYCOMB_ENABLED == 'true' && steps.cache-otel-finalize.outputs.cache-hit != 'true' }}
         run: |
           set -euo pipefail
@@ -633,6 +637,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Emit Honeycomb span (per-image finalize)
+        id: emit-otel-finalize
         if: ${{ !cancelled() && vars.HONEYCOMB_ENABLED == 'true' }}
         env:
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
@@ -763,6 +768,9 @@ jobs:
           SAFE_NAME: ${{ needs.scan.outputs.safe-name }}
           SOURCE_TAG: ${{ needs.scan.outputs.source-tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HARDEN_OUTCOME: ${{ steps.finalize-harden.outcome }}
+          CHECKOUT_OUTCOME: ${{ steps.finalize-checkout.outcome }}
+          MISE_OUTCOME: ${{ steps.finalize-mise.outcome }}
           LOGIN_OUTCOME: ${{ steps.ghcr-login.outcome }}
           SCAN_ARTIFACTS_OUTCOME: ${{ steps.scan-artifacts.outcome }}
           MANIFEST_OUTCOME: ${{ steps.manifest.outcome }}
@@ -772,6 +780,9 @@ jobs:
           COSIGN_OUTCOME: ${{ steps.cosign-sign.outcome }}
           SBOM_OUTCOME: ${{ steps.sbom.outcome }}
           ATTEST_OUTCOME: ${{ steps.attest.outcome }}
+          OTEL_CACHE_OUTCOME: ${{ steps.cache-otel-finalize.outcome }}
+          OTEL_INSTALL_OUTCOME: ${{ steps.install-otel-finalize.outcome }}
+          OTEL_EMIT_OUTCOME: ${{ steps.emit-otel-finalize.outcome }}
           PUSH_REPORTS_OUTCOME: ${{ steps.push-reports.outcome }}
           PREFLIGHT_OUTCOME: ${{ steps.preflight-manifest.outcome }}
           UPLOAD_PR_SCAN_OUTCOME: ${{ steps.upload-pr-scan.outcome }}
@@ -783,6 +794,9 @@ jobs:
           STARTED_AT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq '.run_started_at' 2>/dev/null || true)
           FINALIZE_CONCLUSION="success"
           for outcome in \
+            "$HARDEN_OUTCOME" \
+            "$CHECKOUT_OUTCOME" \
+            "$MISE_OUTCOME" \
             "$LOGIN_OUTCOME" \
             "$SCAN_ARTIFACTS_OUTCOME" \
             "$MANIFEST_OUTCOME" \
@@ -792,6 +806,9 @@ jobs:
             "$COSIGN_OUTCOME" \
             "$SBOM_OUTCOME" \
             "$ATTEST_OUTCOME" \
+            "$OTEL_CACHE_OUTCOME" \
+            "$OTEL_INSTALL_OUTCOME" \
+            "$OTEL_EMIT_OUTCOME" \
             "$PUSH_REPORTS_OUTCOME" \
             "$PREFLIGHT_OUTCOME" \
             "$UPLOAD_PR_SCAN_OUTCOME" \

--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -465,6 +465,7 @@ jobs:
         run: bash .github/scripts/retry-docker-login.sh
 
       - name: Download scan artifacts
+        id: scan-artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: scan-${{ needs.scan.outputs.safe-name }}-${{ needs.scan.outputs.source-tag }}${{ inputs.artifact-suffix }}
@@ -648,6 +649,7 @@ jobs:
             --attrs "image=${{ inputs.image-name }},source_tag=${{ needs.scan.outputs.source-tag }},manifest_digest=${{ steps.push.outputs.digest }},final_tag=${{ steps.push.outputs.final-tag }},final_repo=${{ steps.push.outputs.final-repo }},post_scan_vuln_count=${{ steps.postscan.outputs.vuln-count }},rekor_url=${{ steps.cosign-sign.outputs.rekor-url }},attestation_id=${{ steps.attest.outputs.attestation-id }},attestation_bundle_path=${{ steps.attest.outputs.bundle-path }},deployment.environment=verity-prod"
 
       - name: Push reports to reports branch
+        id: push-reports
         if: steps.compare.outputs.changed == 'true' && inputs.is-pr == false
         env:
           IMAGE_NAME: ${{ inputs.image-name }}
@@ -659,6 +661,7 @@ jobs:
             "reports/${IMAGE_NAME}/${SOURCE_TAG}/post.json" post.json
 
       - name: Update preflight manifest
+        id: preflight-manifest
         if: steps.compare.outputs.changed == 'true' && inputs.is-pr == false
         env:
           IMAGE_NAME: ${{ inputs.image-name }}
@@ -716,6 +719,7 @@ jobs:
           fi
 
       - name: Upload PR scan artifacts
+        id: upload-pr-scan
         if: inputs.is-pr == true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -728,6 +732,7 @@ jobs:
       # Companion artifacts follow _pl-${arch}-${safe-name}-${source-tag}.
       - name: Download per-platform metrics
         if: ${{ !cancelled() }}
+        id: pl-download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: _pl-*-${{ needs.scan.outputs.safe-name }}-${{ needs.scan.outputs.source-tag }}
@@ -759,6 +764,7 @@ jobs:
           SOURCE_TAG: ${{ needs.scan.outputs.source-tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LOGIN_OUTCOME: ${{ steps.ghcr-login.outcome }}
+          SCAN_ARTIFACTS_OUTCOME: ${{ steps.scan-artifacts.outcome }}
           MANIFEST_OUTCOME: ${{ steps.manifest.outcome }}
           POSTSCAN_OUTCOME: ${{ steps.postscan.outcome }}
           COMPARE_OUTCOME: ${{ steps.compare.outcome }}
@@ -766,6 +772,11 @@ jobs:
           COSIGN_OUTCOME: ${{ steps.cosign-sign.outcome }}
           SBOM_OUTCOME: ${{ steps.sbom.outcome }}
           ATTEST_OUTCOME: ${{ steps.attest.outcome }}
+          PUSH_REPORTS_OUTCOME: ${{ steps.push-reports.outcome }}
+          PREFLIGHT_OUTCOME: ${{ steps.preflight-manifest.outcome }}
+          UPLOAD_PR_SCAN_OUTCOME: ${{ steps.upload-pr-scan.outcome }}
+          PL_DOWNLOAD_OUTCOME: ${{ steps.pl-download.outcome }}
+          PL_MERGE_OUTCOME: ${{ steps.pl-merged.outcome }}
         run: |
           set -euo pipefail
           OUT="metrics-${SAFE_NAME}-${SOURCE_TAG}.json"
@@ -773,13 +784,19 @@ jobs:
           FINALIZE_CONCLUSION="success"
           for outcome in \
             "$LOGIN_OUTCOME" \
+            "$SCAN_ARTIFACTS_OUTCOME" \
             "$MANIFEST_OUTCOME" \
             "$POSTSCAN_OUTCOME" \
             "$COMPARE_OUTCOME" \
             "$PUSH_OUTCOME" \
             "$COSIGN_OUTCOME" \
             "$SBOM_OUTCOME" \
-            "$ATTEST_OUTCOME"; do
+            "$ATTEST_OUTCOME" \
+            "$PUSH_REPORTS_OUTCOME" \
+            "$PREFLIGHT_OUTCOME" \
+            "$UPLOAD_PR_SCAN_OUTCOME" \
+            "$PL_DOWNLOAD_OUTCOME" \
+            "$PL_MERGE_OUTCOME"; do
             if [ "$outcome" = "failure" ]; then
               FINALIZE_CONCLUSION="failure"
             fi

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ lint-vuln:
 lint-workflows:
 	@which actionlint > /dev/null || (echo "actionlint not found. Run: make install-tools" && exit 1)
 	actionlint
+	python3 .github/scripts/validate-patch-image-workflow.py
 
 # Lint YAML files
 lint-yaml:


### PR DESCRIPTION
## Summary
- replace one-shot docker/login-action GHCR logins with a retrying docker login helper
- include the retry helper in finalize sparse checkout
- record failed finalize step outcomes in metrics JSON instead of reporting success with null manifest fields
- add a workflow guard that enforces retry login and failure-aware metrics

## Root cause
Patch Image run 26023239839 job 76502018855 failed in the Finalize ollama/ollama job before manifest creation. Full logs show docker/login-action timed out while requesting the GHCR token endpoint: net/http request canceled awaiting headers. Later always-run telemetry/metrics steps emitted manifest_digest: null and displayed if-no-files-found: error as an upload-artifact input, but upload itself succeeded; null manifest values were a symptom of skipped publish steps after the login failure.

## Tests
- python3 .github/scripts/validate-patch-image-workflow.py
- MISE_TRUSTED_CONFIG_PATHS=/tmp/opencode/verity-task-ollama-finalize mise exec actionlint -- actionlint .github/workflows/patch-image.yaml .github/workflows/lint.yaml
- MISE_TRUSTED_CONFIG_PATHS=/tmp/opencode/verity-task-ollama-finalize mise exec shellcheck -- shellcheck .github/scripts/retry-docker-login.sh
- go test ./...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GHCR login resilient in the Patch Image workflow and make finalize metrics failure-aware. Switch to a retrying Docker login and derive the finalize conclusion from all step outcomes, including bootstrap and telemetry steps.

- **Bug Fixes**
  - Use `./.github/scripts/retry-docker-login.sh` for `ghcr.io` login in scan, patch, and finalize; included in finalize sparse checkout.
  - Harden retry logic: require env vars, validate positive integers, per-attempt timeouts, jittered backoff, and clear failure exit.
  - Finalize metrics track outcomes for all steps (harden, checkout, mise, login, scan-artifacts, manifest/publish, signing/SBOM/attest, compare, reports, preflight, PR upload, per‑platform, otel cache/install/emit) and compute `conclusion` from these, reflecting failures even when later steps are skipped.

- **New Features**
  - Added `./.github/scripts/retry-docker-login.sh` (configurable via `DOCKER_LOGIN_ATTEMPTS`, `DOCKER_LOGIN_TIMEOUT_SECONDS`).
  - Added `./.github/scripts/validate-patch-image-workflow.py` to enforce retry login (block `docker/login-action`), ensure finalize sparse checkout includes the script, and assert outcome tracking with derived `FINALIZE_CONCLUSION`; wired into `lint.yaml` and `make lint-workflows`.

<sup>Written for commit 95501119384f0c76f0bef20afa243b23a0d4f000. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/429?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

