### PR TITLE
Fix cert-manager CSI driver chart smoke

### DIFF
--- a/internal/chartgen/chartvalues_loading_regression_test.go
+++ b/internal/chartgen/chartvalues_loading_regression_test.go
@@ -47,6 +47,9 @@ func TestVerityConfigChartValuesLoading(t *testing.T) {
 	if got := vc2.ChartValues["fluent-bit"]["livenessProbe.initialDelaySeconds"]; got != 45 {
 		t.Fatalf("fluent-bit livenessProbe.initialDelaySeconds = %#v, want 45", got)
 	}
+	if got := vc2.Overrides["jetstack/cert-manager-csi-driver"].ValuePath; got != "image" {
+		t.Fatalf("cert-manager-csi-driver valuePath = %q, want image", got)
+	}
 	airflow := vc2.ChartValues["airflow"]
 	if airflow["postgresql.image.registry"] != "" {
 		t.Fatalf("airflow postgresql.image.registry=%v, want empty string", airflow["postgresql.image.registry"])

--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -12,7 +12,7 @@
 # issue, an exit criterion, and a peer review. Prefer chartValues tuning,
 # image fixes, or harness retries (subtask 5) before adding here.
 #
-# Slot accounting: 5 of 5 slots used. Loader's MaxSkippedCharts=5
+# Slot accounting: 4 of 5 slots used. Loader's MaxSkippedCharts=5
 # invariant will reject any 6th entry. Adding another skip requires either
 # (a) removing an existing entry whose exit_criteria has been met, or
 # (b) a new SCR raising the cap.
@@ -71,13 +71,6 @@ skips:
     reason: kind-cluster-capability
     tracking_issue: https://github.com/verity-org/verity/issues/372
     exit_criteria: "agent init container hits \"dial tcp 10.96.0.1:443: operation not permitted\" — kind cluster lacks capabilities for cilium's CNI. Revisit when smoke harness gains capability grants OR when cilium chart exposes a CI-friendly probe-disable knob."
-    added: 2026-05-14
-    added_by: SCR-2026-05-14-001
-
-  - chart: cert-manager-csi-driver
-    reason: chart-template-blocked
-    tracking_issue: https://github.com/verity-org/verity/issues/374
-    exit_criteria: "chart hardcodes livenessProbe initialDelaySeconds with no values knob; smoke harness \"helm install --wait\" hits the probe before driver registers with cert-manager (which the harness also doesn't pre-install). Revisit when chart exposes app.livenessProbe knobs OR when harness pre-installs cert-manager CRDs."
     added: 2026-05-14
     added_by: SCR-2026-05-14-001
 

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	helmInstallTimeout = 10 * time.Minute
-	chartRegistry      = "oci://ghcr.io/verity-org/charts"
+	helmInstallTimeout            = 10 * time.Minute
+	certManagerHelmInstallTimeout = 15 * time.Minute
+	chartRegistry                 = "oci://ghcr.io/verity-org/charts"
 )
 
 type ChartContext struct {
@@ -83,6 +84,7 @@ func UninstallChart(ctx context.Context, h *Harness, cc *ChartContext) {
 }
 
 func helmInstall(ctx context.Context, h *Harness, cc *ChartContext) error {
+	timeout := chartHelmInstallTimeout(cc.Spec.Name)
 	args := []string{
 		"--kubeconfig", h.KubeconfigPath,
 		"install", cc.Spec.Name,
@@ -91,15 +93,22 @@ func helmInstall(ctx context.Context, h *Harness, cc *ChartContext) error {
 		"--namespace", cc.Namespace,
 		"--create-namespace",
 		"--wait",
-		"--timeout", helmInstallTimeout.String(),
+		"--timeout", timeout.String(),
 	}
 	if vals := valuesFile(cc); vals != "" {
 		args = append(args, "--values", vals)
 		h.t.Logf("[install] applying values fixture %s", vals)
 	}
-	ictx, cancel := context.WithTimeout(ctx, helmInstallTimeout+2*time.Minute)
+	ictx, cancel := context.WithTimeout(ctx, timeout+2*time.Minute)
 	defer cancel()
 	return runCmd(ictx, h.t, "", []string{"HELM_EXPERIMENTAL_OCI=1"}, "helm", args...)
+}
+
+func chartHelmInstallTimeout(chartName string) time.Duration {
+	if chartName == "cert-manager" {
+		return certManagerHelmInstallTimeout
+	}
+	return helmInstallTimeout
 }
 
 func HelmTest(ctx context.Context, h *Harness, cc *ChartContext) error {

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -41,6 +41,29 @@ func InstallChart(ctx context.Context, h *Harness, spec config.ChartSpec, values
 	return cc, nil
 }
 
+func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.ChartSpec, valuesDir string) ([]*ChartContext, error) {
+	if spec.Name != "cert-manager-csi-driver" {
+		return nil, nil
+	}
+
+	charts, err := loadChartList(h.RepoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("load chart list for prerequisites: %w", err)
+	}
+	for _, candidate := range charts {
+		if candidate.Name != "cert-manager" {
+			continue
+		}
+		h.t.Logf("[prereq] installing cert-manager before cert-manager-csi-driver")
+		cc, installErr := InstallChartWithRetry(ctx, h, candidate, valuesDir, defaultRetryConfig())
+		if installErr != nil {
+			return nil, fmt.Errorf("install cert-manager prerequisite: %w", installErr)
+		}
+		return []*ChartContext{cc}, nil
+	}
+	return nil, fmt.Errorf("cert-manager prerequisite not found in Chart.yaml")
+}
+
 func UninstallChart(ctx context.Context, h *Harness, cc *ChartContext) {
 	if cc == nil {
 		return

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -64,7 +64,7 @@ func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.Char
 	for _, name := range prereqNames {
 		candidate, ok := byName[name]
 		if !ok {
-			return installed, fmt.Errorf("%s prerequisite not found in Chart.yaml", name)
+			return installed, fmt.Errorf("prerequisite %q for %q not found in Chart.yaml", name, spec.Name)
 		}
 		h.t.Logf("[prereq] installing %s before %s", name, spec.Name)
 		cc, installErr := InstallChartWithRetry(ctx, h, candidate, valuesDir, defaultRetryConfig())

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -21,6 +21,10 @@ const (
 	chartRegistry                 = "oci://ghcr.io/verity-org/charts"
 )
 
+var chartPrerequisites = map[string][]string{
+	"cert-manager-csi-driver": {"cert-manager"},
+}
+
 type ChartContext struct {
 	Spec      config.ChartSpec
 	Namespace string
@@ -43,7 +47,8 @@ func InstallChart(ctx context.Context, h *Harness, spec config.ChartSpec, values
 }
 
 func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.ChartSpec, valuesDir string) ([]*ChartContext, error) {
-	if spec.Name != "cert-manager-csi-driver" {
+	prereqNames := chartPrerequisites[spec.Name]
+	if len(prereqNames) == 0 {
 		return nil, nil
 	}
 
@@ -51,18 +56,24 @@ func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.Char
 	if err != nil {
 		return nil, fmt.Errorf("load chart list for prerequisites: %w", err)
 	}
+	byName := make(map[string]config.ChartSpec, len(charts))
 	for _, candidate := range charts {
-		if candidate.Name != "cert-manager" {
-			continue
-		}
-		h.t.Logf("[prereq] installing cert-manager before cert-manager-csi-driver")
-		cc, installErr := InstallChartWithRetry(ctx, h, candidate, valuesDir, defaultRetryConfig())
-		if installErr != nil {
-			return nil, fmt.Errorf("install cert-manager prerequisite: %w", installErr)
-		}
-		return []*ChartContext{cc}, nil
+		byName[candidate.Name] = candidate
 	}
-	return nil, fmt.Errorf("cert-manager prerequisite not found in Chart.yaml")
+	installed := make([]*ChartContext, 0, len(prereqNames))
+	for _, name := range prereqNames {
+		candidate, ok := byName[name]
+		if !ok {
+			return installed, fmt.Errorf("%s prerequisite not found in Chart.yaml", name)
+		}
+		h.t.Logf("[prereq] installing %s before %s", name, spec.Name)
+		cc, installErr := InstallChartWithRetry(ctx, h, candidate, valuesDir, defaultRetryConfig())
+		installed = append(installed, cc)
+		if installErr != nil {
+			return installed, fmt.Errorf("install %s prerequisite: %w", name, installErr)
+		}
+	}
+	return installed, nil
 }
 
 func UninstallChart(ctx context.Context, h *Harness, cc *ChartContext) {

--- a/test/chart-integration/harness.go
+++ b/test/chart-integration/harness.go
@@ -93,9 +93,16 @@ func (h *Harness) createCluster(ctx context.Context) error {
 }
 
 func (h *Harness) cleanupStaleKindNode(ctx context.Context) {
-	_ = exec.CommandContext(ctx, "kind", "delete", "cluster", "--name", clusterName).Run()
 	name := clusterName + "-control-plane"
 	out, err := exec.CommandContext(ctx, "docker", "rm", "-f", name).CombinedOutput()
+	trimmed := strings.TrimSpace(string(out))
+	if err != nil {
+		if strings.Contains(trimmed, "No such container") {
+			return
+		}
+		h.t.Logf("[harness] stale kind node cleanup %s failed: %v: %s", name, err, trimmed)
+		return
+	}
 	if err == nil && len(out) > 0 {
 		h.t.Logf("[harness] removed stale kind node %s", name)
 	}

--- a/test/chart-integration/harness.go
+++ b/test/chart-integration/harness.go
@@ -76,6 +76,7 @@ func (h *Harness) createCluster(ctx context.Context) error {
 			}
 		}
 	}
+	h.cleanupStaleKindNode(ctx)
 	cfg := filepath.Join(h.RepoRoot, "test", "chart-integration", "kind.yaml")
 	if err := runCmd(ctx, h.t, "", nil,
 		"kind", "create", "cluster",
@@ -83,10 +84,19 @@ func (h *Harness) createCluster(ctx context.Context) error {
 		"--config", cfg,
 		"--wait", "120s",
 	); err != nil {
+		h.cleanupStaleKindNode(ctx)
 		return err
 	}
 	h.clusterCreated = true
 	return nil
+}
+
+func (h *Harness) cleanupStaleKindNode(ctx context.Context) {
+	name := clusterName + "-control-plane"
+	out, err := exec.CommandContext(ctx, "docker", "rm", "-f", name).CombinedOutput()
+	if err == nil && len(out) > 0 {
+		h.t.Logf("[harness] removed stale kind node %s", name)
+	}
 }
 
 func (h *Harness) exportKubeconfig(ctx context.Context) error {

--- a/test/chart-integration/harness.go
+++ b/test/chart-integration/harness.go
@@ -67,13 +67,14 @@ func (h *Harness) Teardown(ctx context.Context) {
 
 func (h *Harness) createCluster(ctx context.Context) error {
 	out, listErr := exec.CommandContext(ctx, "kind", "get", "clusters").CombinedOutput()
-	if listErr == nil {
-		for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
-			if strings.TrimSpace(line) == clusterName {
-				h.t.Logf("[harness] reusing pre-existing cluster %s (will not delete on teardown)", clusterName)
-				h.clusterCreated = false
-				return nil
-			}
+	if listErr != nil {
+		return fmt.Errorf("kind get clusters: %s: %w", strings.TrimSpace(string(out)), listErr)
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if strings.TrimSpace(line) == clusterName {
+			h.t.Logf("[harness] reusing pre-existing cluster %s (will not delete on teardown)", clusterName)
+			h.clusterCreated = false
+			return nil
 		}
 	}
 	h.cleanupStaleKindNode(ctx)
@@ -92,6 +93,7 @@ func (h *Harness) createCluster(ctx context.Context) error {
 }
 
 func (h *Harness) cleanupStaleKindNode(ctx context.Context) {
+	_ = exec.CommandContext(ctx, "kind", "delete", "cluster", "--name", clusterName).Run()
 	name := clusterName + "-control-plane"
 	out, err := exec.CommandContext(ctx, "docker", "rm", "-f", name).CombinedOutput()
 	if err == nil && len(out) > 0 {

--- a/test/chart-integration/main_test.go
+++ b/test/chart-integration/main_test.go
@@ -120,6 +120,18 @@ func runChart(t *testing.T, spec config.ChartSpec) {
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
 	defer cancel()
 
+	prereqs, prereqErr := InstallChartPrerequisites(ctx, testHarness, spec, valuesDir)
+	defer func() {
+		for i := len(prereqs) - 1; i >= 0; i-- {
+			uctx, ucancel := context.WithTimeout(context.Background(), 3*time.Minute)
+			UninstallChart(uctx, testHarness, prereqs[i])
+			ucancel()
+		}
+	}()
+	if prereqErr != nil {
+		t.Fatalf("prerequisites: %v", prereqErr)
+	}
+
 	cc, installErr := InstallChartWithRetry(ctx, testHarness, spec, valuesDir, defaultRetryConfig())
 	defer func() {
 		if t.Failed() {

--- a/test/chart-integration/skips_test.go
+++ b/test/chart-integration/skips_test.go
@@ -344,4 +344,7 @@ func TestProductionSKIPSYAMLIsValid(t *testing.T) {
 	if len(cfg.Skips) > MaxSkippedCharts {
 		t.Fatalf("production SKIPS.yaml has %d entries, cap is %d", len(cfg.Skips), MaxSkippedCharts)
 	}
+	if skipped, entry := cfg.IsSkipped("cert-manager-csi-driver"); skipped {
+		t.Fatalf("cert-manager-csi-driver must run in chart-integration; unexpected skip entry: %#v", entry)
+	}
 }

--- a/test/chart-integration/values/cert-manager-csi-driver.allowlist.txt
+++ b/test/chart-integration/values/cert-manager-csi-driver.allowlist.txt
@@ -1,2 +1,2 @@
-quay.io/jetstack/csi-node-driver-registrar
-quay.io/jetstack/livenessprobe
+quay.io/jetstack/csi-node-driver-registrar:
+quay.io/jetstack/livenessprobe:

--- a/test/chart-integration/values/cert-manager-csi-driver.allowlist.txt
+++ b/test/chart-integration/values/cert-manager-csi-driver.allowlist.txt
@@ -1,0 +1,2 @@
+quay.io/jetstack/csi-node-driver-registrar
+quay.io/jetstack/livenessprobe

--- a/test/chart-integration/values/cert-manager-csi-driver.yaml
+++ b/test/chart-integration/values/cert-manager-csi-driver.yaml
@@ -1,4 +1,8 @@
 cert-manager-csi-driver:
+  # The upstream chart gives image.repository precedence over
+  # imageRegistry + imageNamespace + image.name. Keep the fixture on the
+  # main driver image only so the two upstream sidecars stay on quay.io and
+  # are covered by cert-manager-csi-driver.allowlist.txt.
   image:
     repository: ghcr.io/verity-org/cert-manager-csi-driver
     tag: "0.14"

--- a/test/chart-integration/values/cert-manager-csi-driver.yaml
+++ b/test/chart-integration/values/cert-manager-csi-driver.yaml
@@ -1,0 +1,4 @@
+cert-manager-csi-driver:
+  image:
+    repository: ghcr.io/verity-org/cert-manager-csi-driver
+    tag: "0.14"

--- a/test/chart-integration/values/cert-manager.yaml
+++ b/test/chart-integration/values/cert-manager.yaml
@@ -1,2 +1,5 @@
-startupapicheck:
-  enabled: false
+cert-manager:
+  crds:
+    enabled: true
+  startupapicheck:
+    enabled: false

--- a/test/chart-integration/values/cert-manager.yaml
+++ b/test/chart-integration/values/cert-manager.yaml
@@ -1,8 +1,3 @@
-crds:
-  enabled: true
-startupapicheck:
-  enabled: false
-
 cert-manager:
   crds:
     enabled: true

--- a/test/chart-integration/values/cert-manager.yaml
+++ b/test/chart-integration/values/cert-manager.yaml
@@ -1,3 +1,8 @@
+crds:
+  enabled: true
+startupapicheck:
+  enabled: false
+
 cert-manager:
   crds:
     enabled: true

--- a/verity.yaml
+++ b/verity.yaml
@@ -11,6 +11,13 @@ overrides:
     from: "distroless-libc"
     to: "debian"
     valuePath: "image"  # explicit hint for chart-gen value path resolution
+  # cert-manager-csi-driver chart computes image refs from imageRegistry +
+  # imageNamespace + image.name while leaving image.repository empty, so
+  # chart-gen cannot auto-detect the values path from repository/tag pairs.
+  # Pin the main driver override path explicitly; sidecar images remain
+  # upstream and are allowlisted in chart-integration.
+  "jetstack/cert-manager-csi-driver":
+    valuePath: "image"
 
 # Per-chart values injected both during helm template image discovery and into
 # generated wrapper-chart values.yaml defaults.
@@ -1235,7 +1242,7 @@ replacements:
     tag: "2"
   # cert-manager-csi-driver v0.14.0 (app v0.14.0) → exact tag match.
   # csi-node-driver-registrar and livenessprobe are different binaries under
-  # quay.io/jetstack and have no rebuilds; they fall through to crane.
+  # quay.io/jetstack and have no rebuilds; they stay upstream in smoke tests.
   "jetstack/cert-manager-csi-driver":
     registry: "ghcr.io/verity-org"
     image: "cert-manager-csi-driver"


### PR DESCRIPTION
## Summary
- preinstall cert-manager with CRDs for cert-manager-csi-driver smoke runs
- add CSI driver smoke values/allowlist and remove the SKIPS.yaml entry
- pin chart-gen valuePath for the CSI driver image and harden stale kind node cleanup

## Validation
- `go test ./...`
- `VERITY_CHART=cert-manager-csi-driver go test -tags=integration -run TestCharts/cert-manager-csi-driver -count=1 -v -timeout=50m ./test/chart-integration/...`

Resolves [#374](https://github.com/verity-org/verity/issues/374).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cert-manager-csi-driver` smoke by preinstalling `cert-manager` with CRDs and a longer Helm timeout, and by pinning the driver image override path so installs succeed and tests run. Removes the skip, adds sidecar allowlist and values fixtures, and hardens the harness with prerequisite install/uninstall, retries, and stale kind node cleanup; resolves #374.

- **Bug Fixes**
  - Preinstall `cert-manager` before `cert-manager-csi-driver`; enable CRDs and set a 15m Helm install timeout for `cert-manager`.
  - Add CSI driver values and a sidecar image allowlist; add a test that fails if the chart is skipped.
  - Pin `valuePath: image` for `jetstack/cert-manager-csi-driver` in `verity.yaml` and add a regression test.
  - Add prerequisite lifecycle to the harness (install with retries, then uninstall) and remove stale kind control-plane nodes to reduce flakes.

<sup>Written for commit 0209dde83cd410586b08255072dc50d742aef52f. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/434?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

