### PR TITLE
fix(chart-integration): add NFS smoke fixture

### DIFF
--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -60,13 +60,6 @@ skips:
     added: 2026-05-16
     added_by: SCR-2026-05-14-001 (re-added after #378 + #380 follow-up)
 
-  - chart: nfs-subdir-external-provisioner
-    reason: needs-external-infra
-    tracking_issue: https://github.com/verity-org/verity/issues/373
-    exit_criteria: "harness gains a sidecar NFS server, OR chart bumps to use a CI-friendly NFS mock"
-    added: 2026-05-14
-    added_by: SCR-2026-05-14-001
-
   - chart: cilium
     reason: kind-cluster-capability
     tracking_issue: https://github.com/verity-org/verity/issues/372

--- a/test/chart-integration/harness.go
+++ b/test/chart-integration/harness.go
@@ -14,10 +14,13 @@ import (
 
 const clusterName = "verity-it"
 
+const nfsSubdirChartName = "nfs-subdir-external-provisioner"
+
 type Harness struct {
 	KubeconfigPath string
 	RepoRoot       string
 	clusterCreated bool
+	nfsInstalled   bool
 	t              testLogger
 }
 
@@ -39,6 +42,12 @@ func (h *Harness) Setup(ctx context.Context) error {
 		{"create kind cluster", h.createCluster},
 		{"export kubeconfig", h.exportKubeconfig},
 	}
+	if needsNFSServer(os.Getenv("VERITY_CHART")) {
+		steps = append(steps, struct {
+			name string
+			fn   func(context.Context) error
+		}{"ensure in-cluster NFS server", h.ensureNFSServer})
+	}
 	for _, s := range steps {
 		h.t.Logf("[harness] %s", s.name)
 		if err := s.fn(ctx); err != nil {
@@ -48,8 +57,47 @@ func (h *Harness) Setup(ctx context.Context) error {
 	return nil
 }
 
+func needsNFSServer(chartFilter string) bool {
+	filter := strings.TrimSpace(chartFilter)
+	return filter == "" || filter == nfsSubdirChartName
+}
+
+func (h *Harness) ensureNFSServer(ctx context.Context) error {
+	if err := h.configureKindNFSClient(ctx); err != nil {
+		return err
+	}
+	manifest := filepath.Join(h.RepoRoot, "test", "chart-integration", "nfs-server.yaml")
+	if err := runCmd(ctx, h.t, "", nil,
+		"kubectl", "--kubeconfig", h.KubeconfigPath,
+		"apply", "-f", manifest,
+	); err != nil {
+		return err
+	}
+	if err := runCmd(ctx, h.t, "", nil,
+		"kubectl", "--kubeconfig", h.KubeconfigPath,
+		"-n", "verity-it-infra",
+		"rollout", "status", "deployment/nfs-server", "--timeout=120s",
+	); err != nil {
+		return err
+	}
+	h.nfsInstalled = true
+	return nil
+}
+
+func (h *Harness) configureKindNFSClient(ctx context.Context) error {
+	// nfs-ganesha in the smoke fixture reliably serves NFSv4.0/4.1 in kind,
+	// while mount.nfs defaults to trying v4.2 first on the current kind node
+	// image. Kubelet's in-tree NFS volume plugin does not expose per-volume
+	// mountOptions, so set the node-wide default before the chart pod mounts.
+	return runCmd(ctx, h.t, "", nil,
+		"docker", "exec", clusterName+"-control-plane", "sh", "-c",
+		"mkdir -p /etc/nfsmount.conf.d && printf '[ NFSMount_Global_Options ]\\nDefaultvers=4.1\\n' > /etc/nfsmount.conf.d/verity-nfs.conf",
+	)
+}
+
 func (h *Harness) Teardown(ctx context.Context) {
 	h.t.Helper()
+	h.deleteNFSServer(ctx)
 	if h.clusterCreated {
 		h.t.Logf("[harness] deleting kind cluster %s", clusterName)
 		if err := runCmd(ctx, h.t, "", nil, "kind", "delete", "cluster", "--name", clusterName); err != nil {
@@ -62,6 +110,19 @@ func (h *Harness) Teardown(ctx context.Context) {
 		if err := os.Remove(h.KubeconfigPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			h.t.Logf("[harness] kubeconfig cleanup failed: %v", err)
 		}
+	}
+}
+
+func (h *Harness) deleteNFSServer(ctx context.Context) {
+	if !h.nfsInstalled || h.KubeconfigPath == "" {
+		return
+	}
+	manifest := filepath.Join(h.RepoRoot, "test", "chart-integration", "nfs-server.yaml")
+	if err := runCmd(ctx, h.t, "", nil,
+		"kubectl", "--kubeconfig", h.KubeconfigPath,
+		"delete", "-f", manifest, "--ignore-not-found=true", "--wait=true", "--timeout=120s",
+	); err != nil {
+		h.t.Logf("[harness] NFS server cleanup failed (continuing): %v", err)
 	}
 }
 

--- a/test/chart-integration/nfs-server.yaml
+++ b/test/chart-integration/nfs-server.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: verity-it-infra
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nfs-server
+  namespace: verity-it-infra
+spec:
+  clusterIP: 10.96.0.250
+  selector:
+    app.kubernetes.io/name: nfs-server
+  ports:
+    - name: nfs
+      port: 2049
+      targetPort: nfs
+      protocol: TCP
+    - name: mountd
+      port: 20048
+      targetPort: mountd
+      protocol: TCP
+    - name: rpcbind-tcp
+      port: 111
+      targetPort: rpcbind
+      protocol: TCP
+    - name: rpcbind-udp
+      port: 111
+      targetPort: rpcbind
+      protocol: UDP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-server
+  namespace: verity-it-infra
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nfs-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nfs-server
+    spec:
+      containers:
+        - name: nfs-server
+          image: kubevirtci/nfs-ganesha:latest@sha256:8c1fa882dddb2885c4152e9ce632c466f4b8dce29339455e9b6bfe71f0a3d3ef
+          env:
+            - name: EXPORT_PATH
+              value: /exports
+            - name: PSEUDO_PATH
+              value: /
+          ports:
+            - name: nfs
+              containerPort: 2049
+              protocol: TCP
+            - name: mountd
+              containerPort: 20048
+              protocol: TCP
+            - name: rpcbind
+              containerPort: 111
+              protocol: TCP
+            - name: rpcbind-udp
+              containerPort: 111
+              protocol: UDP
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: export
+              mountPath: /exports
+      volumes:
+        - name: export
+          emptyDir: {}

--- a/test/chart-integration/nfs_server_test.go
+++ b/test/chart-integration/nfs_server_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+package integration
+
+import "testing"
+
+func TestNeedsNFSServer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		filter string
+		want   bool
+	}{
+		{name: "full suite", filter: "", want: true},
+		{name: "nfs shard", filter: nfsSubdirChartName, want: true},
+		{name: "trimmed nfs shard", filter: "  " + nfsSubdirChartName + "  ", want: true},
+		{name: "unrelated shard", filter: "falco", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := needsNFSServer(tc.filter); got != tc.want {
+				t.Fatalf("needsNFSServer(%q)=%v want %v", tc.filter, got, tc.want)
+			}
+		})
+	}
+}

--- a/test/chart-integration/values/nfs-subdir-external-provisioner.yaml
+++ b/test/chart-integration/values/nfs-subdir-external-provisioner.yaml
@@ -1,0 +1,11 @@
+# nfs-subdir-external-provisioner chart-integration smoke-test overrides.
+#
+# The harness creates this Service via test/chart-integration/nfs-server.yaml.
+# The chart's provisioner Deployment mounts the NFS export during startup, so
+# kind smoke needs a real endpoint rather than the verity.yaml render-time
+# placeholder used by image discovery. Use the Service's fixed ClusterIP instead
+# of DNS because kubelet performs the NFS mount from the kind node namespace.
+nfs-subdir-external-provisioner:
+  nfs:
+    server: 10.96.0.250
+    path: /


### PR DESCRIPTION
## Summary
- add an in-cluster nfs-ganesha fixture for chart-integration kind runs
- configure kind node NFS client default to NFSv4.1 so kubelet mounts succeed
- add nfs-subdir-external-provisioner chart values and remove its SKIPS.yaml entry

## Validation
- VERITY_IT_SKIP_CLUSTER=1 go test -tags integration ./test/chart-integration
- go test ./...
- Manual kind check: nfs-subdir-external-provisioner pod reached Ready after NFS fixture + node nfsmount config

Closes [#373](https://github.com/verity-org/verity/issues/373)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-cluster NFS smoke fixture and forces the kind node NFS client default to NFSv4.1 so the `nfs-subdir-external-provisioner` chart runs in CI. Removes the skip, wires chart values to the fixture, and cleans it up after tests (closes #373).

- **New Features**
  - Adds NFS server Deployment and Service (`nfs-server`; fixed ClusterIP 10.96.0.250) in `verity-it-infra` using `kubevirtci/nfs-ganesha`.
  - Auto-installs the fixture for the full suite or when `VERITY_CHART` is `nfs-subdir-external-provisioner`, waits for rollout, and tears it down; includes a unit test for the filter.
  - Forces NFS client default on the kind control-plane to v4.1 to ensure kubelet mounts succeed.
  - Sets chart values to the fixture (`server: 10.96.0.250`, `path: /`) and removes the chart from `SKIPS.yaml`.

<sup>Written for commit c607f6d044463b199b9c0bf5de2cd947346e7274. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/435?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

