### PR TITLE
fix(images): use GNU cp for argocd copyutil

### DIFF
--- a/images/argocd.yaml
+++ b/images/argocd.yaml
@@ -6,12 +6,13 @@ upstream:
 types:
   default:
     base: wolfi-base
-    # busybox supplies `/bin/sh`, `/bin/cp`, and `/bin/ln` for the upstream
-    # argo-cd chart's repo-server and dex `copyutil` initContainers. The main
-    # argocd workload containers exec the argv[0]-aware symlinks below, but
-    # those initContainers hardcode shell/coreutils paths before the main
-    # containers can start.
-    packages: ["argo-cd-{{version}}", "busybox"]
+    # busybox supplies `/bin/sh` and coreutils supplies GNU-compatible `/bin/cp`
+    # and `/bin/ln` for the upstream argo-cd chart's repo-server and dex
+    # `copyutil` initContainers. The main argocd workload containers exec the
+    # argv[0]-aware symlinks below, but those initContainers hardcode
+    # shell/coreutils paths before the main containers can start. BusyBox cp is
+    # insufficient because repo-server uses `cp --update=none`.
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils"]
     # Intentionally NO `entrypoint:` — argo-cd's binary (cmd/main.go) dispatches
     # by `filepath.Base(os.Args[0])` to one of common.Command{CLI,Server,
     # ApplicationController,ApplicationSetController,RepoServer,CMPServer,
@@ -53,9 +54,9 @@ types:
 
   fips:
     base: wolfi-base
-    # busybox supplies the chart copyutil initContainer shell/coreutils; see
-    # default type note above.
-    packages: ["argo-cd-{{version}}", "busybox"]
+    # busybox + coreutils supply the chart copyutil initContainer shell/tools;
+    # see default type note above.
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils"]
     # No `entrypoint:` — see default-type note above for the argv[0] dispatch
     # mechanism. Identical to default type, only the GODEBUG=fips140=on env
     # differs. See SCR-2026-05-14-001 Bucket A.


### PR DESCRIPTION
## Summary
- add coreutils to the argocd image so repo-server copyutil has GNU-compatible cp
- keep busybox for /bin/sh while using coreutils for cp/ln
- fixes the main argo-cd chart-integration failure after [#437](https://github.com/verity-org/verity/pull/437)

## Validation
- go test ./...
- make integer-validate

Follow-up for [#436](https://github.com/verity-org/verity/issues/436).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `coreutils` to the Argo CD image so repo-server/dex copyutil uses GNU `cp`/`ln`, keeping `busybox` for `/bin/sh`. Fixes the chart integration failure where BusyBox `cp` lacks `--update=none`.

<sup>Written for commit 840ea71659f3db02eeeefacd62799d740bb915d9. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

