### PR TITLE
fix(images): add GNU cp to argocd

### DIFF
--- a/images/argocd.yaml
+++ b/images/argocd.yaml
@@ -6,12 +6,12 @@ upstream:
 types:
   default:
     base: wolfi-base
-    # busybox supplies `/bin/sh`, `/bin/cp`, and `/bin/ln` for the upstream
-    # argo-cd chart's repo-server and dex `copyutil` initContainers. The main
-    # argocd workload containers exec the argv[0]-aware symlinks below, but
-    # those initContainers hardcode shell/coreutils paths before the main
-    # containers can start.
-    packages: ["argo-cd-{{version}}", "busybox"]
+    # busybox supplies `/bin/sh`; coreutils supplies GNU `/bin/cp` with
+    # `--update=none` plus `/bin/ln` for the upstream argo-cd chart's
+    # repo-server and dex `copyutil` initContainers. The main argocd workload
+    # containers exec the argv[0]-aware symlinks below, but those initContainers
+    # hardcode shell/coreutils paths before the main containers can start.
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils"]
     # Intentionally NO `entrypoint:` — argo-cd's binary (cmd/main.go) dispatches
     # by `filepath.Base(os.Args[0])` to one of common.Command{CLI,Server,
     # ApplicationController,ApplicationSetController,RepoServer,CMPServer,
@@ -53,9 +53,9 @@ types:
 
   fips:
     base: wolfi-base
-    # busybox supplies the chart copyutil initContainer shell/coreutils; see
-    # default type note above.
-    packages: ["argo-cd-{{version}}", "busybox"]
+    # busybox + coreutils supply the chart copyutil initContainer shell/GNU
+    # coreutils; see default type note above.
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils"]
     # No `entrypoint:` — see default-type note above for the argv[0] dispatch
     # mechanism. Identical to default type, only the GODEBUG=fips140=on env
     # differs. See SCR-2026-05-14-001 Bucket A.


### PR DESCRIPTION
## Summary
- add coreutils to the argocd image so repo-server copyutil supports the chart default `/bin/cp --update=none`
- keep busybox for `/bin/sh` and retain the argv[0] symlink dispatch setup

## Validation
- go test ./...
- make integer-validate
- main argo-cd chart-integration dispatch [#26071627227](https://github.com/verity-org/verity/actions/runs/26071627227) confirmed the remaining failure was BusyBox cp rejecting `--update=none`

Follow-up for [#437](https://github.com/verity-org/verity/pull/437); completes [#436](https://github.com/verity-org/verity/issues/436).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `coreutils` to the Argo CD image so `copyutil` can use GNU `/bin/cp` with `--update=none`, fixing chart integration failures. Keep `busybox` for `/bin/sh` and the argv[0] dispatch; applies to both default and FIPS images.

- **Bug Fixes**
  - Add `coreutils` alongside `busybox` in `images/argocd.yaml` for default and FIPS types to provide GNU `/bin/cp` with `--update=none`.
  - Unblocks upstream chart `copyutil` initContainers that hardcode `/bin/cp --update=none`; BusyBox `cp` was rejecting this flag.

<sup>Written for commit f66215161297628405857acbe4b6b05993dce1ca. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/439?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

