### PR TITLE
fix(images): include gpg in argocd image

### DIFF
--- a/images/argocd.yaml
+++ b/images/argocd.yaml
@@ -11,7 +11,8 @@ types:
     # repo-server and dex `copyutil` initContainers. The main argocd workload
     # containers exec the argv[0]-aware symlinks below, but those initContainers
     # hardcode shell/coreutils paths before the main containers can start.
-    packages: ["argo-cd-{{version}}", "busybox", "coreutils"]
+    # repo-server also generates a transient keyring at startup via `gpg`.
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gnupg"]
     # Intentionally NO `entrypoint:` — argo-cd's binary (cmd/main.go) dispatches
     # by `filepath.Base(os.Args[0])` to one of common.Command{CLI,Server,
     # ApplicationController,ApplicationSetController,RepoServer,CMPServer,
@@ -55,7 +56,7 @@ types:
     base: wolfi-base
     # busybox + coreutils supply the chart copyutil initContainer shell/GNU
     # coreutils; see default type note above.
-    packages: ["argo-cd-{{version}}", "busybox", "coreutils"]
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gnupg"]
     # No `entrypoint:` — see default-type note above for the argv[0] dispatch
     # mechanism. Identical to default type, only the GODEBUG=fips140=on env
     # differs. See SCR-2026-05-14-001 Bucket A.


### PR DESCRIPTION
## Summary
- add gnupg to the argocd image because repo-server runs gpg while initializing /app/config/gpg/keys
- keep the shell/coreutils packages required by chart copyutil initContainers
- fixes the post-[#439](https://github.com/verity-org/verity/pull/439) main argo-cd chart-integration CrashLoopBackOff

## Validation
- go test ./...
- ./verity integer validate images/argocd.yaml

Follow-up for [#436](https://github.com/verity-org/verity/issues/436).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `gnupg` in the Argo CD image (default and FIPS) so repo-server can run `gpg` to initialize its keyring at startup. Keeps `busybox` and `coreutils` for chart copyutil initContainers and fixes the CrashLoopBackOff after the Argo CD chart integration (#439); follow-up to #436.

<sup>Written for commit c7c3b382e48cf9b7b78e5e10f5aab89b6d6aff44. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/440?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

