### PR TITLE
fix(images): add gpg helpers to argocd

### DIFF
--- a/images/argocd.yaml
+++ b/images/argocd.yaml
@@ -8,11 +8,12 @@ types:
     base: wolfi-base
     # busybox supplies `/bin/sh`; coreutils supplies GNU `/bin/cp` with
     # `--update=none` plus `/bin/ln` for the upstream argo-cd chart's
-    # repo-server and dex `copyutil` initContainers. The main argocd workload
-    # containers exec the argv[0]-aware symlinks below, but those initContainers
-    # hardcode shell/coreutils paths before the main containers can start.
-    # repo-server also generates a transient keyring at startup via `gpg`.
-    packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gnupg"]
+    # repo-server and dex `copyutil` initContainers. gpg + gpg-agent supply the
+    # key-generation helpers repo-server runs on startup to initialize
+    # /app/config/gpg/keys. The main argocd workload containers exec the
+    # argv[0]-aware symlinks below, but the chart and repo-server startup path
+    # hardcode these helper binaries before all components can become Ready.
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gpg", "gpg-agent"]
     # Intentionally NO `entrypoint:` — argo-cd's binary (cmd/main.go) dispatches
     # by `filepath.Base(os.Args[0])` to one of common.Command{CLI,Server,
     # ApplicationController,ApplicationSetController,RepoServer,CMPServer,
@@ -54,9 +55,9 @@ types:
 
   fips:
     base: wolfi-base
-    # busybox + coreutils supply the chart copyutil initContainer shell/GNU
-    # coreutils; see default type note above.
-    packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gnupg"]
+    # busybox + coreutils + gpg/gpg-agent supply chart/repo-server helpers;
+    # see default type note above.
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gpg", "gpg-agent"]
     # No `entrypoint:` — see default-type note above for the argv[0] dispatch
     # mechanism. Identical to default type, only the GODEBUG=fips140=on env
     # differs. See SCR-2026-05-14-001 Bucket A.


### PR DESCRIPTION
## Summary
- install `gpg` and `gpg-agent` in argocd so repo-server can initialize `/app/config/gpg/keys`
- retain busybox/coreutils helpers needed by argo-cd chart copyutil initContainers

## Validation
- go test ./...
- make integer-validate
- main argo-cd chart-integration dispatch [#26073379065](https://github.com/verity-org/verity/actions/runs/26073379065) confirmed copyutil now succeeds; repo-server then failed on missing usable `gpg` helpers

Follow-up for [#440](https://github.com/verity-org/verity/pull/440); completes [#436](https://github.com/verity-org/verity/issues/436).