### PR TITLE
fix(images): provide argocd gpg wrapper

### DIFF
--- a/images/argocd.yaml
+++ b/images/argocd.yaml
@@ -10,9 +10,11 @@ types:
     # `--update=none` plus `/bin/ln` for the upstream argo-cd chart's
     # repo-server and dex `copyutil` initContainers. gpg + gpg-agent supply the
     # key-generation helpers repo-server runs on startup to initialize
-    # /app/config/gpg/keys. The main argocd workload containers exec the
-    # argv[0]-aware symlinks below, but the chart and repo-server startup path
-    # hardcode these helper binaries before all components can become Ready.
+    # /app/config/gpg/keys. The upstream image ships gpg-wrapper.sh; the Verity
+    # image maps it to gpg below because repo-server invokes it by name. The
+    # main argocd workload containers exec the argv[0]-aware symlinks below,
+    # but the chart and repo-server startup path hardcode these helper binaries
+    # before all components can become Ready.
     packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gpg", "gpg-agent"]
     # Intentionally NO `entrypoint:` — argo-cd's binary (cmd/main.go) dispatches
     # by `filepath.Base(os.Args[0])` to one of common.Command{CLI,Server,
@@ -39,6 +41,7 @@ types:
       # the published image. Keep the binary executable and let render
       # propagate 0o755 to each shim.
       - {path: /usr/bin/argocd, type: permissions, permissions: 0o755}
+      - {path: /usr/bin/gpg, type: permissions, permissions: 0o755}
       # argo-cd helm chart hardcodes /usr/local/bin/argocd-<subcommand> in
       # container `args:` at template level. These shim symlinks paired with
       # the omitted entrypoint above complete the argv[0]-aware Cobra dispatch
@@ -52,6 +55,7 @@ types:
       - {path: /usr/local/bin/argocd-cmp-server, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
       - {path: /usr/local/bin/argocd-commit-server, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
       - {path: /usr/local/bin/argocd-k8s-auth, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
+      - {path: /usr/local/bin/gpg-wrapper.sh, type: symlink, source: /usr/bin/gpg, uid: 0, gid: 0}
 
   fips:
     base: wolfi-base
@@ -68,6 +72,7 @@ types:
       - {path: /app/config, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       # Keep /usr/bin/argocd executable; see default type note above.
       - {path: /usr/bin/argocd, type: permissions, permissions: 0o755}
+      - {path: /usr/bin/gpg, type: permissions, permissions: 0o755}
       # Same /usr/local/bin shim symlinks as default — see note above.
       - {path: /usr/local/bin/argocd, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
       - {path: /usr/local/bin/argocd-server, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
@@ -78,6 +83,7 @@ types:
       - {path: /usr/local/bin/argocd-cmp-server, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
       - {path: /usr/local/bin/argocd-commit-server, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
       - {path: /usr/local/bin/argocd-k8s-auth, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
+      - {path: /usr/local/bin/gpg-wrapper.sh, type: symlink, source: /usr/bin/gpg, uid: 0, gid: 0}
     melange:
       upstream: "argocd"
       env-file: "fips.env"


### PR DESCRIPTION
## Summary
- add /usr/local/bin/gpg-wrapper.sh as a symlink to /usr/bin/gpg for argocd repo-server startup
- keep gpg executable when apko mutates the wrapper symlink
- fixes the post-[#441](https://github.com/verity-org/verity/pull/441) main argo-cd chart-integration CrashLoopBackOff

## Validation
- go test ./...
- ./verity integer validate images/argocd.yaml

Follow-up for [#436](https://github.com/verity-org/verity/issues/436).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provide `gpg-wrapper.sh` for Argo CD by symlinking it to `/usr/bin/gpg` and keep `gpg` executable to fix repo-server startup crashes. This resolves the CrashLoopBackOff by letting repo-server initialize GPG keys on startup.

- **Bug Fixes**
  - Add `/usr/local/bin/gpg-wrapper.sh` -> `/usr/bin/gpg` symlink in both default and `fips` images.
  - Ensure `/usr/bin/gpg` remains executable so the wrapper works even if `apko` rewrites the symlink.
  - Repo-server can now run GPG helpers at startup and reach Ready.

<sup>Written for commit 0b42d1093c76364d3e86368aeae0652ed2b2b910. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/442?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

