### PR TITLE
fix(images): add argocd gpg wrapper

### DIFF
--- a/images/argocd.yaml
+++ b/images/argocd.yaml
@@ -10,10 +10,12 @@ types:
     # `--update=none` plus `/bin/ln` for the upstream argo-cd chart's
     # repo-server and dex `copyutil` initContainers. gpg + gpg-agent supply the
     # key-generation helpers repo-server runs on startup to initialize
-    # /app/config/gpg/keys. The main argocd workload containers exec the
-    # argv[0]-aware symlinks below, but the chart and repo-server startup path
-    # hardcode these helper binaries before all components can become Ready.
-    packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gpg", "gpg-agent"]
+    # /app/config/gpg/keys. verity-argocd-gpg-wrapper supplies upstream's
+    # /usr/local/bin/gpg-wrapper.sh compatibility script. The main argocd
+    # workload containers exec the argv[0]-aware symlinks below, but the chart
+    # and repo-server startup path hardcode these helper binaries before all
+    # components can become Ready.
+    packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gpg", "gpg-agent", "verity-argocd-gpg-wrapper"]
     # Intentionally NO `entrypoint:` — argo-cd's binary (cmd/main.go) dispatches
     # by `filepath.Base(os.Args[0])` to one of common.Command{CLI,Server,
     # ApplicationController,ApplicationSetController,RepoServer,CMPServer,
@@ -52,11 +54,14 @@ types:
       - {path: /usr/local/bin/argocd-cmp-server, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
       - {path: /usr/local/bin/argocd-commit-server, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
       - {path: /usr/local/bin/argocd-k8s-auth, type: symlink, source: /usr/bin/argocd, uid: 0, gid: 0}
+    melange:
+      bespoke: "verity-argocd-gpg-wrapper.yaml"
 
   fips:
     base: wolfi-base
-    # busybox + coreutils + gpg/gpg-agent supply chart/repo-server helpers;
-    # see default type note above.
+    # busybox + coreutils + gpg/gpg-agent supply repo-server helpers; see
+    # default type note above. FIPS is skipped for the declared 3.3 version;
+    # if re-enabled, add a FIPS-compatible gpg-wrapper package path too.
     packages: ["argo-cd-{{version}}", "busybox", "coreutils", "gpg", "gpg-agent"]
     # No `entrypoint:` — see default-type note above for the argv[0] dispatch
     # mechanism. Identical to default type, only the GODEBUG=fips140=on env

--- a/packages/bespoke/verity-argocd-gpg-wrapper.yaml
+++ b/packages/bespoke/verity-argocd-gpg-wrapper.yaml
@@ -1,0 +1,62 @@
+package:
+  name: verity-argocd-gpg-wrapper
+  version: "3.3.10"
+  epoch: 0
+  description: Argo CD gpg-wrapper.sh compatibility script
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/local/bin"
+      cat > "${{targets.destdir}}/usr/local/bin/gpg-wrapper.sh" <<'EOF'
+      #!/bin/sh
+      # Simple wrapper around gpg to prevent exit code 1 from aborting Argo CD
+      # repo-server secret-key checks. This mirrors upstream argocd's helper.
+      OUTPUT=$(gpg "$@" 2>&1)
+      RET=$?
+      IFS=''
+      case "$RET" in
+      0)
+        echo "$OUTPUT"
+        ;;
+      1)
+        echo "$OUTPUT"
+        RET=0
+        ;;
+      *)
+        echo "$OUTPUT" >&2
+        ;;
+      esac
+      exit $RET
+      EOF
+      chmod 0755 "${{targets.destdir}}/usr/local/bin/gpg-wrapper.sh"
+
+test:
+  pipeline:
+    - runs: |
+        test -x /usr/local/bin/gpg-wrapper.sh
+        tmp="$(mktemp -d)"
+        cat > "$tmp/gpg" <<'EOF'
+        #!/bin/sh
+        echo "fake gpg rc=${GPG_TEST_RC}"
+        exit "${GPG_TEST_RC}"
+        EOF
+        chmod 0755 "$tmp/gpg"
+
+        PATH="$tmp:$PATH" GPG_TEST_RC=0 /usr/local/bin/gpg-wrapper.sh >/tmp/gpg-wrapper-0.out
+        grep -F 'fake gpg rc=0' /tmp/gpg-wrapper-0.out
+
+        PATH="$tmp:$PATH" GPG_TEST_RC=1 /usr/local/bin/gpg-wrapper.sh >/tmp/gpg-wrapper-1.out
+        grep -F 'fake gpg rc=1' /tmp/gpg-wrapper-1.out
+
+        if PATH="$tmp:$PATH" GPG_TEST_RC=2 /usr/local/bin/gpg-wrapper.sh >/tmp/gpg-wrapper-2.out 2>/tmp/gpg-wrapper-2.err; then
+          echo "gpg-wrapper.sh must preserve gpg rc=2 failures" >&2
+          exit 1
+        fi
+        grep -F 'fake gpg rc=2' /tmp/gpg-wrapper-2.err


### PR DESCRIPTION
## Summary
- add `verity-argocd-gpg-wrapper` bespoke package with upstream-compatible `/usr/local/bin/gpg-wrapper.sh`
- include wrapper package in argocd image alongside gpg/gpg-agent and chart helper binaries

## Validation
- go test ./...
- make integer-validate
- generated argocd 3.3 apko config includes `verity-argocd-gpg-wrapper`
- main argo-cd chart-integration dispatch [#26076899613](https://github.com/verity-org/verity/actions/runs/26076899613) confirmed copyutil and gpg now succeed; repo-server then failed on missing `gpg-wrapper.sh`

Follow-up for [#441](https://github.com/verity-org/verity/pull/441); completes [#436](https://github.com/verity-org/verity/issues/436).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `verity-argocd-gpg-wrapper` to ship an upstream-compatible `/usr/local/bin/gpg-wrapper.sh` in the Argo CD default image, fixing repo-server startup failures during GPG key checks. FIPS image remains unchanged for 3.3.

- **Bug Fixes**
  - New bespoke `verity-argocd-gpg-wrapper` with `gpg-wrapper.sh` that mirrors upstream and treats rc=1 as success.
  - Included the wrapper in default image packages and wired via `melange.bespoke`.
  - Unblocks chart `copyutil` and repo-server GPG helpers by providing the expected script.

<sup>Written for commit f2da7be7802cfec73217fd271e41abb997c4bab2. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/443?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

