### PR TITLE
fix(images): align airflow entrypoint with chart

### DIFF
--- a/images/airflow.yaml
+++ b/images/airflow.yaml
@@ -7,6 +7,12 @@ types:
   default:
     base: wolfi-base
     packages: ["airflow-{{version}}", "bash"]
+    # Intentionally NO `entrypoint:` — the upstream Airflow chart leaves
+    # `command:` unset and supplies executable argv via `args:` such as
+    # ["bash", "-c", "exec airflow scheduler"] and
+    # ["airflow", "db", "check-migrations", ...]. If this image sets an
+    # entrypoint to /usr/bin/airflow, Kubernetes appends those args and the
+    # chart runs invalid commands like `airflow airflow db check-migrations`.
     environment:
       AIRFLOW_HOME: /opt/airflow
       # The Wolfi airflow package installs console scripts under

--- a/images/airflow.yaml
+++ b/images/airflow.yaml
@@ -6,8 +6,7 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["airflow-{{version}}"]
-    entrypoint: /usr/bin/airflow
+    packages: ["airflow-{{version}}", "bash"]
     environment:
       AIRFLOW_HOME: /opt/airflow
       # The Wolfi airflow package installs console scripts under
@@ -15,8 +14,8 @@ types:
       # `bash -c` in Jobs/Deployments, so PATH must include that directory.
       PATH: /opt/airflow/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     paths:
-      # Keep the image entrypoint and absolute-path callers working while the
-      # chart uses PATH-based `airflow` invocations.
+      # Keep absolute-path callers working while the chart uses PATH-based
+      # `airflow` invocations.
       - {path: /usr/bin/airflow, type: symlink, source: /opt/airflow/bin/airflow, uid: 0, gid: 0, permissions: 0o755}
       - {path: /opt/airflow, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /opt/airflow/dags, type: directory, uid: 65532, gid: 65532, permissions: 0o755}

--- a/internal/integer/config/airflow_image_test.go
+++ b/internal/integer/config/airflow_image_test.go
@@ -23,6 +23,12 @@ func TestAirflowImageExposesConsoleScriptsOnPath(t *testing.T) {
 	}
 
 	tmpl := def.Types["default"]
+	if tmpl.Entrypoint != "" {
+		t.Fatalf("entrypoint=%q, want empty so Helm chart args become the process command", tmpl.Entrypoint)
+	}
+	if !slices.Contains(tmpl.Packages, "bash") {
+		t.Fatalf("packages=%v must include bash for upstream Helm chart bash -c commands", tmpl.Packages)
+	}
 	path := tmpl.Environment["PATH"]
 	if !pathHasEntry(path, "/opt/airflow/bin") {
 		t.Fatalf("PATH=%q must include /opt/airflow/bin for chart bash -c airflow commands", path)


### PR DESCRIPTION
## Summary
- remove the Airflow image entrypoint so upstream chart args become the container command
- add bash because the Airflow chart runs jobs and deployments with bash -c
- extend airflow image config coverage for chart compatibility
- document the intentional no-entrypoint contract to prevent regression

## Diagnostics
- Investigated failed chart-integration run [26085262911](https://github.com/verity-org/verity/actions/runs/26085262911), job [76696701619](https://github.com/verity-org/verity/actions/runs/26085262911/job/76696701619)
- diagnostics-airflow showed wait-for-airflow-migrations CrashLoopBackOff with Airflow CLI error: invalid choice 'airflow', confirming the image entrypoint was prepending another airflow command

## Tests
- python3/PyYAML parse of images/airflow.yaml and .github/workflows/chart-integration.yaml
- go test ./internal/integer/...
- go test -tags=integration -run TestAirflowPostgresqlImageOverrideIsComposable ./test/chart-integration