### PR TITLE
fix(chart-integration): wait for gitea valkey

### DIFF
--- a/test/chart-integration/gitea_values_test.go
+++ b/test/chart-integration/gitea_values_test.go
@@ -1,0 +1,67 @@
+//go:build integration
+
+package integration
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestGiteaNcShimReportsConnectionFailure(t *testing.T) {
+	script := loadGiteaHelperScript(t, "nc")
+	path := filepath.Join(t.TempDir(), "nc")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write nc shim: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().(*net.TCPAddr)
+	if err := exec.Command(path, "-vz", "-w1", "127.0.0.1", strconv.Itoa(addr.Port)).Run(); err != nil {
+		listener.Close()
+		t.Fatalf("nc shim against listening port failed: %v", err)
+	}
+	listener.Close()
+
+	if err := exec.Command(path, "-vz", "-w1", "127.0.0.1", strconv.Itoa(addr.Port)).Run(); err == nil {
+		t.Fatalf("nc shim succeeded against closed port; configure-gitea would skip its valkey wait loop")
+	}
+}
+
+func loadGiteaHelperScript(t *testing.T, name string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locating test file")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "values", "gitea.yaml"))
+	if err != nil {
+		t.Fatalf("read gitea values: %v", err)
+	}
+	var values struct {
+		Gitea struct {
+			ExtraDeploy []struct {
+				Data map[string]string `yaml:"data"`
+			} `yaml:"extraDeploy"`
+		} `yaml:"gitea"`
+	}
+	if err := yaml.Unmarshal(body, &values); err != nil {
+		t.Fatalf("parse gitea values: %v", err)
+	}
+	for _, deploy := range values.Gitea.ExtraDeploy {
+		if script := deploy.Data[name]; script != "" {
+			return script
+		}
+	}
+	t.Fatalf("gitea helper %q not found", name)
+	return ""
+}

--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -161,7 +161,7 @@ gitea:
 
           host="${args[0]}"
           port="${args[1]}"
-          timeout "${timeout_seconds}" bash -c 'exec 3<>"/dev/tcp/${1}/${2}"; exec 3>&-; exec 3<&-' _ "${host}" "${port}"
+          timeout "${timeout_seconds}" bash -c 'exec 3<>"/dev/tcp/${1}/${2}" && exec 3>&- && exec 3<&-' _ "${host}" "${port}"
   extraVolumes:
     - name: env-to-ini
       configMap:


### PR DESCRIPTION
## Summary
- Fix gitea smoke-test nc shim so failed /dev/tcp opens return non-zero and the chart's valkey wait loop actually retries.
- Add regression coverage that the shim succeeds for an open port and fails for a closed port.

## Diagnostics
- Failing run: [26085262911](https://github.com/verity-org/verity/actions/runs/26085262911), job 76696701603.
- Diagnostics showed gitea restarted once because startup hit valkey before it was accepting connections; configure-gitea logged connection refused but continued.

## Validation
- VERITY_IT_SKIP_CLUSTER=1 go test -tags=integration ./test/chart-integration -run 'TestGiteaNcShimReportsConnectionFailure|TestAirflowPostgresqlImageOverrideIsComposable'
- VERITY_CHART=gitea make chart-integration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `gitea` chart startup wait by making the nc shim correctly fail on closed ports so the Valkey wait loop retries instead of skipping. Adds an integration test to prevent regressions.

- **Bug Fixes**
  - Update `test/chart-integration/values/gitea.yaml` to use `&&` in the `/dev/tcp` open/close sequence so failures return non-zero and the wait loop actually retries.
  - Add `TestGiteaNcShimReportsConnectionFailure` to verify the shim succeeds on an open port and fails on a closed port.

<sup>Written for commit 7466df93e33e743e960b14b8f5e7aadab7bf742c. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/446?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

