### PR TITLE
test(chart-integration): add autoscaler CAPI fixture

### DIFF
--- a/.github/workflows/chart-integration.yaml
+++ b/.github/workflows/chart-integration.yaml
@@ -112,11 +112,18 @@ jobs:
           restore-keys: chart-it-${{ runner.os }}-
 
       - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if printf '%s' "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "GHCR login failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Harness compile and unit-test gate
         env:

--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -12,7 +12,7 @@
 # issue, an exit criterion, and a peer review. Prefer chartValues tuning,
 # image fixes, or harness retries (subtask 5) before adding here.
 #
-# Slot accounting: 3 of 5 slots used. Loader's MaxSkippedCharts=5
+# Slot accounting: 2 of 5 slots used. Loader's MaxSkippedCharts=5
 # invariant will reject any 6th entry. Adding another skip requires either
 # (a) removing an existing entry whose exit_criteria has been met, or
 # (b) a new SCR raising the cap.

--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -12,7 +12,7 @@
 # issue, an exit criterion, and a peer review. Prefer chartValues tuning,
 # image fixes, or harness retries (subtask 5) before adding here.
 #
-# Slot accounting: 4 of 5 slots used. Loader's MaxSkippedCharts=5
+# Slot accounting: 3 of 5 slots used. Loader's MaxSkippedCharts=5
 # invariant will reject any 6th entry. Adding another skip requires either
 # (a) removing an existing entry whose exit_criteria has been met, or
 # (b) a new SCR raising the cap.
@@ -66,25 +66,3 @@ skips:
     exit_criteria: "agent init container hits \"dial tcp 10.96.0.1:443: operation not permitted\" — kind cluster lacks capabilities for cilium's CNI. Revisit when smoke harness gains capability grants OR when cilium chart exposes a CI-friendly probe-disable knob."
     added: 2026-05-14
     added_by: SCR-2026-05-14-001
-
-  - chart: cluster-autoscaler
-    reason: needs-cloud-credentials
-    tracking_issue: https://github.com/verity-org/verity/issues/384
-    exit_criteria: |
-      cluster-autoscaler's binary requires a real AWS region + creds
-      to call DescribeAutoScalingGroups. Without them it crashes with
-      `Failed to regenerate ASG cache: ... an AWS region is required`
-      and trips the no-restart-during-settle gate. Smoke testing in
-      single-node kind cannot provide real cloud creds.
-
-      Un-skipping requires one of:
-      (a) chart exposes a no-op cloud-provider mode that doesn't need
-          real cloud creds (`cloudProvider: externalgrpc` with a
-          stub backend, or similar).
-      (b) smoke harness provisions an in-cluster Cluster-API mock the
-          chart can target with `cloudProvider: clusterapi`.
-      (c) chart-integration smoke gate is relaxed to accept the
-          no-restart-during-settle failure mode for cloud-provider-
-          requiring charts.
-    added: 2026-05-16
-    added_by: SCR-2026-05-14-001 (added after #383 confirmed chronic)

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -25,9 +25,14 @@ var chartPrerequisites = map[string][]string{
 	"cert-manager-csi-driver": {"cert-manager"},
 }
 
-var chartFixtures = map[string][]string{
+var chartCRDFixtures = map[string][]string{
 	"cluster-autoscaler": {
 		filepath.Join("test", "chart-integration", "fixtures", "cluster-autoscaler", "capi-crds.yaml"),
+	},
+}
+
+var chartObjectFixtures = map[string][]string{
+	"cluster-autoscaler": {
 		filepath.Join("test", "chart-integration", "fixtures", "cluster-autoscaler", "capi-objects.yaml"),
 	},
 }
@@ -93,11 +98,12 @@ func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.Char
 }
 
 func InstallChartFixtures(ctx context.Context, h *Harness, chartName string) error {
-	fixtures := chartFixtures[chartName]
-	if len(fixtures) == 0 {
+	crdFixtures := chartCRDFixtures[chartName]
+	objectFixtures := chartObjectFixtures[chartName]
+	if len(crdFixtures) == 0 && len(objectFixtures) == 0 {
 		return nil
 	}
-	for i, fixture := range fixtures {
+	for _, fixture := range crdFixtures {
 		path := filepath.Join(h.RepoRoot, fixture)
 		h.t.Logf("[fixture] applying %s for %s", path, chartName)
 		if err := runCmd(ctx, h.t, "", nil,
@@ -106,22 +112,55 @@ func InstallChartFixtures(ctx context.Context, h *Harness, chartName string) err
 		); err != nil {
 			return fmt.Errorf("apply fixture %s: %w", fixture, err)
 		}
-		if i == 0 {
-			for _, crd := range chartFixtureCRDs[chartName] {
-				if err := runCmd(ctx, h.t, "", nil,
-					"kubectl", "--kubeconfig", h.KubeconfigPath,
-					"wait", "--for=condition=Established", "crd/"+crd, "--timeout=60s",
-				); err != nil {
-					return fmt.Errorf("wait for fixture CRD %s: %w", crd, err)
-				}
-			}
+	}
+	for _, crd := range chartFixtureCRDs[chartName] {
+		if err := runCmd(ctx, h.t, "", nil,
+			"kubectl", "--kubeconfig", h.KubeconfigPath,
+			"wait", "--for=condition=Established", "crd/"+crd, "--timeout=60s",
+		); err != nil {
+			return fmt.Errorf("wait for fixture CRD %s: %w", crd, err)
+		}
+	}
+	for _, fixture := range objectFixtures {
+		path := filepath.Join(h.RepoRoot, fixture)
+		h.t.Logf("[fixture] applying %s for %s", path, chartName)
+		if err := runCmd(ctx, h.t, "", nil,
+			"kubectl", "--kubeconfig", h.KubeconfigPath,
+			"apply", "--validate=false", "-f", path,
+		); err != nil {
+			return fmt.Errorf("apply fixture %s: %w", fixture, err)
+		}
+	}
+	if err := seedChartFixtureStatus(ctx, h, chartName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func seedChartFixtureStatus(ctx context.Context, h *Harness, chartName string) error {
+	switch chartName {
+	case "cluster-autoscaler":
+		// Normal kubectl apply cannot write status when the CRD exposes a status
+		// subresource. Seed the scale paths that cluster-autoscaler reads from
+		// the MachineDeployment /scale endpoint; no CAPI controller runs in this
+		// bounded smoke fixture to populate them for us.
+		if err := runCmd(ctx, h.t, "", nil,
+			"kubectl", "--kubeconfig", h.KubeconfigPath,
+			"-n", "cluster-autoscaler",
+			"patch", "machinedeployment.cluster.x-k8s.io/verity-it-smoke-md",
+			"--subresource=status",
+			"--type=merge",
+			"-p", `{"status":{"replicas":0,"selector":"cluster.x-k8s.io/cluster-name=verity-it,cluster.x-k8s.io/deployment-name=verity-it-smoke-md"}}`,
+		); err != nil {
+			return fmt.Errorf("seed cluster-autoscaler fixture status: %w", err)
 		}
 	}
 	return nil
 }
 
 func UninstallChartFixtures(ctx context.Context, h *Harness, chartName string) {
-	fixtures := chartFixtures[chartName]
+	fixtures := append([]string{}, chartCRDFixtures[chartName]...)
+	fixtures = append(fixtures, chartObjectFixtures[chartName]...)
 	for i := len(fixtures) - 1; i >= 0; i-- {
 		path := filepath.Join(h.RepoRoot, fixtures[i])
 		if err := runCmd(ctx, h.t, "", nil,

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -25,6 +25,22 @@ var chartPrerequisites = map[string][]string{
 	"cert-manager-csi-driver": {"cert-manager"},
 }
 
+var chartFixtures = map[string][]string{
+	"cluster-autoscaler": {
+		filepath.Join("test", "chart-integration", "fixtures", "cluster-autoscaler", "capi-crds.yaml"),
+		filepath.Join("test", "chart-integration", "fixtures", "cluster-autoscaler", "capi-objects.yaml"),
+	},
+}
+
+var chartFixtureCRDs = map[string][]string{
+	"cluster-autoscaler": {
+		"clusters.cluster.x-k8s.io",
+		"machinedeployments.cluster.x-k8s.io",
+		"machinesets.cluster.x-k8s.io",
+		"machines.cluster.x-k8s.io",
+	},
+}
+
 type ChartContext struct {
 	Spec      config.ChartSpec
 	Namespace string
@@ -74,6 +90,47 @@ func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.Char
 		}
 	}
 	return installed, nil
+}
+
+func InstallChartFixtures(ctx context.Context, h *Harness, chartName string) error {
+	fixtures := chartFixtures[chartName]
+	if len(fixtures) == 0 {
+		return nil
+	}
+	for i, fixture := range fixtures {
+		path := filepath.Join(h.RepoRoot, fixture)
+		h.t.Logf("[fixture] applying %s for %s", path, chartName)
+		if err := runCmd(ctx, h.t, "", nil,
+			"kubectl", "--kubeconfig", h.KubeconfigPath,
+			"apply", "--validate=false", "-f", path,
+		); err != nil {
+			return fmt.Errorf("apply fixture %s: %w", fixture, err)
+		}
+		if i == 0 {
+			for _, crd := range chartFixtureCRDs[chartName] {
+				if err := runCmd(ctx, h.t, "", nil,
+					"kubectl", "--kubeconfig", h.KubeconfigPath,
+					"wait", "--for=condition=Established", "crd/"+crd, "--timeout=60s",
+				); err != nil {
+					return fmt.Errorf("wait for fixture CRD %s: %w", crd, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func UninstallChartFixtures(ctx context.Context, h *Harness, chartName string) {
+	fixtures := chartFixtures[chartName]
+	for i := len(fixtures) - 1; i >= 0; i-- {
+		path := filepath.Join(h.RepoRoot, fixtures[i])
+		if err := runCmd(ctx, h.t, "", nil,
+			"kubectl", "--kubeconfig", h.KubeconfigPath,
+			"delete", "-f", path, "--ignore-not-found=true", "--wait=true", "--timeout=120s",
+		); err != nil {
+			h.t.Logf("[fixture] cleanup %s failed (continuing): %v", path, err)
+		}
+	}
 }
 
 func UninstallChart(ctx context.Context, h *Harness, cc *ChartContext) {

--- a/test/chart-integration/fixtures/cluster-autoscaler/capi-crds.yaml
+++ b/test/chart-integration/fixtures/cluster-autoscaler/capi-crds.yaml
@@ -1,0 +1,99 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusters.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    singular: machinedeployment
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+          labelSelectorPath: .status.selector
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: machinesets.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    kind: MachineSet
+    listKind: MachineSetList
+    plural: machinesets
+    singular: machineset
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+          labelSelectorPath: .status.selector
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: machines.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    kind: Machine
+    listKind: MachineList
+    plural: machines
+    singular: machine
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/test/chart-integration/fixtures/cluster-autoscaler/capi-objects.yaml
+++ b/test/chart-integration/fixtures/cluster-autoscaler/capi-objects.yaml
@@ -47,6 +47,3 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
         name: verity-it-smoke-machine
-status:
-  replicas: 0
-  selector: cluster.x-k8s.io/cluster-name=verity-it,cluster.x-k8s.io/deployment-name=verity-it-smoke-md

--- a/test/chart-integration/fixtures/cluster-autoscaler/capi-objects.yaml
+++ b/test/chart-integration/fixtures/cluster-autoscaler/capi-objects.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-autoscaler
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: verity-it
+  namespace: cluster-autoscaler
+spec:
+  controlPlaneEndpoint:
+    host: 127.0.0.1
+    port: 6443
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: verity-it-smoke-md
+  namespace: cluster-autoscaler
+  labels:
+    cluster.x-k8s.io/cluster-name: verity-it
+    smoke: "true"
+  annotations:
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "1"
+spec:
+  clusterName: verity-it
+  replicas: 0
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: verity-it
+      cluster.x-k8s.io/deployment-name: verity-it-smoke-md
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: verity-it
+        cluster.x-k8s.io/deployment-name: verity-it-smoke-md
+    spec:
+      clusterName: verity-it
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: verity-it-smoke-bootstrap
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: verity-it-smoke-machine
+status:
+  replicas: 0
+  selector: cluster.x-k8s.io/cluster-name=verity-it,cluster.x-k8s.io/deployment-name=verity-it-smoke-md

--- a/test/chart-integration/main_test.go
+++ b/test/chart-integration/main_test.go
@@ -131,14 +131,14 @@ func runChart(t *testing.T, spec config.ChartSpec) {
 	if prereqErr != nil {
 		t.Fatalf("prerequisites: %v", prereqErr)
 	}
-	if err := InstallChartFixtures(ctx, testHarness, spec.Name); err != nil {
-		t.Fatalf("fixtures: %v", err)
-	}
 	defer func() {
 		fctx, fcancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		UninstallChartFixtures(fctx, testHarness, spec.Name)
 		fcancel()
 	}()
+	if err := InstallChartFixtures(ctx, testHarness, spec.Name); err != nil {
+		t.Fatalf("fixtures: %v", err)
+	}
 
 	cc, installErr := InstallChartWithRetry(ctx, testHarness, spec, valuesDir, defaultRetryConfig())
 	defer func() {

--- a/test/chart-integration/main_test.go
+++ b/test/chart-integration/main_test.go
@@ -131,6 +131,14 @@ func runChart(t *testing.T, spec config.ChartSpec) {
 	if prereqErr != nil {
 		t.Fatalf("prerequisites: %v", prereqErr)
 	}
+	if err := InstallChartFixtures(ctx, testHarness, spec.Name); err != nil {
+		t.Fatalf("fixtures: %v", err)
+	}
+	defer func() {
+		fctx, fcancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		UninstallChartFixtures(fctx, testHarness, spec.Name)
+		fcancel()
+	}()
 
 	cc, installErr := InstallChartWithRetry(ctx, testHarness, spec, valuesDir, defaultRetryConfig())
 	defer func() {

--- a/test/chart-integration/values/cluster-autoscaler.yaml
+++ b/test/chart-integration/values/cluster-autoscaler.yaml
@@ -1,0 +1,7 @@
+cluster-autoscaler:
+  cloudProvider: clusterapi
+  autoDiscovery:
+    clusterName: verity-it
+    namespace: cluster-autoscaler
+    labels:
+      - smoke: "true"


### PR DESCRIPTION
## Summary
- add a bounded Cluster API smoke fixture for `cluster-autoscaler`
- run the wrapper with `cloudProvider: clusterapi` and a fake scalable MachineDeployment
- remove `cluster-autoscaler` from `test/chart-integration/SKIPS.yaml`

Closes [#444](https://github.com/verity-org/verity/issues/444).
Unblocks [#384](https://github.com/verity-org/verity/issues/384).

## Verification
- `go test ./...`
- `VERITY_CHART=cluster-autoscaler make chart-integration`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable smoke testing for `cluster-autoscaler` using a bounded Cluster API fixture. The harness applies CRDs/objects, seeds CAPI scale/status, and cleans up; runs with `cloudProvider: clusterapi` against a fake `MachineDeployment`. Closes #444; unblocks #384.

- **New Features**
  - Harness applies CRD/object fixtures, waits for CRDs to be Established, seeds CAPI scale/status via the status subresource, and cleans up in reverse order.
  - Added minimal CAPI CRDs and a fake `MachineDeployment`; set chart values to `cloudProvider: clusterapi` with autodiscovery (clusterName, namespace, labels) and an allowlist; removed the `cluster-autoscaler` skip (slots now 2/5).

- **Bug Fixes**
  - Retry GHCR login in chart-integration workflow to reduce flakiness.

<sup>Written for commit 2ef4f9b274df73eaf017268984f4af0cda710b2c. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/447?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

