### PR TITLE
Fix opensearch-dashboards chart smoke

### DIFF
--- a/cmd/opensearch_dashboards_config_test.go
+++ b/cmd/opensearch_dashboards_config_test.go
@@ -29,9 +29,15 @@ func TestOpenSearchDashboardsImageUsesConfigScrubbingEntrypoint(t *testing.T) {
 	text := string(bespoke)
 	assert.Contains(t, text, "name: verity-opensearch-dashboards-config")
 	assert.Contains(t, text, "sed '/^opensearch_security\\./d'")
+	assert.Contains(t, text, "OPENSEARCH_HOSTS")
+	assert.Contains(t, text, "opensearch.hosts")
+	assert.Contains(t, text, "SERVER_HOST")
+	assert.Contains(t, text, "opensearch.username")
 	assert.Contains(t, text, "exec /usr/share/opensearch-dashboards/bin/opensearch-dashboards")
 	assert.False(t, strings.Contains(text, "opensearch_security.multitenancy.enabled: true"))
 
-	_, err = os.Stat(filepath.Join(repo, "test", "chart-integration", "values", "opensearch-dashboards.yaml"))
-	assert.True(t, os.IsNotExist(err), "smoke override should stay removed once image entrypoint fixes default config")
+	values, err := os.ReadFile(filepath.Join(repo, "test", "chart-integration", "values", "opensearch-dashboards.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(values), "opensearch.hosts")
+	assert.Contains(t, string(values), "opensearch.ssl.verificationMode: none")
 }

--- a/packages/bespoke/verity-opensearch-dashboards-config.yaml
+++ b/packages/bespoke/verity-opensearch-dashboards-config.yaml
@@ -25,6 +25,7 @@ pipeline:
       }
 
       if [ -f "$config" ]; then
+        config_writable=1
         tmp="$(mktemp "${config}.verity.XXXXXX")"
         sed '/^opensearch_security\./d' "$config" > "$tmp"
         chmod 0644 "$tmp"
@@ -32,29 +33,31 @@ pipeline:
           # ConfigMap subPath mounts cannot be atomically replaced. Fall back to
           # in-place copy when possible; if the mount is read-only, keep the
           # caller-provided config and continue.
-          cat "$tmp" > "$config" 2>/dev/null || true
+          cat "$tmp" > "$config" 2>/dev/null || config_writable=0
           rm -f "$tmp"
         fi
 
-        if [ -n "${SERVER_HOST:-}" ]; then
-          printf 'server.host: "%s"\n' "$(yaml_quote "$SERVER_HOST")" >> "$config"
-        fi
+        if [ "$config_writable" -eq 1 ]; then
+          if [ -n "${SERVER_HOST:-}" ]; then
+            printf 'server.host: "%s"\n' "$(yaml_quote "$SERVER_HOST")" >> "$config"
+          fi
 
-        if [ -n "${OPENSEARCH_HOSTS:-}" ]; then
-          case "$OPENSEARCH_HOSTS" in
-            \[* ) printf 'opensearch.hosts: %s\n' "$OPENSEARCH_HOSTS" >> "$config" ;;
-            * ) printf 'opensearch.hosts: ["%s"]\n' "$(yaml_quote "$OPENSEARCH_HOSTS")" >> "$config" ;;
-          esac
-        elif [ -n "${OPENSEARCH_URL:-}" ]; then
-          printf 'opensearch.hosts: ["%s"]\n' "$(yaml_quote "$OPENSEARCH_URL")" >> "$config"
-        fi
+          if [ -n "${OPENSEARCH_HOSTS:-}" ]; then
+            case "$OPENSEARCH_HOSTS" in
+              \[* ) printf 'opensearch.hosts: %s\n' "$OPENSEARCH_HOSTS" >> "$config" ;;
+              * ) printf 'opensearch.hosts: ["%s"]\n' "$(yaml_quote "$OPENSEARCH_HOSTS")" >> "$config" ;;
+            esac
+          elif [ -n "${OPENSEARCH_URL:-}" ]; then
+            printf 'opensearch.hosts: ["%s"]\n' "$(yaml_quote "$OPENSEARCH_URL")" >> "$config"
+          fi
 
-        if [ -n "${OPENSEARCH_USERNAME:-}" ]; then
-          printf 'opensearch.username: "%s"\n' "$(yaml_quote "$OPENSEARCH_USERNAME")" >> "$config"
-        fi
+          if [ -n "${OPENSEARCH_USERNAME:-}" ]; then
+            printf 'opensearch.username: "%s"\n' "$(yaml_quote "$OPENSEARCH_USERNAME")" >> "$config"
+          fi
 
-        if [ -n "${OPENSEARCH_PASSWORD:-}" ]; then
-          printf 'opensearch.password: "%s"\n' "$(yaml_quote "$OPENSEARCH_PASSWORD")" >> "$config"
+          if [ -n "${OPENSEARCH_PASSWORD:-}" ]; then
+            printf 'opensearch.password: "%s"\n' "$(yaml_quote "$OPENSEARCH_PASSWORD")" >> "$config"
+          fi
         fi
       fi
 

--- a/packages/bespoke/verity-opensearch-dashboards-config.yaml
+++ b/packages/bespoke/verity-opensearch-dashboards-config.yaml
@@ -20,11 +20,42 @@ pipeline:
 
       config="${OPENSEARCH_DASHBOARDS_CONFIG:-/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml}"
 
+      yaml_quote() {
+        printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+      }
+
       if [ -f "$config" ]; then
         tmp="$(mktemp "${config}.verity.XXXXXX")"
         sed '/^opensearch_security\./d' "$config" > "$tmp"
         chmod 0644 "$tmp"
-        mv "$tmp" "$config"
+        if ! mv "$tmp" "$config"; then
+          # ConfigMap subPath mounts cannot be atomically replaced. Fall back to
+          # in-place copy when possible; if the mount is read-only, keep the
+          # caller-provided config and continue.
+          cat "$tmp" > "$config" 2>/dev/null || true
+          rm -f "$tmp"
+        fi
+
+        if [ -n "${SERVER_HOST:-}" ]; then
+          printf 'server.host: "%s"\n' "$(yaml_quote "$SERVER_HOST")" >> "$config"
+        fi
+
+        if [ -n "${OPENSEARCH_HOSTS:-}" ]; then
+          case "$OPENSEARCH_HOSTS" in
+            \[* ) printf 'opensearch.hosts: %s\n' "$OPENSEARCH_HOSTS" >> "$config" ;;
+            * ) printf 'opensearch.hosts: ["%s"]\n' "$(yaml_quote "$OPENSEARCH_HOSTS")" >> "$config" ;;
+          esac
+        elif [ -n "${OPENSEARCH_URL:-}" ]; then
+          printf 'opensearch.hosts: ["%s"]\n' "$(yaml_quote "$OPENSEARCH_URL")" >> "$config"
+        fi
+
+        if [ -n "${OPENSEARCH_USERNAME:-}" ]; then
+          printf 'opensearch.username: "%s"\n' "$(yaml_quote "$OPENSEARCH_USERNAME")" >> "$config"
+        fi
+
+        if [ -n "${OPENSEARCH_PASSWORD:-}" ]; then
+          printf 'opensearch.password: "%s"\n' "$(yaml_quote "$OPENSEARCH_PASSWORD")" >> "$config"
+        fi
       fi
 
       exec /usr/share/opensearch-dashboards/bin/opensearch-dashboards "$@"

--- a/test/chart-integration/assertions_test.go
+++ b/test/chart-integration/assertions_test.go
@@ -654,4 +654,7 @@ func TestOpenSearchDashboardsInstallsOpenSearchPrerequisiteInSameNamespace(t *te
 	if !prereqs[0].SameNamespace {
 		t.Fatalf("opensearch prerequisite must install in the dashboard namespace so opensearch-cluster-master resolves")
 	}
+	if !preserveNamespaceOnRetry("opensearch-dashboards") {
+		t.Fatalf("opensearch-dashboards retry cleanup must preserve namespace so same-namespace prerequisites survive")
+	}
 }

--- a/test/chart-integration/assertions_test.go
+++ b/test/chart-integration/assertions_test.go
@@ -642,3 +642,16 @@ func TestInstallChartRejectsArgumentInjection(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenSearchDashboardsInstallsOpenSearchPrerequisiteInSameNamespace(t *testing.T) {
+	prereqs := chartPrerequisites["opensearch-dashboards"]
+	if len(prereqs) != 1 {
+		t.Fatalf("opensearch-dashboards prereqs = %#v, want exactly one", prereqs)
+	}
+	if prereqs[0].Name != "opensearch" {
+		t.Fatalf("prereq name = %q, want opensearch", prereqs[0].Name)
+	}
+	if !prereqs[0].SameNamespace {
+		t.Fatalf("opensearch prerequisite must install in the dashboard namespace so opensearch-cluster-master resolves")
+	}
+}

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -56,23 +56,25 @@ var chartFixtureCRDs = map[string][]string{
 }
 
 type ChartContext struct {
-	Spec      config.ChartSpec
-	Namespace string
-	ValuesDir string
+	Spec              config.ChartSpec
+	Namespace         string
+	ValuesDir         string
+	PreserveNamespace bool
 }
 
 func InstallChart(ctx context.Context, h *Harness, spec config.ChartSpec, valuesDir string) (*ChartContext, error) {
-	return installChartInNamespace(ctx, h, spec, valuesDir, sanitizeNamespace(spec.Name))
+	return installChartInNamespace(ctx, h, spec, valuesDir, sanitizeNamespace(spec.Name), false)
 }
 
-func installChartInNamespace(ctx context.Context, h *Harness, spec config.ChartSpec, valuesDir, namespace string) (*ChartContext, error) {
+func installChartInNamespace(ctx context.Context, h *Harness, spec config.ChartSpec, valuesDir, namespace string, preserveNamespace bool) (*ChartContext, error) {
 	if err := discovery.ValidateChartSpec(spec); err != nil {
 		return nil, fmt.Errorf("validate chart spec: %w", err)
 	}
 	cc := &ChartContext{
-		Spec:      spec,
-		Namespace: namespace,
-		ValuesDir: valuesDir,
+		Spec:              spec,
+		Namespace:         namespace,
+		ValuesDir:         valuesDir,
+		PreserveNamespace: preserveNamespace,
 	}
 	if err := helmInstall(ctx, h, cc); err != nil {
 		return cc, fmt.Errorf("helm install: %w", err)
@@ -105,7 +107,7 @@ func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.Char
 			namespace = sanitizeNamespace(spec.Name)
 		}
 		h.t.Logf("[prereq] installing %s before %s in namespace %s", prereq.Name, spec.Name, namespace)
-		cc, installErr := installChartWithRetryInNamespace(ctx, h, candidate, valuesDir, namespace, defaultRetryConfig())
+		cc, installErr := installChartWithRetryInNamespace(ctx, h, candidate, valuesDir, namespace, false, defaultRetryConfig())
 		installed = append(installed, cc)
 		if installErr != nil {
 			return installed, fmt.Errorf("install %s prerequisite: %w", prereq.Name, installErr)
@@ -199,12 +201,24 @@ func UninstallChart(ctx context.Context, h *Harness, cc *ChartContext) {
 	); err != nil {
 		h.t.Logf("[uninstall] helm uninstall %s: %v (continuing)", cc.Spec.Name, err)
 	}
+	if cc.PreserveNamespace {
+		return
+	}
 	if err := runCmd(ctx, h.t, "", nil,
 		"kubectl", "--kubeconfig", h.KubeconfigPath,
 		"delete", "namespace", cc.Namespace, "--ignore-not-found", "--wait=false",
 	); err != nil {
 		h.t.Logf("[uninstall] kubectl delete ns %s: %v (continuing)", cc.Namespace, err)
 	}
+}
+
+func preserveNamespaceOnRetry(chartName string) bool {
+	for _, prereq := range chartPrerequisites[chartName] {
+		if prereq.SameNamespace {
+			return true
+		}
+	}
+	return false
 }
 
 func helmInstall(ctx context.Context, h *Harness, cc *ChartContext) error {

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -21,8 +21,17 @@ const (
 	chartRegistry                 = "oci://ghcr.io/verity-org/charts"
 )
 
-var chartPrerequisites = map[string][]string{
-	"cert-manager-csi-driver": {"cert-manager"},
+type chartPrerequisite struct {
+	Name          string
+	SameNamespace bool
+}
+
+var chartPrerequisites = map[string][]chartPrerequisite{
+	"cert-manager-csi-driver": {{Name: "cert-manager"}},
+	// OpenSearch Dashboards blocks startup until it can query the default
+	// opensearch-cluster-master service. Install the OpenSearch prerequisite in
+	// the dashboard namespace so the chart default resolves during the smoke test.
+	"opensearch-dashboards": {{Name: "opensearch", SameNamespace: true}},
 }
 
 var chartCRDFixtures = map[string][]string{
@@ -53,12 +62,16 @@ type ChartContext struct {
 }
 
 func InstallChart(ctx context.Context, h *Harness, spec config.ChartSpec, valuesDir string) (*ChartContext, error) {
+	return installChartInNamespace(ctx, h, spec, valuesDir, sanitizeNamespace(spec.Name))
+}
+
+func installChartInNamespace(ctx context.Context, h *Harness, spec config.ChartSpec, valuesDir, namespace string) (*ChartContext, error) {
 	if err := discovery.ValidateChartSpec(spec); err != nil {
 		return nil, fmt.Errorf("validate chart spec: %w", err)
 	}
 	cc := &ChartContext{
 		Spec:      spec,
-		Namespace: sanitizeNamespace(spec.Name),
+		Namespace: namespace,
 		ValuesDir: valuesDir,
 	}
 	if err := helmInstall(ctx, h, cc); err != nil {
@@ -68,8 +81,8 @@ func InstallChart(ctx context.Context, h *Harness, spec config.ChartSpec, values
 }
 
 func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.ChartSpec, valuesDir string) ([]*ChartContext, error) {
-	prereqNames := chartPrerequisites[spec.Name]
-	if len(prereqNames) == 0 {
+	prereqs := chartPrerequisites[spec.Name]
+	if len(prereqs) == 0 {
 		return nil, nil
 	}
 
@@ -81,17 +94,21 @@ func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.Char
 	for _, candidate := range charts {
 		byName[candidate.Name] = candidate
 	}
-	installed := make([]*ChartContext, 0, len(prereqNames))
-	for _, name := range prereqNames {
-		candidate, ok := byName[name]
+	installed := make([]*ChartContext, 0, len(prereqs))
+	for _, prereq := range prereqs {
+		candidate, ok := byName[prereq.Name]
 		if !ok {
-			return installed, fmt.Errorf("prerequisite %q for %q not found in Chart.yaml", name, spec.Name)
+			return installed, fmt.Errorf("prerequisite %q for %q not found in Chart.yaml", prereq.Name, spec.Name)
 		}
-		h.t.Logf("[prereq] installing %s before %s", name, spec.Name)
-		cc, installErr := InstallChartWithRetry(ctx, h, candidate, valuesDir, defaultRetryConfig())
+		namespace := sanitizeNamespace(candidate.Name)
+		if prereq.SameNamespace {
+			namespace = sanitizeNamespace(spec.Name)
+		}
+		h.t.Logf("[prereq] installing %s before %s in namespace %s", prereq.Name, spec.Name, namespace)
+		cc, installErr := installChartWithRetryInNamespace(ctx, h, candidate, valuesDir, namespace, defaultRetryConfig())
 		installed = append(installed, cc)
 		if installErr != nil {
-			return installed, fmt.Errorf("install %s prerequisite: %w", name, installErr)
+			return installed, fmt.Errorf("install %s prerequisite: %w", prereq.Name, installErr)
 		}
 	}
 	return installed, nil

--- a/test/chart-integration/harness_retry.go
+++ b/test/chart-integration/harness_retry.go
@@ -221,7 +221,7 @@ func InstallChartWithRetry(
 	valuesDir string,
 	cfg retryConfig,
 ) (*ChartContext, error) {
-	return installChartWithRetryInNamespace(ctx, h, spec, valuesDir, sanitizeNamespace(spec.Name), cfg)
+	return installChartWithRetryInNamespace(ctx, h, spec, valuesDir, sanitizeNamespace(spec.Name), preserveNamespaceOnRetry(spec.Name), cfg)
 }
 
 func installChartWithRetryInNamespace(
@@ -230,6 +230,7 @@ func installChartWithRetryInNamespace(
 	spec config.ChartSpec,
 	valuesDir string,
 	namespace string,
+	preserveNamespace bool,
 	cfg retryConfig,
 ) (*ChartContext, error) {
 	if cfg.MaxAttempts <= 0 {
@@ -238,7 +239,7 @@ func installChartWithRetryInNamespace(
 	var lastCC *ChartContext
 	var lastErr error
 	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
-		cc, err := installChartInNamespace(ctx, h, spec, valuesDir, namespace)
+		cc, err := installChartInNamespace(ctx, h, spec, valuesDir, namespace, preserveNamespace)
 		if err == nil {
 			if attempt > 1 {
 				h.t.Logf("chart-integration[%s]: install succeeded on attempt %d/%d", spec.Name, attempt, cfg.MaxAttempts)

--- a/test/chart-integration/harness_retry.go
+++ b/test/chart-integration/harness_retry.go
@@ -264,7 +264,7 @@ func installChartWithRetryInNamespace(
 			// Best-effort cleanup before next attempt — reuse the
 			// existing teardown path so we don't reimplement it.
 			//
-			// UninstallChart uses `kubectl delete ns --wait=false` so
+			// UninstallChart normally uses `kubectl delete ns --wait=false` so
 			// the final teardown after runChart returns is fast. For
 			// the retry path that semantics is wrong: starting a
 			// fresh `helm install` against a namespace still in
@@ -275,18 +275,23 @@ func installChartWithRetryInNamespace(
 			//
 			// Block here until the namespace is fully deleted (or
 			// the wait budget expires); only then start the backoff
-			// timer. The 90s budget accommodates kind's local-path
-			// PVC reclaim plus finalizer drain for stateful charts.
+			// timer. Charts with same-namespace prerequisites set
+			// PreserveNamespace, so UninstallChart removes only the main
+			// release and leaves the namespace/prerequisite live; those retries
+			// must skip the deletion wait. The 90s budget accommodates kind's
+			// local-path PVC reclaim plus finalizer drain for stateful charts.
 			if cc != nil {
 				uctx, ucancel := context.WithTimeout(ctx, 3*time.Minute)
 				UninstallChart(uctx, h, cc)
 				ucancel()
-				wctx, wcancel := context.WithTimeout(ctx, 90*time.Second)
-				if err := waitNamespaceDeleted(wctx, h, cc.Namespace); err != nil {
-					h.t.Logf("chart-integration[%s]: attempt %d cleanup: namespace %q deletion did not complete within budget: %v (continuing)",
-						spec.Name, attempt, cc.Namespace, err)
+				if !cc.PreserveNamespace {
+					wctx, wcancel := context.WithTimeout(ctx, 90*time.Second)
+					if err := waitNamespaceDeleted(wctx, h, cc.Namespace); err != nil {
+						h.t.Logf("chart-integration[%s]: attempt %d cleanup: namespace %q deletion did not complete within budget: %v (continuing)",
+							spec.Name, attempt, cc.Namespace, err)
+					}
+					wcancel()
 				}
-				wcancel()
 			}
 			select {
 			case <-ctx.Done():

--- a/test/chart-integration/harness_retry.go
+++ b/test/chart-integration/harness_retry.go
@@ -221,13 +221,24 @@ func InstallChartWithRetry(
 	valuesDir string,
 	cfg retryConfig,
 ) (*ChartContext, error) {
+	return installChartWithRetryInNamespace(ctx, h, spec, valuesDir, sanitizeNamespace(spec.Name), cfg)
+}
+
+func installChartWithRetryInNamespace(
+	ctx context.Context,
+	h *Harness,
+	spec config.ChartSpec,
+	valuesDir string,
+	namespace string,
+	cfg retryConfig,
+) (*ChartContext, error) {
 	if cfg.MaxAttempts <= 0 {
 		cfg = defaultRetryConfig()
 	}
 	var lastCC *ChartContext
 	var lastErr error
 	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
-		cc, err := InstallChart(ctx, h, spec, valuesDir)
+		cc, err := installChartInNamespace(ctx, h, spec, valuesDir, namespace)
 		if err == nil {
 			if attempt > 1 {
 				h.t.Logf("chart-integration[%s]: install succeeded on attempt %d/%d", spec.Name, attempt, cfg.MaxAttempts)
@@ -378,7 +389,9 @@ func parsePodStatusJSON(raw []byte) podStatusSnapshot {
 // (finalizers, PVC reclaim, helm release Secret removal) before the
 // next `helm install` runs, otherwise the next install would race
 // the still-terminating namespace and fail with
-//   `namespace "<ns>" is being terminated`
+//
+//	`namespace "<ns>" is being terminated`
+//
 // or AlreadyExists, neither of which is a pull-class failure and so
 // would abort the retry budget on a transient teardown lag.
 //

--- a/test/chart-integration/values/opensearch-dashboards.yaml
+++ b/test/chart-integration/values/opensearch-dashboards.yaml
@@ -1,0 +1,31 @@
+# Chart-integration override for opensearch-dashboards 3.6.0.
+#
+# Verity's current published image entrypoint rewrites the config file in-place
+# before exec. Mount a writable config directory, seed it with the smoke-test
+# connection settings, and point Dashboards at the OpenSearch prerequisite that
+# the harness installs into this same namespace.
+opensearch-dashboards:
+  extraVolumes:
+    - name: verity-config
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: verity-config
+      mountPath: /usr/share/opensearch-dashboards/config
+  extraInitContainers:
+    - name: write-verity-config
+      image: ghcr.io/verity-org/busybox:1
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -c
+        - |
+          cat > /config/opensearch_dashboards.yml <<'EOF'
+          server.host: "0.0.0.0"
+          opensearch.hosts: ["https://opensearch-cluster-master:9200"]
+          opensearch.ssl.verificationMode: none
+          opensearch.username: "admin"
+          opensearch.password: "admin"
+          EOF
+      volumeMounts:
+        - name: verity-config
+          mountPath: /config


### PR DESCRIPTION
## Summary
- Install the opensearch prerequisite in the opensearch-dashboards smoke namespace so the default backend service resolves.
- Add a writable smoke-test config fixture for opensearch-dashboards that points at the prerequisite backend.
- Make the image entrypoint preserve env-derived settings and tolerate ConfigMap subPath config mounts.

## Diagnosis
- Failing scheduled chart-integration run [26085262911](https://github.com/verity-org/verity/actions/runs/26085262911), job 76696701523 showed opensearch-dashboards repeatedly unable to retrieve OpenSearch node version information, with only connection errors in pod logs.
- The dashboards chart was installed without an OpenSearch backend in its namespace, and the published Verity entrypoint needs a writable config file for explicit smoke-test settings.

## Tests
- VERITY_IT_SKIP_CLUSTER=1 go test -tags=integration ./test/chart-integration/... ./cmd/...
- go test ./cmd/...
- VERITY_CHART=opensearch-dashboards make chart-integration