### PR TITLE
Reduce OpenSearch smoke fixture footprint

### DIFF
--- a/test/chart-integration/values/opensearch.yaml
+++ b/test/chart-integration/values/opensearch.yaml
@@ -5,6 +5,19 @@
 # create /usr/share/opensearch/config/opensearch.keystore.tmp during bootstrap.
 # Running as the image's nonroot user keeps that config directory writable.
 opensearch:
+  # Keep the smoke cluster small enough for single-node kind runners and for
+  # charts (opensearch-dashboards) that install OpenSearch as a same-namespace
+  # prerequisite before scheduling their own pod.
+  singleNode: true
+
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "512Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+
   # The chart's default init chown targets uid/gid 1000 and uses
   # docker.io/library/busybox. With the pod running as 65532 and fsGroup set,
   # kubelet volume ownership is sufficient for the smoke-test PVC.


### PR DESCRIPTION
## Summary
- Run the OpenSearch chart-integration fixture as a single-node cluster.
- Lower OpenSearch CPU/memory requests so opensearch-dashboards can schedule alongside its same-namespace backend prerequisite on one-node kind runners.

## Diagnosis
- Post-merge main verification run [26111283195](https://github.com/verity-org/verity/actions/runs/26111283195) showed opensearch-dashboards Pending with `Insufficient cpu` after the OpenSearch prerequisite deployed three pods.

## Tests
- VERITY_IT_SKIP_CLUSTER=1 go test -tags=integration ./test/chart-integration/... ./cmd/...
- VERITY_CHART=opensearch-dashboards make chart-integration


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink the OpenSearch chart-integration smoke fixture to a single node with lower CPU/memory so `opensearch-dashboards` can schedule on single-node kind runners. Fixes Pending `opensearch-dashboards` pods caused by Insufficient cpu when the OpenSearch prerequisite deployed multiple pods.

<sup>Written for commit 27ef04eb0a737ee052dbb0800b88735b37b469b6. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

