### PR TITLE
fix(chart-integration): extend airflow migration budget

### DIFF
--- a/test/chart-integration/airflow_values_test.go
+++ b/test/chart-integration/airflow_values_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -26,6 +27,9 @@ func TestAirflowPostgresqlImageOverrideIsComposable(t *testing.T) {
 		Airflow struct {
 			DefaultAirflowRepository string `yaml:"defaultAirflowRepository"`
 			DefaultAirflowTag        string `yaml:"defaultAirflowTag"`
+			Images                   struct {
+				MigrationsWaitTimeout int `yaml:"migrationsWaitTimeout"`
+			} `yaml:"images"`
 			Postgresql               struct {
 				Image struct {
 					Registry   string `yaml:"registry"`
@@ -43,10 +47,19 @@ func TestAirflowPostgresqlImageOverrideIsComposable(t *testing.T) {
 	if values.Airflow.DefaultAirflowTag != "3" {
 		t.Fatalf("defaultAirflowTag=%q want 3", values.Airflow.DefaultAirflowTag)
 	}
+	if values.Airflow.Images.MigrationsWaitTimeout < 900 {
+		t.Fatalf("migrationsWaitTimeout=%d want at least 900", values.Airflow.Images.MigrationsWaitTimeout)
+	}
 	if values.Airflow.Postgresql.Image.Registry != "ghcr.io" {
 		t.Fatalf("registry=%q want ghcr.io", values.Airflow.Postgresql.Image.Registry)
 	}
 	if values.Airflow.Postgresql.Image.Repository != "verity-org/bitnamilegacy/postgresql" {
 		t.Fatalf("repository=%q want verity-org/bitnamilegacy/postgresql", values.Airflow.Postgresql.Image.Repository)
+	}
+}
+
+func TestAirflowHasExtendedHelmInstallTimeout(t *testing.T) {
+	if got, want := chartHelmInstallTimeout("airflow"), 20*time.Minute; got != want {
+		t.Fatalf("chartHelmInstallTimeout(airflow)=%s want %s", got, want)
 	}
 }

--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	helmInstallTimeout            = 10 * time.Minute
+	airflowHelmInstallTimeout     = 20 * time.Minute
 	certManagerHelmInstallTimeout = 15 * time.Minute
 	chartRegistry                 = "oci://ghcr.io/verity-org/charts"
 )
@@ -243,6 +244,9 @@ func helmInstall(ctx context.Context, h *Harness, cc *ChartContext) error {
 }
 
 func chartHelmInstallTimeout(chartName string) time.Duration {
+	if chartName == "airflow" {
+		return airflowHelmInstallTimeout
+	}
 	if chartName == "cert-manager" {
 		return certManagerHelmInstallTimeout
 	}

--- a/test/chart-integration/values/airflow.yaml
+++ b/test/chart-integration/values/airflow.yaml
@@ -6,6 +6,12 @@ airflow:
   # Verity Wolfi rebuild and no longer needs an apache/airflow allowlist.
   defaultAirflowRepository: ghcr.io/verity-org/airflow
   defaultAirflowTag: "3"
+  images:
+    # Airflow 3 metadata DB migrations can exceed the upstream chart's 300s
+    # init-container wait budget on GitHub hosted runners. Keep the smoke test
+    # bounded by the harness timeout, but let migrations finish instead of
+    # making every workload initContainer fail at exactly five minutes.
+    migrationsWaitTimeout: 900
   postgresql:
     image:
       # The generated wrapper currently concentrates the GHCR host in the


### PR DESCRIPTION
## Summary
- extend Airflow chart smoke Helm timeout to 20 minutes
- raise Airflow migration wait timeout to 900s in the smoke values fixture
- add regression coverage for the Airflow timeout/value budget

## Diagnostics
- After [#445](https://github.com/verity-org/verity/pull/445) merged, main verification run [26115797466](https://github.com/verity-org/verity/actions/runs/26115797466) failed the airflow shard at job [76804661134](https://github.com/verity-org/verity/actions/runs/26115797466/job/76804661134)
- diagnostics showed the original argv issue was fixed, but wait-for-airflow-migrations timed out at exactly 300s while migrations were still unapplied

## Tests
- python3/PyYAML parse of test/chart-integration/values/airflow.yaml
- go test -tags=integration -run 'TestAirflowPostgresqlImageOverrideIsComposable|TestAirflowHasExtendedHelmInstallTimeout' ./test/chart-integration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Airflow smoke test timeouts so migrations can complete reliably. Helm install now allows 20 minutes and the migrations wait budget is 900s to prevent 300s timeouts.

- **Bug Fixes**
  - Set Airflow Helm install timeout to 20m via `chartHelmInstallTimeout("airflow")`.
  - Raise `airflow.images.migrationsWaitTimeout` to 900s in smoke values.
  - Add regression tests to lock these timeouts.

<sup>Written for commit e297e754034e1d3df2b1620f8182356c1fc82036. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/450?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

