### PR TITLE
fix(images): make airflow home chart-writable

### DIFF
--- a/images/airflow.yaml
+++ b/images/airflow.yaml
@@ -23,10 +23,14 @@ types:
       # Keep absolute-path callers working while the chart uses PATH-based
       # `airflow` invocations.
       - {path: /usr/bin/airflow, type: symlink, source: /opt/airflow/bin/airflow, uid: 0, gid: 0, permissions: 0o755}
-      - {path: /opt/airflow, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
-      - {path: /opt/airflow/dags, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
-      - {path: /opt/airflow/logs, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
-      - {path: /opt/airflow/plugins, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+      # The upstream chart runs Airflow containers as uid 50000 with fsGroup 0.
+      # Airflow creates /opt/airflow/airflow.cfg on first CLI use and writes
+      # runtime logs/plugins, so these directories must be writable by that
+      # chart user/group instead of only by the Wolfi nonroot uid.
+      - {path: /opt/airflow, type: directory, uid: 50000, gid: 0, permissions: 0o775}
+      - {path: /opt/airflow/dags, type: directory, uid: 50000, gid: 0, permissions: 0o775}
+      - {path: /opt/airflow/logs, type: directory, uid: 50000, gid: 0, permissions: 0o775}
+      - {path: /opt/airflow/plugins, type: directory, uid: 50000, gid: 0, permissions: 0o775}
 
 versions:
   "3": {}

--- a/internal/integer/config/airflow_image_test.go
+++ b/internal/integer/config/airflow_image_test.go
@@ -44,8 +44,27 @@ func TestAirflowImageExposesConsoleScriptsOnPath(t *testing.T) {
 	if !foundSymlink {
 		t.Fatal("missing /usr/bin/airflow -> /opt/airflow/bin/airflow symlink")
 	}
+
+	for _, path := range []string{"/opt/airflow", "/opt/airflow/dags", "/opt/airflow/logs", "/opt/airflow/plugins"} {
+		p, ok := findPath(tmpl.Paths, path)
+		if !ok {
+			t.Fatalf("missing %s path entry", path)
+		}
+		if p.UID != 50000 || p.GID != 0 || p.Permissions != "0o775" {
+			t.Fatalf("%s ownership/perms = uid:%d gid:%d mode:%s, want uid:50000 gid:0 mode:0o775", path, p.UID, p.GID, p.Permissions)
+		}
+	}
 }
 
 func pathHasEntry(path, want string) bool {
 	return slices.Contains(strings.Split(path, ":"), want)
+}
+
+func findPath(paths []PathDef, want string) (PathDef, bool) {
+	for _, p := range paths {
+		if p.Path == want {
+			return p, true
+		}
+	}
+	return PathDef{}, false
 }

--- a/internal/integer/config/airflow_image_test.go
+++ b/internal/integer/config/airflow_image_test.go
@@ -45,13 +45,13 @@ func TestAirflowImageExposesConsoleScriptsOnPath(t *testing.T) {
 		t.Fatal("missing /usr/bin/airflow -> /opt/airflow/bin/airflow symlink")
 	}
 
-	for _, path := range []string{"/opt/airflow", "/opt/airflow/dags", "/opt/airflow/logs", "/opt/airflow/plugins"} {
-		p, ok := findPath(tmpl.Paths, path)
+	for _, dirPath := range []string{"/opt/airflow", "/opt/airflow/dags", "/opt/airflow/logs", "/opt/airflow/plugins"} {
+		p, ok := findPath(tmpl.Paths, dirPath)
 		if !ok {
-			t.Fatalf("missing %s path entry", path)
+			t.Fatalf("missing %s path entry", dirPath)
 		}
 		if p.UID != 50000 || p.GID != 0 || p.Permissions != "0o775" {
-			t.Fatalf("%s ownership/perms = uid:%d gid:%d mode:%s, want uid:50000 gid:0 mode:0o775", path, p.UID, p.GID, p.Permissions)
+			t.Fatalf("%s ownership/perms = uid:%d gid:%d mode:%s, want uid:50000 gid:0 mode:0o775", dirPath, p.UID, p.GID, p.Permissions)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- make /opt/airflow and runtime subdirs writable by the upstream chart user (uid 50000, gid 0)
- keep no-entrypoint/binary path behavior from [#445](https://github.com/verity-org/verity/pull/445)
- add regression coverage for Airflow chart user ownership/perms

## Diagnostics
- Main verification [26121441105](https://github.com/verity-org/verity/actions/runs/26121441105), job [76824243362](https://github.com/verity-org/verity/actions/runs/26121441105/job/76824243362), showed airflow migration Job crash-looped and was TTL-deleted before final diagnostics; workload initContainers kept waiting for unapplied migrations.
- Reproduced the migration crash locally with the published image under chart UID/GID: docker run --user 50000:0 ghcr.io/verity-org/airflow:3 bash -c "airflow db migrate" fails with PermissionError for /opt/airflow/airflow.cfg because /opt/airflow was owned by nonroot 65532 and mode 0755.

## Tests
- go test ./internal/integer/config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/opt/airflow` and runtime dirs writable by the upstream chart user (uid 50000, fsGroup 0) to stop migration job crash loops and unblock initContainers. Keeps the `/usr/bin/airflow` symlink behavior and adds tests to prevent PATH shadowing and permission regressions.

- **Bug Fixes**
  - Set ownership/mode for `/opt/airflow`, `/opt/airflow/dags`, `/opt/airflow/logs`, `/opt/airflow/plugins` to uid 50000, gid 0, permissions `0o775`.
  - Preserve `/usr/bin/airflow` -> `/opt/airflow/bin/airflow` symlink for absolute-path callers.
  - Add tests verifying required path entries, expected ownership/permissions, and that `airflow` on PATH resolves to `/opt/airflow/bin/airflow`.

<sup>Written for commit 6a9e9077e2aee8b230fc5d0adc97a15287e57a0b. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/451?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

