### PR TITLE
fix(images): set airflow chart user env

### DIFF
--- a/images/airflow.yaml
+++ b/images/airflow.yaml
@@ -15,6 +15,9 @@ types:
     # chart runs invalid commands like `airflow airflow db check-migrations`.
     environment:
       AIRFLOW_HOME: /opt/airflow
+      # The chart runs containers as numeric uid 50000 without a passwd entry.
+      # Airflow's CLI calls getpass.getuser(), so provide USER explicitly.
+      USER: airflow
       # The Wolfi airflow package installs console scripts under
       # /opt/airflow/bin. The upstream Helm chart invokes `airflow` via
       # `bash -c` in Jobs/Deployments, so PATH must include that directory.

--- a/internal/integer/config/airflow_image_test.go
+++ b/internal/integer/config/airflow_image_test.go
@@ -33,6 +33,9 @@ func TestAirflowImageExposesConsoleScriptsOnPath(t *testing.T) {
 	if !pathHasEntry(path, "/opt/airflow/bin") {
 		t.Fatalf("PATH=%q must include /opt/airflow/bin for chart bash -c airflow commands", path)
 	}
+	if tmpl.Environment["USER"] != "airflow" {
+		t.Fatalf("USER=%q want airflow so Airflow CLI getpass.getuser works under chart uid 50000", tmpl.Environment["USER"])
+	}
 
 	foundSymlink := false
 	for _, p := range tmpl.Paths {


### PR DESCRIPTION
## Summary
- set USER=airflow in the Airflow image environment for chart-run numeric uid 50000
- add regression coverage for the Airflow CLI getpass requirement

## Diagnostics
- Main verification [26126203290](https://github.com/verity-org/verity/actions/runs/26126203290), job [76840476269](https://github.com/verity-org/verity/actions/runs/26126203290/job/76840476269), still showed the migration Job crash-looping while workload initContainers waited for migrations.
- The fixed image was pulled (`ghcr.io/verity-org/airflow@sha256:b80b036...`) and had writable /opt/airflow, so permissions were no longer the blocker.
- Local reproduction under the chart uid/gid found the next root cause: `docker run --user 50000:0 ghcr.io/verity-org/airflow:3 bash -c "airflow db migrate"` fails with `OSError: No username set in the environment` from `getpass.getuser()`.
- Adding `USER=airflow` makes `airflow db migrate` complete locally under uid 50000.

## Tests
- go test ./internal/integer/config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets USER=airflow in the Airflow image so chart-run containers (uid 50000) can run the Airflow CLI without user lookup errors. This unblocks `airflow db migrate` and stops the migration Job crash loop.

- **Bug Fixes**
  - Add USER env to the image so `getpass.getuser()` works when running as uid 50000 with no passwd entry.
  - Add a regression test to assert USER=airflow is set (and PATH still includes `/opt/airflow/bin`).

<sup>Written for commit 51351a3ea1ad352578126429a2b6bca9a1935a9f. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/452?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

