### PR TITLE
fix(images): add shell for airflow probes

### DIFF
--- a/images/airflow.yaml
+++ b/images/airflow.yaml
@@ -6,7 +6,7 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["airflow-{{version}}", "bash"]
+    packages: ["airflow-{{version}}", "bash", "busybox"]
     # Intentionally NO `entrypoint:` — the upstream Airflow chart leaves
     # `command:` unset and supplies executable argv via `args:` such as
     # ["bash", "-c", "exec airflow scheduler"] and
@@ -19,8 +19,9 @@ types:
       # Airflow's CLI calls getpass.getuser(), so provide USER explicitly.
       USER: airflow
       # The Wolfi airflow package installs console scripts under
-      # /opt/airflow/bin. The upstream Helm chart invokes `airflow` via
-      # `bash -c` in Jobs/Deployments, so PATH must include that directory.
+      # /opt/airflow/bin. The upstream Helm chart invokes `airflow` via `bash`
+      # in Jobs/Deployments and `sh` in exec probes, so PATH must include that
+      # directory and the image must ship both shells.
       PATH: /opt/airflow/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     paths:
       # Keep absolute-path callers working while the chart uses PATH-based

--- a/internal/integer/config/airflow_image_test.go
+++ b/internal/integer/config/airflow_image_test.go
@@ -29,6 +29,9 @@ func TestAirflowImageExposesConsoleScriptsOnPath(t *testing.T) {
 	if !slices.Contains(tmpl.Packages, "bash") {
 		t.Fatalf("packages=%v must include bash for upstream Helm chart bash -c commands", tmpl.Packages)
 	}
+	if !slices.Contains(tmpl.Packages, "busybox") {
+		t.Fatalf("packages=%v must include busybox for upstream Helm chart sh-based exec probes", tmpl.Packages)
+	}
 	path := tmpl.Environment["PATH"]
 	if !pathHasEntry(path, "/opt/airflow/bin") {
 		t.Fatalf("PATH=%q must include /opt/airflow/bin for chart bash -c airflow commands", path)


### PR DESCRIPTION
## Summary
- add busybox to the Airflow image so the upstream chart exec probes can run `sh`
- extend regression coverage for the chart probe shell requirement

## Diagnostics
- Main verification [26128679446](https://github.com/verity-org/verity/actions/runs/26128679446), job [76848609011](https://github.com/verity-org/verity/actions/runs/26128679446/job/76848609011), showed migrations now complete and workloads start.
- Remaining blocker: scheduler/dag-processor/triggerer/worker probes fail with `exec: "sh": executable file not found in $PATH`, keeping pods unready until Helm timeout.

## Tests
- go test ./internal/integer/config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `busybox` to the Airflow image so Helm exec probes can run `sh`, fixing failing probes and unready pods. Extend tests to enforce `busybox` presence and console scripts on PATH.

- **Bug Fixes**
  - Include `busybox` alongside `bash` in `images/airflow.yaml` to provide `sh` for exec probes; resolves “exec: 'sh' not found” and lets pods become ready.
  - Add test in `airflow_image_test.go` to require `busybox` and verify `/opt/airflow/bin` is on PATH.

<sup>Written for commit dc43050130004c0c6a93e98bd3c2f2954cc14226. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/453?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

