### PR TITLE
fix(images): set airflow entrypoint home

### DIFF
--- a/images/airflow.yaml
+++ b/images/airflow.yaml
@@ -18,6 +18,9 @@ types:
       # The chart runs containers as numeric uid 50000 without a passwd entry.
       # Airflow's CLI calls getpass.getuser(), so provide USER explicitly.
       USER: airflow
+      # The packaged /entrypoint script is used by upstream chart exec probes
+      # and runs with `set -u`, so it requires AIRFLOW_USER_HOME_DIR.
+      AIRFLOW_USER_HOME_DIR: /opt/airflow
       # The Wolfi airflow package installs console scripts under
       # /opt/airflow/bin. The upstream Helm chart invokes `airflow` via `bash`
       # in Jobs/Deployments and `sh` in exec probes, so PATH must include that

--- a/internal/integer/config/airflow_image_test.go
+++ b/internal/integer/config/airflow_image_test.go
@@ -39,6 +39,9 @@ func TestAirflowImageExposesConsoleScriptsOnPath(t *testing.T) {
 	if tmpl.Environment["USER"] != "airflow" {
 		t.Fatalf("USER=%q want airflow so Airflow CLI getpass.getuser works under chart uid 50000", tmpl.Environment["USER"])
 	}
+	if tmpl.Environment["AIRFLOW_USER_HOME_DIR"] != "/opt/airflow" {
+		t.Fatalf("AIRFLOW_USER_HOME_DIR=%q want /opt/airflow for /entrypoint-based chart probes", tmpl.Environment["AIRFLOW_USER_HOME_DIR"])
+	}
 
 	foundSymlink := false
 	for _, p := range tmpl.Paths {


### PR DESCRIPTION
## Summary
- set AIRFLOW_USER_HOME_DIR=/opt/airflow for the packaged Airflow /entrypoint script
- add regression coverage for upstream chart /entrypoint probes

## Diagnostics
- Main verification [26130772824](https://github.com/verity-org/verity/actions/runs/26130772824), job [76855186683](https://github.com/verity-org/verity/actions/runs/26130772824/job/76855186683), showed migrations complete and all workloads running, but Helm still timed out because probes restarted/held readiness.
- Diagnostics showed liveness/startup probes fail with `/entrypoint: line 189: AIRFLOW_USER_HOME_DIR: unbound variable`.
- Local reproduction confirms `/entrypoint airflow jobs check --help` fails without AIRFLOW_USER_HOME_DIR and succeeds when it is set to /opt/airflow.

## Tests
- go test ./internal/integer/config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set AIRFLOW_USER_HOME_DIR to /opt/airflow in the Airflow image to stop /entrypoint-based liveness/startup probes from failing in the upstream Helm chart. Fixes Helm timeouts and adds a regression test.

- **Bug Fixes**
  - Define AIRFLOW_USER_HOME_DIR=/opt/airflow to satisfy /entrypoint with set -u; unblocks airflow jobs check used by probes.
  - Add a test to ensure the env var is set in the image config.

<sup>Written for commit c74889a0ffe0cc4babeff5401099528e70db04b2. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/454?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

