### PR TITLE
fix(chart-it): seed workload identity cert

### DIFF
--- a/test/chart-integration/chart.go
+++ b/test/chart-integration/chart.go
@@ -4,7 +4,14 @@ package integration
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,6 +52,14 @@ var chartObjectFixtures = map[string][]string{
 	"cluster-autoscaler": {
 		filepath.Join("test", "chart-integration", "fixtures", "cluster-autoscaler", "capi-objects.yaml"),
 	},
+}
+
+var chartTakeOwnership = map[string]bool{
+	// workload-identity-webhook's fixture pre-seeds the server-cert Secret with
+	// well-formed CI-only cert data before Helm renders the chart's otherwise empty
+	// Secret. --take-ownership lets Helm adopt that Secret instead of failing on an
+	// existing resource.
+	"workload-identity-webhook": true,
 }
 
 var chartFixtureCRDs = map[string][]string{
@@ -120,9 +135,6 @@ func InstallChartPrerequisites(ctx context.Context, h *Harness, spec config.Char
 func InstallChartFixtures(ctx context.Context, h *Harness, chartName string) error {
 	crdFixtures := chartCRDFixtures[chartName]
 	objectFixtures := chartObjectFixtures[chartName]
-	if len(crdFixtures) == 0 && len(objectFixtures) == 0 {
-		return nil
-	}
 	for _, fixture := range crdFixtures {
 		path := filepath.Join(h.RepoRoot, fixture)
 		h.t.Logf("[fixture] applying %s for %s", path, chartName)
@@ -174,8 +186,91 @@ func seedChartFixtureStatus(ctx context.Context, h *Harness, chartName string) e
 		); err != nil {
 			return fmt.Errorf("seed cluster-autoscaler fixture status: %w", err)
 		}
+	case "workload-identity-webhook":
+		if err := seedWorkloadIdentityWebhookCertSecret(ctx, h, sanitizeNamespace(chartName)); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+func seedWorkloadIdentityWebhookCertSecret(ctx context.Context, h *Harness, namespace string) error {
+	manifest, err := workloadIdentityWebhookCertSecretManifest(namespace, time.Now())
+	if err != nil {
+		return fmt.Errorf("build workload-identity-webhook cert secret fixture: %w", err)
+	}
+	tmp, err := os.CreateTemp("", "workload-identity-webhook-cert-secret-*.yaml")
+	if err != nil {
+		return fmt.Errorf("create cert secret fixture: %w", err)
+	}
+	path := tmp.Name()
+	defer os.Remove(path)
+	if _, err := tmp.WriteString(manifest); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write cert secret fixture: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close cert secret fixture: %w", err)
+	}
+	h.t.Logf("[fixture] seeding workload-identity-webhook server cert Secret in namespace %s", namespace)
+	if err := runCmd(ctx, h.t, "", nil,
+		"kubectl", "--kubeconfig", h.KubeconfigPath,
+		"apply", "--validate=false", "-f", path,
+	); err != nil {
+		return fmt.Errorf("apply workload-identity-webhook cert secret fixture: %w", err)
+	}
+	return nil
+}
+
+func workloadIdentityWebhookCertSecretManifest(namespace string, now time.Time) (string, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", err
+	}
+	service := "azure-wi-webhook-webhook-service"
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(now.UnixNano()),
+		Subject: pkix.Name{
+			CommonName: service,
+		},
+		DNSNames: []string{
+			service,
+			service + "." + namespace,
+			service + "." + namespace + ".svc",
+		},
+		NotBefore:             now.Add(-1 * time.Hour),
+		NotAfter:              now.Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return "", err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-wi-webhook-server-cert
+  namespace: %s
+type: kubernetes.io/tls
+data:
+  ca.crt: %s
+  tls.crt: %s
+  tls.key: %s
+`, namespace, namespace,
+		base64.StdEncoding.EncodeToString(certPEM),
+		base64.StdEncoding.EncodeToString(certPEM),
+		base64.StdEncoding.EncodeToString(keyPEM),
+	), nil
 }
 
 func UninstallChartFixtures(ctx context.Context, h *Harness, chartName string) {
@@ -237,6 +332,9 @@ func helmInstall(ctx context.Context, h *Harness, cc *ChartContext) error {
 	if vals := valuesFile(cc); vals != "" {
 		args = append(args, "--values", vals)
 		h.t.Logf("[install] applying values fixture %s", vals)
+	}
+	if chartTakeOwnership[cc.Spec.Name] {
+		args = append(args, "--take-ownership")
 	}
 	ictx, cancel := context.WithTimeout(ctx, timeout+2*time.Minute)
 	defer cancel()

--- a/test/chart-integration/workload_identity_webhook_test.go
+++ b/test/chart-integration/workload_identity_webhook_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/base64"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWorkloadIdentityWebhookCertSecretManifestSeedsWellFormedSecret(t *testing.T) {
+	manifest, err := workloadIdentityWebhookCertSecretManifest("workload-identity-webhook", time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("workloadIdentityWebhookCertSecretManifest: %v", err)
+	}
+	for _, want := range []string{
+		"kind: Namespace",
+		"name: workload-identity-webhook",
+		"kind: Secret",
+		"name: azure-wi-webhook-server-cert",
+		"type: kubernetes.io/tls",
+		"  ca.crt:",
+		"  tls.crt:",
+		"  tls.key:",
+	} {
+		if !strings.Contains(manifest, want) {
+			t.Fatalf("manifest missing %q:\n%s", want, manifest)
+		}
+	}
+
+	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
+		re := regexp.MustCompile(`(?m)^  ` + regexp.QuoteMeta(key) + `: (\S+)$`)
+		match := re.FindStringSubmatch(manifest)
+		if len(match) != 2 {
+			t.Fatalf("manifest missing data.%s:\n%s", key, manifest)
+		}
+		if _, err := base64.StdEncoding.DecodeString(match[1]); err != nil {
+			t.Fatalf("data.%s is not base64: %v", key, err)
+		}
+	}
+}
+
+func TestWorkloadIdentityWebhookUsesTakeOwnershipForSeededSecret(t *testing.T) {
+	if !chartTakeOwnership["workload-identity-webhook"] {
+		t.Fatalf("workload-identity-webhook must use --take-ownership to adopt seeded server-cert Secret")
+	}
+}


### PR DESCRIPTION
## Summary
- diagnose workload-identity-webhook restart as liveness killing manager while cert-rotator leaves the empty server-cert Secret temporarily malformed
- pre-seed a CI-only well-formed server cert Secret fixture before Helm install
- use Helm take-ownership so the wrapper chart adopts the seeded Secret

## Validation
- VERITY_IT_SKIP_CLUSTER=1 go test -count=1 -tags=integration -run 'TestWorkloadIdentityWebhook|TestLoadAllowlist|TestLoadAllowlistMissing|TestLoadAllowlistPresentRegression|TestIsAccepted|TestClassifyMissingAllowlist|TestClassifyMissingAllowlistDoesNotConsultAllowlist|TestHarnessClusterCreatedFieldDefault|TestInstallChartRejectsArgumentInjection|TestClassifyHelmFailure|TestClassifyHelmFailureStringer|TestClassifyHelmFailureParsesPodJSON|TestClassifyHelmFailureMalformedJSON|TestLoadSkips|TestIsSkipped|TestProductionSKIPSYAMLIsValid' -v ./test/chart-integration/...
- VERITY_CHART=workload-identity-webhook go test -count=1 -tags=integration -run '^TestCharts$' -v ./test/chart-integration/...

Fixes current main failure from [run 26140273936](https://github.com/verity-org/verity/actions/runs/26140273936).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-seeds a valid server-cert Secret for `workload-identity-webhook` during chart integration to stop webhook restarts during install. Helm adopts the Secret with `--take-ownership` to avoid conflicts.

- **Bug Fixes**
  - Generate and apply a CI-only self-signed cert Secret (ca.crt, tls.crt, tls.key) before Helm install.
  - Enable Helm `--take-ownership` for `workload-identity-webhook` so the chart adopts the seeded Secret.
  - Add tests to validate the Secret manifest and ensure take-ownership is set.
  - Prevents liveness kills caused by a temporarily malformed Secret during cert rotation, stabilizing CI.

<sup>Written for commit a0b14a81582a0d8cd0c645e475d11e0bc1e41736. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/455?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

