### PR TITLE
fix(site): keep Vite cache out of source

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -170,6 +170,10 @@ jobs:
 
       - name: Build site
         working-directory: site
+        env:
+          # Keep Vite/Astro dependency prebundle writes out of the checked-out
+          # source tree so Harden Runner does not flag them as source overwrites.
+          VITE_CACHE_DIR: ${{ runner.temp }}/verity-site-vite-cache
         run: npm ci && npm run build
 
       - name: Upload Pages artifact

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
   output: 'static',
   integrations: [sitemap()],
   vite: {
+    cacheDir: process.env.VITE_CACHE_DIR ?? 'node_modules/.vite',
     plugins: [tailwindcss()],
   },
 });

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,12 +2,14 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import sitemap from '@astrojs/sitemap';
 
+const viteCacheDir = process.env.VITE_CACHE_DIR?.trim() || 'node_modules/.vite';
+
 export default defineConfig({
   site: 'https://verity.supply',
   output: 'static',
   integrations: [sitemap()],
   vite: {
-    cacheDir: process.env.VITE_CACHE_DIR ?? 'node_modules/.vite',
+    cacheDir: viteCacheDir,
     plugins: [tailwindcss()],
   },
 });


### PR DESCRIPTION
## Summary
- diagnose Build Site run 26150502414 Harden Runner source-overwrite failure in Build Catalog / Build site
- route Astro/Vite dependency prebundle cache via VITE_CACHE_DIR with blank-value fallback
- set Build Site workflow cache path to runner temp, outside checked-out source

## Diagnosis
Scheduled Build Site run 26150502414 failed in job 76916441886 during Build site after npm run build. Harden Runner reported Source code overwritten for site/node_modules/.vite/deps_temp_4e856ce5/astro_* files opened by node. Those files are Vite/Astro dependency prebundle cache writes under node_modules/.vite in the checkout.

## Validation
- node config assertion for whitespace-only VITE_CACHE_DIR fallback
- npm ci --silent
- VITE_CACHE_DIR=/tmp/verity-site-vite-cache-local npm run build
- npm run lint -- --quiet
- verified temp cache exists and site/node_modules/.vite is not created

## Review loop
- replied to and resolved Copilot review thread about blank VITE_CACHE_DIR handling