### PR TITLE
fix(ci): retry integer image registry writes

### DIFF
--- a/.github/scripts/retry-registry-command.sh
+++ b/.github/scripts/retry-registry-command.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Retry registry-facing commands to absorb transient GHCR 5xx failures.
+# Usage: retry-registry-command.sh "label" command [args...]
+
+if [ "$#" -lt 2 ]; then
+  echo "::error::usage: $0 <label> <command> [args...]" >&2
+  exit 2
+fi
+
+LABEL="$1"
+shift
+
+MAX_ATTEMPTS="${REGISTRY_COMMAND_ATTEMPTS:-4}"
+BASE_DELAY_SECONDS="${REGISTRY_COMMAND_BASE_DELAY_SECONDS:-10}"
+
+case "$MAX_ATTEMPTS" in
+  ''|*[!0-9]*|0)
+    echo "::error::REGISTRY_COMMAND_ATTEMPTS must be a positive integer" >&2
+    exit 2
+    ;;
+esac
+
+case "$BASE_DELAY_SECONDS" in
+  ''|*[!0-9]*|0)
+    echo "::error::REGISTRY_COMMAND_BASE_DELAY_SECONDS must be a positive integer" >&2
+    exit 2
+    ;;
+esac
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  echo "::group::${LABEL} (attempt ${attempt}/${MAX_ATTEMPTS})" >&2
+  rc=0
+  if "$@"; then
+    echo "::endgroup::" >&2
+    exit 0
+  else
+    rc=$?
+    echo "::endgroup::" >&2
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "::error::${LABEL} failed after ${MAX_ATTEMPTS} attempts (exit ${rc})" >&2
+    exit "$rc"
+  fi
+
+  wait_seconds=$(( BASE_DELAY_SECONDS * attempt + RANDOM % BASE_DELAY_SECONDS ))
+  echo "${LABEL} failed (exit ${rc}); retrying in ${wait_seconds}s..." >&2
+  sleep "$wait_seconds"
+done

--- a/.github/scripts/validate-integer-build-image-workflow.py
+++ b/.github/scripts/validate-integer-build-image-workflow.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Guard integer-build-image workflow retry behavior that actionlint cannot express."""
+
+from pathlib import Path
+import sys
+
+
+WORKFLOW = Path(".github/workflows/integer-build-image.yaml")
+RETRY_HELPER = Path(".github/scripts/retry-registry-command.sh")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        print(f"integer-build-image workflow check failed: {message}", file=sys.stderr)
+        sys.exit(1)
+
+
+def uncomment(text: str) -> str:
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def main() -> None:
+    workflow = uncomment(WORKFLOW.read_text(encoding="utf-8"))
+    helper = RETRY_HELPER.read_text(encoding="utf-8")
+
+    require(
+        "docker/login-action" not in workflow,
+        "Integer Build Image must use retrying GHCR login, not one-shot docker/login-action",
+    )
+    require(
+        "bash .github/scripts/retry-docker-login.sh" in workflow,
+        "Integer Build Image must use retrying GHCR login helper",
+    )
+
+    for label in ("apko publish", "crane digest", "cosign sign"):
+        require(
+            "bash .github/scripts/retry-registry-command.sh" in workflow
+            and f'"{label}"' in workflow,
+            f"{label} must run through retry-registry-command.sh",
+        )
+
+    require(
+        'digest=$(bash .github/scripts/retry-registry-command.sh \\' in workflow,
+        "digest retrieval must capture retry helper stdout",
+    )
+    require(
+        'MAX_ATTEMPTS="${REGISTRY_COMMAND_ATTEMPTS:-4}"' in helper,
+        "retry helper must default to a bounded number of attempts",
+    )
+    require(
+        "sleep \"$wait_seconds\"" in helper and "RANDOM" in helper,
+        "retry helper must back off with jitter between attempts",
+    )
+    require(
+        ">&2" in helper,
+        "retry helper must log to stderr so crane digest stdout stays clean",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -323,11 +323,11 @@ jobs:
           check registry "$INPUT_REGISTRY" '^[a-zA-Z0-9./:_-]+$'
 
       - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          DOCKER_REGISTRY: ghcr.io
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/retry-docker-login.sh
 
       - name: Cache Go modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -481,12 +481,16 @@ jobs:
 
           APKO_ARGS+=("$tmpconfig" "${REFSARR[@]}")
 
-          apko "${APKO_ARGS[@]}"
+          bash .github/scripts/retry-registry-command.sh \
+            "apko publish" \
+            apko "${APKO_ARGS[@]}"
 
           rm -f "$tmpconfig"
 
           # Capture the digest of the published index for signing
-          digest=$(crane digest "${INPUT_REGISTRY}/${INPUT_IMAGE}:${PRIMARY_TAG}")
+          digest=$(bash .github/scripts/retry-registry-command.sh \
+            "crane digest" \
+            crane digest "${INPUT_REGISTRY}/${INPUT_IMAGE}:${PRIMARY_TAG}")
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       # ── Security scan ──────────────────────────────────────────────────────
@@ -523,7 +527,9 @@ jobs:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           # Sign by digest — immutable reference that covers all tags pointing to this image.
-          cosign sign --yes "${INPUT_REGISTRY}/${INPUT_IMAGE}@${DIGEST}"
+          bash .github/scripts/retry-registry-command.sh \
+            "cosign sign" \
+            cosign sign --yes "${INPUT_REGISTRY}/${INPUT_IMAGE}@${DIGEST}"
 
       - name: Attest SBOM
         if: hashFiles('sbom-amd64.spdx.json') != ''

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -59,6 +59,9 @@ jobs:
       - name: Validate patch-image workflow guards
         run: python3 .github/scripts/validate-patch-image-workflow.py
 
+      - name: Validate integer-build-image workflow guards
+        run: python3 .github/scripts/validate-integer-build-image-workflow.py
+
       - name: Run yamllint
         run: yamllint -c .yamllint.yml .
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ lint-workflows:
 	@which actionlint > /dev/null || (echo "actionlint not found. Run: make install-tools" && exit 1)
 	actionlint
 	python3 .github/scripts/validate-patch-image-workflow.py
+	python3 .github/scripts/validate-integer-build-image-workflow.py
 
 # Lint YAML files
 lint-yaml:


### PR DESCRIPTION
## Summary
- replace Integer Build Image GHCR login with existing retry helper
- add bounded retry/backoff helper for registry-facing publish, digest, and cosign sign commands
- add workflow guard validation and wire it into lint checks

## Validation
- python3 .github/scripts/validate-integer-build-image-workflow.py
- python3 .github/scripts/validate-patch-image-workflow.py
- retry helper stdout/failure smoke tests
- make lint-workflows (blocked locally: actionlint not installed; CI runs this with mise tools)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded, jittered retries for GHCR operations in the integer build image workflow to reduce flakiness from transient 5xx errors. Also replaces one-shot GHCR login with a retrying helper and adds workflow guards.

- **Bug Fixes**
  - Added `.github/scripts/retry-registry-command.sh` with capped attempts, linear backoff + jitter, and stderr logging (keeps `crane digest` stdout clean). Tunable via `REGISTRY_COMMAND_ATTEMPTS` and `REGISTRY_COMMAND_BASE_DELAY_SECONDS`.
  - Wrapped `apko publish`, `crane digest`, and `cosign sign` with the retry helper; digest capture runs through the helper.
  - Replaced `docker/login-action` with `retry-docker-login.sh` for GHCR login.
  - Added `.github/scripts/validate-integer-build-image-workflow.py` to enforce retry usage and correctness; wired into `lint.yaml` and `make lint-workflows`.

<sup>Written for commit 879eddddcfd713c413ac58974bb8c87d673cb6d0. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/457?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

