### PR TITLE
fix(site): harden catalog build cache

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -170,6 +170,8 @@ jobs:
 
       - name: Build site
         working-directory: site
+        env:
+          VITE_CACHE_DIR: ${{ runner.temp }}/verity-vite-cache
         run: npm ci && npm run build
 
       - name: Upload Pages artifact

--- a/internal/integer/catalog/catalog.go
+++ b/internal/integer/catalog/catalog.go
@@ -73,7 +73,7 @@ func Generate(imagesDir, reportsDir, registry string, pkgs []apkindex.Package, e
 		return nil, fmt.Errorf("reading images dir %q: %w", imagesDir, err)
 	}
 
-	var images []Image
+	images := []Image{}
 
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
@@ -109,6 +109,7 @@ func buildImage(def *config.ImageDef, registry, reportsDir string, pkgs []apkind
 	img := Image{
 		Name:        def.Name,
 		Description: def.Description,
+		Versions:    []Version{},
 	}
 
 	// Fetch EOL data from endoflife.date API if client is available.
@@ -141,8 +142,9 @@ func buildImage(def *config.ImageDef, registry, reportsDir string, pkgs []apkind
 		baseTags := discovery.DeriveTags(v, "", fullVersion)
 
 		ver := Version{
-			Version: v,
-			EOL:     eolDate,
+			Version:  v,
+			EOL:      eolDate,
+			Variants: []Variant{},
 		}
 
 		typeNames := sortedKeys(def.Types)
@@ -176,6 +178,9 @@ func buildImage(def *config.ImageDef, registry, reportsDir string, pkgs []apkind
 
 func buildVariant(imageName, version, typeName, registry, reportsDir string, baseTags []string) Variant {
 	typeTags := discovery.ApplyTypeSuffix(baseTags, typeName)
+	if len(typeTags) == 0 {
+		typeTags = []string{version}
+	}
 	ref := fmt.Sprintf("%s/%s:%s", registry, imageName, typeTags[0])
 	variant := Variant{
 		Type:   typeName,

--- a/internal/integer/catalog/catalog.go
+++ b/internal/integer/catalog/catalog.go
@@ -177,9 +177,12 @@ func buildImage(def *config.ImageDef, registry, reportsDir string, pkgs []apkind
 }
 
 func buildVariant(imageName, version, typeName, registry, reportsDir string, baseTags []string) Variant {
+	if len(baseTags) == 0 && version != "" {
+		baseTags = []string{version}
+	}
 	typeTags := discovery.ApplyTypeSuffix(baseTags, typeName)
 	if len(typeTags) == 0 {
-		typeTags = []string{version}
+		typeTags = []string{typeName}
 	}
 	ref := fmt.Sprintf("%s/%s:%s", registry, imageName, typeTags[0])
 	variant := Variant{

--- a/internal/integer/catalog/catalog_internal_test.go
+++ b/internal/integer/catalog/catalog_internal_test.go
@@ -1,0 +1,14 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildVariantFallbackPreservesTypeSuffix(t *testing.T) {
+	variant := buildVariant("node", "24", "dev", "ghcr.io/verity-org", "", nil)
+
+	assert.Equal(t, []string{"24-dev"}, variant.Tags)
+	assert.Equal(t, "ghcr.io/verity-org/node:24-dev", variant.Ref)
+}

--- a/internal/integer/catalog/catalog_test.go
+++ b/internal/integer/catalog/catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,6 +87,33 @@ func TestGenerate_NoReports(t *testing.T) {
 
 	assert.Equal(t, "ghcr.io/verity-org", cat.Registry)
 	assert.NotEmpty(t, cat.GeneratedAt)
+}
+
+func TestGenerate_MarshalsEmptySlicesAsArrays(t *testing.T) {
+	imagesDir := t.TempDir()
+	writeFile(t, imagesDir, "empty.yaml", `
+name: empty
+description: "No versions yet"
+upstream:
+  package: "empty"
+types:
+  default:
+    base: wolfi-base
+    packages: ["empty"]
+versions: {}
+`)
+
+	cat, err := catalog.Generate(imagesDir, "", "ghcr.io/verity-org", nil, nil)
+	require.NoError(t, err)
+
+	out, err := json.Marshal(cat)
+	require.NoError(t, err)
+	jsonText := string(out)
+	assert.True(t, strings.Contains(jsonText, `"images":[`), jsonText)
+	assert.True(t, strings.Contains(jsonText, `"versions":[]`), jsonText)
+	assert.NotContains(t, jsonText, `"images":null`)
+	assert.NotContains(t, jsonText, `"versions":null`)
+	assert.NotContains(t, jsonText, `"variants":null`)
 }
 
 func TestGenerate_WithReports(t *testing.T) {

--- a/internal/integer/catalog/catalog_test.go
+++ b/internal/integer/catalog/catalog_test.go
@@ -102,6 +102,19 @@ types:
     packages: ["empty"]
 versions: {}
 `)
+	writeFile(t, imagesDir, "skipped.yaml", `
+name: skipped
+description: "All variants skipped"
+upstream:
+  package: "skipped-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["skipped-{{version}}"]
+versions:
+  "1":
+    skip-types: ["default"]
+`)
 
 	cat, err := catalog.Generate(imagesDir, "", "ghcr.io/verity-org", nil, nil)
 	require.NoError(t, err)
@@ -111,6 +124,7 @@ versions: {}
 	jsonText := string(out)
 	assert.True(t, strings.Contains(jsonText, `"images":[`), jsonText)
 	assert.True(t, strings.Contains(jsonText, `"versions":[]`), jsonText)
+	assert.True(t, strings.Contains(jsonText, `"variants":[]`), jsonText)
 	assert.NotContains(t, jsonText, `"images":null`)
 	assert.NotContains(t, jsonText, `"versions":null`)
 	assert.NotContains(t, jsonText, `"variants":null`)

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
   output: 'static',
   integrations: [sitemap()],
   vite: {
+    cacheDir: process.env.VITE_CACHE_DIR ?? 'node_modules/.vite',
     plugins: [tailwindcss()],
   },
 });

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,12 +2,14 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import sitemap from '@astrojs/sitemap';
 
+const viteCacheDir = process.env.VITE_CACHE_DIR?.trim() || 'node_modules/.vite';
+
 export default defineConfig({
   site: 'https://verity.supply',
   output: 'static',
   integrations: [sitemap()],
   vite: {
-    cacheDir: process.env.VITE_CACHE_DIR ?? 'node_modules/.vite',
+    cacheDir: viteCacheDir,
     plugins: [tailwindcss()],
   },
 });

--- a/site/src/data/integer-catalog.ts
+++ b/site/src/data/integer-catalog.ts
@@ -6,23 +6,23 @@ import type { IntegerImage, IntegerVariant, IntegerVersion } from "../lib/catalo
 interface RawIntegerCatalog {
   generatedAt: string;
   registry: string;
-  images: Array<{
+  images?: Array<{
     name: string;
     description: string;
-    versions: Array<{
+    versions?: Array<{
       version: string;
       latest?: boolean;
       eol?: string;
-      variants: Array<{
+      variants?: Array<{
         type: string;
-        tags: string[];
+        tags?: string[] | null;
         ref: string;
         digest: string;
         builtAt: string;
         status: "success" | "failure" | "unknown";
-      }>;
-    }>;
-  }>;
+      }> | null;
+    }> | null;
+  }> | null;
 }
 
 interface CatalogResult {

--- a/site/src/data/integer-catalog.ts
+++ b/site/src/data/integer-catalog.ts
@@ -51,18 +51,18 @@ function loadCatalog(): CatalogResult {
     return { images: [], registry: "" };
   }
 
-  const images = data.images.map((img) => ({
+  const images = (data.images ?? []).map((img) => ({
     name: img.name,
     description: img.description,
-    versions: img.versions.map(
+    versions: (img.versions ?? []).map(
       (v): IntegerVersion => ({
         version: v.version,
         latest: v.latest,
         eol: v.eol,
-        variants: v.variants.map(
+        variants: (v.variants ?? []).map(
           (r): IntegerVariant => ({
             type: r.type,
-            tags: r.tags,
+            tags: r.tags ?? [],
             ref: r.ref,
             digest: r.digest,
             builtAt: r.builtAt,


### PR DESCRIPTION
## Summary
- Move Vite/Astro prebundle cache out of the repository during Build Site so Harden Runner no longer reports node_modules/.vite source overwrites.
- Make generated integer catalog JSON and site loading resilient to empty/null slices so static route generation does not crash on sparse catalog entries.

## Root cause
Scheduled Build Site run [26150502414](https://github.com/verity-org/verity/actions/runs/26150502414) failed in job [76916441886](https://github.com/verity-org/verity/actions/runs/26150502414/job/76916441886): Astro/Vite wrote dependency cache files under site/node_modules/.vite while Harden Runner source monitoring was enabled, and the generated integer catalog could emit null arrays that the Astro site read with .map().

## Validation
- go test ./...
- cd site && VITE_CACHE_DIR=/tmp/verity-vite-cache-post-rebase npm run build && npm run lint && npm run format:check
- temporary null-array integer catalog build smoke test passed

## Notes
- actionlint is not installed in this environment, so workflow syntax validation was limited to review plus GitHub CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the site build by moving the `vite` prebundle cache to a temp dir and making the integer catalog JSON and site loader null-safe. This avoids Harden Runner false positives and prevents static route crashes on sparse catalog data.

- **Bug Fixes**
  - Set `VITE_CACHE_DIR` to `${{ runner.temp }}/verity-vite-cache` in the workflow; `astro.config.mjs` reads it as `vite.cacheDir` with fallback to `node_modules/.vite`.
  - Initialize catalog slices (images/versions/variants) as empty arrays; add tag/type fallbacks in `buildVariant` to preserve version/type suffixes; make the site loader accept null/optional arrays and default `tags` to `[]`. Tests cover JSON arrays, tag/type fallbacks, and empty `variants` in the site.

<sup>Written for commit 9f4d713a51238e1fc6da05049b02382339db53ae. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/458?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

