### PR TITLE
fix(integer): retry GHCR publish and signing

### DIFF
--- a/.github/scripts/retry-docker-login.sh
+++ b/.github/scripts/retry-docker-login.sh
@@ -12,14 +12,14 @@ MAX_ATTEMPTS="${DOCKER_LOGIN_ATTEMPTS:-4}"
 TIMEOUT_SECONDS="${DOCKER_LOGIN_TIMEOUT_SECONDS:-45}"
 
 case "$MAX_ATTEMPTS" in
-  ''|*[!0-9]*|0)
+  ''|*[!0-9]*|0|0[0-9]*)
     echo "::error::DOCKER_LOGIN_ATTEMPTS must be a positive integer"
     exit 2
     ;;
 esac
 
 case "$TIMEOUT_SECONDS" in
-  ''|*[!0-9]*|0)
+  ''|*[!0-9]*|0|0[0-9]*)
     echo "::error::DOCKER_LOGIN_TIMEOUT_SECONDS must be a positive integer"
     exit 2
     ;;

--- a/.github/scripts/retry-registry-command.sh
+++ b/.github/scripts/retry-registry-command.sh
@@ -16,14 +16,14 @@ MAX_ATTEMPTS="${REGISTRY_COMMAND_ATTEMPTS:-4}"
 BASE_DELAY_SECONDS="${REGISTRY_COMMAND_BASE_DELAY_SECONDS:-10}"
 
 case "$MAX_ATTEMPTS" in
-  ''|*[!0-9]*|0)
+  ''|*[!0-9]*|0|0[0-9]*)
     echo "::error::REGISTRY_COMMAND_ATTEMPTS must be a positive integer" >&2
     exit 2
     ;;
 esac
 
 case "$BASE_DELAY_SECONDS" in
-  ''|*[!0-9]*|0)
+  ''|*[!0-9]*|0|0[0-9]*)
     echo "::error::REGISTRY_COMMAND_BASE_DELAY_SECONDS must be a positive integer" >&2
     exit 2
     ;;

--- a/.github/scripts/validate-integer-build-image-workflow.py
+++ b/.github/scripts/validate-integer-build-image-workflow.py
@@ -50,6 +50,14 @@ def main() -> None:
         "retry helper must default to a bounded number of attempts",
     )
     require(
+        "|0|0[0-9]*)" in helper,
+        "retry helper numeric guards must reject zero and leading-zero values",
+    )
+    require(
+        "else\n    rc=$?" in helper,
+        "retry helper must capture the failing command status inside the else branch",
+    )
+    require(
         "sleep \"$wait_seconds\"" in helper and "RANDOM" in helper,
         "retry helper must back off with jitter between attempts",
     )

--- a/.github/scripts/validate-retry-helpers.sh
+++ b/.github/scripts/validate-retry-helpers.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression checks for retry helper behavior that shellcheck/actionlint cannot prove.
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+out=$(REGISTRY_COMMAND_ATTEMPTS=1 \
+  bash .github/scripts/retry-registry-command.sh \
+  "stdout clean" bash -c 'printf sha256:abc' 2>"$tmpdir/success.err")
+if [ "$out" != "sha256:abc" ]; then
+  echo "retry helper must preserve command stdout exactly" >&2
+  exit 1
+fi
+
+if REGISTRY_COMMAND_ATTEMPTS=1 REGISTRY_COMMAND_BASE_DELAY_SECONDS=1 \
+  bash .github/scripts/retry-registry-command.sh \
+  "expected failure" bash -c 'exit 7' >"$tmpdir/failure.out" 2>"$tmpdir/failure.err"; then
+  echo "retry helper must fail when the final command attempt fails" >&2
+  exit 1
+fi
+
+if ! grep -q "exit 7" "$tmpdir/failure.err"; then
+  echo "retry helper must report the command exit code from the failed attempt" >&2
+  exit 1
+fi
+
+if REGISTRY_COMMAND_ATTEMPTS=00 \
+  bash .github/scripts/retry-registry-command.sh \
+  "bad attempts" true >"$tmpdir/bad-attempts.out" 2>"$tmpdir/bad-attempts.err"; then
+  echo "retry helper must reject leading-zero attempt counts" >&2
+  exit 1
+fi
+
+if REGISTRY_COMMAND_BASE_DELAY_SECONDS=00 \
+  bash .github/scripts/retry-registry-command.sh \
+  "bad delay" true >"$tmpdir/bad-delay.out" 2>"$tmpdir/bad-delay.err"; then
+  echo "retry helper must reject leading-zero delay values" >&2
+  exit 1
+fi
+
+echo "✓ retry helper validation passed"

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -442,6 +442,7 @@ jobs:
           BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           export BUILD_TIMESTAMP
           tmpconfig=$(mktemp --suffix=.apko.yaml)
+          trap 'rm -f "$tmpconfig"' EXIT
           cp "$CONFIG_PATH" "$tmpconfig"
           yq -i '
             .annotations["org.opencontainers.image.title"]       = strenv(OCI_TITLE) |
@@ -484,8 +485,6 @@ jobs:
           bash .github/scripts/retry-registry-command.sh \
             "apko publish" \
             apko "${APKO_ARGS[@]}"
-
-          rm -f "$tmpconfig"
 
           # Capture the digest of the published index for signing
           digest=$(bash .github/scripts/retry-registry-command.sh \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -62,6 +62,9 @@ jobs:
       - name: Validate integer-build-image workflow guards
         run: python3 .github/scripts/validate-integer-build-image-workflow.py
 
+      - name: Validate retry helpers
+        run: bash .github/scripts/validate-retry-helpers.sh
+
       - name: Run yamllint
         run: yamllint -c .yamllint.yml .
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ lint-workflows:
 	actionlint
 	python3 .github/scripts/validate-patch-image-workflow.py
 	python3 .github/scripts/validate-integer-build-image-workflow.py
+	bash .github/scripts/validate-retry-helpers.sh
 
 # Lint YAML files
 lint-yaml:


### PR DESCRIPTION
## Summary
- add bounded exponential retry with jitter around apko GHCR publish
- retry published digest lookup before signing
- retry cosign keyless signing upload to absorb transient GHCR 502s
- add workflow validation for the retry guards

## Validation
- python3 .github/scripts/validate-integer-build-image-workflow.py
- actionlint .github/workflows/integer-build-image.yaml via mise x actionlint@1.7.12
- go test ./...

## Root cause
Recent Integer Build Image failures were transient GHCR 502 responses during blob upload/lookup/signature upload, not image config failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded retry with jitter around GHCR publish, digest lookup, and keyless signing in the Integer Build Image workflow to absorb transient 502s. Adds validation and tests to enforce these guards and error handling.

- **Bug Fixes**
  - Wrap `apko` publish, `crane digest`, and `cosign sign` with `retry_with_backoff` (defaults: 5 attempts, 15s start delay, 120s max, small jitter).
  - Harden retry helpers to reject zero and leading-zero numeric values, and preserve the failing command’s exit code.
  - Add `.github/scripts/validate-retry-helpers.sh` and strengthen `.github/scripts/validate-integer-build-image-workflow.py`; run in `lint.yaml` and `make lint-workflows`.
  - Ensure temp config cleanup with `trap` during build.

<sup>Written for commit 556b07c849bfe043b400e78506884eaf37a6e73b. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/459?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

