### PR TITLE
Fix OpenSearch Dashboards duplicate smoke config

### DIFF
--- a/cmd/opensearch_dashboards_config_test.go
+++ b/cmd/opensearch_dashboards_config_test.go
@@ -31,6 +31,8 @@ func TestOpenSearchDashboardsImageUsesConfigScrubbingEntrypoint(t *testing.T) {
 	assert.Contains(t, text, "sed '/^opensearch_security\\./d'")
 	assert.Contains(t, text, "OPENSEARCH_HOSTS")
 	assert.Contains(t, text, "opensearch.hosts")
+	assert.Contains(t, text, "has_yaml_key 'opensearch\\.hosts'")
+	assert.Contains(t, text, "has_yaml_key 'server\\.host'")
 	assert.Contains(t, text, "SERVER_HOST")
 	assert.Contains(t, text, "opensearch.username")
 	assert.Contains(t, text, "exec /usr/share/opensearch-dashboards/bin/opensearch-dashboards")
@@ -40,4 +42,6 @@ func TestOpenSearchDashboardsImageUsesConfigScrubbingEntrypoint(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(values), "opensearch.hosts")
 	assert.Contains(t, string(values), "opensearch.ssl.verificationMode: none")
+	assert.Contains(t, string(values), "opensearchHosts: \"\"")
+	assert.Contains(t, string(values), "serverHost: \"\"")
 }

--- a/packages/bespoke/verity-opensearch-dashboards-config.yaml
+++ b/packages/bespoke/verity-opensearch-dashboards-config.yaml
@@ -24,6 +24,10 @@ pipeline:
         printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
       }
 
+      has_yaml_key() {
+        grep -Eq "^[[:space:]]*$1[[:space:]]*:" "$config"
+      }
+
       if [ -f "$config" ]; then
         config_writable=1
         tmp="$(mktemp "${config}.verity.XXXXXX")"
@@ -38,24 +42,24 @@ pipeline:
         fi
 
         if [ "$config_writable" -eq 1 ]; then
-          if [ -n "${SERVER_HOST:-}" ]; then
+          if [ -n "${SERVER_HOST:-}" ] && ! has_yaml_key 'server\.host'; then
             printf 'server.host: "%s"\n' "$(yaml_quote "$SERVER_HOST")" >> "$config"
           fi
 
-          if [ -n "${OPENSEARCH_HOSTS:-}" ]; then
+          if [ -n "${OPENSEARCH_HOSTS:-}" ] && ! has_yaml_key 'opensearch\.hosts'; then
             case "$OPENSEARCH_HOSTS" in
               \[* ) printf 'opensearch.hosts: %s\n' "$OPENSEARCH_HOSTS" >> "$config" ;;
               * ) printf 'opensearch.hosts: ["%s"]\n' "$(yaml_quote "$OPENSEARCH_HOSTS")" >> "$config" ;;
             esac
-          elif [ -n "${OPENSEARCH_URL:-}" ]; then
+          elif [ -n "${OPENSEARCH_URL:-}" ] && ! has_yaml_key 'opensearch\.hosts'; then
             printf 'opensearch.hosts: ["%s"]\n' "$(yaml_quote "$OPENSEARCH_URL")" >> "$config"
           fi
 
-          if [ -n "${OPENSEARCH_USERNAME:-}" ]; then
+          if [ -n "${OPENSEARCH_USERNAME:-}" ] && ! has_yaml_key 'opensearch\.username'; then
             printf 'opensearch.username: "%s"\n' "$(yaml_quote "$OPENSEARCH_USERNAME")" >> "$config"
           fi
 
-          if [ -n "${OPENSEARCH_PASSWORD:-}" ]; then
+          if [ -n "${OPENSEARCH_PASSWORD:-}" ] && ! has_yaml_key 'opensearch\.password'; then
             printf 'opensearch.password: "%s"\n' "$(yaml_quote "$OPENSEARCH_PASSWORD")" >> "$config"
           fi
         fi

--- a/test/chart-integration/values/opensearch-dashboards.yaml
+++ b/test/chart-integration/values/opensearch-dashboards.yaml
@@ -3,8 +3,13 @@
 # Verity's current published image entrypoint rewrites the config file in-place
 # before exec. Mount a writable config directory, seed it with the smoke-test
 # connection settings, and point Dashboards at the OpenSearch prerequisite that
-# the harness installs into this same namespace.
+# the harness installs into this same namespace. Disable the chart-provided env
+# equivalents so the currently published entrypoint does not append duplicate
+# YAML keys into the persistent emptyDir config across restarts.
 opensearch-dashboards:
+  opensearchHosts: ""
+  serverHost: ""
+
   extraVolumes:
     - name: verity-config
       emptyDir: {}


### PR DESCRIPTION
## Summary
- Disable the opensearch-dashboards chart env shims in the smoke values file when explicit config is mounted.
- Make the Verity opensearch-dashboards entrypoint idempotent: only append env-derived keys when the config file does not already define them.
- Add regression coverage for both the idempotency guard and the smoke values env suppression.

## Diagnosis
- Full main chart-integration run [26181269375](https://github.com/verity-org/verity/actions/runs/26181269375), job [77024816782](https://github.com/verity-org/verity/actions/runs/26181269375/job/77024816782), crashed with `YAMLException: duplicated mapping key`.
- Diagnostics showed `opensearch_dashboards.yml` contained repeated `server.host` and `opensearch.hosts` entries: the init container seeded explicit keys, then the image entrypoint appended chart env-derived equivalents on each start/restart.

## Tests
- `VERITY_IT_SKIP_CLUSTER=1 go test -tags=integration ./test/chart-integration/... ./cmd/...`
- `go test ./cmd/...`
- `helm template opensearch-dashboards oci://ghcr.io/verity-org/charts/opensearch-dashboards --version 3.6.0 --values test/chart-integration/values/opensearch-dashboards.yaml`
- `VERITY_CHART=opensearch-dashboards make chart-integration`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate keys in `opensearch_dashboards.yml` that caused OpenSearch Dashboards to crash during chart-integration runs. Makes the entrypoint idempotent and disables chart env shims in smoke values to prevent repeated config writes across restarts.

- **Bug Fixes**
  - EntryPoint: append env-derived settings only if the YAML key is missing.
  - Smoke values: set `opensearchHosts` and `serverHost` to empty to disable chart env shims when mounting explicit config.
  - Tests: add regression coverage for idempotency and env shim suppression.

<sup>Written for commit c398fdd7bac79ee94e78cf68edff451699cac2c7. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/460?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

