### PR TITLE
fix(charts): route rabbitmq cluster operator to verity image

### DIFF
--- a/internal/chartgen/chartvalues_loading_regression_test.go
+++ b/internal/chartgen/chartvalues_loading_regression_test.go
@@ -67,6 +67,13 @@ func TestVerityConfigChartValuesLoading(t *testing.T) {
 	if valkey["image.tag"] != "9.0" {
 		t.Fatalf("valkey image.tag=%v, want 9.0", valkey["image.tag"])
 	}
+	rabbitmqClusterOperator := vc2.Replacements["rabbitmq/cluster-operator"]
+	if rabbitmqClusterOperator.Image != "rabbitmq-cluster-operator" {
+		t.Fatalf("rabbitmq/cluster-operator replacement image=%q, want rabbitmq-cluster-operator", rabbitmqClusterOperator.Image)
+	}
+	if rabbitmqClusterOperator.Tag != "2" {
+		t.Fatalf("rabbitmq/cluster-operator replacement tag=%q, want 2", rabbitmqClusterOperator.Tag)
+	}
 
 	// victoria-logs-single has NO chartValues but its only image is in
 	// unpatchableImages — the new processChart passthrough branch must

--- a/verity.yaml
+++ b/verity.yaml
@@ -875,6 +875,17 @@ replacements:
     image: "tempo"
     tag: "2"
 
+  # rabbitmq-cluster-operator 0.2.3 renders the cluster operator image as
+  # `ghcr.io/rabbitmq/cluster-operator:2.21.0`. Verity's rebuild is named
+  # `rabbitmq-cluster-operator` (images/rabbitmq-cluster-operator.yaml)
+  # and publishes floating-major tag `2`; without this explicit mapping the
+  # wrapper leaves the upstream ghcr.io/rabbitmq image in place and the
+  # chart-integration image-origin gate fails.
+  "rabbitmq/cluster-operator":
+    registry: "ghcr.io/verity-org"
+    image: "rabbitmq-cluster-operator"
+    tag: "2"
+
   # kyverno chart (3.7.2). Chart renders images under
   # `reg.kyverno.io/kyverno/*` (Kyverno's pull-through mirror); repoPath
   # strips the host so keys match `kyverno/<name>`. The cleanup-controller,


### PR DESCRIPTION
## Summary

The full chart-integration run after [#466](https://github.com/verity-org/verity/pull/466) failed only `rabbitmq-cluster-operator`:

- Run: [26224806123](https://github.com/verity-org/verity/actions/runs/26224806123)
- Job: [rabbitmq-cluster-operator](https://github.com/verity-org/verity/actions/runs/26224806123/job/77169020803)

The chart installed successfully but failed the image-origin gate because it still ran upstream:

```text
spec rabbitmq-cluster-operator ghcr.io/rabbitmq/cluster-operator:2.21.0
status rabbitmq-cluster-operator ghcr.io/rabbitmq/cluster-operator@sha256:188436...
```

## Root Cause

`verity.yaml` had no replacement entry for `rabbitmq/cluster-operator`. The Verity rebuild exists as `images/rabbitmq-cluster-operator.yaml` and publishes `ghcr.io/verity-org/rabbitmq-cluster-operator:2`, but chart-gen had no mapping from the chart image path (`rabbitmq/cluster-operator`) to the rebuild name (`rabbitmq-cluster-operator`).

## Changes

- Add explicit replacement:

```yaml
"rabbitmq/cluster-operator":
  registry: "ghcr.io/verity-org"
  image: "rabbitmq-cluster-operator"
  tag: "2"
```

- Add regression coverage in `internal/chartgen/chartvalues_loading_regression_test.go` so the replacement remains present.

## Test Plan

- `go test ./internal/chartgen/...`
- `go test -tags integration ./test/chart-integration/... -run "TestLoadAllowlist|TestIsAccepted|TestProductionSKIPSYAMLIsValid"`
- `git diff --check`

## Verification Plan

After merge:
1. Trigger Chart Generation on `main`.
2. Trigger full chart-integration on `main` or targeted `rabbitmq-cluster-operator`.
3. Confirm `rabbitmq-cluster-operator` passes image-origin gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the `rabbitmq/cluster-operator` chart image to our rebuild `ghcr.io/verity-org/rabbitmq-cluster-operator:2`, fixing the image-origin gate failure in chart-integration. Adds a regression test to keep this mapping in place.

- **Bug Fixes**
  - Add explicit replacement in `verity.yaml` from `rabbitmq/cluster-operator` to `ghcr.io/verity-org/rabbitmq-cluster-operator:2`.
  - Add test assertions in `internal/chartgen/chartvalues_loading_regression_test.go` for image name and tag.

<sup>Written for commit eed050124e409254fc790c83f2766a7b5600992e. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/467?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

