### PR TITLE
fix(charts): tighten rabbitmq cluster operator replacement guard

### DIFF
--- a/internal/chartgen/chartvalues_loading_regression_test.go
+++ b/internal/chartgen/chartvalues_loading_regression_test.go
@@ -67,7 +67,13 @@ func TestVerityConfigChartValuesLoading(t *testing.T) {
 	if valkey["image.tag"] != "9.0" {
 		t.Fatalf("valkey image.tag=%v, want 9.0", valkey["image.tag"])
 	}
-	rabbitmqClusterOperator := vc2.Replacements["rabbitmq/cluster-operator"]
+	rabbitmqClusterOperator, ok := vc2.Replacements["rabbitmq/cluster-operator"]
+	if !ok {
+		t.Fatalf("missing replacement for rabbitmq/cluster-operator")
+	}
+	if rabbitmqClusterOperator.Registry != "ghcr.io/verity-org" {
+		t.Fatalf("rabbitmq/cluster-operator replacement registry=%q, want ghcr.io/verity-org", rabbitmqClusterOperator.Registry)
+	}
 	if rabbitmqClusterOperator.Image != "rabbitmq-cluster-operator" {
 		t.Fatalf("rabbitmq/cluster-operator replacement image=%q, want rabbitmq-cluster-operator", rabbitmqClusterOperator.Image)
 	}

--- a/verity.yaml
+++ b/verity.yaml
@@ -875,7 +875,7 @@ replacements:
     image: "tempo"
     tag: "2"
 
-  # rabbitmq-cluster-operator 0.2.3 renders the cluster operator image as
+  # rabbitmq-cluster-operator 0.3.0 renders the cluster operator image as
   # `ghcr.io/rabbitmq/cluster-operator:2.21.0`. Verity's rebuild is named
   # `rabbitmq-cluster-operator` (images/rabbitmq-cluster-operator.yaml)
   # and publishes floating-major tag `2`; without this explicit mapping the


### PR DESCRIPTION
## Summary

Follow-up to [#467](https://github.com/verity-org/verity/pull/467), addressing the post-merge review comments on the rabbitmq-cluster-operator replacement.

## Changes

- Updates the replacement comment to match the current chart version (`rabbitmq-cluster-operator` 0.3.0).
- Strengthens the regression test:
  - uses comma-ok lookup for `rabbitmq/cluster-operator`
  - fails explicitly when the replacement is missing
  - asserts the registry is `ghcr.io/verity-org`
  - continues to assert image and tag

## Test Plan

- `go test ./internal/chartgen/...`

## Context

[#467](https://github.com/verity-org/verity/pull/467) fixed the current chart-integration image-origin failure by mapping `ghcr.io/rabbitmq/cluster-operator:2.21.0` to `ghcr.io/verity-org/rabbitmq-cluster-operator:2`. This PR only tightens the comments/tests requested by review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the `rabbitmq/cluster-operator` replacement so it always routes to `ghcr.io/verity-org/rabbitmq-cluster-operator:2` and prevents image-origin regressions. Hardens the regression test and updates the chart comment to 0.3.0.

- **Bug Fixes**
  - Test now fails if the `rabbitmq/cluster-operator` replacement is missing, checks registry is `ghcr.io/verity-org`, and keeps image/tag assertions.
  - Updated `verity.yaml` comment to `rabbitmq-cluster-operator` 0.3.0.

<sup>Written for commit 1a9e412b72da4653dd2a3b88f52f970a08c09865. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/468?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

