### PR TITLE
fix(images): add rabbitmq operator chart manager path

### DIFF
--- a/images/rabbitmq-cluster-operator.yaml
+++ b/images/rabbitmq-cluster-operator.yaml
@@ -8,6 +8,12 @@ types:
     base: wolfi-base
     packages: ["rabbitmq-cluster-operator"]
     entrypoint: /usr/bin/manager
+    paths:
+      # cloudpirates rabbitmq-cluster-operator chart 0.3.0 hardcodes
+      # command: /manager (matching upstream image layout). Wolfi's
+      # package installs the binary at /usr/bin/manager. Keep the
+      # rebuild drop-in compatible with the chart.
+      - { path: /manager, type: symlink, source: /usr/bin/manager, uid: 0, gid: 0 }
 
 versions:
   "2": {}

--- a/internal/integer/config/rabbitmq_cluster_operator_image_test.go
+++ b/internal/integer/config/rabbitmq_cluster_operator_image_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRabbitMQClusterOperatorImageHasChartManagerPath(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locating test file")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	def, err := LoadImage(filepath.Join(repoRoot, "images", "rabbitmq-cluster-operator.yaml"))
+	if err != nil {
+		t.Fatalf("load rabbitmq-cluster-operator image: %v", err)
+	}
+	if err := Validate(def); err != nil {
+		t.Fatalf("validate rabbitmq-cluster-operator image: %v", err)
+	}
+
+	tmpl := def.Types["default"]
+	if tmpl.Entrypoint != "/usr/bin/manager" {
+		t.Fatalf("entrypoint=%q, want /usr/bin/manager", tmpl.Entrypoint)
+	}
+
+	found := false
+	for _, p := range tmpl.Paths {
+		if p.Path == "/manager" && p.Type == "symlink" && p.Source == "/usr/bin/manager" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("missing /manager -> /usr/bin/manager symlink required by chart command")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to [#467](https://github.com/verity-org/verity/pull/467). The replacement now routes the chart to the Verity rebuild, but full chart-integration still failed because the chart hardcodes `command: /manager` while the Wolfi package installs the binary at `/usr/bin/manager`.

Failing run: [26228376918](https://github.com/verity-org/verity/actions/runs/26228376918)  
Failing job: [rabbitmq-cluster-operator](https://github.com/verity-org/verity/actions/runs/26228376918/job/77181760689)

Diagnostic evidence:

```text
exec: "/manager": stat /manager: no such file or directory
```

## Changes

- Add `/manager -> /usr/bin/manager` symlink to `images/rabbitmq-cluster-operator.yaml`.
- Add regression test validating:
  - entrypoint remains `/usr/bin/manager`
  - chart-required `/manager` symlink exists and targets `/usr/bin/manager`

## Test Plan

- `go test ./internal/integer/config ./internal/chartgen/...`
- `git diff --check`

## Verification Plan

After merge:
1. Trigger the relevant Integer Build Image for `rabbitmq-cluster-operator` to publish the symlinked image.
2. Trigger Chart Generation and chart-integration for `rabbitmq-cluster-operator` on main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `rabbitmq-cluster-operator` chart crashes by aligning the image with the chart’s hardcoded `/manager` command. Keeps the actual binary at `/usr/bin/manager` while making the image drop-in compatible.

- **Bug Fixes**
  - Add `/manager` -> `/usr/bin/manager` symlink in `images/rabbitmq-cluster-operator.yaml`.
  - Add regression test to verify the `/usr/bin/manager` entrypoint and the symlink.

<sup>Written for commit 819aa140be4035db82d5275b473c3f3500b26965. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/469?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

