### PR TITLE
fix(images): keep rabbitmq operator manager executable

### DIFF
--- a/images/rabbitmq-cluster-operator.yaml
+++ b/images/rabbitmq-cluster-operator.yaml
@@ -9,6 +9,10 @@ types:
     packages: ["rabbitmq-cluster-operator"]
     entrypoint: /usr/bin/manager
     paths:
+      # apko applies chmod to symlink path mutations and follows links. Pair
+      # the chart shim below with an explicit executable target permission so
+      # /usr/bin/manager cannot be left non-executable in the published image.
+      - { path: /usr/bin/manager, type: permissions, permissions: 0o755 }
       # cloudpirates rabbitmq-cluster-operator chart 0.3.0 hardcodes
       # command: /manager (matching upstream image layout). Wolfi's
       # package installs the binary at /usr/bin/manager. Keep the

--- a/internal/integer/config/rabbitmq_cluster_operator_image_test.go
+++ b/internal/integer/config/rabbitmq_cluster_operator_image_test.go
@@ -24,6 +24,13 @@ func TestRabbitMQClusterOperatorImageHasChartManagerPath(t *testing.T) {
 	if tmpl.Entrypoint != "/usr/bin/manager" {
 		t.Fatalf("entrypoint=%q, want /usr/bin/manager", tmpl.Entrypoint)
 	}
+	manager, ok := findPath(tmpl.Paths, "/usr/bin/manager")
+	if !ok {
+		t.Fatal("missing /usr/bin/manager permissions entry")
+	}
+	if manager.Type != "permissions" || manager.Permissions != "0o755" {
+		t.Fatalf("/usr/bin/manager path entry = type:%q mode:%q, want permissions 0o755", manager.Type, manager.Permissions)
+	}
 
 	found := false
 	for _, p := range tmpl.Paths {


### PR DESCRIPTION
## Summary

Follow-up to [#469](https://github.com/verity-org/verity/pull/469). The `/manager` symlink now exists, but the next main verification failed with permission denied because the symlink target can still be left non-executable in the published image.

Failing run: [26236267500](https://github.com/verity-org/verity/actions/runs/26236267500)  
Failing job: [rabbitmq-cluster-operator](https://github.com/verity-org/verity/actions/runs/26236267500/job/77210275444)

Diagnostic evidence:

```text
exec: "/manager": permission denied
```

## Changes

- Add explicit `/usr/bin/manager` `permissions: 0o755` mutation in `images/rabbitmq-cluster-operator.yaml`.
- Keep `/manager -> /usr/bin/manager` symlink from [#469](https://github.com/verity-org/verity/pull/469).
- Extend regression test to assert both:
  - `/usr/bin/manager` target is executable
  - `/manager` symlink exists and points to `/usr/bin/manager`

## Test Plan

- `go test ./internal/integer/config ./internal/chartgen/...`
- `git diff --check`

## Verification Plan

After merge:
1. Rebuild/publish `ghcr.io/verity-org/rabbitmq-cluster-operator:2`.
2. Run targeted `chart-integration` for `rabbitmq-cluster-operator`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes container startup for the RabbitMQ cluster operator by making `/usr/bin/manager` executable and keeping the `/manager` symlink. Ensures the chart that runs `/manager` works with our image.

- **Bug Fixes**
  - Set `/usr/bin/manager` permissions to `0o755` in `images/rabbitmq-cluster-operator.yaml`.
  - Keep `/manager -> /usr/bin/manager` symlink for chart compatibility.
  - Extend tests to assert the entrypoint, the `/usr/bin/manager` executable permission, and the `/manager` symlink target.

<sup>Written for commit 0e4298b3c87955a56760d079fe3b091fd3c2e3e6. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/470?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

