### PR TITLE
test(integer): share image path test helpers

### DIFF
--- a/internal/integer/config/airflow_image_test.go
+++ b/internal/integer/config/airflow_image_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strings"
 	"testing"
 )
 
@@ -63,17 +62,4 @@ func TestAirflowImageExposesConsoleScriptsOnPath(t *testing.T) {
 			t.Fatalf("%s ownership/perms = uid:%d gid:%d mode:%s, want uid:50000 gid:0 mode:0o775", dirPath, p.UID, p.GID, p.Permissions)
 		}
 	}
-}
-
-func pathHasEntry(path, want string) bool {
-	return slices.Contains(strings.Split(path, ":"), want)
-}
-
-func findPath(paths []PathDef, want string) (PathDef, bool) {
-	for _, p := range paths {
-		if p.Path == want {
-			return p, true
-		}
-	}
-	return PathDef{}, false
 }

--- a/internal/integer/config/helpers_test.go
+++ b/internal/integer/config/helpers_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"slices"
+	"strings"
+)
+
+func pathHasEntry(path, want string) bool {
+	return slices.Contains(strings.Split(path, ":"), want)
+}
+
+func findPath(paths []PathDef, want string) (PathDef, bool) {
+	for _, p := range paths {
+		if p.Path == want {
+			return p, true
+		}
+	}
+	return PathDef{}, false
+}


### PR DESCRIPTION
## Summary

Follow-up to [#470](https://github.com/verity-org/verity/pull/470) review feedback.

The RabbitMQ image regression test used `findPath`, which was defined in `airflow_image_test.go`. That worked because both files share the same package, but it made the RabbitMQ test depend on an unrelated Airflow test file.

## Changes

- Move `findPath` and `pathHasEntry` into `internal/integer/config/helpers_test.go`.
- Remove the duplicate helper definitions from `airflow_image_test.go`.

## Test Plan

- `go test ./internal/integer/config`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the `findPath` and `pathHasEntry` test helpers into a shared `internal/integer/config/helpers_test.go` for reuse across image tests. Removed the duplicate helpers from `airflow_image_test.go` to avoid hidden coupling with the RabbitMQ test.

<sup>Written for commit 64b7f976f8cfd647c536d48f753b1069d6213487. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/471?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

