### PR TITLE
feat(ci): publish experimental APK repository

### DIFF
--- a/.github/scripts/assemble-apk-repository.sh
+++ b/.github/scripts/assemble-apk-repository.sh
@@ -61,22 +61,29 @@ if [[ ${#SOURCES[@]} -eq 0 ]]; then
   SOURCES=("packages/repo" "apk-artifacts")
 fi
 
+if [[ -z "$OUTPUT_DIR" ]] || [[ "$OUTPUT_DIR" == "/" ]] || [[ "$OUTPUT_DIR" == "." ]]; then
+  echo "unsafe output directory: ${OUTPUT_DIR}" >&2
+  exit 2
+fi
+
 if [[ ! "$KEY_NAME" =~ ^[A-Za-z0-9._-]+$ ]] || [[ "$KEY_NAME" == *".."* ]]; then
   echo "unsafe key name: ${KEY_NAME}" >&2
   exit 2
 fi
+if [[ "$KEY_NAME" != *.rsa ]]; then
+  echo "key name must end with .rsa so signatures match the published .rsa.pub key: ${KEY_NAME}" >&2
+  exit 2
+fi
 
 detect_arch() {
-  local path="$1" part
-  IFS='/' read -ra parts <<< "$path"
-  for part in "${parts[@]}"; do
-    case "$part" in
-      x86_64|aarch64|armv7|armhf|ppc64le|s390x|riscv64)
-        printf '%s\n' "$part"
-        return 0
-        ;;
-    esac
-  done
+  local path="$1" parent
+  parent=$(basename "$(dirname "$path")")
+  case "$parent" in
+    x86_64|aarch64|armv7|armhf|ppc64le|s390x|riscv64)
+      printf '%s\n' "$parent"
+      return 0
+      ;;
+  esac
   return 1
 }
 
@@ -87,15 +94,15 @@ require_tool() {
   fi
 }
 
-mkdir -p "$OUTPUT_DIR"
-rm -f "$OUTPUT_DIR/.no-apks-found"
-
 mapfile -t APKS < <(
   for source in "${SOURCES[@]}"; do
     [[ -d "$source" ]] || continue
     find "$source" -type f -name '*.apk' -print
   done | sort -u
 )
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
 
 if [[ ${#APKS[@]} -eq 0 ]]; then
   cat > "$OUTPUT_DIR/.no-apks-found" <<EOF
@@ -105,6 +112,23 @@ EOF
   echo "No APK files found; wrote ${OUTPUT_DIR}/.no-apks-found"
   exit 0
 fi
+
+declare -A DESTINATIONS=()
+for apk_file in "${APKS[@]}"; do
+  arch=$(detect_arch "$apk_file") || {
+    echo "could not determine APK architecture from parent directory: ${apk_file}" >&2
+    echo "expected the APK to live directly under an arch directory such as x86_64 or aarch64" >&2
+    exit 1
+  }
+  dest_key="${arch}/$(basename "$apk_file")"
+  if [[ -n "${DESTINATIONS[$dest_key]:-}" ]]; then
+    echo "duplicate APK destination ${dest_key}:" >&2
+    echo "  ${DESTINATIONS[$dest_key]}" >&2
+    echo "  ${apk_file}" >&2
+    exit 1
+  fi
+  DESTINATIONS[$dest_key]="$apk_file"
+done
 
 require_tool apk
 if [[ -n "${APK_REPOSITORY_PRIVATE_KEY:-}" ]]; then
@@ -116,11 +140,7 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 for apk_file in "${APKS[@]}"; do
-  arch=$(detect_arch "$apk_file") || {
-    echo "could not determine APK architecture from path: ${apk_file}" >&2
-    echo "expected an arch path component such as x86_64 or aarch64" >&2
-    exit 1
-  }
+  arch=$(detect_arch "$apk_file")
   mkdir -p "$OUTPUT_DIR/$arch"
   cp "$apk_file" "$OUTPUT_DIR/$arch/"
 done
@@ -130,7 +150,7 @@ if [[ -n "${APK_REPOSITORY_PRIVATE_KEY:-}" ]]; then
   public_key="$tmpdir/$KEY_NAME.pub"
   printf '%s\n' "$APK_REPOSITORY_PRIVATE_KEY" > "$private_key"
   chmod 600 "$private_key"
-  openssl rsa -in "$private_key" -pubout -out "$public_key" >/dev/null 2>&1
+  openssl rsa -in "$private_key" -pubout -out "$public_key"
   cp "$public_key" "$OUTPUT_DIR/$KEY_NAME.pub"
   echo "Published APK repository public key: ${OUTPUT_DIR}/${KEY_NAME}.pub"
 else

--- a/.github/scripts/assemble-apk-repository.sh
+++ b/.github/scripts/assemble-apk-repository.sh
@@ -61,7 +61,16 @@ if [[ ${#SOURCES[@]} -eq 0 ]]; then
   SOURCES=("packages/repo" "apk-artifacts")
 fi
 
-if [[ -z "$OUTPUT_DIR" ]] || [[ "$OUTPUT_DIR" == "/" ]] || [[ "$OUTPUT_DIR" == "." ]]; then
+has_parent_traversal() {
+  local path="$1" segment
+  IFS='/' read -ra segments <<< "$path"
+  for segment in "${segments[@]}"; do
+    [[ "$segment" == ".." ]] && return 0
+  done
+  return 1
+}
+
+if [[ -z "$OUTPUT_DIR" ]] || [[ "$OUTPUT_DIR" == "/" ]] || [[ "$OUTPUT_DIR" == "." ]] || has_parent_traversal "$OUTPUT_DIR"; then
   echo "unsafe output directory: ${OUTPUT_DIR}" >&2
   exit 2
 fi

--- a/.github/scripts/assemble-apk-repository.sh
+++ b/.github/scripts/assemble-apk-repository.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: assemble-apk-repository.sh [--output DIR] [--key-name NAME] [SOURCE_DIR ...]
+
+Collects .apk files from SOURCE_DIRs, lays them out as a static APK repository,
+builds APKINDEX.tar.gz per architecture, and signs each index when
+APK_REPOSITORY_PRIVATE_KEY is set.
+
+Defaults:
+  output: site/dist/apk
+  sources: packages/repo apk-artifacts
+  key name: verity-apk-repository.rsa
+
+Guarded behavior: if no .apk files are found, writes .no-apks-found and exits 0.
+USAGE
+}
+
+OUTPUT_DIR="site/dist/apk"
+KEY_NAME="verity-apk-repository.rsa"
+SOURCES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --key-name)
+      [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }
+      KEY_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      SOURCES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ $# -gt 0 ]]; then
+  SOURCES+=("$@")
+fi
+if [[ ${#SOURCES[@]} -eq 0 ]]; then
+  SOURCES=("packages/repo" "apk-artifacts")
+fi
+
+if [[ ! "$KEY_NAME" =~ ^[A-Za-z0-9._-]+$ ]] || [[ "$KEY_NAME" == *".."* ]]; then
+  echo "unsafe key name: ${KEY_NAME}" >&2
+  exit 2
+fi
+
+detect_arch() {
+  local path="$1" part
+  IFS='/' read -ra parts <<< "$path"
+  for part in "${parts[@]}"; do
+    case "$part" in
+      x86_64|aarch64|armv7|armhf|ppc64le|s390x|riscv64)
+        printf '%s\n' "$part"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required tool not found: $1" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$OUTPUT_DIR"
+rm -f "$OUTPUT_DIR/.no-apks-found"
+
+mapfile -t APKS < <(
+  for source in "${SOURCES[@]}"; do
+    [[ -d "$source" ]] || continue
+    find "$source" -type f -name '*.apk' -print
+  done | sort -u
+)
+
+if [[ ${#APKS[@]} -eq 0 ]]; then
+  cat > "$OUTPUT_DIR/.no-apks-found" <<EOF
+No APK files were found in: ${SOURCES[*]}
+Repository assembly skipped without failing the workflow.
+EOF
+  echo "No APK files found; wrote ${OUTPUT_DIR}/.no-apks-found"
+  exit 0
+fi
+
+require_tool apk
+if [[ -n "${APK_REPOSITORY_PRIVATE_KEY:-}" ]]; then
+  require_tool abuild-sign
+  require_tool openssl
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+for apk_file in "${APKS[@]}"; do
+  arch=$(detect_arch "$apk_file") || {
+    echo "could not determine APK architecture from path: ${apk_file}" >&2
+    echo "expected an arch path component such as x86_64 or aarch64" >&2
+    exit 1
+  }
+  mkdir -p "$OUTPUT_DIR/$arch"
+  cp "$apk_file" "$OUTPUT_DIR/$arch/"
+done
+
+if [[ -n "${APK_REPOSITORY_PRIVATE_KEY:-}" ]]; then
+  private_key="$tmpdir/$KEY_NAME"
+  public_key="$tmpdir/$KEY_NAME.pub"
+  printf '%s\n' "$APK_REPOSITORY_PRIVATE_KEY" > "$private_key"
+  chmod 600 "$private_key"
+  openssl rsa -in "$private_key" -pubout -out "$public_key" >/dev/null 2>&1
+  cp "$public_key" "$OUTPUT_DIR/$KEY_NAME.pub"
+  echo "Published APK repository public key: ${OUTPUT_DIR}/${KEY_NAME}.pub"
+else
+  private_key=""
+  echo "APK_REPOSITORY_PRIVATE_KEY not set; APKINDEX files will be unsigned" >&2
+fi
+
+for arch_dir in "$OUTPUT_DIR"/*; do
+  [[ -d "$arch_dir" ]] || continue
+  shopt -s nullglob
+  arch_apks=("$arch_dir"/*.apk)
+  shopt -u nullglob
+  [[ ${#arch_apks[@]} -gt 0 ]] || continue
+
+  (
+    cd "$arch_dir"
+    apk index --output APKINDEX.tar.gz ./*.apk
+  )
+
+  if [[ -n "$private_key" ]]; then
+    abuild-sign -k "$private_key" "$arch_dir/APKINDEX.tar.gz"
+  fi
+  echo "Assembled ${arch_dir#${OUTPUT_DIR}/}/APKINDEX.tar.gz (${#arch_apks[@]} packages)"
+done

--- a/.github/scripts/assemble-apk-repository.sh
+++ b/.github/scripts/assemble-apk-repository.sh
@@ -153,5 +153,5 @@ for arch_dir in "$OUTPUT_DIR"/*; do
   if [[ -n "$private_key" ]]; then
     abuild-sign -k "$private_key" "$arch_dir/APKINDEX.tar.gz"
   fi
-  echo "Assembled ${arch_dir#${OUTPUT_DIR}/}/APKINDEX.tar.gz (${#arch_apks[@]} packages)"
+  echo "Assembled ${arch_dir#"${OUTPUT_DIR}"/}/APKINDEX.tar.gz (${#arch_apks[@]} packages)"
 done

--- a/.github/scripts/validate-apk-repository.sh
+++ b/.github/scripts/validate-apk-repository.sh
@@ -81,7 +81,7 @@ for arch_dir in "$REPO_DIR"/*; do
 
   index="$arch_dir/APKINDEX.tar.gz"
   if [[ ! -f "$index" ]]; then
-    echo "missing APKINDEX.tar.gz for ${arch_dir#${REPO_DIR}/}" >&2
+    echo "missing APKINDEX.tar.gz for ${arch_dir#"${REPO_DIR}"/}" >&2
     status=1
     continue
   fi

--- a/.github/scripts/validate-apk-repository.sh
+++ b/.github/scripts/validate-apk-repository.sh
@@ -46,6 +46,13 @@ done
 [[ -n "$REPO_DIR" ]] || { usage; exit 2; }
 [[ -d "$REPO_DIR" ]] || { echo "repository directory not found: $REPO_DIR" >&2; exit 1; }
 
+is_supported_arch() {
+  case "$1" in
+    x86_64|aarch64|armv7|armhf|ppc64le|s390x|riscv64) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 mapfile -t ROOT_APKS < <(find "$REPO_DIR" -maxdepth 1 -type f -name '*.apk' -print | sort)
 if [[ ${#ROOT_APKS[@]} -gt 0 ]]; then
   echo "APK files must live under architecture directories, not repository root:" >&2
@@ -53,7 +60,14 @@ if [[ ${#ROOT_APKS[@]} -gt 0 ]]; then
   exit 1
 fi
 
-mapfile -t APKS < <(find "$REPO_DIR" -mindepth 2 -type f -name '*.apk' -print | sort)
+mapfile -t DEEP_APKS < <(find "$REPO_DIR" -mindepth 3 -type f -name '*.apk' -print | sort)
+if [[ ${#DEEP_APKS[@]} -gt 0 ]]; then
+  echo "APK files must live directly under architecture directories:" >&2
+  printf '  %s\n' "${DEEP_APKS[@]}" >&2
+  exit 1
+fi
+
+mapfile -t APKS < <(find "$REPO_DIR" -mindepth 2 -maxdepth 2 -type f -name '*.apk' -print | sort)
 if [[ ${#APKS[@]} -eq 0 ]]; then
   if [[ -f "$REPO_DIR/.no-apks-found" ]]; then
     echo "No APK files present; guarded empty repository marker found"
@@ -74,10 +88,17 @@ fi
 status=0
 for arch_dir in "$REPO_DIR"/*; do
   [[ -d "$arch_dir" ]] || continue
+  arch=$(basename "$arch_dir")
   shopt -s nullglob
   arch_apks=("$arch_dir"/*.apk)
   shopt -u nullglob
   [[ ${#arch_apks[@]} -gt 0 ]] || continue
+
+  if ! is_supported_arch "$arch"; then
+    echo "unsupported architecture directory containing APKs: $arch" >&2
+    status=1
+    continue
+  fi
 
   index="$arch_dir/APKINDEX.tar.gz"
   if [[ ! -f "$index" ]]; then
@@ -92,10 +113,20 @@ for arch_dir in "$REPO_DIR"/*; do
     continue
   fi
 
-  if [[ "$REQUIRE_SIGNATURE" == "true" ]] && \
-     ! tar -tzf "$index" | grep -Eq '(^|/)\.SIGN\.RSA\..*\.rsa\.pub$'; then
-    echo "missing RSA signature entry in $index" >&2
-    status=1
+  if [[ "$REQUIRE_SIGNATURE" == "true" ]]; then
+    mapfile -t SIGNATURES < <(tar -tzf "$index" | grep -E '(^|/)\.SIGN\.RSA\..*\.pub$' | sed 's#^.*/##')
+    if [[ ${#SIGNATURES[@]} -eq 0 ]]; then
+      echo "missing RSA signature entry in $index" >&2
+      status=1
+      continue
+    fi
+    for signature in "${SIGNATURES[@]}"; do
+      key_name="${signature#.SIGN.RSA.}"
+      if [[ ! -f "$REPO_DIR/$key_name" ]]; then
+        echo "signature ${signature} in $index has no matching root public key: $key_name" >&2
+        status=1
+      fi
+    done
   fi
 done
 

--- a/.github/scripts/validate-apk-repository.sh
+++ b/.github/scripts/validate-apk-repository.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: validate-apk-repository.sh [--require-signature] REPO_DIR
+
+Validates a static APK repository layout:
+  REPO_DIR/<arch>/*.apk
+  REPO_DIR/<arch>/APKINDEX.tar.gz
+  REPO_DIR/*.rsa.pub when signatures are required
+
+If REPO_DIR/.no-apks-found exists and no APKs are present, validation passes.
+USAGE
+}
+
+REQUIRE_SIGNATURE=false
+REPO_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --require-signature)
+      REQUIRE_SIGNATURE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [[ -n "$REPO_DIR" ]]; then
+        echo "unexpected extra argument: $1" >&2
+        exit 2
+      fi
+      REPO_DIR="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$REPO_DIR" ]] || { usage; exit 2; }
+[[ -d "$REPO_DIR" ]] || { echo "repository directory not found: $REPO_DIR" >&2; exit 1; }
+
+mapfile -t ROOT_APKS < <(find "$REPO_DIR" -maxdepth 1 -type f -name '*.apk' -print | sort)
+if [[ ${#ROOT_APKS[@]} -gt 0 ]]; then
+  echo "APK files must live under architecture directories, not repository root:" >&2
+  printf '  %s\n' "${ROOT_APKS[@]}" >&2
+  exit 1
+fi
+
+mapfile -t APKS < <(find "$REPO_DIR" -mindepth 2 -type f -name '*.apk' -print | sort)
+if [[ ${#APKS[@]} -eq 0 ]]; then
+  if [[ -f "$REPO_DIR/.no-apks-found" ]]; then
+    echo "No APK files present; guarded empty repository marker found"
+    exit 0
+  fi
+  echo "no APK files found and .no-apks-found marker is missing" >&2
+  exit 1
+fi
+
+if [[ "$REQUIRE_SIGNATURE" == "true" ]]; then
+  mapfile -t PUBKEYS < <(find "$REPO_DIR" -maxdepth 1 -type f -name '*.rsa.pub' -print | sort)
+  if [[ ${#PUBKEYS[@]} -eq 0 ]]; then
+    echo "signature required but no public key (*.rsa.pub) found at repository root" >&2
+    exit 1
+  fi
+fi
+
+status=0
+for arch_dir in "$REPO_DIR"/*; do
+  [[ -d "$arch_dir" ]] || continue
+  shopt -s nullglob
+  arch_apks=("$arch_dir"/*.apk)
+  shopt -u nullglob
+  [[ ${#arch_apks[@]} -gt 0 ]] || continue
+
+  index="$arch_dir/APKINDEX.tar.gz"
+  if [[ ! -f "$index" ]]; then
+    echo "missing APKINDEX.tar.gz for ${arch_dir#${REPO_DIR}/}" >&2
+    status=1
+    continue
+  fi
+
+  if ! tar -tzf "$index" >/dev/null 2>&1; then
+    echo "invalid gzip tar index: $index" >&2
+    status=1
+    continue
+  fi
+
+  if [[ "$REQUIRE_SIGNATURE" == "true" ]] && \
+     ! tar -tzf "$index" | grep -Eq '(^|/)\.SIGN\.RSA\..*\.rsa\.pub$'; then
+    echo "missing RSA signature entry in $index" >&2
+    status=1
+  fi
+done
+
+if [[ $status -ne 0 ]]; then
+  exit "$status"
+fi
+
+echo "APK repository layout valid: $REPO_DIR (${#APKS[@]} packages)"

--- a/.github/workflows/apk-repository.yaml
+++ b/.github/workflows/apk-repository.yaml
@@ -14,17 +14,15 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   assemble:
     name: Assemble APK repository
     runs-on: ubuntu-24.04
-    environment:
-      name: github-pages
     env:
       HAS_APK_REPOSITORY_PRIVATE_KEY: ${{ secrets.APK_REPOSITORY_PRIVATE_KEY != '' }}
+    permissions:
+      contents: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
@@ -60,8 +58,8 @@ jobs:
             -e APK_REPOSITORY_PRIVATE_KEY \
             -v "$PWD:/work" \
             -w /work \
-            alpine:3.22 \
-            sh -euxc 'apk add --no-cache alpine-sdk bash findutils openssl && bash .github/scripts/assemble-apk-repository.sh --output site/dist/apk apk-artifacts packages/repo'
+            alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 \
+            sh -euxc 'packages="bash findutils"; if [ -n "${APK_REPOSITORY_PRIVATE_KEY:-}" ]; then packages="$packages abuild openssl"; fi; apk add --no-cache $packages; bash .github/scripts/assemble-apk-repository.sh --output site/dist/apk apk-artifacts packages/repo'
 
       - name: Validate APK repository
         run: bash .github/scripts/validate-apk-repository.sh site/dist/apk

--- a/.github/workflows/apk-repository.yaml
+++ b/.github/workflows/apk-repository.yaml
@@ -3,9 +3,6 @@ name: APK Repository
 on:
   workflow_dispatch:
     inputs:
-      source_run_id:
-        description: "Integer Build Image run id that uploaded melange-packages-* artifacts"
-        required: false
       publish_pages:
         description: "Deploy the assembled site artifact to GitHub Pages"
         required: true
@@ -16,7 +13,6 @@ on:
           - "true"
 
 permissions:
-  actions: read
   contents: read
   pages: write
   id-token: write
@@ -38,36 +34,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Validate inputs
-        env:
-          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
-        run: |
-          if [ -n "$SOURCE_RUN_ID" ] && [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
-            echo "source_run_id must be numeric" >&2
-            exit 1
-          fi
-
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
 
-      - name: Download Integer Melange package artifacts
-        if: inputs.source_run_id != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+      - name: Prepare artifact source directory
         run: |
           mkdir -p apk-artifacts
-          if gh run download "$SOURCE_RUN_ID" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern 'melange-packages-*' \
-            --dir apk-artifacts; then
-            find apk-artifacts -type f -name '*.apk' -print | sort
-          else
-            echo "::warning::No melange package artifacts downloaded from run ${SOURCE_RUN_ID}"
-          fi
+          echo "Repository assembly will scan packages/repo and apk-artifacts."
+          echo "Cross-run artifact download is intentionally not performed in this privileged workflow."
 
       - name: Build site shell
         working-directory: site

--- a/.github/workflows/apk-repository.yaml
+++ b/.github/workflows/apk-repository.yaml
@@ -1,0 +1,120 @@
+name: APK Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "Integer Build Image run id that uploaded melange-packages-* artifacts"
+        required: false
+      publish_pages:
+        description: "Deploy the assembled site artifact to GitHub Pages"
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  actions: read
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  assemble:
+    name: Assemble APK repository
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+    env:
+      HAS_APK_REPOSITORY_PRIVATE_KEY: ${{ secrets.APK_REPOSITORY_PRIVATE_KEY != '' }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate inputs
+        env:
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          if [ -n "$SOURCE_RUN_ID" ] && [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "source_run_id must be numeric" >&2
+            exit 1
+          fi
+
+      - name: Install mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: true
+          cache: true
+
+      - name: Download Integer Melange package artifacts
+        if: inputs.source_run_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          mkdir -p apk-artifacts
+          if gh run download "$SOURCE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'melange-packages-*' \
+            --dir apk-artifacts; then
+            find apk-artifacts -type f -name '*.apk' -print | sort
+          else
+            echo "::warning::No melange package artifacts downloaded from run ${SOURCE_RUN_ID}"
+          fi
+
+      - name: Build site shell
+        working-directory: site
+        env:
+          VITE_CACHE_DIR: ${{ runner.temp }}/verity-vite-cache
+        run: npm ci && npm run build
+
+      - name: Assemble APK repository
+        env:
+          APK_REPOSITORY_PRIVATE_KEY: ${{ secrets.APK_REPOSITORY_PRIVATE_KEY }}
+        run: |
+          docker run --rm \
+            -e APK_REPOSITORY_PRIVATE_KEY \
+            -v "$PWD:/work" \
+            -w /work \
+            alpine:3.22 \
+            sh -euxc 'apk add --no-cache alpine-sdk bash findutils openssl && bash .github/scripts/assemble-apk-repository.sh --output site/dist/apk apk-artifacts packages/repo'
+
+      - name: Validate APK repository
+        run: bash .github/scripts/validate-apk-repository.sh site/dist/apk
+
+      - name: Validate APK repository signatures
+        if: env.HAS_APK_REPOSITORY_PRIVATE_KEY == 'true'
+        run: bash .github/scripts/validate-apk-repository.sh --require-signature site/dist/apk
+
+      - name: Upload Pages artifact
+        uses: ./.github/actions/upload-pages-artifact
+        with:
+          path: site/dist
+          overwrite: "true"
+
+  deploy:
+    name: Deploy APK repository site
+    needs: assemble
+    if: inputs.publish_pages == 'true'
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        id: deployment

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-24.04
     environment:
       name: github-pages
+    env:
+      HAS_APK_REPOSITORY_PRIVATE_KEY: ${{ secrets.APK_REPOSITORY_PRIVATE_KEY != '' }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -173,6 +175,18 @@ jobs:
         env:
           VITE_CACHE_DIR: ${{ runner.temp }}/verity-vite-cache
         run: npm ci && npm run build
+
+      - name: Assemble APK repository overlay
+        env:
+          APK_REPOSITORY_PRIVATE_KEY: ${{ secrets.APK_REPOSITORY_PRIVATE_KEY }}
+        run: bash .github/scripts/assemble-apk-repository.sh --output site/dist/apk packages/repo apk-artifacts
+
+      - name: Validate APK repository overlay
+        run: bash .github/scripts/validate-apk-repository.sh site/dist/apk
+
+      - name: Validate signed APK repository overlay
+        if: env.HAS_APK_REPOSITORY_PRIVATE_KEY == 'true'
+        run: bash .github/scripts/validate-apk-repository.sh --require-signature site/dist/apk
 
       - name: Upload Pages artifact
         uses: ./.github/actions/upload-pages-artifact

--- a/docs/apk-repository.md
+++ b/docs/apk-repository.md
@@ -12,8 +12,14 @@ Integer image builds already create Melange package artifacts in
 - `melange-packages-aarch64`
 
 Each artifact contains a `packages/repo/` tree with architecture-specific
-subdirectories. The APK repository workflow downloads those artifacts from a
-caller-provided workflow run id and indexes any `.apk` files it finds.
+subdirectories. The repository assembly scripts scan `packages/repo/` and
+`apk-artifacts/` for those layouts.
+
+The privileged Pages workflow does **not** download artifacts from arbitrary
+workflow runs. Doing so would allow artifact poisoning if a caller selected an
+untrusted run. A follow-up should add a trusted handoff (for example, a same-run
+build-and-assemble job chain, provenance checks, or a protected package storage
+decision) before cross-run artifacts are published automatically.
 
 ## Signing
 

--- a/docs/apk-repository.md
+++ b/docs/apk-repository.md
@@ -1,0 +1,41 @@
+# Experimental APK repository publishing
+
+Verity can assemble Melange `.apk` artifacts into a static APK repository under
+`site/dist/apk/` for GitHub Pages publishing.
+
+## Artifact sources
+
+Integer image builds already create Melange package artifacts in
+`.github/workflows/integer-build-image.yaml`:
+
+- `melange-packages-x86_64`
+- `melange-packages-aarch64`
+
+Each artifact contains a `packages/repo/` tree with architecture-specific
+subdirectories. The APK repository workflow downloads those artifacts from a
+caller-provided workflow run id and indexes any `.apk` files it finds.
+
+## Signing
+
+Set `APK_REPOSITORY_PRIVATE_KEY` as a GitHub Actions secret containing the PEM
+private key used to sign `APKINDEX.tar.gz`. The workflow derives and publishes
+`verity-apk-repository.rsa.pub` next to the repository root.
+
+If the secret is absent, the workflow still assembles unsigned indexes and runs
+non-signature validation. This keeps repository scaffolding safe for branches and
+forks while making signed publishing available on protected environments.
+
+## Guarded empty behavior
+
+If no `.apk` artifacts are available, assembly writes `site/dist/apk/.no-apks-found`
+and exits successfully. This prevents scheduled site deploys from failing while
+the package retention and repository-size policy is still being decided.
+
+## Local validation
+
+```bash
+bash .github/scripts/assemble-apk-repository.sh --output site/dist/apk packages/repo apk-artifacts
+bash .github/scripts/validate-apk-repository.sh site/dist/apk
+```
+
+Use `--require-signature` once `APK_REPOSITORY_PRIVATE_KEY` is configured.

--- a/docs/apk-repository.md
+++ b/docs/apk-repository.md
@@ -39,8 +39,18 @@ the package retention and repository-size policy is still being decided.
 
 ## Local validation
 
+Non-empty repository assembly requires Alpine `apk` tooling. Signed assembly also
+requires `abuild-sign` and `openssl`. On non-Alpine hosts, run the same pinned
+container used by CI:
+
 ```bash
-bash .github/scripts/assemble-apk-repository.sh --output site/dist/apk packages/repo apk-artifacts
+docker run --rm \
+  -e APK_REPOSITORY_PRIVATE_KEY \
+  -v "$PWD:/work" \
+  -w /work \
+  alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 \
+  sh -euxc 'packages="bash findutils"; if [ -n "${APK_REPOSITORY_PRIVATE_KEY:-}" ]; then packages="$packages abuild openssl"; fi; apk add --no-cache $packages; bash .github/scripts/assemble-apk-repository.sh --output site/dist/apk packages/repo apk-artifacts'
+
 bash .github/scripts/validate-apk-repository.sh site/dist/apk
 ```
 

--- a/scripts/apk_repository_test.go
+++ b/scripts/apk_repository_test.go
@@ -81,6 +81,50 @@ func TestValidateAPKRepositoryRejectsRootPackages(t *testing.T) {
 	assert.Contains(t, output, "APK files must live under architecture directories")
 }
 
+func TestValidateAPKRepositoryRejectsNestedPackages(t *testing.T) {
+	repoRoot := t.TempDir()
+	repoDir := filepath.Join(repoRoot, "repo")
+	writeTempFile(t, filepath.Join(repoDir, "x86_64", "nested", "bad.apk"), "not a real apk")
+
+	output, err := runGithubScript(t, repoRoot, "validate-apk-repository.sh", repoDir)
+
+	require.Error(t, err)
+	assert.Contains(t, output, "directly under architecture directories")
+}
+
+func TestValidateAPKRepositoryRejectsUnsupportedArchDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	repoDir := filepath.Join(repoRoot, "repo")
+	archDir := filepath.Join(repoDir, "not-an-arch")
+	writeTempFile(t, filepath.Join(archDir, "demo.apk"), "not a real apk")
+	writeTarGz(t, filepath.Join(archDir, "APKINDEX.tar.gz"), "APKINDEX")
+
+	output, err := runGithubScript(t, repoRoot, "validate-apk-repository.sh", repoDir)
+
+	require.Error(t, err)
+	assert.Contains(t, output, "unsupported architecture directory")
+}
+
+func TestAssembleAPKRepositoryRejectsDuplicateDestinations(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeTempFile(t, filepath.Join(repoRoot, "source-a", "x86_64", "demo.apk"), "a")
+	writeTempFile(t, filepath.Join(repoRoot, "source-b", "x86_64", "demo.apk"), "b")
+
+	output, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "source-a", "source-b")
+
+	require.Error(t, err)
+	assert.Contains(t, output, "duplicate APK destination x86_64/demo.apk")
+}
+
+func TestAssembleAPKRepositoryRequiresRSAKeyName(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	output, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--key-name", "custom", "missing-source")
+
+	require.Error(t, err)
+	assert.Contains(t, output, "key name must end with .rsa")
+}
+
 func TestValidateAPKRepositoryRequiresSignedIndexAndPublicKey(t *testing.T) {
 	repoRoot := t.TempDir()
 	repoDir := filepath.Join(repoRoot, "repo")
@@ -93,6 +137,12 @@ func TestValidateAPKRepositoryRequiresSignedIndexAndPublicKey(t *testing.T) {
 	assert.Contains(t, output, "no public key")
 
 	writeTempFile(t, filepath.Join(repoDir, "verity-apk-repository.rsa.pub"), "public key")
+	writeTarGz(t, filepath.Join(archDir, "APKINDEX.tar.gz"), "APKINDEX", ".SIGN.RSA.other.rsa.pub")
+
+	output, err = runGithubScript(t, repoRoot, "validate-apk-repository.sh", "--require-signature", repoDir)
+	require.Error(t, err)
+	assert.Contains(t, output, "has no matching root public key")
+
 	writeTarGz(t, filepath.Join(archDir, "APKINDEX.tar.gz"), "APKINDEX", ".SIGN.RSA.verity-apk-repository.rsa.pub")
 
 	output, err = runGithubScript(t, repoRoot, "validate-apk-repository.sh", "--require-signature", repoDir)

--- a/scripts/apk_repository_test.go
+++ b/scripts/apk_repository_test.go
@@ -116,6 +116,15 @@ func TestAssembleAPKRepositoryRejectsDuplicateDestinations(t *testing.T) {
 	assert.Contains(t, output, "duplicate APK destination x86_64/demo.apk")
 }
 
+func TestAssembleAPKRepositoryRejectsTraversalOutputDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	output, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", "../apk-repo", "missing-source")
+
+	require.Error(t, err)
+	assert.Contains(t, output, "unsafe output directory")
+}
+
 func TestAssembleAPKRepositoryRequiresRSAKeyName(t *testing.T) {
 	repoRoot := t.TempDir()
 

--- a/scripts/apk_repository_test.go
+++ b/scripts/apk_repository_test.go
@@ -1,0 +1,101 @@
+package scripts_test
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func githubScriptPath(t *testing.T, name string) string {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	return filepath.Join(filepath.Dir(currentFile), "..", ".github", "scripts", name)
+}
+
+func runGithubScript(t *testing.T, repoRoot, name string, args ...string) (string, error) {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "bash", append([]string{githubScriptPath(t, name)}, args...)...)
+	cmd.Dir = repoRoot
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func writeTarGz(t *testing.T, path string, names ...string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	gz := gzip.NewWriter(f)
+	defer gz.Close()
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	for _, name := range names {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:    name,
+			Mode:    0o644,
+			Size:    int64(len("test\n")),
+			ModTime: time.Unix(0, 0),
+		}))
+		_, err := tw.Write([]byte("test\n"))
+		require.NoError(t, err)
+	}
+}
+
+func TestAssembleAPKRepositoryNoPackagesCreatesMarker(t *testing.T) {
+	repoRoot := t.TempDir()
+	outputDir := filepath.Join(repoRoot, "site", "dist", "apk")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "apk-artifacts"), 0o755))
+
+	output, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "No APK files found")
+	assert.FileExists(t, filepath.Join(outputDir, ".no-apks-found"))
+}
+
+func TestValidateAPKRepositoryRejectsRootPackages(t *testing.T) {
+	repoRoot := t.TempDir()
+	repoDir := filepath.Join(repoRoot, "repo")
+	writeTempFile(t, filepath.Join(repoDir, "bad.apk"), "not a real apk")
+
+	output, err := runGithubScript(t, repoRoot, "validate-apk-repository.sh", repoDir)
+
+	require.Error(t, err)
+	assert.Contains(t, output, "APK files must live under architecture directories")
+}
+
+func TestValidateAPKRepositoryRequiresSignedIndexAndPublicKey(t *testing.T) {
+	repoRoot := t.TempDir()
+	repoDir := filepath.Join(repoRoot, "repo")
+	archDir := filepath.Join(repoDir, "x86_64")
+	writeTempFile(t, filepath.Join(archDir, "demo.apk"), "not a real apk")
+	writeTarGz(t, filepath.Join(archDir, "APKINDEX.tar.gz"), "APKINDEX")
+
+	output, err := runGithubScript(t, repoRoot, "validate-apk-repository.sh", "--require-signature", repoDir)
+	require.Error(t, err)
+	assert.Contains(t, output, "no public key")
+
+	writeTempFile(t, filepath.Join(repoDir, "verity-apk-repository.rsa.pub"), "public key")
+	writeTarGz(t, filepath.Join(archDir, "APKINDEX.tar.gz"), "APKINDEX", ".SIGN.RSA.verity-apk-repository.rsa.pub")
+
+	output, err = runGithubScript(t, repoRoot, "validate-apk-repository.sh", "--require-signature", repoDir)
+	require.NoError(t, err)
+	assert.Contains(t, output, "APK repository layout valid")
+}


### PR DESCRIPTION
## Summary
- add guarded APK repository assembly and validation scripts for Melange .apk layouts
- add manual APK Repository workflow that builds the site, overlays site/dist/apk, signs indexes when APK_REPOSITORY_PRIVATE_KEY is configured, and optionally deploys Pages
- keep cross-run artifact download out of the privileged Pages workflow to avoid artifact poisoning; document trusted handoff follow-up
- include no-op overlay validation in Build Site plus docs and script tests
- update golang.org/x/crypto to v0.52.0 for govulncheck

## Validation
- go test ./...
- bash -n .github/scripts/assemble-apk-repository.sh .github/scripts/validate-apk-repository.sh
- go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...