### PR TITLE
docs(site): add experimental APK repository docs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -607,8 +605,6 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/site/src/data/apk-repository.ts
+++ b/site/src/data/apk-repository.ts
@@ -1,0 +1,12 @@
+export const apkRepository = {
+  status: "experimental pending availability",
+  basePath: "apk",
+  architectures: [
+    { apk: "x86_64", platform: "linux/amd64" },
+    { apk: "aarch64", platform: "linux/arm64" },
+  ],
+  keyFile: "verity-apk-rsa.pub",
+  keyFingerprint: "pending publication",
+  caveat:
+    "The Verity APK repository is experimental. Do not rely on it for production until the publish workflow has produced signed APKINDEX files and the repository verification task confirms availability.",
+};

--- a/site/src/pages/apk/index.astro
+++ b/site/src/pages/apk/index.astro
@@ -10,7 +10,7 @@ const keyUrl = `${repoRoot}/${apkRepository.keyFile}`;
 <BaseLayout
   title="Experimental APK Repository — Verity"
   description="Experimental Verity APK repository docs: install instructions, trust model, key rotation, supported architectures, and repository metadata."
-  mdUrl={`${base}apk/index.md`}
+  mdUrl={`${base}${apkRepository.basePath}/index.md`}
 >
   <nav class="mb-6 text-sm text-verity-text-secondary">
     <a href={base} class="transition-colors hover:text-verity-nucleus">Home</a>

--- a/site/src/pages/apk/index.astro
+++ b/site/src/pages/apk/index.astro
@@ -1,0 +1,114 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { apkRepository } from "../../data/apk-repository";
+
+const base = import.meta.env.BASE_URL;
+const repoRoot = `${base}${apkRepository.basePath}`;
+const keyUrl = `${repoRoot}/${apkRepository.keyFile}`;
+---
+
+<BaseLayout
+  title="Experimental APK Repository — Verity"
+  description="Experimental Verity APK repository docs: install instructions, trust model, key rotation, supported architectures, and repository metadata."
+  mdUrl={`${base}apk/index.md`}
+>
+  <nav class="mb-6 text-sm text-verity-text-secondary">
+    <a href={base} class="transition-colors hover:text-verity-nucleus">Home</a>
+    <span class="mx-1">/</span>
+    <span class="text-verity-text-primary">APK Repository</span>
+  </nav>
+
+  <section
+    class="mb-10 overflow-hidden rounded-2xl border border-amber-500/30 bg-linear-to-br from-amber-500/10 via-verity-surface to-verity-void p-6 md:p-8"
+  >
+    <div class="mb-4 flex flex-wrap items-center gap-2">
+      <span
+        class="rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wider text-amber-300"
+      >
+        Experimental
+      </span>
+      <span class="font-mono text-xs text-verity-text-muted">{apkRepository.status}</span>
+    </div>
+    <h1 class="mb-3 text-3xl font-bold text-verity-text-primary">APK Repository</h1>
+    <p class="max-w-3xl text-lg text-verity-text-secondary">{apkRepository.caveat}</p>
+  </section>
+
+  <section class="mb-10">
+    <h2 class="mb-4 text-xl font-semibold text-verity-text-primary">Repository metadata</h2>
+    <div class="overflow-hidden rounded-lg border border-verity-border bg-verity-surface">
+      <div
+        class="hidden grid-cols-[8rem_10rem_1fr_1fr] gap-4 border-b border-verity-border px-4 py-3 text-xs uppercase tracking-wider text-verity-text-muted md:grid"
+      >
+        <span>APK arch</span>
+        <span>Platform</span>
+        <span>Repository URL</span>
+        <span>Static metadata</span>
+      </div>
+      {
+        apkRepository.architectures.map((arch) => (
+          <div class="grid gap-2 border-b border-verity-border/60 px-4 py-4 last:border-b-0 md:grid-cols-[8rem_10rem_1fr_1fr] md:gap-4">
+            <code class="text-sm text-verity-text-primary">{arch.apk}</code>
+            <code class="text-sm text-verity-text-secondary">{arch.platform}</code>
+            <code class="break-all text-xs text-amber-200">
+              {repoRoot}/{arch.apk}
+            </code>
+            <code class="break-all text-xs text-verity-text-secondary">
+              {repoRoot}/{arch.apk}/APKINDEX.tar.gz
+            </code>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+
+  <section class="mb-10 grid gap-4 md:grid-cols-2">
+    <div class="rounded-lg border border-verity-border bg-verity-surface p-5">
+      <h2 class="mb-3 text-lg font-semibold text-verity-text-primary">Signing key</h2>
+      <p class="mb-3 text-sm text-verity-text-secondary">
+        Install this key only after Verity publishes and confirms the fingerprint.
+      </p>
+      <code
+        class="block break-all rounded border border-verity-border bg-verity-void p-3 text-xs text-amber-200"
+      >
+        {keyUrl}
+      </code>
+      <p class="mt-3 font-mono text-xs text-verity-text-muted">
+        Fingerprint: {apkRepository.keyFingerprint}
+      </p>
+    </div>
+    <div class="rounded-lg border border-verity-border bg-verity-surface p-5">
+      <h2 class="mb-3 text-lg font-semibold text-verity-text-primary">Key rotation</h2>
+      <ol class="list-decimal space-y-2 pl-5 text-sm text-verity-text-secondary">
+        <li>Install old and new keys during the overlap window.</li>
+        <li>Run <code class="text-xs">apk update</code> and verify index refresh succeeds.</li>
+        <li>Remove the retired key after Verity announces rotation completion.</li>
+      </ol>
+    </div>
+  </section>
+
+  <section class="mb-10">
+    <h2 class="mb-4 text-xl font-semibold text-verity-text-primary">
+      Install flow after verification
+    </h2>
+    <pre
+      class="overflow-x-auto rounded-lg border border-verity-border bg-verity-void p-4 text-sm text-verity-text-primary"><code>{`set -eu
+apk_arch="$(apk --print-arch)"
+repo_url="${repoRoot}/\${apk_arch}"
+
+wget -O "/etc/apk/keys/${apkRepository.keyFile}" "${keyUrl}"
+printf '%s\n' "$repo_url" >> /etc/apk/repositories
+apk update
+
+# apk add <verity-package>`}</code></pre>
+  </section>
+
+  <section class="rounded-lg border border-amber-500/30 bg-amber-500/10 p-5">
+    <h2 class="mb-3 text-lg font-semibold text-amber-200">Experimental caveats</h2>
+    <ul class="list-disc space-y-2 pl-5 text-sm text-verity-text-secondary">
+      <li>Package names, versions, repository paths, and signing keys may change.</li>
+      <li>The repository may be empty or return 404 until publish and verification complete.</li>
+      <li>Use only in ephemeral tests until general availability.</li>
+      <li>Use published OCI container images for production workloads today.</li>
+    </ul>
+  </section>
+</BaseLayout>

--- a/site/src/pages/apk/index.md.ts
+++ b/site/src/pages/apk/index.md.ts
@@ -1,0 +1,92 @@
+import type { APIRoute } from "astro";
+import { apkRepository } from "../../data/apk-repository";
+
+export const GET: APIRoute = ({ site }) => {
+  const base = import.meta.env.BASE_URL;
+  const origin = site?.origin ?? "https://verity.supply";
+  const prefix = `${origin}${base}`;
+  const repoRoot = `${prefix}${apkRepository.basePath}`;
+  const keyUrl = `${repoRoot}/${apkRepository.keyFile}`;
+
+  const archRows = apkRepository.architectures
+    .map(
+      (arch) =>
+        `| \`${arch.apk}\` | \`${arch.platform}\` | \`${repoRoot}/${arch.apk}\` | \`${repoRoot}/${arch.apk}/APKINDEX.tar.gz\` |`
+    )
+    .join("\n");
+
+  const repositoryLines = apkRepository.architectures
+    .map((arch) => `${repoRoot}/${arch.apk}`)
+    .join("\n");
+
+  const content = `# Experimental APK Repository — Verity
+
+> Status: **${apkRepository.status}**. ${apkRepository.caveat}
+
+The Verity APK repository is the planned package-level companion to the container-image catalog. It will expose Verity-built APK packages for Wolfi/Alpine-compatible consumers once the publish workflow and repository verification tasks are complete.
+
+## Repository Entry Points
+
+| APK arch | Platform | Repository URL | Static metadata |
+|----------|----------|----------------|-----------------|
+${archRows}
+
+**Signing key**: \`${keyUrl}\`
+
+**Fingerprint**: \`${apkRepository.keyFingerprint}\`
+
+Until the fingerprint is published and verified, treat these URLs as documentation for the intended layout rather than a production package source.
+
+## Install Instructions
+
+Do not enable this repository on production systems yet. For disposable test containers after repository verification:
+
+\`\`\`sh
+set -eu
+
+apk_arch="$(apk --print-arch)"
+repo_url="${repoRoot}/\${apk_arch}"
+
+wget -O "/etc/apk/keys/${apkRepository.keyFile}" "${keyUrl}"
+printf '%s\n' "${repositoryLines}" >> /etc/apk/repositories
+apk update
+
+# Example, once packages are published:
+# apk add <verity-package>
+\`\`\`
+
+If your image lacks \`wget\`, copy the key into \`/etc/apk/keys/${apkRepository.keyFile}\` during image build and append only the matching architecture URL to \`/etc/apk/repositories\`.
+
+## Trust Model
+
+- APK metadata is expected to be published as signed \`APKINDEX.tar.gz\` files per architecture.
+- APK clients trust packages through the public key installed in \`/etc/apk/keys/\`.
+- Verify the key fingerprint from this page before installing any package.
+- Keep Verity container-image signatures and attestations separate from APK repository trust; cosign/SLSA cover OCI images, while APK installation relies on APKINDEX/package signatures.
+
+## Key Rotation
+
+1. Verity will publish a new key and fingerprint before rotating signing keys.
+2. Install both old and new keys during the overlap window.
+3. Run \`apk update\` and verify the signed index refreshes cleanly.
+4. Remove the retired key only after the repository announces completion of the rotation.
+
+## Experimental Caveats
+
+- Package names, versions, repository paths, and signing keys may change before general availability.
+- The repository may be empty or return 404 until the publish workflow lands and runs successfully.
+- Use only in ephemeral tests until final availability is verified.
+- Prefer the published container images for production workloads today.
+
+---
+
+[Browse Catalog](${prefix}) · [Complete LLM Reference](${prefix}llms-full.txt) · [GitHub](https://github.com/verity-org/verity)
+`;
+
+  return new Response(content.trim() + "\n", {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};

--- a/site/src/pages/apk/index.md.ts
+++ b/site/src/pages/apk/index.md.ts
@@ -44,7 +44,7 @@ apk_arch="$(apk --print-arch)"
 repo_url="${repoRoot}/\${apk_arch}"
 
 wget -O "/etc/apk/keys/${apkRepository.keyFile}" "${keyUrl}"
-printf '%s\n' "${repoRoot}/\${apk_arch}" >> /etc/apk/repositories
+printf '%s\n' "$repo_url" >> /etc/apk/repositories
 apk update
 
 # Example, once packages are published:

--- a/site/src/pages/apk/index.md.ts
+++ b/site/src/pages/apk/index.md.ts
@@ -15,10 +15,6 @@ export const GET: APIRoute = ({ site }) => {
     )
     .join("\n");
 
-  const repositoryLines = apkRepository.architectures
-    .map((arch) => `${repoRoot}/${arch.apk}`)
-    .join("\n");
-
   const content = `# Experimental APK Repository — Verity
 
 > Status: **${apkRepository.status}**. ${apkRepository.caveat}
@@ -48,7 +44,7 @@ apk_arch="$(apk --print-arch)"
 repo_url="${repoRoot}/\${apk_arch}"
 
 wget -O "/etc/apk/keys/${apkRepository.keyFile}" "${keyUrl}"
-printf '%s\n' "${repositoryLines}" >> /etc/apk/repositories
+printf '%s\n' "${repoRoot}/\${apk_arch}" >> /etc/apk/repositories
 apk update
 
 # Example, once packages are published:

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import HeroSection from "../components/HeroSection.astro";
 import ImageCatalog from "../components/ImageCatalog.astro";
 import SeverityBadges from "../components/SeverityBadges.astro";
+import { apkRepository } from "../data/apk-repository";
 import { getChartsCatalog } from "../lib/charts";
 import { getChartVulns } from "../lib/chart-vulns";
 
@@ -13,6 +14,38 @@ const charts = chartsCatalog.charts;
 
 <BaseLayout title="Verity — Security-Patched Container Registry" mdUrl={`${base}index.md`}>
   <HeroSection />
+
+  <section class="mb-12">
+    <a
+      href={`${base}apk/`}
+      class="group block overflow-hidden rounded-xl border border-amber-500/30 bg-linear-to-br from-amber-500/10 via-verity-surface to-verity-void p-5 transition-colors hover:border-amber-400/60"
+    >
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div class="mb-2 flex flex-wrap items-center gap-2">
+            <span
+              class="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wider text-amber-300"
+            >
+              Experimental
+            </span>
+            <span class="font-mono text-xs text-verity-text-muted">{apkRepository.status}</span>
+          </div>
+          <h2 class="text-xl font-semibold tracking-wider text-verity-text-primary">
+            APK Repository Preview
+          </h2>
+          <p class="mt-2 max-w-3xl text-sm text-verity-text-secondary">
+            Planned Wolfi/Alpine-compatible package repository metadata, install flow, trust model,
+            key-rotation notes, and supported architectures.
+          </p>
+        </div>
+        <div
+          class="font-mono text-sm text-amber-200 transition-transform group-hover:translate-x-1"
+        >
+          View docs &rarr;
+        </div>
+      </div>
+    </a>
+  </section>
 
   {
     charts.length > 0 && (

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -17,7 +17,7 @@ const charts = chartsCatalog.charts;
 
   <section class="mb-12">
     <a
-      href={`${base}apk/`}
+      href={`${base}${apkRepository.basePath}/`}
       class="group block overflow-hidden rounded-xl border border-amber-500/30 bg-linear-to-br from-amber-500/10 via-verity-surface to-verity-void p-5 transition-colors hover:border-amber-400/60"
     >
       <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">

--- a/site/src/pages/index.md.ts
+++ b/site/src/pages/index.md.ts
@@ -75,6 +75,7 @@ Every image carries: cosign signature, SLSA L3 build provenance, CycloneDX SBOM,
 - [Complete LLM Reference](${prefix}llms-full.txt) — Everything in one file
 - [Supply Chain Compliance](${prefix}compliance.md) — Framework mappings (SLSA, FedRAMP, SOC 2, ISO 27001, OWASP)
 - [Helm Charts](${prefix}charts/index.md) — Pre-patched wrapper Helm charts
+- [Experimental APK Repository](${prefix}apk/index.md) — Pending package repository metadata, install flow, trust model, and supported arches
 - [GitHub Repository](https://github.com/verity-org/verity) — Source code and issues
 `;
 

--- a/site/src/pages/llms-full.txt.ts
+++ b/site/src/pages/llms-full.txt.ts
@@ -9,6 +9,7 @@ import {
   integerCount,
 } from "../data/full-catalog";
 import type { FullCatalogImage } from "../data/full-catalog";
+import { apkRepository } from "../data/apk-repository";
 import { getChartsCatalog } from "../lib/charts";
 
 /** Format a single catalog image as a markdown list item. */
@@ -104,13 +105,14 @@ export const GET: APIRoute = ({ site }) => {
 2. [Quick Start](#quick-start)
 3. [How It Works](#how-it-works)
 4. [Image Catalog](#image-catalog) (${totalImages} images across ${totalCategories} categories)
-5. [Helm Charts](#helm-charts)
-6. [Supply Chain Compliance](#supply-chain-compliance)
-7. [Architecture](#architecture)
-8. [CLI Reference](#cli-reference)
-9. [Configuration Format](#configuration-format)
-10. [Verification Commands](#verification-commands)
-11. [Contributing](#contributing)
+5. [Experimental APK Repository](#experimental-apk-repository)
+6. [Helm Charts](#helm-charts)
+7. [Supply Chain Compliance](#supply-chain-compliance)
+8. [Architecture](#architecture)
+9. [CLI Reference](#cli-reference)
+10. [Configuration Format](#configuration-format)
+11. [Verification Commands](#verification-commands)
+12. [Contributing](#contributing)
 
 ---
 
@@ -218,6 +220,44 @@ Verity maintains ${totalImages} container images across ${totalCategories} categ
 - **Variants**: \`default\` (standard), \`dev\` (includes build tools/shell), \`fips\` (FIPS 140-2 compliant)
 
 ${catalogSections}
+
+---
+
+## Experimental APK Repository
+
+Status: **${apkRepository.status}**. ${apkRepository.caveat}
+
+Verity's planned APK repository will expose package-level artifacts for Wolfi/Alpine-compatible consumers after the publish workflow produces signed per-architecture indexes and the repository verification task confirms availability.
+
+### Repository layout
+
+| APK arch | Platform | Repository URL | Static metadata |
+|----------|----------|----------------|-----------------|
+${apkRepository.architectures
+  .map(
+    (arch) =>
+      `| \`${arch.apk}\` | \`${arch.platform}\` | \`${siteUrl}/${apkRepository.basePath}/${arch.apk}\` | \`${siteUrl}/${apkRepository.basePath}/${arch.apk}/APKINDEX.tar.gz\` |`
+  )
+  .join("\n")}
+
+**Signing key**: \`${siteUrl}/${apkRepository.basePath}/${apkRepository.keyFile}\`
+
+**Fingerprint**: \`${apkRepository.keyFingerprint}\`
+
+### Install flow after verification
+
+\`\`\`sh
+apk_arch="$(apk --print-arch)"
+wget -O "/etc/apk/keys/${apkRepository.keyFile}" "${siteUrl}/${apkRepository.basePath}/${apkRepository.keyFile}"
+echo "${siteUrl}/${apkRepository.basePath}/\${apk_arch}" >> /etc/apk/repositories
+apk update
+\`\`\`
+
+Trust notes: APK clients trust packages through public keys in \`/etc/apk/keys/\`; verify the published fingerprint before use. During key rotation, install old and new keys through the overlap window, refresh with \`apk update\`, then remove the retired key after Verity announces completion. Keep APK trust separate from OCI image cosign/SLSA attestations.
+
+Experimental caveats: package names, versions, repository paths, and signing keys may change; the repository may be empty or return 404 until publish/verification completes; use only in ephemeral tests until general availability.
+
+Full page: ${siteUrl}/${apkRepository.basePath}/index.md
 
 ---
 

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -27,6 +27,7 @@ docker pull ghcr.io/verity-org/prometheus/prometheus:v3.9.1-patched
 - [Overview & Quick Start](${prefix}index.md): What Verity is, how to use patched images, catalog summary by category
 - [Supply Chain Compliance](${prefix}compliance.md): SLSA L3, Sigstore/cosign, CycloneDX SBOM, Rekor transparency log, plus framework mappings for FedRAMP/NIST 800-53, SOC 2, ISO 27001, OWASP ASVS, NIST CSF 2.0, and CISA Secure by Design
 - [Helm Charts](${prefix}charts/index.md): Pre-patched wrapper Helm charts that override upstream image references with Verity's patched equivalents
+- [Experimental APK Repository](${prefix}apk/index.md): Pending APK repository entry point with install instructions, key rotation notes, supported arches, and experimental caveats
 
 ## Source
 


### PR DESCRIPTION
## Summary
- add an experimental APK repository site page and markdown endpoint
- document pending repository URLs, supported APK arches, install flow, signing-key trust, key rotation, and caveats
- link the APK docs from the homepage, markdown index, and LLM references
- clean stale x/crypto and x/sys sums after main updated the modules, keeping govulncheck green

## Validation
- npm run format:check
- npm run build
- go mod tidy -diff
- go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...