### PR TITLE
fix(chartgen): retry transient helm push failures

### DIFF
--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -2,6 +2,7 @@ package chartgen
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -15,6 +16,19 @@ import (
 	"github.com/verity-org/verity/internal/config"
 	"github.com/verity-org/verity/internal/discovery"
 )
+
+const (
+	helmPushMaxAttempts = 4
+	helmPushTimeout     = 5 * time.Minute
+	helmPushBaseBackoff = 5 * time.Second
+	helmPushMaxBackoff  = 30 * time.Second
+)
+
+type commandRunner func(ctx context.Context, timeout time.Duration, name string, args ...string) (string, error)
+
+type contextSleeper func(ctx context.Context, delay time.Duration) error
+
+var errHelmPushFailed = errors.New("helm push failed")
 
 // WrapperChart holds the generated wrapper chart YAML content.
 type WrapperChart struct {
@@ -123,10 +137,93 @@ func PackageChart(chart *WrapperChart) (string, error) {
 
 // PushChart pushes a packaged chart archive to an OCI registry.
 func PushChart(tgzPath, registry string) error {
-	if _, err := runCommand(context.Background(), 5*time.Minute, "helm", "push", tgzPath, registry); err != nil {
-		return fmt.Errorf("helm push %s to %s: %w", tgzPath, registry, err)
+	return pushChartWithRetry(context.Background(), tgzPath, registry, runCommand, sleepContext, helmPushMaxAttempts)
+}
+
+func pushChartWithRetry(ctx context.Context, tgzPath, registry string, runner commandRunner, sleeper contextSleeper, maxAttempts int) error {
+	if maxAttempts < 1 {
+		maxAttempts = 1
 	}
-	return nil
+
+	errs := make([]error, 0, maxAttempts)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		_, err := runner(ctx, helmPushTimeout, "helm", "push", tgzPath, registry)
+		if err == nil {
+			return nil
+		}
+
+		errs = append(errs, err)
+		if attempt == maxAttempts || !isRetriableHelmPushError(err) {
+			return helmPushError(tgzPath, registry, attempt, maxAttempts, errs)
+		}
+
+		delay := helmPushBackoff(attempt)
+		fmt.Fprintf(os.Stderr, "warning: helm push %s to %s failed on attempt %d/%d; retrying in %s: %v\n", tgzPath, registry, attempt, maxAttempts, delay, err)
+		if sleepErr := sleeper(ctx, delay); sleepErr != nil {
+			errs = append(errs, fmt.Errorf("wait before retry: %w", sleepErr))
+			return helmPushError(tgzPath, registry, attempt, maxAttempts, errs)
+		}
+	}
+
+	return helmPushError(tgzPath, registry, maxAttempts, maxAttempts, errs)
+}
+
+func helmPushBackoff(failedAttempt int) time.Duration {
+	delay := helmPushBaseBackoff << max(failedAttempt-1, 0)
+	if delay > helmPushMaxBackoff {
+		return helmPushMaxBackoff
+	}
+	return delay
+}
+
+func isRetriableHelmPushError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	retriableFragments := []string{
+		`failed to perform "tag" on destination`,
+		"not found",
+		"timeout",
+		"temporary",
+		"connection reset",
+		"tls handshake timeout",
+		"unexpected eof",
+		"server closed idle connection",
+		"too many requests",
+		"429",
+		"503 service unavailable",
+		"502 bad gateway",
+		"504 gateway timeout",
+	}
+	for _, fragment := range retriableFragments {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func helmPushError(tgzPath, registry string, attempts, maxAttempts int, errs []error) error {
+	parts := make([]string, 0, len(errs))
+	for i, err := range errs {
+		if err == nil {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("attempt %d: %v", i+1, err))
+	}
+	return fmt.Errorf("%w: %s to %s after %d/%d attempt(s): %s", errHelmPushFailed, tgzPath, registry, attempts, maxAttempts, strings.Join(parts, "; "))
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // buildValuesTree converts flat dotted-path overrides to a nested map scoped

--- a/internal/chartgen/chart.go
+++ b/internal/chartgen/chart.go
@@ -145,31 +145,37 @@ func pushChartWithRetry(ctx context.Context, tgzPath, registry string, runner co
 		maxAttempts = 1
 	}
 
-	errs := make([]error, 0, maxAttempts)
+	details := make([]string, 0, maxAttempts)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		_, err := runner(ctx, helmPushTimeout, "helm", "push", tgzPath, registry)
 		if err == nil {
 			return nil
 		}
 
-		errs = append(errs, err)
+		details = append(details, fmt.Sprintf("attempt %d: %v", attempt, err))
 		if attempt == maxAttempts || !isRetriableHelmPushError(err) {
-			return helmPushError(tgzPath, registry, attempt, maxAttempts, errs)
+			return helmPushError(tgzPath, registry, attempt, maxAttempts, details)
 		}
 
 		delay := helmPushBackoff(attempt)
 		fmt.Fprintf(os.Stderr, "warning: helm push %s to %s failed on attempt %d/%d; retrying in %s: %v\n", tgzPath, registry, attempt, maxAttempts, delay, err)
 		if sleepErr := sleeper(ctx, delay); sleepErr != nil {
-			errs = append(errs, fmt.Errorf("wait before retry: %w", sleepErr))
-			return helmPushError(tgzPath, registry, attempt, maxAttempts, errs)
+			details = append(details, fmt.Sprintf("wait before retry after attempt %d: %v", attempt, sleepErr))
+			return helmPushError(tgzPath, registry, attempt, maxAttempts, details)
 		}
 	}
 
-	return helmPushError(tgzPath, registry, maxAttempts, maxAttempts, errs)
+	return helmPushError(tgzPath, registry, maxAttempts, maxAttempts, details)
 }
 
 func helmPushBackoff(failedAttempt int) time.Duration {
-	delay := helmPushBaseBackoff << max(failedAttempt-1, 0)
+	delay := helmPushBaseBackoff
+	for i := 1; i < failedAttempt; i++ {
+		if delay >= helmPushMaxBackoff/2 {
+			return helmPushMaxBackoff
+		}
+		delay *= 2
+	}
 	if delay > helmPushMaxBackoff {
 		return helmPushMaxBackoff
 	}
@@ -183,7 +189,6 @@ func isRetriableHelmPushError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	retriableFragments := []string{
 		`failed to perform "tag" on destination`,
-		"not found",
 		"timeout",
 		"temporary",
 		"connection reset",
@@ -204,15 +209,8 @@ func isRetriableHelmPushError(err error) bool {
 	return false
 }
 
-func helmPushError(tgzPath, registry string, attempts, maxAttempts int, errs []error) error {
-	parts := make([]string, 0, len(errs))
-	for i, err := range errs {
-		if err == nil {
-			continue
-		}
-		parts = append(parts, fmt.Sprintf("attempt %d: %v", i+1, err))
-	}
-	return fmt.Errorf("%w: %s to %s after %d/%d attempt(s): %s", errHelmPushFailed, tgzPath, registry, attempts, maxAttempts, strings.Join(parts, "; "))
+func helmPushError(tgzPath, registry string, attempts, maxAttempts int, details []string) error {
+	return fmt.Errorf("%w: %s to %s after %d/%d attempt(s): %s", errHelmPushFailed, tgzPath, registry, attempts, maxAttempts, strings.Join(details, "; "))
 }
 
 func sleepContext(ctx context.Context, delay time.Duration) error {

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -15,8 +15,10 @@ import (
 
 var (
 	errTransientTagRace  = errors.New(`helm push: failed to perform "Tag" on destination: sha256:abc: not found`)
+	errGenericNotFound   = errors.New("helm push: 404 not found")
 	errUnauthorizedPush  = errors.New("helm push: unauthorized: authentication required")
 	errTemporaryRegistry = errors.New("temporary registry error")
+	errRetrySleep        = errors.New("retry sleep interrupted")
 )
 
 func TestPushChartWithRetrySucceedsAfterTransientTagRace(t *testing.T) {
@@ -80,6 +82,29 @@ func TestPushChartWithRetryStopsOnPermanentError(t *testing.T) {
 	}
 }
 
+func TestPushChartWithRetryDoesNotRetryGenericNotFound(t *testing.T) {
+	var attempts int
+	runner := func(context.Context, time.Duration, string, ...string) (string, error) {
+		attempts++
+		return "", errGenericNotFound
+	}
+	sleeper := func(context.Context, time.Duration) error {
+		t.Fatal("sleeper should not be called for generic not found errors")
+		return nil
+	}
+
+	err := pushChartWithRetry(context.Background(), "/tmp/wrapper.tgz", "oci://ghcr.io/verity-org/charts", runner, sleeper, 4)
+	if err == nil {
+		t.Fatal("pushChartWithRetry() error = nil, want error")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+	if !strings.Contains(err.Error(), "404 not found") {
+		t.Fatalf("error = %v, want original not found detail", err)
+	}
+}
+
 func TestPushChartWithRetryPreservesErrorsAfterExhaustion(t *testing.T) {
 	var attempts int
 	runner := func(context.Context, time.Duration, string, ...string) (string, error) {
@@ -99,6 +124,38 @@ func TestPushChartWithRetryPreservesErrorsAfterExhaustion(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %v, missing %q", err, want)
 		}
+	}
+}
+
+func TestPushChartWithRetryLabelsSleepErrorsWithoutFakeAttempt(t *testing.T) {
+	runner := func(context.Context, time.Duration, string, ...string) (string, error) {
+		return "", errTemporaryRegistry
+	}
+	sleeper := func(context.Context, time.Duration) error { return errRetrySleep }
+
+	err := pushChartWithRetry(context.Background(), "/tmp/wrapper.tgz", "oci://ghcr.io/verity-org/charts", runner, sleeper, 4)
+	if err == nil {
+		t.Fatal("pushChartWithRetry() error = nil, want error")
+	}
+	for _, want := range []string{"attempt 1: temporary registry error", "wait before retry after attempt 1: retry sleep interrupted"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, missing %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "attempt 2") {
+		t.Fatalf("error = %v, should not invent attempt 2 for sleep failure", err)
+	}
+}
+
+func TestHelmPushBackoffCapsWithoutOverflow(t *testing.T) {
+	if got := helmPushBackoff(1); got != 5*time.Second {
+		t.Fatalf("helmPushBackoff(1) = %s, want 5s", got)
+	}
+	if got := helmPushBackoff(2); got != 10*time.Second {
+		t.Fatalf("helmPushBackoff(2) = %s, want 10s", got)
+	}
+	if got := helmPushBackoff(99); got != helmPushMaxBackoff {
+		t.Fatalf("helmPushBackoff(99) = %s, want %s", got, helmPushMaxBackoff)
 	}
 }
 

--- a/internal/chartgen/chartgen_test.go
+++ b/internal/chartgen/chartgen_test.go
@@ -1,14 +1,106 @@
 package chartgen
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/verity-org/verity/internal/config"
 )
+
+var (
+	errTransientTagRace  = errors.New(`helm push: failed to perform "Tag" on destination: sha256:abc: not found`)
+	errUnauthorizedPush  = errors.New("helm push: unauthorized: authentication required")
+	errTemporaryRegistry = errors.New("temporary registry error")
+)
+
+func TestPushChartWithRetrySucceedsAfterTransientTagRace(t *testing.T) {
+	var attempts int
+	var sleeps []time.Duration
+	runner := func(_ context.Context, timeout time.Duration, name string, args ...string) (string, error) {
+		attempts++
+		if timeout != helmPushTimeout {
+			t.Fatalf("timeout = %s, want %s", timeout, helmPushTimeout)
+		}
+		if name != "helm" || strings.Join(args, " ") != "push /tmp/wrapper.tgz oci://ghcr.io/verity-org/charts" {
+			t.Fatalf("command = %s %s", name, strings.Join(args, " "))
+		}
+		if attempts < 3 {
+			return "", errTransientTagRace
+		}
+		return "ok", nil
+	}
+	sleeper := func(_ context.Context, delay time.Duration) error {
+		sleeps = append(sleeps, delay)
+		return nil
+	}
+
+	if err := pushChartWithRetry(context.Background(), "/tmp/wrapper.tgz", "oci://ghcr.io/verity-org/charts", runner, sleeper, 4); err != nil {
+		t.Fatalf("pushChartWithRetry() error = %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	wantSleeps := []time.Duration{5 * time.Second, 10 * time.Second}
+	if len(sleeps) != len(wantSleeps) {
+		t.Fatalf("sleeps = %v, want %v", sleeps, wantSleeps)
+	}
+	for i := range wantSleeps {
+		if sleeps[i] != wantSleeps[i] {
+			t.Fatalf("sleeps = %v, want %v", sleeps, wantSleeps)
+		}
+	}
+}
+
+func TestPushChartWithRetryStopsOnPermanentError(t *testing.T) {
+	var attempts int
+	runner := func(context.Context, time.Duration, string, ...string) (string, error) {
+		attempts++
+		return "", errUnauthorizedPush
+	}
+	sleeper := func(context.Context, time.Duration) error {
+		t.Fatal("sleeper should not be called for permanent errors")
+		return nil
+	}
+
+	err := pushChartWithRetry(context.Background(), "/tmp/wrapper.tgz", "oci://ghcr.io/verity-org/charts", runner, sleeper, 4)
+	if err == nil {
+		t.Fatal("pushChartWithRetry() error = nil, want error")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+	if !strings.Contains(err.Error(), "unauthorized") || !strings.Contains(err.Error(), "attempt 1") {
+		t.Fatalf("error = %v, want original error and attempt detail", err)
+	}
+}
+
+func TestPushChartWithRetryPreservesErrorsAfterExhaustion(t *testing.T) {
+	var attempts int
+	runner := func(context.Context, time.Duration, string, ...string) (string, error) {
+		attempts++
+		return "", fmt.Errorf("%w %d", errTemporaryRegistry, attempts)
+	}
+	sleeper := func(context.Context, time.Duration) error { return nil }
+
+	err := pushChartWithRetry(context.Background(), "/tmp/wrapper.tgz", "oci://ghcr.io/verity-org/charts", runner, sleeper, 3)
+	if err == nil {
+		t.Fatal("pushChartWithRetry() error = nil, want error")
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	for _, want := range []string{"attempt 1", "temporary registry error 1", "attempt 2", "temporary registry error 2", "attempt 3", "temporary registry error 3"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, missing %q", err, want)
+		}
+	}
+}
 
 func TestDryRunResultJSON(t *testing.T) {
 	res := DryRunResult{


### PR DESCRIPTION
## Summary
- add bounded retry/backoff for transient helm push failures during wrapper chart publishing
- preserve per-attempt error details for diagnosis
- cover retry success, permanent failure, and retry exhaustion paths

## Validation
- /home/omer/go/bin/golangci-lint run ./... --timeout 5m
- make test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bounded retries with exponential backoff to `helm push` and improve diagnostics to reduce flaky wrapper chart publishing.

- **Bug Fixes**
  - Retry transient `helm push` failures with exponential backoff (up to 4 attempts; 5s doubling to 30s; 5m per attempt) and stderr warnings before retries.
  - Stop on permanent errors (e.g., unauthorized, generic 404) and include per-attempt details; label sleep interruptions without counting a new attempt.
  - Added tests for transient recovery, early stop on unauthorized/404, retry exhaustion with aggregated errors, backoff capping, and sleep interruption labeling.

<sup>Written for commit f8f43e94bdc892593ec8d0b36bfd70a4c0403214. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/479?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

