### PR TITLE
chore: update Renovate schedule to allow any time

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -104,7 +104,7 @@
     "schedule": ["at any time"]
   },
   "timezone": "UTC",
-  "schedule": ["before 4am on Monday"],
+  "schedule": ["at any time"]
   "prConcurrentLimit": 3,
   "prCreation": "immediate"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -104,7 +104,7 @@
     "schedule": ["at any time"]
   },
   "timezone": "UTC",
-  "schedule": ["at any time"]
+  "schedule": ["at any time"],
   "prConcurrentLimit": 3,
   "prCreation": "immediate"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set Renovate to run “at any time” (vs “before 4am on Monday”) so PRs can open anytime in UTC, and remove a duplicate schedule entry.

<sup>Written for commit 6bfb3f65bde2c057ad273a9efd6dff8d4057d776. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/482?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

