### PR TITLE
fix(apk): preserve Astro-built apk docs page across overlay assembly

### DIFF
--- a/.github/scripts/assemble-apk-repository.sh
+++ b/.github/scripts/assemble-apk-repository.sh
@@ -23,9 +23,10 @@ and APKINDEX.tar.gz files) are removed at the start of each run.
 USAGE
 }
 
-# Architectures the script writes to OUTPUT_DIR. Kept in sync with detect_arch
-# below — any arch listed here may have a top-level directory removed on a
-# fresh run.
+# Architectures the script writes to OUTPUT_DIR. Single source of truth —
+# both `detect_arch` (which classifies incoming .apk files) and the
+# pre-assembly cleanup loop iterate over this list, so adding a new arch
+# only requires editing one place.
 SUPPORTED_ARCHES=(x86_64 aarch64 armv7 armhf ppc64le s390x riscv64)
 
 OUTPUT_DIR="site/dist/apk"
@@ -95,14 +96,14 @@ if [[ "$KEY_NAME" != *.rsa ]]; then
 fi
 
 detect_arch() {
-  local path="$1" parent
+  local path="$1" parent arch
   parent=$(basename "$(dirname "$path")")
-  case "$parent" in
-    x86_64|aarch64|armv7|armhf|ppc64le|s390x|riscv64)
-      printf '%s\n' "$parent"
+  for arch in "${SUPPORTED_ARCHES[@]}"; do
+    if [[ "$parent" == "$arch" ]]; then
+      printf '%s\n' "$arch"
       return 0
-      ;;
-  esac
+    fi
+  done
   return 1
 }
 
@@ -125,7 +126,7 @@ mapfile -t APKS < <(
 # still explains the repository even when no .apk files were produced.
 mkdir -p "$OUTPUT_DIR"
 rm -f "$OUTPUT_DIR/.no-apks-found"
-rm -f "$OUTPUT_DIR"/*.rsa.pub
+rm -f "$OUTPUT_DIR/$KEY_NAME.pub"
 for arch in "${SUPPORTED_ARCHES[@]}"; do
   rm -rf "${OUTPUT_DIR:?}/$arch"
 done

--- a/.github/scripts/assemble-apk-repository.sh
+++ b/.github/scripts/assemble-apk-repository.sh
@@ -15,8 +15,18 @@ Defaults:
   key name: verity-apk-repository.rsa
 
 Guarded behavior: if no .apk files are found, writes .no-apks-found and exits 0.
+
+Preservation: any files in OUTPUT_DIR that this script does not own
+(e.g. index.html, index.md from a prior Astro build) are left untouched.
+Only managed artifacts (.no-apks-found, arch directories, the public key,
+and APKINDEX.tar.gz files) are removed at the start of each run.
 USAGE
 }
+
+# Architectures the script writes to OUTPUT_DIR. Kept in sync with detect_arch
+# below — any arch listed here may have a top-level directory removed on a
+# fresh run.
+SUPPORTED_ARCHES=(x86_64 aarch64 armv7 armhf ppc64le s390x riscv64)
 
 OUTPUT_DIR="site/dist/apk"
 KEY_NAME="verity-apk-repository.rsa"
@@ -110,8 +120,15 @@ mapfile -t APKS < <(
   done | sort -u
 )
 
-rm -rf "$OUTPUT_DIR"
+# Clean only artifacts this script manages. Preserve any other files (notably
+# index.html and index.md emitted by the Astro build) so the published page
+# still explains the repository even when no .apk files were produced.
 mkdir -p "$OUTPUT_DIR"
+rm -f "$OUTPUT_DIR/.no-apks-found"
+rm -f "$OUTPUT_DIR"/*.rsa.pub
+for arch in "${SUPPORTED_ARCHES[@]}"; do
+  rm -rf "${OUTPUT_DIR:?}/$arch"
+done
 
 if [[ ${#APKS[@]} -eq 0 ]]; then
   cat > "$OUTPUT_DIR/.no-apks-found" <<EOF

--- a/.github/scripts/assemble-apk-repository.sh
+++ b/.github/scripts/assemble-apk-repository.sh
@@ -125,10 +125,10 @@ mapfile -t APKS < <(
 # index.html and index.md emitted by the Astro build) so the published page
 # still explains the repository even when no .apk files were produced.
 mkdir -p "$OUTPUT_DIR"
-rm -f "$OUTPUT_DIR/.no-apks-found"
-rm -f "$OUTPUT_DIR/$KEY_NAME.pub"
+rm -f "${OUTPUT_DIR:?}/.no-apks-found"
+rm -f "${OUTPUT_DIR:?}/${KEY_NAME}.pub"
 for arch in "${SUPPORTED_ARCHES[@]}"; do
-  rm -rf "${OUTPUT_DIR:?}/$arch"
+  rm -rf "${OUTPUT_DIR:?}/${arch}"
 done
 
 if [[ ${#APKS[@]} -eq 0 ]]; then

--- a/scripts/apk_repository_test.go
+++ b/scripts/apk_repository_test.go
@@ -137,6 +137,70 @@ func TestAssembleAPKRepositoryCleansStaleArchAndMarker(t *testing.T) {
 	assert.FileExists(t, filepath.Join(outputDir, "index.html"))
 }
 
+func TestAssembleAPKRepositoryDoesNotRemoveUnrelatedRSAPubFiles(t *testing.T) {
+	// Regression for cubic review thread on #485:
+	// the cleanup previously globbed `*.rsa.pub` and would have erased any
+	// neighbouring public key file even if it was not the one this script
+	// publishes. Only the configured `$KEY_NAME.pub` should be touched.
+	repoRoot := t.TempDir()
+	outputDir := filepath.Join(repoRoot, "site", "dist", "apk")
+	// This script's managed key — should be cleaned.
+	managedKey := filepath.Join(outputDir, "verity-apk-repository.rsa.pub")
+	writeTempFile(t, managedKey, "stale managed key")
+	// An unrelated `.rsa.pub` published by a sibling system (e.g. a key
+	// rotation overlap that lays down both old and new keys) — must NOT
+	// be erased by this script.
+	unrelatedKey := filepath.Join(outputDir, "alpine-devel@example.test-1234abcd.rsa.pub")
+	writeTempFile(t, unrelatedKey, "unrelated key payload")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "apk-artifacts"), 0o755))
+
+	_, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(managedKey)
+	assert.True(t, os.IsNotExist(statErr), "the script's managed public key must be cleaned before a fresh run")
+	assert.FileExists(t, unrelatedKey, "unrelated .rsa.pub files in the output directory must be preserved")
+	body, readErr := os.ReadFile(unrelatedKey)
+	require.NoError(t, readErr)
+	assert.Equal(t, "unrelated key payload", string(body), "unrelated key file contents must not be modified")
+}
+
+func TestAssembleAPKRepositoryDetectArchUsesSupportedArchesAllowlist(t *testing.T) {
+	// Regression for cubic review thread on #485:
+	// SUPPORTED_ARCHES and detect_arch previously held independent allowlists,
+	// which would drift if a new arch was added to one but not the other.
+	// detect_arch now consumes SUPPORTED_ARCHES directly. Verify the two
+	// halves still agree by exercising every supported arch end-to-end and
+	// confirming an unsupported arch is rejected with the documented message.
+	for _, arch := range []string{"x86_64", "aarch64", "armv7", "armhf", "ppc64le", "s390x", "riscv64"} {
+		t.Run(arch, func(t *testing.T) {
+			repoRoot := t.TempDir()
+			outputDir := filepath.Join(repoRoot, "site", "dist", "apk")
+			apkPath := filepath.Join(repoRoot, "apk-artifacts", arch, "demo.apk")
+			writeTempFile(t, apkPath, "not a real apk")
+
+			// We do not require the run to succeed end-to-end (the fake .apk
+			// will be rejected by `apk index`). We assert that detect_arch
+			// does NOT reject the arch up-front with the
+			// "could not determine APK architecture" error.
+			out, _ := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+			assert.NotContains(t, out, "could not determine APK architecture",
+				"detect_arch must accept %q because it is in SUPPORTED_ARCHES", arch)
+		})
+	}
+
+	t.Run("rejects unsupported arch", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		outputDir := filepath.Join(repoRoot, "site", "dist", "apk")
+		writeTempFile(t, filepath.Join(repoRoot, "apk-artifacts", "loongarch64", "demo.apk"), "fake")
+
+		out, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+		require.Error(t, err)
+		assert.Contains(t, out, "could not determine APK architecture",
+			"detect_arch must reject arches that are not in SUPPORTED_ARCHES")
+	})
+}
+
 func TestValidateAPKRepositoryRejectsRootPackages(t *testing.T) {
 	repoRoot := t.TempDir()
 	repoDir := filepath.Join(repoRoot, "repo")

--- a/scripts/apk_repository_test.go
+++ b/scripts/apk_repository_test.go
@@ -70,6 +70,73 @@ func TestAssembleAPKRepositoryNoPackagesCreatesMarker(t *testing.T) {
 	assert.FileExists(t, filepath.Join(outputDir, ".no-apks-found"))
 }
 
+func TestAssembleAPKRepositoryPreservesPreexistingDocsWhenNoPackages(t *testing.T) {
+	repoRoot := t.TempDir()
+	outputDir := filepath.Join(repoRoot, "site", "dist", "apk")
+	indexHTML := filepath.Join(outputDir, "index.html")
+	indexMD := filepath.Join(outputDir, "index.md")
+	writeTempFile(t, indexHTML, "<html>docs</html>")
+	writeTempFile(t, indexMD, "# docs")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "apk-artifacts"), 0o755))
+
+	output, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "No APK files found")
+	assert.FileExists(t, indexHTML, "Astro-built apk/index.html must survive overlay assembly")
+	assert.FileExists(t, indexMD, "Astro-built apk/index.md must survive overlay assembly")
+	htmlContents, readErr := os.ReadFile(indexHTML)
+	require.NoError(t, readErr)
+	assert.Equal(t, "<html>docs</html>", string(htmlContents), "index.html must not be overwritten")
+}
+
+func TestAssembleAPKRepositoryPreservesDocsWhenPackagesPresent(t *testing.T) {
+	repoRoot := t.TempDir()
+	outputDir := filepath.Join(repoRoot, "site", "dist", "apk")
+	indexHTML := filepath.Join(outputDir, "index.html")
+	writeTempFile(t, indexHTML, "<html>docs</html>")
+	writeTempFile(t, filepath.Join(repoRoot, "apk-artifacts", "x86_64", "demo.apk"), "not a real apk")
+
+	// apk index will fail on the fake .apk; we only care the script reached the
+	// preservation point and did not delete the existing docs page before
+	// failing.
+	_, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+	if err != nil {
+		// Failures from `apk index` against a fake archive are expected in the
+		// test environment. The preservation guarantee is independent of that
+		// outcome, so we ignore the error and assert on the file state below.
+		_ = err
+	}
+
+	assert.FileExists(t, indexHTML, "Astro-built apk/index.html must survive even when APKs are present")
+}
+
+func TestAssembleAPKRepositoryCleansStaleArchAndMarker(t *testing.T) {
+	repoRoot := t.TempDir()
+	outputDir := filepath.Join(repoRoot, "site", "dist", "apk")
+	// Stale artifacts from a previous run that should be removed.
+	writeTempFile(t, filepath.Join(outputDir, ".no-apks-found"), "old marker")
+	writeTempFile(t, filepath.Join(outputDir, "x86_64", "old.apk"), "stale")
+	writeTempFile(t, filepath.Join(outputDir, "verity-apk-repository.rsa.pub"), "stale key")
+	// Pre-existing doc that must NOT be removed.
+	writeTempFile(t, filepath.Join(outputDir, "index.html"), "<html>docs</html>")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "apk-artifacts"), 0o755))
+
+	_, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+	require.NoError(t, err)
+
+	// Stale arch dir removed.
+	_, statErr := os.Stat(filepath.Join(outputDir, "x86_64"))
+	assert.True(t, os.IsNotExist(statErr), "stale arch directory should be removed")
+	// Stale key removed.
+	_, statErr = os.Stat(filepath.Join(outputDir, "verity-apk-repository.rsa.pub"))
+	assert.True(t, os.IsNotExist(statErr), "stale public key should be removed")
+	// Fresh marker written.
+	assert.FileExists(t, filepath.Join(outputDir, ".no-apks-found"))
+	// Docs preserved.
+	assert.FileExists(t, filepath.Join(outputDir, "index.html"))
+}
+
 func TestValidateAPKRepositoryRejectsRootPackages(t *testing.T) {
 	repoRoot := t.TempDir()
 	repoDir := filepath.Join(repoRoot, "repo")

--- a/scripts/apk_repository_test.go
+++ b/scripts/apk_repository_test.go
@@ -180,10 +180,14 @@ func TestAssembleAPKRepositoryDetectArchUsesSupportedArchesAllowlist(t *testing.
 			writeTempFile(t, apkPath, "not a real apk")
 
 			// We do not require the run to succeed end-to-end (the fake .apk
-			// will be rejected by `apk index`). We assert that detect_arch
-			// does NOT reject the arch up-front with the
-			// "could not determine APK architecture" error.
-			out, _ := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+			// will be rejected by `apk index`). The script may exit with an
+			// error from `apk index`, but it must NOT reject the arch up-front
+			// with the "could not determine APK architecture" error — that
+			// would mean detect_arch and SUPPORTED_ARCHES have drifted apart.
+			out, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
+			// Intentionally ignore err — see comment above; the only failure
+			// mode this test cares about is the detect_arch rejection text.
+			_ = err
 			assert.NotContains(t, out, "could not determine APK architecture",
 				"detect_arch must accept %q because it is in SUPPORTED_ARCHES", arch)
 		})

--- a/scripts/apk_repository_test.go
+++ b/scripts/apk_repository_test.go
@@ -179,15 +179,13 @@ func TestAssembleAPKRepositoryDetectArchUsesSupportedArchesAllowlist(t *testing.
 			apkPath := filepath.Join(repoRoot, "apk-artifacts", arch, "demo.apk")
 			writeTempFile(t, apkPath, "not a real apk")
 
-			// We do not require the run to succeed end-to-end (the fake .apk
-			// will be rejected by `apk index`). The script may exit with an
-			// error from `apk index`, but it must NOT reject the arch up-front
-			// with the "could not determine APK architecture" error — that
-			// would mean detect_arch and SUPPORTED_ARCHES have drifted apart.
+			// The fake .apk causes the script to fail at a later step (either
+			// `require_tool apk` or `apk index`). require.Error captures that
+			// expected failure explicitly so the test reads as
+			// "fails for a non-detect_arch reason" rather than discarding the
+			// return value silently.
 			out, err := runGithubScript(t, repoRoot, "assemble-apk-repository.sh", "--output", outputDir, "apk-artifacts")
-			// Intentionally ignore err — see comment above; the only failure
-			// mode this test cares about is the detect_arch rejection text.
-			_ = err
+			require.Error(t, err, "fake .apk should cause apk index (or require_tool) to fail")
 			assert.NotContains(t, out, "could not determine APK architecture",
 				"detect_arch must accept %q because it is in SUPPORTED_ARCHES", arch)
 		})


### PR DESCRIPTION
## Summary

`https://verity.supply/apk/` returns 404 in production. Root cause:
`.github/scripts/assemble-apk-repository.sh` runs `rm -rf "\$OUTPUT_DIR"`
(default `site/dist/apk`) **after** the Astro build, wiping out the
`index.html` + `index.md` emitted by `site/src/pages/apk/index.astro`.

Effect: every visitor that clicks the homepage's prominent **APK Repository
Preview → View docs** CTA lands on GitHub Pages' generic 404. The
experimental-caveats page that was supposed to explain what's published, the
key fingerprint, and that the repository may be empty is silently deleted on
every nightly run. The deleted page even contains the line *"The repository
may be empty or return 404 until publish and verification complete"* — which
is now unreachable.

## Fix

Replace the blanket `rm -rf` with targeted cleanup of only the artifacts this
script manages:

- `.no-apks-found` marker
- `*.rsa.pub` keys it publishes
- Arch directories listed in the new `SUPPORTED_ARCHES` array (kept in sync
  with the existing `detect_arch` allowlist)

Anything else in the output directory — notably the Astro-built docs page —
is preserved.

## Tests

Three new tests in `scripts/apk_repository_test.go`:

- `TestAssembleAPKRepositoryPreservesPreexistingDocsWhenNoPackages`
- `TestAssembleAPKRepositoryPreservesDocsWhenPackagesPresent`
- `TestAssembleAPKRepositoryCleansStaleArchAndMarker`

All existing tests continue to pass.

## Related

- Companion PRs (independent, opt-in mergeable in any order):
  - Site nav / layout / missing index pages
  - Site WCAG contrast + readability
  - Responsive mobile tables for compliance and VulnTable

## Test plan

```bash
go test ./scripts/ -run TestAssembleAPK -v
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the Astro-built APK docs page during overlay assembly so https://verity.supply/apk/ no longer returns 404. Tightens cleanup to script-owned artifacts, unifies arch allowlist, and hardens cleanup paths.

- **Bug Fixes**
  - Replace `rm -rf $OUTPUT_DIR` with targeted cleanup of `.no-apks-found`, `$KEY_NAME.pub`, and arch dirs from `SUPPORTED_ARCHES`; preserve docs in `site/dist/apk` (e.g., `index.html`, `index.md`).
  - Make `detect_arch` iterate `SUPPORTED_ARCHES` to prevent allowlist drift; scope key cleanup to `$KEY_NAME.pub` and protect unrelated `.rsa.pub` files.
  - Brace cleanup paths using `${VAR:?}/...` for consistency and safety.
  - Add tests for docs preservation, scoped key cleanup, and arch allowlist (including a negative case); update the `detect_arch` test to assert failures with `require.Error` instead of ignoring the error.

<sup>Written for commit b89a222c5cf872028900aa9b1897222beba679f7. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/485?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

