### PR TITLE
fix(site): repair mobile layout and missing catalog/images index pages

### DIFF
--- a/site/src/components/HeroSection.astro
+++ b/site/src/components/HeroSection.astro
@@ -58,7 +58,7 @@ const pipelineSteps = [
 
     <div class="flex flex-wrap gap-3 mb-10">
       <a
-        href="#catalog"
+        href={`${base}catalog/`}
         class="inline-flex items-center text-xs tracking-[0.12em] uppercase px-5 py-3 rounded-md bg-verity-nucleus text-[#002820] shadow-[0_0_24px_rgba(0,240,204,0.25)] hover:bg-[#33FFD6] active:bg-verity-orbit active:shadow-none transition-all duration-[180ms]"
       >
         Browse Catalog →
@@ -87,7 +87,7 @@ const pipelineSteps = [
     <div class="flex flex-wrap items-center gap-y-2">
       {
         pipelineSteps.map((step, i) => (
-          <>
+          <div class="inline-flex items-center shrink-0">
             <div
               class:list={[
                 "border rounded px-4 py-3 min-w-[120px] text-center transition-all duration-[180ms]",
@@ -109,9 +109,11 @@ const pipelineSteps = [
               </span>
             </div>
             {i < pipelineSteps.length - 1 && (
-              <span class="text-verity-nucleus px-2.5 text-base">→</span>
+              <span aria-hidden="true" class="text-verity-nucleus px-2.5 text-base">
+                →
+              </span>
             )}
-          </>
+          </div>
         ))
       }
     </div>

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -4,7 +4,6 @@ const base = import.meta.env.BASE_URL;
 interface NavLink {
   href: string;
   label: string;
-  external?: boolean;
   badge?: string;
 }
 

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -1,16 +1,34 @@
 ---
 const base = import.meta.env.BASE_URL;
+
+interface NavLink {
+  href: string;
+  label: string;
+  external?: boolean;
+  badge?: string;
+}
+
+const links: NavLink[] = [
+  { href: `${base}catalog/`, label: "Catalog" },
+  { href: `${base}charts/`, label: "Charts" },
+  { href: `${base}apk/`, label: "APK", badge: "EXP" },
+  { href: `${base}compliance/`, label: "Compliance" },
+];
+const githubHref = "https://github.com/verity-org/verity";
 ---
 
 <nav class="sticky top-0 z-40 bg-verity-void/80 border-b border-verity-border backdrop-blur-none">
-  <div class="max-w-[1120px] mx-auto px-6 py-3.5 flex items-center justify-between gap-6">
-    <a href={base} class="flex items-center gap-2.5 group">
+  <div
+    class="max-w-[1120px] mx-auto px-4 sm:px-6 py-3.5 flex items-center justify-between gap-3 sm:gap-6"
+  >
+    <a href={base} class="flex items-center gap-2.5 group min-w-0">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 80 80"
         width="28"
         height="28"
         class="flex-shrink-0"
+        aria-hidden="true"
       >
         <defs>
           <linearGradient id="verity-nav-teal" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -60,31 +78,126 @@ const base = import.meta.env.BASE_URL;
       >
     </a>
 
-    <div class="flex items-center gap-6">
+    {/* Desktop nav — hidden below md to avoid horizontal overflow on phones */}
+    <div class="hidden md:flex items-center gap-6">
+      {
+        links.map((link) => (
+          <a
+            href={link.href}
+            class="text-xs tracking-[0.12em] uppercase text-verity-text-secondary hover:text-verity-nucleus hover:[text-shadow:0_0_8px_rgba(0,240,204,0.5)] transition-colors py-2"
+          >
+            {link.label}
+            {link.badge && (
+              <span class="ml-1.5 rounded-sm border border-amber-500/40 bg-amber-500/10 px-1 py-px text-[9px] tracking-wider text-amber-200">
+                {link.badge}
+              </span>
+            )}
+          </a>
+        ))
+      }
       <a
-        href={`${base}catalog/`}
-        class="text-xs tracking-[0.12em] uppercase text-verity-text-secondary hover:text-verity-nucleus hover:[text-shadow:0_0_8px_rgba(0,240,204,0.5)] transition-colors"
-      >
-        Catalog
-      </a>
-      <a
-        href={`${base}charts/`}
-        class="text-xs tracking-[0.12em] uppercase text-verity-text-secondary hover:text-verity-nucleus hover:[text-shadow:0_0_8px_rgba(0,240,204,0.5)] transition-colors"
-      >
-        Charts
-      </a>
-      <a
-        href={`${base}compliance/`}
-        class="text-xs tracking-[0.12em] uppercase text-verity-text-secondary hover:text-verity-nucleus hover:[text-shadow:0_0_8px_rgba(0,240,204,0.5)] transition-colors"
-      >
-        Compliance
-      </a>
-      <a
-        href="https://github.com/verity-org/verity"
+        href={githubHref}
         class="text-xs tracking-[0.12em] uppercase text-verity-text border border-verity-border-2 px-2.5 py-1.5 rounded-md hover:border-verity-nucleus hover:text-verity-nucleus transition-colors"
       >
         GitHub ↗
       </a>
     </div>
+
+    {/* Mobile hamburger toggle — visible below md */}
+    <button
+      type="button"
+      class="md:hidden inline-flex items-center justify-center w-11 h-11 rounded-md border border-verity-border-2 text-verity-text hover:border-verity-nucleus hover:text-verity-nucleus transition-colors"
+      aria-controls="mobile-nav"
+      aria-expanded="false"
+      aria-label="Open menu"
+      data-nav-toggle
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="22"
+        height="22"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+        data-nav-icon-open
+      >
+        <line x1="3" y1="6" x2="21" y2="6"></line>
+        <line x1="3" y1="12" x2="21" y2="12"></line>
+        <line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="22"
+        height="22"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+        class="hidden"
+        data-nav-icon-close
+      >
+        <line x1="6" y1="6" x2="18" y2="18"></line>
+        <line x1="6" y1="18" x2="18" y2="6"></line>
+      </svg>
+    </button>
+  </div>
+
+  {/* Mobile disclosure panel */}
+  <div
+    id="mobile-nav"
+    class="md:hidden hidden border-t border-verity-border bg-verity-void"
+    data-nav-panel
+  >
+    <ul class="px-4 py-3 flex flex-col">
+      {
+        links.map((link) => (
+          <li>
+            <a
+              href={link.href}
+              class="flex items-center justify-between gap-2 text-sm tracking-[0.12em] uppercase text-verity-text-secondary hover:text-verity-nucleus transition-colors py-3 border-b border-verity-border/50"
+            >
+              <span>{link.label}</span>
+              {link.badge && (
+                <span class="rounded-sm border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] tracking-wider text-amber-200">
+                  {link.badge}
+                </span>
+              )}
+            </a>
+          </li>
+        ))
+      }
+      <li class="pt-3">
+        <a
+          href={githubHref}
+          class="block w-full text-center text-sm tracking-[0.12em] uppercase text-verity-text border border-verity-border-2 py-3 rounded-md hover:border-verity-nucleus hover:text-verity-nucleus transition-colors"
+        >
+          GitHub ↗
+        </a>
+      </li>
+    </ul>
   </div>
 </nav>
+
+<script>
+  const toggle = document.querySelector<HTMLButtonElement>("[data-nav-toggle]");
+  const panel = document.querySelector<HTMLElement>("[data-nav-panel]");
+  const iconOpen = document.querySelector<SVGElement>("[data-nav-icon-open]");
+  const iconClose = document.querySelector<SVGElement>("[data-nav-icon-close]");
+
+  if (toggle && panel && iconOpen && iconClose) {
+    toggle.addEventListener("click", () => {
+      const isOpen = panel.classList.toggle("hidden") === false;
+      toggle.setAttribute("aria-expanded", String(isOpen));
+      toggle.setAttribute("aria-label", isOpen ? "Close menu" : "Open menu");
+      iconOpen.classList.toggle("hidden", isOpen);
+      iconClose.classList.toggle("hidden", !isOpen);
+    });
+  }
+</script>

--- a/site/src/pages/catalog/index.astro
+++ b/site/src/pages/catalog/index.astro
@@ -1,0 +1,31 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import ImageCatalog from "../../components/ImageCatalog.astro";
+import { totalImages, totalCategories, copaCount, integerCount } from "../../data/full-catalog";
+
+const base = import.meta.env.BASE_URL;
+---
+
+<BaseLayout title={`Image Catalog — Verity`}>
+  <nav class="text-sm text-verity-text-secondary mb-6">
+    <a href={base} class="hover:text-verity-nucleus transition-colors">Home</a>
+    <span class="mx-1">/</span>
+    <span class="text-verity-text-primary">Catalog</span>
+  </nav>
+
+  <section class="mb-8">
+    <h1 class="text-2xl font-semibold text-verity-text-primary tracking-wider mb-3">
+      Image Catalog
+    </h1>
+    <p class="text-sm text-verity-text-secondary mb-2">
+      {totalImages} security-patched container images across {totalCategories} categories. Every image
+      is scanned, patched, signed, and published to
+      <code class="text-verity-text-primary text-xs">ghcr.io/verity-org</code>.
+    </p>
+    <p class="text-xs text-verity-text-muted">
+      {copaCount} Copa-patched upstream images · {integerCount} Wolfi-based hardened images
+    </p>
+  </section>
+
+  <ImageCatalog />
+</BaseLayout>

--- a/site/src/pages/images/[id].astro
+++ b/site/src/pages/images/[id].astro
@@ -34,6 +34,8 @@ const awaitingFixVulns = image.vulnerabilities.filter((v) => !v.fixedVersion);
   <nav class="text-sm text-verity-text-secondary mb-6">
     <a href={base} class="hover:text-verity-nucleus transition-colors">Home</a>
     <span class="mx-1">/</span>
+    <a href={`${base}catalog/`} class="hover:text-verity-nucleus transition-colors">Catalog</a>
+    <span class="mx-1">/</span>
     <span class="text-verity-text-primary truncate">{display.split("/").pop()?.split(":")[0]}</span>
   </nav>
 

--- a/site/src/pages/images/index.astro
+++ b/site/src/pages/images/index.astro
@@ -1,0 +1,27 @@
+---
+// The `/images/[id]` dynamic routes carry scanned image detail pages. Their
+// listing lives in the unified catalog at `/catalog/`, which surfaces every
+// image with its source badge, severity summary, and pull reference. This
+// stub page exists so the bare `/images/` URL is reachable instead of
+// returning 404 — it immediately redirects to the catalog.
+
+const base = import.meta.env.BASE_URL;
+const target = `${base}catalog/`;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Image Catalog — Verity</title>
+    <meta http-equiv="refresh" content={`0;url=${target}`} />
+    <link rel="canonical" href={target} />
+  </head>
+  <body>
+    <p>Redirecting to <a href={target}>the image catalog</a>.</p>
+    <script is:inline define:vars={{ target }}>
+      window.location.replace(target);
+    </script>
+  </body>
+</html>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -62,7 +62,7 @@ const charts = chartsCatalog.charts;
         <p class="text-sm text-verity-text-secondary mb-4">
           Drop-in Helm wrapper charts with all image references pre-patched.
         </p>
-        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {charts.slice(0, 3).map((chart) => {
             const installCmd = `helm install ${chart.wrapperName} ${chart.registry}/${chart.wrapperName} --version ${chart.wrapperVersion}`;
             const overrideCount = chart.imageMappings.length + chart.valueOverrides.length;


### PR DESCRIPTION
## Summary

Five related regressions left the live site partially broken, especially on
mobile. Captured during a desktop + iPhone 14 Pro emulation sweep of every
public page.

### 1. `/catalog/` returned 404 on every viewport

`site/src/pages/catalog/` contained only the `[...name].astro` dynamic
route — no `index.astro`. The global Nav links to `/catalog/` on every
page, so from any non-home page the primary CTA was a dead link.

### 2. `/images/` returned 404

Same pattern: only `[id].astro`. The image-detail breadcrumb stopped at
\"Home\", giving the user no way back to a list.

### 3. Nav overflowed the mobile viewport on every page

The brand block + 4 link labels + GitHub button + gaps + padding
measured ~549px on a 393px iPhone viewport. No \`flex-wrap\`, no
hamburger, no responsive collapse. iOS Safari then applied shrink-to-fit
and expanded the layout viewport to ~566px, zooming every page down ~30%.
Effective body text rendered at ~10–11px on every page, not just home.

### 4. Home Helm Charts grid expanded past viewport

The Helm Charts section used \`grid gap-4 sm:grid-cols-2 lg:grid-cols-3\`
with no \`grid-cols-1\` baseclass. With \`truncate\`'d helm install
commands inside, mobile cells expanded to ~550px to fit the unwrappable
string, blowing past the 393px viewport on home specifically.

### 5. Hero CTA \"Browse Catalog →\" only worked on home

\`href=\"#catalog\"\` is a pure in-page anchor; from any non-home page it
silently no-ops.

## Changes

- **`components/Nav.astro`** — split into a desktop row (md+) and a mobile
  disclosure panel with a 44×44 hamburger toggle. Adds an APK entry to the
  global Nav, marked with an experimental pill. The toggle script handles
  `aria-expanded` and icon swap, and the disclosure links are full-width
  ≥44px high tap targets.
- **`pages/catalog/index.astro` (new)** — renders the existing
  `ImageCatalog` component under proper page chrome.
- **`pages/images/index.astro` (new)** — meta-refresh + client-side
  redirect to `/catalog/`, so the bare URL is no longer a 404.
- **`pages/index.astro`** — explicit `grid-cols-1` on the Helm Charts grid
  so mobile cells stay within the viewport.
- **`components/HeroSection.astro`** — CTA links to `\${base}catalog/`
  (works from any page); pipeline steps wrap as inline-flex units so the
  → arrows no longer orphan onto new lines.
- **`pages/images/[id].astro`** — breadcrumb now includes a \"Catalog\" hop.

## Verification

Built locally (`npm run build` — 360 pages) and re-ran the Playwright sweep
at iPhone 14 Pro emulation:

- Every page reports `document.scrollWidth === window.innerWidth` (393).
- iOS shrink-to-fit no longer triggers.
- Desktop layout unchanged at 1440×900 — same nav, same hero, same
  sections.
- Hamburger panel opens / closes and updates `aria-expanded`.

## Related

This is part 2 of 4 independent PRs that together restore the verity.supply
mobile + a11y story:

- (companion) `fix(apk): preserve Astro-built apk docs page` — restores
  `/apk/` itself
- (this) Site nav / layout / missing index pages
- (companion) WCAG AA contrast + readability
- (companion) Responsive mobile tables for compliance + VulnTable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile layout and navigation by adding a responsive menu and restoring the `/catalog/` and `/images/` index routes. Mobile pages now render at the correct size, and primary links work from any page.

- **Bug Fixes**
  - Added `pages/catalog/index.astro` to render the catalog listing.
  - Added `pages/images/index.astro` to redirect to `/catalog/`; image detail breadcrumb now includes “Catalog”.
  - Rebuilt `Nav.astro` with a desktop row and mobile hamburger panel; added APK link with an “EXP” badge; improves ARIA and tap targets.
  - Prevented home grid overflow by adding `grid-cols-1` to the Helm Charts section.
  - Updated Hero CTA to `/${base}catalog/` and grouped pipeline steps so arrows don’t wrap separately.

- **Refactors**
  - Removed unused `external` flag from `NavLink` in `Nav.astro`.

<sup>Written for commit 576368b4b6345f2f8d698258f4dc9194e7c65502. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/486?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

