### PR TITLE
fix(site): bump muted text luminance, label sizes, and add skip-to-content for WCAG AA

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -16,7 +16,7 @@ const generated = new Date(catalog.generatedAt).toLocaleDateString("en-US", {
   >
     <div class="col-span-2 sm:col-span-1">
       <div
-        class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3 flex items-baseline gap-1.5"
+        class="text-[11px] tracking-[0.25em] text-verity-text uppercase mb-3 flex items-baseline gap-1.5"
       >
         <span>VERITY</span>
         <span class="text-verity-border-2">/</span>
@@ -28,36 +28,36 @@ const generated = new Date(catalog.generatedAt).toLocaleDateString("en-US", {
     </div>
 
     <div>
-      <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">REGISTRY</div>
+      <div class="text-[11px] tracking-[0.25em] text-verity-text uppercase mb-3">REGISTRY</div>
       <a
         href="https://github.com/orgs/verity-org/packages"
-        class="block py-1 hover:text-verity-nucleus transition-colors"
+        class="block py-2 hover:text-verity-nucleus transition-colors"
       >
         ghcr.io/verity-org ↗
       </a>
-      <a href={`${base}charts/`} class="block py-1 hover:text-verity-nucleus transition-colors">
+      <a href={`${base}charts/`} class="block py-2 hover:text-verity-nucleus transition-colors">
         OCI Helm charts
       </a>
     </div>
 
     <div>
-      <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">DOCS</div>
-      <a href={`${base}llms.txt`} class="block py-1 hover:text-verity-nucleus transition-colors">
+      <div class="text-[11px] tracking-[0.25em] text-verity-text uppercase mb-3">DOCS</div>
+      <a href={`${base}llms.txt`} class="block py-2 hover:text-verity-nucleus transition-colors">
         LLM reference
       </a>
-      <a href={`${base}compliance/`} class="block py-1 hover:text-verity-nucleus transition-colors">
+      <a href={`${base}compliance/`} class="block py-2 hover:text-verity-nucleus transition-colors">
         Compliance mapping
       </a>
       <a
         href="https://github.com/verity-org/verity/blob/main/ARCHITECTURE.md"
-        class="block py-1 hover:text-verity-nucleus transition-colors"
+        class="block py-2 hover:text-verity-nucleus transition-colors"
       >
         Architecture
       </a>
     </div>
 
     <div>
-      <div class="text-[10px] tracking-[0.25em] text-verity-text uppercase mb-3">PIPELINE</div>
+      <div class="text-[11px] tracking-[0.25em] text-verity-text uppercase mb-3">PIPELINE</div>
       <p class="text-verity-text-muted leading-relaxed">
         Daily · 02:00 UTC<br />
         cosign · SLSA L3 · CycloneDX

--- a/site/src/components/HeroSection.astro
+++ b/site/src/components/HeroSection.astro
@@ -31,7 +31,7 @@ const pipelineSteps = [
   </div>
 
   <div class="relative">
-    <div class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mb-7">
+    <div class="text-[11px] tracking-[0.25em] text-verity-text-muted uppercase mb-7">
       SELF-MAINTAINING REGISTRY · PATCHED DAILY · 02:00 UTC
     </div>
 
@@ -75,7 +75,7 @@ const pipelineSteps = [
       <div
         class="bg-verity-surface border-b border-verity-border px-3.5 py-2 flex items-center justify-between"
       >
-        <span class="text-[10px] tracking-[0.12em] uppercase text-verity-text-muted">
+        <span class="text-[11px] tracking-[0.12em] uppercase text-verity-text-muted">
           $ pull a patched image
         </span>
         <CopyButton text={pullCmd} />
@@ -96,7 +96,7 @@ const pipelineSteps = [
                   : "border-verity-border-2 bg-verity-surface",
               ]}
             >
-              <span class="block text-[9px] tracking-[0.25em] text-verity-text-muted">
+              <span class="block text-[10px] tracking-[0.25em] text-verity-text-muted">
                 {step.n}
               </span>
               <span
@@ -123,13 +123,13 @@ const pipelineSteps = [
     class="bg-verity-surface border border-verity-border rounded p-4 text-center hover:border-verity-border-2 hover:bg-verity-surface-2 transition-colors"
   >
     <div class="text-2xl text-verity-text">{totalImages}</div>
-    <div class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">Images</div>
+    <div class="text-[11px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">Images</div>
   </div>
   <div
     class="bg-verity-surface border border-verity-border rounded p-4 text-center hover:border-verity-border-2 hover:bg-verity-surface-2 transition-colors"
   >
     <div class="text-2xl text-verity-text">{totalCategories}</div>
-    <div class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">
+    <div class="text-[11px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">
       Categories
     </div>
   </div>
@@ -137,13 +137,13 @@ const pipelineSteps = [
     class="bg-verity-surface border border-verity-border rounded p-4 text-center hover:border-verity-border-2 hover:bg-verity-surface-2 transition-colors"
   >
     <div class="text-base text-verity-text tracking-[0.04em]">amd64 + arm64</div>
-    <div class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">Platforms</div>
+    <div class="text-[11px] tracking-[0.25em] text-verity-text-muted uppercase mt-1">Platforms</div>
   </div>
   <div
     class="bg-[rgba(0,240,204,0.06)] border border-verity-nucleus rounded p-4 text-center hover:shadow-[0_0_20px_rgba(0,240,204,0.2)] transition-all"
   >
     <div class="text-2xl text-verity-nucleus">FIPS</div>
-    <div class="text-[10px] tracking-[0.25em] text-verity-nucleus uppercase mt-1 opacity-90">
+    <div class="text-[11px] tracking-[0.25em] text-verity-nucleus uppercase mt-1 opacity-90">
       Available
     </div>
   </div>
@@ -151,7 +151,7 @@ const pipelineSteps = [
 
 <section class="grid md:grid-cols-2 gap-4 mb-4">
   <div class="bg-verity-surface border border-verity-border rounded p-5">
-    <h2 class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mb-4">
+    <h2 class="text-[11px] tracking-[0.25em] text-verity-text-muted uppercase mb-4">
       How it works
     </h2>
     <div class="space-y-3 text-sm">
@@ -205,7 +205,7 @@ const pipelineSteps = [
   </div>
 
   <div class="bg-verity-surface border border-verity-border rounded p-5">
-    <h2 class="text-[10px] tracking-[0.25em] text-verity-text-muted uppercase mb-4">
+    <h2 class="text-[11px] tracking-[0.25em] text-verity-text-muted uppercase mb-4">
       Use a patched image
     </h2>
     <p class="text-sm text-verity-text-muted mb-3">Replace your image reference. That's it.</p>

--- a/site/src/components/ImageCatalog.astro
+++ b/site/src/components/ImageCatalog.astro
@@ -202,10 +202,10 @@ function getVulnSummary(image: FullCatalogImage): VulnSummary {
     filterBtns?.forEach((btn) => {
       const btnFilter = btn.getAttribute("data-filter");
       if (btnFilter === filter) {
-        btn.classList.add("bg-verity-nucleus", "text-white");
+        btn.classList.add("bg-verity-nucleus", "text-[#002820]");
         btn.classList.remove("text-verity-text-secondary", "hover:bg-verity-void");
       } else {
-        btn.classList.remove("bg-verity-nucleus", "text-white");
+        btn.classList.remove("bg-verity-nucleus", "text-[#002820]");
         btn.classList.add("text-verity-text-secondary", "hover:bg-verity-void");
       }
     });

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -33,8 +33,14 @@ const base = import.meta.env.BASE_URL;
     {mdUrl && <link rel="alternate" type="text/markdown" href={mdUrl} title="Markdown version" />}
   </head>
   <body class="min-h-screen flex flex-col bg-verity-void text-verity-text-primary">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:rounded-md focus:bg-verity-nucleus focus:text-[#002820] focus:shadow-[0_0_24px_rgba(0,240,204,0.25)] focus:outline-hidden"
+    >
+      Skip to main content
+    </a>
     <Nav />
-    <main class="flex-1 max-w-6xl mx-auto w-full px-4 py-8">
+    <main id="main-content" tabindex="-1" class="flex-1 max-w-6xl mx-auto w-full px-4 py-8">
       <slot />
     </main>
     <Footer />

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -24,11 +24,17 @@
   --color-verity-border: #152230;
   --color-verity-border-2: #1f2b35;
 
-  /* Text */
+  /* Text — luminance tuned for WCAG AA against --color-verity-void (#060d12).
+     Previously: verity-text-secondary #7a8e9c → contrast 5.7 ✓,
+     verity-text-muted #5a6e7c → contrast 3.7 ✗ (failed AA for normal text).
+     verity-text-secondary bumped to #95a8b8 → contrast 6.9 (AAA).
+     verity-text-muted bumped to #7a8e9c → contrast 5.7 (AA + AAA large).
+     The pair stays visually distinguishable while every caption-sized
+     muted run passes AA against the void background. */
   --color-verity-text: #e8edf2;
   --color-verity-text-primary: #c5d5dd;
-  --color-verity-text-secondary: #7a8e9c;
-  --color-verity-text-muted: #5a6e7c;
+  --color-verity-text-secondary: #95a8b8;
+  --color-verity-text-muted: #7a8e9c;
   --color-verity-text-dim: #2e4a5a;
   --color-verity-text-ghost: #2a3f50;
 


### PR DESCRIPTION
## Summary

A compositing-aware Playwright contrast audit found multiple text elements
below WCAG AA (4.5 for normal text, 3.0 for large) against the `verity-void`
body background.

| Where | Before | After |
|-------|-------:|------:|
| `verity-text-muted` body text (\"How it works\", footer captions, table cell text on /charts and /apk) | 3.7 ✗ | 5.7 ✓ |
| `verity-text-secondary` (breadcrumbs, list items) | 5.7 ✓ | 6.9 ✓ (AAA) |
| Active filter button on /catalog (\"All\", \"Wolfi-Based\", \"Patched\") — white text on bright teal | 1.5 ✗ | passes via dark teal text |
| 10px stat-tile labels and section captions across home + footer | 10px small | 11px (matches existing tracking) |
| Pipeline step numbers in hero | 9px | 10px |
| Footer link tap targets | 20px tall | ~32px tall (py-2) |

After this PR, the same audit reports **0 unique low-contrast text combos**
across `/`, `/apk/`, `/compliance/`, `/charts/`, and `/catalog/`.

## Changes

- **`styles/global.css`** — lift `--color-verity-text-secondary` to
  `#95a8b8` (contrast 6.9) and `--color-verity-text-muted` to `#7a8e9c`
  (contrast 5.7). Both clear AA for body text and AAA for large text. The
  unused `verity-text-dim` / `verity-text-ghost` slots are unchanged.
- **`components/HeroSection.astro`** — `text-[10px]` → `text-[11px]` for
  stat-tile labels, section captions, the \"\$ pull a patched image\"
  hint, and the \"How it works\" / \"Use a patched image\" mini-headers;
  pipeline step numbers from `text-[9px]` → `text-[10px]`.
- **`components/Footer.astro`** — same 10 → 11 bump on column headings,
  and `py-1` → `py-2` on every footer link for a ~32px touch target.
- **`components/ImageCatalog.astro`** — active filter button text becomes
  dark teal `text-[#002820]` instead of white on bright `bg-verity-nucleus`
  (which rendered at contrast 1.5, the worst hit in the audit).
- **`layouts/BaseLayout.astro`** — add a visible-on-focus \"Skip to main
  content\" link and `id=\"main-content\" tabindex=\"-1\"` target so
  keyboard and screen-reader users can jump past the sticky nav.

## Verification

```bash
# Build + serve locally
cd site && npm run build && npx astro preview --port 4323
# Run the compositing-aware audit
node /tmp/opencode/verity-review/a11y-audit.js
```

Output after this PR (excerpt):
```
=== home === (0 unique low-contrast text combos)
=== apk/ === (0 unique low-contrast text combos)
=== compliance/ === (0 unique low-contrast text combos)
=== charts/ === (0 unique low-contrast text combos)
=== catalog/ === (0 unique low-contrast text combos)
```

## Related

Part of a 4-PR sweep fixing verity.supply mobile + a11y issues found during
a desktop + iPhone 14 Pro design review:

- (companion) `fix(apk): preserve Astro-built apk docs page`
- (companion) Site nav / mobile layout / missing index pages
- (this) WCAG AA contrast + readability
- (companion) Responsive tables for compliance + VulnTable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve site accessibility to meet WCAG AA by increasing text contrast, bumping small label sizes, and fixing low-contrast UI states. Adds a visible-on-focus “Skip to main content” link for better keyboard navigation.

- **Bug Fixes**
  - Raise text contrast tokens: secondary #95a8b8 (6.9) and muted #7a8e9c (5.7) against the body background.
  - Bump small labels 10px→11px and pipeline step numbers 9px→10px; increase footer link tap targets to ~32px.
  - Fix catalog active filter contrast by using dark teal text on bright teal.
  - Playwright contrast audit now reports 0 failures on '/', '/apk', '/compliance', '/charts', and '/catalog'.

- **New Features**
  - Add a visible-on-focus “Skip to main content” link with a `tabindex="-1"` target to jump past the sticky nav.

<sup>Written for commit 3e17a409c4251d1a1c090c536f6647c3230a5c25. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/487?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

