### PR TITLE
fix(site): stack VulnTable and compliance Framework Reference as cards on mobile

### DIFF
--- a/site/src/components/VulnTable.astro
+++ b/site/src/components/VulnTable.astro
@@ -13,32 +13,56 @@ const sorted = sortBySeverity(vulnerabilities, (v) => v.severity);
 
 {
   sorted.length > 0 ? (
-    <div class="overflow-x-auto">
-      <table class="w-full text-sm">
-        <thead>
-          <tr class="border-b border-verity-border text-left text-verity-text-secondary">
-            <th class="pb-2 pr-4 font-medium">ID</th>
-            <th class="pb-2 pr-4 font-medium">Package</th>
-            <th class="pb-2 pr-4 font-medium">Installed</th>
-            <th class="pb-2 pr-4 font-medium">Fixed</th>
-            <th class="pb-2 font-medium">Severity</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sorted.map((v) => (
-            <tr class="border-b border-verity-border/50">
-              <td class="py-2 pr-4 font-mono text-xs">{v.id}</td>
-              <td class="py-2 pr-4">{v.pkgName}</td>
-              <td class="py-2 pr-4 font-mono text-xs">{v.installedVersion}</td>
-              <td class="py-2 pr-4 font-mono text-xs">{v.fixedVersion}</td>
-              <td class="py-2">
-                <VulnBadge severity={v.severity} />
-              </td>
+    <>
+      {/* Card layout on mobile — table columns become labeled rows so users
+          don't need to scroll horizontally across a 5-column grid. */}
+      <ul class="space-y-3 sm:hidden">
+        {sorted.map((v) => (
+          <li class="rounded-lg border border-verity-border bg-verity-surface p-4 space-y-2">
+            <div class="flex items-start justify-between gap-3">
+              <span class="font-mono text-xs text-verity-text-primary break-all">{v.id}</span>
+              <VulnBadge severity={v.severity} />
+            </div>
+            <dl class="grid grid-cols-[5rem_1fr] gap-x-3 gap-y-1 text-xs">
+              <dt class="text-verity-text-secondary">Package</dt>
+              <dd class="text-verity-text-primary break-all">{v.pkgName}</dd>
+              <dt class="text-verity-text-secondary">Installed</dt>
+              <dd class="font-mono text-verity-text-primary break-all">{v.installedVersion}</dd>
+              <dt class="text-verity-text-secondary">Fixed</dt>
+              <dd class="font-mono text-verity-text-primary break-all">{v.fixedVersion}</dd>
+            </dl>
+          </li>
+        ))}
+      </ul>
+
+      {/* Table layout on sm+ — denser, scannable across many vulns. */}
+      <div class="hidden sm:block overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-verity-border text-left text-verity-text-secondary">
+              <th class="pb-2 pr-4 font-medium">ID</th>
+              <th class="pb-2 pr-4 font-medium">Package</th>
+              <th class="pb-2 pr-4 font-medium">Installed</th>
+              <th class="pb-2 pr-4 font-medium">Fixed</th>
+              <th class="pb-2 font-medium">Severity</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {sorted.map((v) => (
+              <tr class="border-b border-verity-border/50">
+                <td class="py-2 pr-4 font-mono text-xs">{v.id}</td>
+                <td class="py-2 pr-4">{v.pkgName}</td>
+                <td class="py-2 pr-4 font-mono text-xs">{v.installedVersion}</td>
+                <td class="py-2 pr-4 font-mono text-xs">{v.fixedVersion}</td>
+                <td class="py-2">
+                  <VulnBadge severity={v.severity} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
   ) : (
     <p class="text-verity-text-muted">No vulnerabilities found.</p>
   )

--- a/site/src/pages/compliance.astro
+++ b/site/src/pages/compliance.astro
@@ -3,6 +3,180 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import CopyButton from "../components/CopyButton.astro";
 
 const base = import.meta.env.BASE_URL;
+
+interface FrameworkRow {
+  control: string;
+  meets: string;
+}
+interface Framework {
+  name: string;
+  href: string;
+  subtitle?: string;
+  rows: FrameworkRow[];
+}
+
+const frameworks: Framework[] = [
+  {
+    name: "SLSA v1.0",
+    href: "https://slsa.dev/",
+    rows: [
+      {
+        control: "Build L3 — Hardened provenance",
+        meets:
+          "Platform-generated provenance via actions/attest-build-provenance on ephemeral runners",
+      },
+      {
+        control: "Source integrity",
+        meets: "Version-controlled manifests in Git; provenance links artifacts to commit SHAs",
+      },
+    ],
+  },
+  {
+    name: "EO 14028",
+    href: "https://www.nist.gov/system/files/documents/2022/02/04/software-supply-chain-security-guidance-under-EO-14028-section-4e.pdf",
+    rows: [
+      {
+        control: "SBOM for delivered software",
+        meets: "CycloneDX SBOM attested to every container image",
+      },
+    ],
+  },
+  {
+    name: "NIST SSDF",
+    href: "https://csrc.nist.gov/Projects/ssdf",
+    rows: [
+      {
+        control: "PS.1 — Protect software integrity",
+        meets: "Cosign keyless signatures; Rekor transparency log",
+      },
+      {
+        control: "PW.4 — Verify third-party components",
+        meets: "Trivy scanning of all upstream images; Copa patching",
+      },
+      {
+        control: "RV.1 — Identify and confirm vulnerabilities",
+        meets: "Daily scheduled scans; auto-generated PRs",
+      },
+    ],
+  },
+  {
+    name: "NIST 800-53r5",
+    href: "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final",
+    subtitle: "(FedRAMP)",
+    rows: [
+      {
+        control: "SR-3 / SR-4 — Supply chain provenance",
+        meets: "SLSA L3 provenance attestations linking artifacts to source, build, and runner",
+      },
+      {
+        control: "SR-11 — Component authenticity",
+        meets: "Cosign OIDC-based signatures verify artifact origin",
+      },
+      {
+        control: "SI-7 — Software integrity",
+        meets: "Signature verification detects any post-build tampering",
+      },
+      {
+        control: "RA-5 — Vulnerability monitoring",
+        meets: "Daily Trivy scans; 30-day report retention for audit evidence",
+      },
+    ],
+  },
+  {
+    name: "SOC 2",
+    href: "https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2",
+    rows: [
+      {
+        control: "CC8.1 — Change management",
+        meets: "PR-gated changes; provenance ties artifacts to specific commits and runs",
+      },
+      {
+        control: "CC7.1 — Monitoring and detection",
+        meets: "Daily CVE scans; vulnerability report artifacts retained",
+      },
+      {
+        control: "CC6.1 — Logical access controls",
+        meets: "Scoped GITHUB_TOKEN; least-privilege workflow permissions; no static keys",
+      },
+    ],
+  },
+  {
+    name: "ISO 27001:2022",
+    href: "https://www.iso.org/standard/27001",
+    rows: [
+      {
+        control: "A.5.21 — ICT supply chain security",
+        meets: "Pinned dependencies; SBOM attestation; continuous upstream scanning",
+      },
+      {
+        control: "A.8.25 — Secure development lifecycle",
+        meets: "Automated CI gates (lint, test, scan) before any artifact is published",
+      },
+      {
+        control: "A.8.30 — Outsourced development",
+        meets: "Third-party images scanned, patched, re-signed under Verity identity",
+      },
+    ],
+  },
+  {
+    name: "OWASP ASVS v4",
+    href: "https://owasp.org/www-project-application-security-verification-standard/",
+    rows: [
+      {
+        control: "V14.2 — Dependency verification",
+        meets: "All deps pinned by hash; Renovate auto-updates; no mutable tags",
+      },
+      {
+        control: "V10.3 — Deployed application integrity",
+        meets: "Cosign + gh attestation verify for end-to-end integrity",
+      },
+    ],
+  },
+  {
+    name: "NIST CSF 2.0",
+    href: "https://www.nist.gov/cyberframework",
+    rows: [
+      {
+        control: "GV.SC — Supply chain risk management",
+        meets: "Provenance, signing, SBOM, pinning, and scanning as a unified supply chain posture",
+      },
+    ],
+  },
+  {
+    name: "CISA Secure by Design",
+    href: "https://www.cisa.gov/securebydesign",
+    rows: [
+      {
+        control: "Radical transparency",
+        meets: "Public vulnerability reports; SBOM on every image; Rekor for public audit",
+      },
+    ],
+  },
+  {
+    name: "OpenSSF Scorecard",
+    href: "https://bestpractices.openssf.org/",
+    rows: [
+      {
+        control: "Pinned-Dependencies",
+        meets: "Actions pinned by SHA; Go deps via go.sum; Renovate auto-updates",
+      },
+      {
+        control: "Signed-Releases",
+        meets: "All OCI artifacts signed with cosign keyless",
+      },
+    ],
+  },
+  {
+    name: "Sigstore",
+    href: "https://docs.sigstore.dev/",
+    rows: [
+      {
+        control: "Artifact transparency",
+        meets: "All signatures in the Rekor transparency log; verifiable by anyone",
+      },
+    ],
+  },
+];
 ---
 
 <BaseLayout title="Supply Chain Compliance — Verity" mdUrl={`${base}compliance.md`}>
@@ -560,7 +734,44 @@ const base = import.meta.env.BASE_URL;
     <p class="text-sm text-verity-text-muted mb-4">
       Quick-reference mapping of Verity controls to specific framework requirements.
     </p>
-    <div class="overflow-x-auto">
+
+    {
+      /* Mobile card layout — each framework groups its rows in a card so users
+        don't have to swipe across a 3-column table on narrow viewports. */
+    }
+    <ul class="space-y-4 sm:hidden">
+      {
+        frameworks.map((fw) => (
+          <li class="rounded-lg border border-verity-border bg-verity-surface overflow-hidden">
+            <div class="border-b border-verity-border px-4 py-3 bg-verity-void/40">
+              <a
+                href={fw.href}
+                class="font-medium text-verity-text-primary underline decoration-verity-border-2 hover:decoration-verity-nucleus transition-colors"
+              >
+                {fw.name}
+              </a>
+              {fw.subtitle && <div class="text-xs text-verity-text-secondary">{fw.subtitle}</div>}
+            </div>
+            <ul class="divide-y divide-verity-border/60">
+              {fw.rows.map((row) => (
+                <li class="px-4 py-3 space-y-1">
+                  <div class="text-xs uppercase tracking-wider text-verity-text-secondary">
+                    Control
+                  </div>
+                  <div class="text-sm text-verity-text-primary">{row.control}</div>
+                  <div class="text-xs uppercase tracking-wider text-verity-text-secondary pt-1">
+                    How Verity meets it
+                  </div>
+                  <div class="text-sm text-verity-text-muted">{row.meets}</div>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))
+      }
+    </ul>
+
+    <div class="hidden sm:block overflow-x-auto">
       <table class="w-full text-sm border border-verity-border rounded-lg overflow-hidden">
         <thead class="bg-verity-surface text-left">
           <tr>

--- a/site/src/pages/compliance.astro
+++ b/site/src/pages/compliance.astro
@@ -15,6 +15,27 @@ interface Framework {
   rows: FrameworkRow[];
 }
 
+// Split a string at backtick-fenced spans so we can render inline code
+// without resorting to `set:html`. Returns alternating { text, code } segments.
+type MeetsSegment = { kind: "text" | "code"; value: string };
+function parseMeets(text: string): MeetsSegment[] {
+  const segments: MeetsSegment[] = [];
+  const re = new RegExp("`([^`]+)`", "g");
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > lastIndex) {
+      segments.push({ kind: "text", value: text.slice(lastIndex, m.index) });
+    }
+    segments.push({ kind: "code", value: m[1] });
+    lastIndex = re.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ kind: "text", value: text.slice(lastIndex) });
+  }
+  return segments;
+}
+
 const frameworks: Framework[] = [
   {
     name: "SLSA v1.0",
@@ -23,7 +44,7 @@ const frameworks: Framework[] = [
       {
         control: "Build L3 — Hardened provenance",
         meets:
-          "Platform-generated provenance via actions/attest-build-provenance on ephemeral runners",
+          "Platform-generated provenance via `actions/attest-build-provenance` on ephemeral runners",
       },
       {
         control: "Source integrity",
@@ -128,7 +149,7 @@ const frameworks: Framework[] = [
       },
       {
         control: "V10.3 — Deployed application integrity",
-        meets: "Cosign + gh attestation verify for end-to-end integrity",
+        meets: "Cosign + `gh attestation verify` for end-to-end integrity",
       },
     ],
   },
@@ -762,7 +783,17 @@ const frameworks: Framework[] = [
                   <div class="text-xs uppercase tracking-wider text-verity-text-secondary pt-1">
                     How Verity meets it
                   </div>
-                  <div class="text-sm text-verity-text-muted">{row.meets}</div>
+                  <div class="text-sm text-verity-text-muted">
+                    {parseMeets(row.meets).map((seg) =>
+                      seg.kind === "code" ? (
+                        <code class="bg-verity-void text-verity-text-primary px-1 rounded text-xs">
+                          {seg.value}
+                        </code>
+                      ) : (
+                        seg.value
+                      )
+                    )}
+                  </div>
                 </li>
               ))}
             </ul>
@@ -781,246 +812,44 @@ const frameworks: Framework[] = [
           </tr>
         </thead>
         <tbody class="divide-y divide-verity-border">
-          <tr>
-            <td
-              class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary"
-              rowspan="2"
-            >
-              <a href="https://slsa.dev/" class="underline hover:text-gray-700">SLSA v1.0</a>
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted">Build L3 &mdash; Hardened provenance</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Platform-generated provenance via <code
-                class="bg-verity-void text-verity-text-primary px-1 rounded text-xs"
-                >actions/attest-build-provenance</code
-              > on ephemeral runners</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted">Source integrity</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Version-controlled manifests in Git; provenance links artifacts to commit SHAs</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary">
-              <a
-                href="https://www.nist.gov/system/files/documents/2022/02/04/software-supply-chain-security-guidance-under-EO-14028-section-4e.pdf"
-                class="text-verity-orbit hover:text-verity-nucleus transition-colors underline"
-                >EO 14028</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted">SBOM for delivered software</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >CycloneDX SBOM attested to every container image</td
-            >
-          </tr>
-          <tr>
-            <td
-              class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary"
-              rowspan="3"
-            >
-              <a href="https://csrc.nist.gov/Projects/ssdf" class="underline hover:text-gray-700"
-                >NIST SSDF</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted">PS.1 &mdash; Protect software integrity</td
-            >
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Cosign keyless signatures; Rekor transparency log</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >PW.4 &mdash; Verify third-party components</td
-            >
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Trivy scanning of all upstream images; Copa patching</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >RV.1 &mdash; Identify and confirm vulnerabilities</td
-            >
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Daily scheduled scans; auto-generated PRs</td
-            >
-          </tr>
-          <tr>
-            <td
-              class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary"
-              rowspan="4"
-            >
-              <a
-                href="https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final"
-                class="text-verity-orbit hover:text-verity-nucleus transition-colors underline"
-                >NIST 800-53r5</a
-              >
-              <div class="text-xs font-normal text-verity-text-secondary">(FedRAMP)</div>
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >SR-3 / SR-4 &mdash; Supply chain provenance</td
-            >
-            <td class="px-4 py-3 text-verity-text-muted"
-              >SLSA L3 provenance attestations linking artifacts to source, build, and runner</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted">SR-11 &mdash; Component authenticity</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Cosign OIDC-based signatures verify artifact origin</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted">SI-7 &mdash; Software integrity</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Signature verification detects any post-build tampering</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted">RA-5 &mdash; Vulnerability monitoring</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Daily Trivy scans; 30-day report retention for audit evidence</td
-            >
-          </tr>
-          <tr>
-            <td
-              class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary"
-              rowspan="3"
-            >
-              <a
-                href="https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2"
-                class="text-verity-orbit hover:text-verity-nucleus transition-colors underline"
-                >SOC 2</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted">CC8.1 &mdash; Change management</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >PR-gated changes; provenance ties artifacts to specific commits and runs</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted">CC7.1 &mdash; Monitoring and detection</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Daily CVE scans; vulnerability report artifacts retained</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted">CC6.1 &mdash; Logical access controls</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Scoped GITHUB_TOKEN; least-privilege workflow permissions; no static keys</td
-            >
-          </tr>
-          <tr>
-            <td
-              class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary"
-              rowspan="3"
-            >
-              <a href="https://www.iso.org/standard/27001" class="underline hover:text-gray-700"
-                >ISO 27001:2022</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >A.5.21 &mdash; ICT supply chain security</td
-            >
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Pinned dependencies; SBOM attestation; continuous upstream scanning</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >A.8.25 &mdash; Secure development lifecycle</td
-            >
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Automated CI gates (lint, test, scan) before any artifact is published</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted">A.8.30 &mdash; Outsourced development</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Third-party images scanned, patched, re-signed under Verity identity</td
-            >
-          </tr>
-          <tr>
-            <td
-              class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary"
-              rowspan="2"
-            >
-              <a
-                href="https://owasp.org/www-project-application-security-verification-standard/"
-                class="text-verity-orbit hover:text-verity-nucleus transition-colors underline"
-                >OWASP ASVS v4</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted">V14.2 &mdash; Dependency verification</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >All deps pinned by hash; Renovate auto-updates; no mutable tags</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >V10.3 &mdash; Deployed application integrity</td
-            >
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Cosign + <code class="bg-verity-void text-verity-text-primary px-1 rounded text-xs"
-                >gh attestation verify</code
-              > for end-to-end integrity</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary">
-              <a href="https://www.nist.gov/cyberframework" class="underline hover:text-gray-700"
-                >NIST CSF 2.0</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >GV.SC &mdash; Supply chain risk management</td
-            >
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Provenance, signing, SBOM, pinning, and scanning as a unified supply chain posture</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary">
-              <a href="https://www.cisa.gov/securebydesign" class="underline hover:text-gray-700"
-                >CISA Secure by Design</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted">Radical transparency</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Public vulnerability reports; SBOM on every image; Rekor for public audit</td
-            >
-          </tr>
-          <tr>
-            <td
-              class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary"
-              rowspan="2"
-            >
-              <a href="https://bestpractices.openssf.org/" class="underline hover:text-gray-700"
-                >OpenSSF Scorecard</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted">Pinned-Dependencies</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >Actions pinned by SHA; Go deps via go.sum; Renovate auto-updates</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 text-verity-text-muted">Signed-Releases</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >All OCI artifacts signed with cosign keyless</td
-            >
-          </tr>
-          <tr>
-            <td class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary">
-              <a href="https://docs.sigstore.dev/" class="underline hover:text-gray-700">Sigstore</a
-              >
-            </td>
-            <td class="px-4 py-3 text-verity-text-muted">Artifact transparency</td>
-            <td class="px-4 py-3 text-verity-text-muted"
-              >All signatures in the Rekor transparency log; verifiable by anyone</td
-            >
-          </tr>
+          {
+            frameworks.map((fw) =>
+              fw.rows.map((row, rowIdx) => (
+                <tr>
+                  {rowIdx === 0 && (
+                    <td
+                      class="px-4 py-3 font-medium whitespace-nowrap text-verity-text-primary align-top"
+                      rowspan={fw.rows.length}
+                    >
+                      <a
+                        href={fw.href}
+                        class="underline decoration-verity-border-2 hover:decoration-verity-nucleus transition-colors"
+                      >
+                        {fw.name}
+                      </a>
+                      {fw.subtitle && (
+                        <div class="text-xs font-normal text-verity-text-secondary">
+                          {fw.subtitle}
+                        </div>
+                      )}
+                    </td>
+                  )}
+                  <td class="px-4 py-3 text-verity-text-muted">{row.control}</td>
+                  <td class="px-4 py-3 text-verity-text-muted">
+                    {parseMeets(row.meets).map((seg) =>
+                      seg.kind === "code" ? (
+                        <code class="bg-verity-void text-verity-text-primary px-1 rounded text-xs">
+                          {seg.value}
+                        </code>
+                      ) : (
+                        seg.value
+                      )
+                    )}
+                  </td>
+                </tr>
+              ))
+            )
+          }
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary

Two large tables relied on `overflow-x: auto` to handle narrow viewports:

- The compliance Framework Reference table — 24 rows × 3 cols, ~490px wide.
- The per-image vulnerability table on `/images/[id]/` — 5 cols, similarly wide.

On iPhone 14 Pro emulation that produced a horizontal scroll **inside** the
page — better than blowing the outer layout but still a poor reading
experience for documentation-heavy content full of long control labels and
unwrappable CVE identifiers.

## Changes

Both components now branch on viewport width:

- **Below `sm` (640px)** — each row renders as a labeled card. The
  compliance cards group rows by framework with a header link; the vuln
  cards lead with the CVE id + severity badge, followed by a definition
  list of Package / Installed / Fixed. Monospaced identifiers use
  `break-all` so long refs wrap cleanly without overflowing the card.
- **At `sm` and above** — the original tables are preserved. They're
  denser and easier to scan when there's real horizontal space.

The compliance page also extracts the framework data into a typed
`Framework[]` array at the top of the file. The previous inline `rowspan`
HTML was easy to misalign by hand; the array keeps the desktop table and
mobile cards in sync from a single source.

## Verification

Built locally and re-checked at both viewports:

- Desktop /compliance: 1 table rendered, 23 tbody rows (unchanged).
- Mobile /compliance: 0 tables visible, 34 cards across 11 frameworks.
- Image-detail pages with no remaining CVEs continue to render the
  \"No vulnerabilities found\" branch (the only path currently exercised
  by the scan-data baseline).

## Related

Part of a 4-PR sweep fixing verity.supply mobile + a11y issues:

- (companion) `fix(apk): preserve Astro-built apk docs page`
- (companion) Site nav / mobile layout / missing index pages
- (companion) WCAG AA contrast + readability
- (this) Responsive tables for compliance + VulnTable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced horizontal-scrolling tables with mobile card layouts for the Compliance Framework Reference and `VulnTable` to remove overflow on small screens. The desktop compliance table is now generated from a single `Framework[]` source to avoid drift.

- **New Features**
  - On `< sm`, each row renders as a card: compliance groups rows by framework with a header link; vuln cards show CVE ID + severity, then Package / Installed / Fixed. Long identifiers wrap with `break-all`.
  - On `sm+`, the original table view remains for dense, scannable layouts.

- **Refactors**
  - Desktop compliance table is rendered from the same typed `Framework[]` used by mobile cards (keeps data in sync; preserves `rowspan` for multi-row frameworks).
  - Added `parseMeets` to render backtick-fenced inline code spans consistently across cards and table.

<sup>Written for commit 89ace29b9f8f00bae07845df12d437161a4b488a. Summary will update on new commits. <a href="https://cubic.dev/pr/verity-org/verity/pull/488?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

