### PR TITLE
Add privileged BPF chart-integration smoke

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - chart-integration-privileged
+    - bpf

--- a/.github/workflows/chart-integration-privileged.yaml
+++ b/.github/workflows/chart-integration-privileged.yaml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/chart-integration-privileged.yaml
+++ b/.github/workflows/chart-integration-privileged.yaml
@@ -1,0 +1,118 @@
+name: chart-integration-privileged
+
+on:
+  workflow_run:
+    workflows: ['Chart Generation']
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: chart-integration-privileged-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chart-test:
+    name: ${{ matrix.chart }} privileged
+    if: |
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - chart-integration-privileged
+      - bpf
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - chart: falco
+            kind_config: test/chart-integration/kind.yaml
+            kind_wait: 120s
+          - chart: cilium
+            kind_config: test/chart-integration/kind-cilium.yaml
+            kind_wait: 0s
+    env:
+      VERITY_CHART: ${{ matrix.chart }}
+      VERITY_IT_RUN_SKIPPED_CHARTS: ${{ matrix.chart }}
+      VERITY_IT_KIND_CONFIG: ${{ matrix.kind_config }}
+      VERITY_IT_KIND_CREATE_WAIT: ${{ matrix.kind_wait }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/dev/go/pkg/mod
+            ~/.cache/go-build
+          key: chart-it-privileged-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: chart-it-privileged-${{ runner.os }}-
+
+      - name: Log in to GHCR
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if printf '%s' "${{ secrets.GITHUB_TOKEN }}" \
+              | docker login ghcr.io -u "${{ github.actor }}" --password-stdin; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "GHCR login failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+
+      - name: Harness compile and unit-test gate
+        env:
+          VERITY_IT_SKIP_CLUSTER: "1"
+          TEST_REGEX: Test(KindConfigPath|KindCreateWait|ShouldSkipChart|LoadSkips|IsSkipped|ProductionSKIPSYAMLIsValid)
+        run: |
+          go test -tags=integration \
+            -run "$TEST_REGEX" \
+            -v ./test/chart-integration/...
+
+      - name: Run privileged chart smoke test
+        id: smoke
+        run: make chart-integration
+
+      - name: Record shard outcome
+        if: always()
+        run: |
+          set -euo pipefail
+          outcome="${{ steps.smoke.outcome }}"
+          {
+            if [ "$outcome" = "success" ]; then
+              echo "## ✅ ${{ matrix.chart }} privileged: success"
+            else
+              echo "## ❌ ${{ matrix.chart }} privileged: ${outcome}"
+              echo ""
+              echo "Inspect diagnostics-${{ matrix.chart }}-privileged for cluster-info and kind logs."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload diagnostics on failure
+        if: always() && steps.smoke.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: diagnostics-${{ matrix.chart }}-privileged
+          path: |
+            _dump-${{ matrix.chart }}
+            _kind-logs-${{ matrix.chart }}
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/chart-integration.yaml
+++ b/.github/workflows/chart-integration.yaml
@@ -130,7 +130,7 @@ jobs:
           VERITY_IT_SKIP_CLUSTER: "1"
         run: |
           go test -tags=integration \
-            -run 'TestLoadAllowlist|TestLoadAllowlistMissing|TestLoadAllowlistPresentRegression|TestIsAccepted|TestClassifyMissingAllowlist|TestClassifyMissingAllowlistDoesNotConsultAllowlist|TestHarnessClusterCreatedFieldDefault|TestInstallChartRejectsArgumentInjection|TestClassifyHelmFailure|TestClassifyHelmFailureStringer|TestClassifyHelmFailureParsesPodJSON|TestClassifyHelmFailureMalformedJSON|TestLoadSkips|TestIsSkipped|TestProductionSKIPSYAMLIsValid' \
+            -run 'TestLoadAllowlist|TestLoadAllowlistMissing|TestLoadAllowlistPresentRegression|TestIsAccepted|TestClassifyMissingAllowlist|TestClassifyMissingAllowlistDoesNotConsultAllowlist|TestHarnessClusterCreatedFieldDefault|TestKindConfigPath|TestKindCreateWait|TestInstallChartRejectsArgumentInjection|TestClassifyHelmFailure|TestClassifyHelmFailureStringer|TestClassifyHelmFailureParsesPodJSON|TestClassifyHelmFailureMalformedJSON|TestLoadSkips|TestIsSkipped|TestShouldSkipChart|TestProductionSKIPSYAMLIsValid' \
             -v ./test/chart-integration/...
 
       - name: Run chart smoke test

--- a/test/chart-integration/airflow_values_test.go
+++ b/test/chart-integration/airflow_values_test.go
@@ -30,7 +30,7 @@ func TestAirflowPostgresqlImageOverrideIsComposable(t *testing.T) {
 			Images                   struct {
 				MigrationsWaitTimeout int `yaml:"migrationsWaitTimeout"`
 			} `yaml:"images"`
-			Postgresql               struct {
+			Postgresql struct {
 				Image struct {
 					Registry   string `yaml:"registry"`
 					Repository string `yaml:"repository"`

--- a/test/chart-integration/harness.go
+++ b/test/chart-integration/harness.go
@@ -139,13 +139,15 @@ func (h *Harness) createCluster(ctx context.Context) error {
 		}
 	}
 	h.cleanupStaleKindNode(ctx)
-	cfg := filepath.Join(h.RepoRoot, "test", "chart-integration", "kind.yaml")
-	if err := runCmd(ctx, h.t, "", nil,
-		"kind", "create", "cluster",
+	args := []string{
+		"create", "cluster",
 		"--name", clusterName,
-		"--config", cfg,
-		"--wait", "120s",
-	); err != nil {
+		"--config", kindConfigPath(h.RepoRoot),
+	}
+	if wait := kindCreateWait(); wait != "" {
+		args = append(args, "--wait", wait)
+	}
+	if err := runCmd(ctx, h.t, "", nil, "kind", args...); err != nil {
 		h.cleanupStaleKindNode(ctx)
 		return err
 	}

--- a/test/chart-integration/harness_config.go
+++ b/test/chart-integration/harness_config.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	kindConfigEnv     = "VERITY_IT_KIND_CONFIG"
+	kindCreateWaitEnv = "VERITY_IT_KIND_CREATE_WAIT"
+)
+
+func kindConfigPath(repoRoot string) string {
+	value := strings.TrimSpace(os.Getenv(kindConfigEnv))
+	if value == "" {
+		return filepath.Join(repoRoot, "test", "chart-integration", "kind.yaml")
+	}
+	if filepath.IsAbs(value) {
+		return value
+	}
+	return filepath.Join(repoRoot, value)
+}
+
+func kindCreateWait() string {
+	value := strings.TrimSpace(os.Getenv(kindCreateWaitEnv))
+	if value == "" {
+		return "120s"
+	}
+	return value
+}

--- a/test/chart-integration/harness_config_test.go
+++ b/test/chart-integration/harness_config_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package integration
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestKindConfigPathUsesDefault_whenEnvUnset(t *testing.T) {
+	// Given
+	repoRoot := t.TempDir()
+
+	// When
+	got := kindConfigPath(repoRoot)
+
+	// Then
+	want := filepath.Join(repoRoot, "test", "chart-integration", "kind.yaml")
+	if got != want {
+		t.Fatalf("kindConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestKindConfigPathUsesOverride_whenEnvSet(t *testing.T) {
+	// Given
+	repoRoot := t.TempDir()
+	t.Setenv(kindConfigEnv, "test/chart-integration/kind-cilium.yaml")
+
+	// When
+	got := kindConfigPath(repoRoot)
+
+	// Then
+	want := filepath.Join(repoRoot, "test", "chart-integration", "kind-cilium.yaml")
+	if got != want {
+		t.Fatalf("kindConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestKindCreateWaitUsesDefault_whenEnvUnset(t *testing.T) {
+	// When
+	got := kindCreateWait()
+
+	// Then
+	if got != "120s" {
+		t.Fatalf("kindCreateWait() = %q, want 120s", got)
+	}
+}
+
+func TestKindCreateWaitUsesOverride_whenEnvSet(t *testing.T) {
+	// Given
+	t.Setenv(kindCreateWaitEnv, "0s")
+
+	// When
+	got := kindCreateWait()
+
+	// Then
+	if got != "0s" {
+		t.Fatalf("kindCreateWait() = %q, want 0s", got)
+	}
+}

--- a/test/chart-integration/kind-cilium.yaml
+++ b/test/chart-integration/kind-cilium.yaml
@@ -1,0 +1,13 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: verity-it
+networking:
+  disableDefaultCNI: true
+  podSubnet: 10.10.0.0/16
+  serviceSubnet: 10.11.0.0/16
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: /sys/fs/bpf
+        containerPath: /sys/fs/bpf
+        propagation: Bidirectional

--- a/test/chart-integration/main_test.go
+++ b/test/chart-integration/main_test.go
@@ -97,7 +97,7 @@ func TestCharts(t *testing.T) {
 		}
 		matched++
 		t.Run(spec.Name, func(t *testing.T) {
-			if skip, entry := skipsCfg.IsSkipped(spec.Name); skip {
+			if skip, entry := shouldSkipChart(skipsCfg, spec.Name); skip {
 				// Drop a sentinel for the workflow's Record-shard-outcome step
 				// so the GitHub Step Summary can render "skipped" distinctly
 				// from "success". The step grade gracefully degrades if the

--- a/test/chart-integration/skip_policy_test.go
+++ b/test/chart-integration/skip_policy_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+package integration
+
+import "testing"
+
+func TestShouldSkipChartHonorsSKIPSByDefault(t *testing.T) {
+	// Given
+	cfg, err := LoadSkips(writeSkips(t, validSkipsYAML))
+	if err != nil {
+		t.Fatalf("LoadSkips: %v", err)
+	}
+
+	// When
+	hit, entry := shouldSkipChart(cfg, "falco")
+
+	// Then
+	if !hit {
+		t.Fatal("shouldSkipChart(falco) = false, want true")
+	}
+	if entry == nil || entry.Chart != "falco" {
+		t.Fatalf("skip entry = %#v, want falco entry", entry)
+	}
+}
+
+func TestShouldSkipChartOverrideRunsOnlyListedSkippedCharts(t *testing.T) {
+	// Given
+	t.Setenv(runSkippedChartsEnv, " falco , cilium ")
+	cfg, err := LoadSkips(writeSkips(t, validSkipsYAML))
+	if err != nil {
+		t.Fatalf("LoadSkips: %v", err)
+	}
+
+	// When
+	hit, entry := shouldSkipChart(cfg, "falco")
+
+	// Then
+	if hit || entry != nil {
+		t.Fatalf("shouldSkipChart(falco) = (%v, %#v), want (false, nil)", hit, entry)
+	}
+}
+
+func TestShouldSkipChartOverrideDoesNotAffectUnlistedSkips(t *testing.T) {
+	// Given
+	t.Setenv(runSkippedChartsEnv, "cilium")
+	cfg, err := LoadSkips(writeSkips(t, validSkipsYAML))
+	if err != nil {
+		t.Fatalf("LoadSkips: %v", err)
+	}
+
+	// When
+	hit, entry := shouldSkipChart(cfg, "falco")
+
+	// Then
+	if !hit {
+		t.Fatal("shouldSkipChart(falco) = false, want true")
+	}
+	if entry == nil || entry.Chart != "falco" {
+		t.Fatalf("skip entry = %#v, want falco entry", entry)
+	}
+}

--- a/test/chart-integration/skips.go
+++ b/test/chart-integration/skips.go
@@ -49,6 +49,8 @@ const MaxSkippedCharts = 5
 // string to enumerate un-issued skips.
 const skipsNeedsNewIssueSentinel = "needs new issue"
 
+const runSkippedChartsEnv = "VERITY_IT_RUN_SKIPPED_CHARTS"
+
 // Static error sentinels. Defining them here (vs. inline errors.New /
 // fmt.Errorf at call sites) keeps golangci-lint's err113 happy and lets
 // tests errors.Is-match on intent if they ever need to.
@@ -229,4 +231,21 @@ func (s *SkipsConfig) IsSkipped(chart string) (bool, *SkipEntry) {
 		return true, e
 	}
 	return false, nil
+}
+
+func shouldSkipChart(cfg *SkipsConfig, chart string) (bool, *SkipEntry) {
+	skip, entry := cfg.IsSkipped(chart)
+	if !skip || runSkippedChart(chart) {
+		return false, nil
+	}
+	return true, entry
+}
+
+func runSkippedChart(chart string) bool {
+	for item := range strings.SplitSeq(os.Getenv(runSkippedChartsEnv), ",") {
+		if strings.TrimSpace(item) == chart {
+			return true
+		}
+	}
+	return false
 }

--- a/test/chart-integration/values/cilium.yaml
+++ b/test/chart-integration/values/cilium.yaml
@@ -1,0 +1,6 @@
+ipam:
+  mode: kubernetes
+kubeProxyReplacement: false
+bpf:
+  autoMount:
+    enabled: true

--- a/test/chart-integration/values/falco.yaml
+++ b/test/chart-integration/values/falco.yaml
@@ -1,0 +1,10 @@
+driver:
+  kind: modern_ebpf
+  modernEbpf:
+    leastPrivileged: false
+falcoctl:
+  artifact:
+    install:
+      enabled: true
+    follow:
+      enabled: true


### PR DESCRIPTION
## Summary

- add a separate privileged chart-integration workflow for Falco and Cilium on self-hosted BPF runners
- add harness env controls for explicit skipped-chart reruns and alternate kind config/wait behavior
- add Cilium CNI-disabled kind config plus Falco/Cilium smoke values
- keep hosted `chart-integration` honoring `SKIPS.yaml`
- checkout the trusted default branch in the privileged workflow to avoid running untrusted PR code on self-hosted BPF runners

Tracks [#325](https://github.com/verity-org/verity/issues/325) and [#372](https://github.com/verity-org/verity/issues/372).

## Validation

- `go test -race ./...`
- `VERITY_IT_SKIP_CLUSTER=1 go test -race -tags=integration ./test/chart-integration/...`
- `golangci-lint run --timeout=5m`
- `actionlint .github/workflows/chart-integration.yaml .github/workflows/chart-integration-privileged.yaml`
- YAML parse/line/trailing-whitespace fallback for new YAML files

## Manual smoke notes

- Local Falco smoke still fails DaemonSet readiness on non-target host.
- Local Cilium smoke installs, then fails image-origin because currently published wrapper pulls upstream `quay.io/cilium/*`.
- No upstream image allowlist added; target BPF runner must validate the new privileged workflow.
