### PR TITLE
fix(integer): enable FIPS mode by default

### DIFF
--- a/images/etcd.yaml
+++ b/images/etcd.yaml
@@ -32,6 +32,8 @@ types:
     base: wolfi-fips
     packages: ["etcd-{{version}}"]
     entrypoint: /usr/bin/etcd
+    environment:
+      GODEBUG: "fips140=on"
     paths:
       - {path: /var/lib/etcd, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
       - {path: /usr/bin/etcd, type: permissions, uid: 0, gid: 0, permissions: 0o755}

--- a/images/golang.yaml
+++ b/images/golang.yaml
@@ -37,6 +37,7 @@ types:
       GOPATH: /go
       GOTOOLCHAIN: local
       GOFIPS140: latest
+      GODEBUG: "fips140=on"
       PATH: /go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     paths:
       - {path: /go, type: directory, uid: 65532, gid: 65532, permissions: 0o755}

--- a/images/golang.yaml
+++ b/images/golang.yaml
@@ -44,7 +44,8 @@ types:
       - {path: /go/src, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
-  "1.23": {}
+  "1.23":
+    skip-types: [fips]
   "1.24": {}
   "1.25": {}
   "1.26": {}

--- a/images/node.yaml
+++ b/images/node.yaml
@@ -33,7 +33,7 @@ types:
       NODE_ENV: production
       OPENSSL_MODULES: /usr/lib/ossl-modules
       OPENSSL_CONF: /etc/ssl/openssl-fips.cnf
-      NODE_OPTIONS: "--openssl-config=/etc/ssl/openssl-fips.cnf"
+      NODE_OPTIONS: "--openssl-config=/etc/ssl/openssl-fips.cnf --force-fips"
     paths:
       - {path: /app, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 

--- a/internal/integer/config/fips_defaults_test.go
+++ b/internal/integer/config/fips_defaults_test.go
@@ -1,0 +1,48 @@
+package config_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/config"
+)
+
+const opensslFIPSConfig = "/etc/ssl/openssl-fips.cnf"
+
+func TestRepositoryFIPSVariantsEnableRuntimeFIPSByDefault(t *testing.T) {
+	paths, err := filepath.Glob("../../../images/*.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths)
+
+	for _, path := range paths {
+		def, err := config.LoadImage(path)
+		require.NoError(t, err)
+
+		fips, ok := def.Types["fips"]
+		if !ok {
+			continue
+		}
+
+		env := fips.Environment
+		godebug := env["GODEBUG"]
+		nodeOptions := env["NODE_OPTIONS"]
+		hasGoFIPS := strings.Contains(godebug, "fips140=on")
+		hasOpenSSLFIPS := env["OPENSSL_CONF"] == opensslFIPSConfig
+		hasNodeFIPS := strings.Contains(nodeOptions, "--force-fips")
+
+		require.Truef(
+			t,
+			hasGoFIPS || hasOpenSSLFIPS || hasNodeFIPS,
+			"%s fips variant must explicitly enable runtime FIPS by default",
+			filepath.Base(path),
+		)
+
+		if def.Name == "node" {
+			require.Contains(t, nodeOptions, "--openssl-config="+opensslFIPSConfig)
+			require.Contains(t, nodeOptions, "--force-fips")
+		}
+	}
+}

--- a/internal/integer/config/fips_defaults_test.go
+++ b/internal/integer/config/fips_defaults_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/verity-org/verity/internal/integer/config"
+	"github.com/verity-org/verity/internal/integer/discovery"
 )
 
 const opensslFIPSConfig = "/etc/ssl/openssl-fips.cnf"
@@ -45,4 +46,12 @@ func TestRepositoryFIPSVariantsEnableRuntimeFIPSByDefault(t *testing.T) {
 			require.Contains(t, nodeOptions, "--force-fips")
 		}
 	}
+}
+
+func TestRepositoryGo123DoesNotPublishFIPSVariant(t *testing.T) {
+	def, err := config.LoadImage("../../../images/golang.yaml")
+	require.NoError(t, err)
+
+	require.True(t, discovery.ShouldSkipType(def, "1.23", "fips"))
+	require.False(t, discovery.ShouldSkipType(def, "1.24", "fips"))
 }


### PR DESCRIPTION
## Summary
- force Node FIPS variants on at startup with --force-fips
- set Go FIPS runtime defaults for supported Go FIPS variants
- skip the Go 1.23 FIPS variant because Go 1.23 ignores GODEBUG=fips140=on
- add regression coverage requiring every FIPS variant to declare a runtime FIPS switch and guarding the Go 1.23 skip

## Validation
- rtk go test ./...
- rtk make integer-validate