### PR TITLE
fix(integer): skip unavailable etcd 3.5 builds

### DIFF
--- a/images/etcd.yaml
+++ b/images/etcd.yaml
@@ -41,5 +41,5 @@ types:
 
 versions:
   "3.5":
-    {}
+    skip-types: [default, fips]
   "3.6": {}

--- a/internal/integer/discovery/etcd_skip_test.go
+++ b/internal/integer/discovery/etcd_skip_test.go
@@ -1,0 +1,48 @@
+package discovery_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	"github.com/verity-org/verity/internal/integer/discovery"
+)
+
+func TestDiscoverFromFiles_SkipsUnavailableEtcd35Builds(t *testing.T) {
+	const etcdYAML = `
+name: etcd
+description: "etcd"
+upstream:
+  package: "etcd-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["etcd-{{version}}"]
+    entrypoint: /usr/bin/etcd
+  fips:
+    base: wolfi-fips
+    packages: ["etcd-{{version}}"]
+    entrypoint: /usr/bin/etcd
+versions:
+  "3.5":
+    skip-types: [default, fips]
+  "3.6": {}
+`
+	imagesDir := setupImages(t, map[string]string{"etcd.yaml": etcdYAML})
+	genDir := t.TempDir()
+
+	pkgs := []apkindex.Package{
+		{Name: "etcd-3.5"},
+		{Name: "etcd-3.6"},
+	}
+
+	imgs, err := discovery.DiscoverFromFiles(opts(imagesDir, genDir, pkgs))
+	require.NoError(t, err)
+	require.Len(t, imgs, 2)
+
+	for _, img := range imgs {
+		assert.Equal(t, "3.6", img.Version)
+	}
+}


### PR DESCRIPTION
## Summary
- skip etcd 3.5 default/fips Integer builds because arm64 package resolution fails with no etcd-3.5 provider
- add discovery regression coverage proving etcd 3.5 emits no builds while etcd 3.6 still emits both types

## Validation
- rtk go test ./internal/integer/discovery -run TestDiscoverFromFiles_SkipsUnavailableEtcd35Builds
- rtk go test ./internal/integer/...
- rtk make integer-validate
- rtk go test ./...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `etcd` 3.5 default and FIPS builds due to a missing `etcd-3.5` provider that breaks arm64 package resolution. Add a regression test to ensure discovery excludes 3.5 and still emits both types for 3.6.

<sup>Written for commit c6e6d305927d3ea16e0018a29d81b8ba93a1f322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

