### PR TITLE
fix(chart-integration): allow workload identity v1.6 image

### DIFF
--- a/test/chart-integration/values/workload-identity-webhook.allowlist.txt
+++ b/test/chart-integration/values/workload-identity-webhook.allowlist.txt
@@ -1,9 +1,9 @@
 # workload-identity-webhook upstream image allowlist (SCR-2026-04-30-001)
 #
-# The Azure workload-identity-webhook chart 1.5.1 pulls one image
+# The Azure workload-identity-webhook chart 1.6.0 pulls one image
 # directly from MCR (Microsoft Container Registry):
 #
-#   mcr.microsoft.com/oss/azure/workload-identity/webhook:v1.5.1
+#   mcr.microsoft.com/oss/v2/azure/workload-identity/webhook:v1.6.0
 #                                                         — the
 #                                                           mutating
 #                                                           admission
@@ -28,7 +28,7 @@
 # Format note: the isAccepted helper in test/chart-integration/
 # assertions.go uses strings.HasPrefix; `:` and `@` separator
 # forms scope the prefix to one image's tag/digest refs without
-# bleeding to unrelated `mcr.microsoft.com/oss/azure/workload-
+# bleeding to unrelated `mcr.microsoft.com/oss/v2/azure/workload-
 # identity/*` repos.
-mcr.microsoft.com/oss/azure/workload-identity/webhook:
-mcr.microsoft.com/oss/azure/workload-identity/webhook@
+mcr.microsoft.com/oss/v2/azure/workload-identity/webhook:
+mcr.microsoft.com/oss/v2/azure/workload-identity/webhook@

--- a/test/chart-integration/workload_identity_allowlist_test.go
+++ b/test/chart-integration/workload_identity_allowlist_test.go
@@ -1,0 +1,25 @@
+//go:build integration
+
+package integration
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkloadIdentityWebhookAllowlistAcceptsCurrentMCRPath(t *testing.T) {
+	root, err := findRepoRoot()
+	if err != nil {
+		t.Skipf("findRepoRoot failed (likely not running in repo): %v", err)
+	}
+	path := filepath.Join(root, "test", "chart-integration", "values", "workload-identity-webhook.allowlist.txt")
+	allow, err := loadAllowlist(path)
+	if err != nil {
+		t.Fatalf("load workload-identity-webhook allowlist: %v", err)
+	}
+	image := "mcr.microsoft.com/oss/v2/azure/workload-identity/webhook:v1.6.0"
+	imageID := "mcr.microsoft.com/oss/v2/azure/workload-identity/webhook@sha256:6873b8cec3fb5d585e712ea18af1c1c24107c589e4eafd20a91e260092bc8acb"
+	if !isAccepted(image, imageID, allow) {
+		t.Fatalf("current workload-identity-webhook MCR image must be allowlisted: image=%q imageID=%q", image, imageID)
+	}
+}


### PR DESCRIPTION
## Summary
- update workload-identity-webhook allowlist to match chart 1.6.0 MCR v2 image path
- add focused integration test covering the current MCR tag and digest path

## Verification
- go test -tags=integration -run 'TestWorkloadIdentityWebhookAllowlistAcceptsCurrentMCRPath|TestIsAccepted|TestLoadAllowlist' -v ./test/chart-integration/...
- VERITY_CHART=workload-identity-webhook make chart-integration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the workload-identity-webhook allowlist to accept the chart 1.6.0 image from `mcr.microsoft.com/oss/v2/azure/workload-identity/webhook` (tag and digest). Adds an integration test to ensure the current v1.6.0 tag and digest are allowed.

<sup>Written for commit 41e33856a12f892324b4a61042ddaee8642ddd49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

