### PR TITLE
test(integer): smoke terraform 1.11 fips

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -166,6 +166,9 @@ jobs:
           - image: haproxy
             version: "3.1"
             type: fips
+          - image: terraform
+            version: "1.11"
+            type: fips
           - image: node
             version: "22"
             type: dev


### PR DESCRIPTION
Closes #590

## Root cause
- terraform 1.11 fips depends on bespoke melange output (verity-opentofu-1.11), but the standing integer smoke job only did a plain apko build and never built/appended the bespoke APK repo for melange-backed images.
- That left terraform fips unexercised in smoke, so the missing-package failure only surfaced later in integer-fips smoke/nightly paths.

## Fix
- add terraform:1.11-fips to the integer smoke matrix
- make the shared smoke job run .github/scripts/melange-check.sh and .github/scripts/melange-build.sh before apko build when the target type needs bespoke melange output
- keep the non-melange path unchanged

## CI test
- PR smoke now explicitly builds terraform:1.11-fips
- validated locally with actionlint, yamllint, ./verity integer validate, and a full manual melange + apko smoke build for terraform 1.11 fips

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `terraform` 1.11 FIPS to the integer smoke matrix so CI builds and scans it early.

<sup>Written for commit f43570fef2f91665919df68670fcdefeb8447a1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

