### PR TITLE
fix(integer): rebase vault default on bespoke build

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -558,6 +558,15 @@ jobs:
           path: trivy-report.json
           retention-days: 30
 
+      - name: Enforce zero HIGH/CRITICAL for vault default
+        if: inputs.image == 'vault' && inputs.type == 'default'
+        run: |
+          findings=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' trivy-report.json)
+          if [ "$findings" -ne 0 ]; then
+            echo "vault default image must stay zero HIGH/CRITICAL, found ${findings}" >&2
+            exit 1
+          fi
+
       # ── Sign & attest ──────────────────────────────────────────────────────
 
       - name: Sign image with cosign (keyless)

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -558,12 +558,25 @@ jobs:
           path: trivy-report.json
           retention-days: 30
 
-      - name: Enforce zero HIGH/CRITICAL for vault default
-        if: inputs.image == 'vault' && inputs.type == 'default'
+      - name: Resolve Trivy gate policy
+        id: trivy-gate
+        run: |
+          case "${{ inputs.image }}:${{ inputs.type }}" in
+            vault:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=vault default" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "enabled=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Enforce Trivy gate
+        if: steps.trivy-gate.outputs.enabled == 'true'
         run: |
           findings=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' trivy-report.json)
           if [ "$findings" -ne 0 ]; then
-            echo "vault default image must stay zero HIGH/CRITICAL, found ${findings}" >&2
+            echo "${{ steps.trivy-gate.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
             exit 1
           fi
 

--- a/images/vault.yaml
+++ b/images/vault.yaml
@@ -11,6 +11,8 @@ types:
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: ""
       HOME: /home/vault
+    melange:
+      bespoke: "vault-fips.yaml"
     paths:
       - {path: /vault/config, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /vault/data, type: directory, uid: 65532, gid: 65532, permissions: 0o700}
@@ -41,10 +43,5 @@ types:
       - {path: /home/vault, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
-  # default ships the wolfi vault apk (1.14.x line); the fips variant is a
-  # bespoke source build of the current release, so each version label only
-  # publishes the type whose contents match it.
-  "1":
-    skip-types: [fips]
   "2":
-    skip-types: [default]
+    {}

--- a/packages/bespoke/vault-fips.yaml
+++ b/packages/bespoke/vault-fips.yaml
@@ -1,9 +1,9 @@
-# Bespoke Vault build for the Verity FIPS variant.
+# Bespoke Vault build for Verity vault variants.
 #
 # Wolfi removed its vault recipe when HashiCorp relicensed to BUSL-1.1
 # (moved to Chainguard enterprise-packages, May 2024); the wolfi apk repo
 # still serves a stale vault 1.14.1 with known CVEs. This recipe builds the
-# current upstream release from source so the FIPS variant ships a
+# current upstream release from source so Verity vault variants ship a
 # zero-known-CVE binary. BUSL-1.1 redistribution reviewed and accepted by
 # the Verity maintainers (see PR #545).
 #
@@ -11,8 +11,8 @@
 # surface for a hardened variant. API and CLI are unaffected; only the web
 # UI is absent.
 #
-# GOFIPS140=v1.0.0 is injected by the melange env-file (fips.env), matching
-# the etcd/go-profile pattern.
+# GOFIPS140=v1.0.0 is injected only when the FIPS image type uses the melange
+# env-file (fips.env), matching the etcd/go-profile pattern.
 package:
   name: vault
   version: 2.0.3


### PR DESCRIPTION
Closes [#552](https://github.com/verity-org/verity/issues/552)

## Root cause
- default `vault:1` shipped frozen Wolfi `vault-1.14.1-r1`
- Wolfi removed the Vault recipe after HashiCorp's BUSL-1.1 relicense, so that apk will never receive fixes
- Trivy on 2026-07-02 showed 72 HIGH/CRITICAL findings

## What changed
- rebase default `vault` type onto the existing bespoke Vault v2 source build
- keep `fips` on the same bespoke recipe, with GOFIPS140 injected only via `fips.env`
- retire `vault:1`; publish default as `vault:2` and keep `vault:2-fips`
- add a nightly/CI gate in `integer-build-image.yaml` that fails `vault` default if Trivy finds any HIGH/CRITICAL vulnerabilities

## Verification
- `yamllint -c .yamllint.yml .`
- `go build -o verity .`
- `./verity integer validate`
- `go test ./...`
- `./verity integer discover --only vault` => `vault:2-default` tags `2,latest`; `vault:2-fips` tags `2-fips,latest-fips`
- manual bespoke melange + apko build of default vault image followed by Trivy scan => 0 HIGH/CRITICAL

## Before / after
- before: 72 HIGH/CRITICAL on frozen Wolfi `vault:1`
- after: 0 HIGH/CRITICAL on bespoke-built `vault:2` default image

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebased the default `vault` image onto our bespoke source build and added a CI Trivy gate for `vault:default` to keep it at zero HIGH/CRITICAL. The default image now scans clean.

- **Bug Fixes**
  - Default `vault` now builds via bespoke `melange` recipe (`vault-fips.yaml`), replacing the frozen Wolfi `vault-1.14.x`; HIGH/CRITICAL goes from 72 to 0.
  - CI adds a policy step that enables the Trivy gate only for `vault:default`; `jq` counts HIGH/CRITICAL in `trivy-report.json` and fails on any finding.

- **Migration**
  - Use `vault:2` (tags `2`, `latest`) or `vault:2-fips` (tags `2-fips`, `latest-fips`); `vault:1` is retired.
  - FIPS behavior is unchanged; `GOFIPS140` is injected only via `fips.env`.

<sup>Written for commit 12f177aec78975efbada9b81e57cf5abf9459e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

