### PR TITLE
fix(integer): build haproxy 3.0/3.1 streams

### DIFF
--- a/.github/scripts/melange-build.sh
+++ b/.github/scripts/melange-build.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-#
-# Resolves the melange YAML source (bespoke or upstream), generates
-# an ephemeral signing key, and builds a single-arch APK package.
-# Expects BESPOKE/UPSTREAM, ENV_FILE, and BUILD_OPTION env vars.
-
-mkdir -p melange-work
+mkdir -p melange-work/specs
 
 validate_filename() {
   local label="$1" value="$2"
@@ -21,24 +16,14 @@ validate_filename() {
   fi
 }
 
-if [ -n "${BESPOKE:-}" ]; then
-  validate_filename "BESPOKE" "$BESPOKE"
-  if [ ! -f "packages/bespoke/${BESPOKE}" ]; then
-    echo "Bespoke build file not found: packages/bespoke/${BESPOKE}" >&2
-    exit 1
-  fi
-
-  cp "packages/bespoke/${BESPOKE}" melange-work/build.yaml
-
-  # Bespoke builds may use Wolfi-specific pipelines (e.g. py/pip-build-install).
-  # Fetch the pipelines/ tree from the pinned wolfi_commit so they resolve.
+fetch_wolfi_pipelines() {
   commit=$(jq -r '.wolfi_commit' packages/upstream.lock.json)
   if [ "$commit" = "null" ] || [ -z "$commit" ]; then
     echo "wolfi_commit missing or null in packages/upstream.lock.json" >&2
     exit 1
   fi
 
-  echo "Fetching wolfi pipelines/ at commit ${commit} for bespoke build"
+  echo "Fetching wolfi pipelines/ at commit ${commit}"
   tmp_wolfi=$(mktemp -d)
   trap 'rm -rf "$tmp_wolfi"' EXIT
   git -C "$tmp_wolfi" init --quiet
@@ -48,6 +33,52 @@ if [ -n "${BESPOKE:-}" ]; then
   git -C "$tmp_wolfi" checkout --quiet FETCH_HEAD -- pipelines
   rm -rf melange-work/pipelines
   cp -r "$tmp_wolfi/pipelines" melange-work/pipelines
+}
+
+build_one() {
+  local build_yaml="$1"
+
+  MELANGE_ARGS=(
+    build "$build_yaml"
+    --arch x86_64
+    --signing-key melange-work/melange.rsa
+    --out-dir packages/repo
+    --repository-append https://packages.wolfi.dev/os
+    --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    --runner docker
+  )
+
+  if [ -d melange-work/pipelines ]; then
+    MELANGE_ARGS+=(--pipeline-dirs melange-work/pipelines)
+  fi
+
+  if [ -n "${ENV_FILE:-}" ]; then
+    MELANGE_ARGS+=(--env-file "packages/overrides/${ENV_FILE}")
+  fi
+  if [ -n "${BUILD_OPTION:-}" ]; then
+    MELANGE_ARGS+=(--build-option "$BUILD_OPTION")
+  fi
+
+  echo "Running: melange ${MELANGE_ARGS[*]}"
+  melange "${MELANGE_ARGS[@]}"
+}
+
+BESPOKE_JSON=${BESPOKE_JSON:-[]}
+
+if [ "$BESPOKE_JSON" != '[]' ]; then
+  while IFS= read -r bespoke; do
+    validate_filename "BESPOKE" "$bespoke"
+    if [ ! -f "packages/bespoke/${bespoke}" ]; then
+      echo "Bespoke build file not found: packages/bespoke/${bespoke}" >&2
+      exit 1
+    fi
+    spec_dir="melange-work/specs/${bespoke}"
+    rm -rf "$spec_dir"
+    mkdir -p "$spec_dir"
+    cp "packages/bespoke/${bespoke}" "$spec_dir/build.yaml"
+  done < <(printf '%s' "$BESPOKE_JSON" | jq -r '.[]')
+
+  fetch_wolfi_pipelines
 elif [ -n "${UPSTREAM:-}" ]; then
   commit=$(jq -r '.wolfi_commit' packages/upstream.lock.json)
   if [ "$commit" = "null" ] || [ -z "$commit" ]; then
@@ -66,14 +97,17 @@ elif [ -n "${UPSTREAM:-}" ]; then
   fi
   url="https://raw.githubusercontent.com/wolfi-dev/os/${commit}/${file}"
   echo "Fetching upstream melange YAML: ${url}"
-  curl -fsSL "$url" -o melange-work/build.yaml.tmp
-  actual_sha=$(sha256sum melange-work/build.yaml.tmp | awk '{print $1}')
+  spec_dir="melange-work/specs/${UPSTREAM}"
+  rm -rf "$spec_dir"
+  mkdir -p "$spec_dir"
+  curl -fsSL "$url" -o "$spec_dir/build.yaml.tmp"
+  actual_sha=$(sha256sum "$spec_dir/build.yaml.tmp" | awk '{print $1}')
   if [ "$actual_sha" != "$expected_sha" ]; then
     echo "sha256 mismatch for ${UPSTREAM}: expected ${expected_sha}, got ${actual_sha}" >&2
-    rm -f melange-work/build.yaml.tmp
+    rm -f "$spec_dir/build.yaml.tmp"
     exit 1
   fi
-  mv melange-work/build.yaml.tmp melange-work/build.yaml
+  mv "$spec_dir/build.yaml.tmp" "$spec_dir/build.yaml"
 
   echo "Fetching wolfi pipelines/ and ${UPSTREAM}/ companion dir at commit ${commit}"
   tmp_wolfi=$(mktemp -d)
@@ -93,36 +127,22 @@ elif [ -n "${UPSTREAM:-}" ]; then
   rm -rf melange-work/pipelines
   cp -r "$tmp_wolfi/pipelines" melange-work/pipelines
   if [ -d "$tmp_wolfi/${UPSTREAM}" ]; then
-    cp -r "$tmp_wolfi/${UPSTREAM}/." melange-work/
-    echo "Copied ${UPSTREAM}/ companion files into melange-work/"
+    cp -r "$tmp_wolfi/${UPSTREAM}/." "$spec_dir/"
   fi
 else
-  echo "Neither BESPOKE nor UPSTREAM is set" >&2
+  echo "Neither BESPOKE_JSON nor UPSTREAM is set" >&2
   exit 1
 fi
 
 melange keygen melange-work/melange.rsa
 
-MELANGE_ARGS=(
-  build melange-work/build.yaml
-  --arch x86_64
-  --signing-key melange-work/melange.rsa
-  --out-dir packages/repo
-  --repository-append https://packages.wolfi.dev/os
-  --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-  --runner docker
-)
-
-if [ -d melange-work/pipelines ]; then
-  MELANGE_ARGS+=(--pipeline-dirs melange-work/pipelines)
+shopt -s nullglob
+builds=(melange-work/specs/*/build.yaml)
+if [ ${#builds[@]} -eq 0 ]; then
+  echo "No melange build YAMLs staged in melange-work/specs" >&2
+  exit 1
 fi
 
-if [ -n "${ENV_FILE:-}" ]; then
-  MELANGE_ARGS+=(--env-file "packages/overrides/${ENV_FILE}")
-fi
-if [ -n "${BUILD_OPTION:-}" ]; then
-  MELANGE_ARGS+=(--build-option "$BUILD_OPTION")
-fi
-
-echo "Running: melange ${MELANGE_ARGS[*]}"
-melange "${MELANGE_ARGS[@]}"
+for build_yaml in "${builds[@]}"; do
+  build_one "$build_yaml"
+done

--- a/.github/scripts/melange-check.sh
+++ b/.github/scripts/melange-check.sh
@@ -10,24 +10,35 @@ set -euo pipefail
 
 image_yaml="images/${IMAGE}.yaml"
 
-bespoke=$(yq -r ".types.\"${TYPE}\".melange.bespoke // \"\"" "$image_yaml")
+raw_bespoke=$(yq -o=json ".types.\"${TYPE}\".melange.bespoke // []" "$image_yaml")
 upstream=$(yq -r ".types.\"${TYPE}\".melange.upstream // \"\"" "$image_yaml")
 env_file=$(yq -r ".types.\"${TYPE}\".melange.env-file // \"\"" "$image_yaml")
 build_option=$(yq -r ".types.\"${TYPE}\".melange.build-option // \"\"" "$image_yaml")
 
-if [ -n "$bespoke" ] || [ -n "$upstream" ]; then
+bespoke_json=$(printf '%s' "$raw_bespoke" | jq -c 'if type == "array" then . elif . == null or . == "" then [] else [.] end')
+
+if [ "$bespoke_json" != '[]' ] || [ -n "$upstream" ]; then
   needed=true
 else
   needed=false
 fi
 
-for field_name in bespoke upstream; do
-  field_val="${!field_name}"
-  if [ -n "$field_val" ] && [[ ! "$field_val" =~ ^[A-Za-z0-9._-]+$ ]]; then
-    echo "melange.${field_name} contains unsafe characters: '${field_val}'" >&2
+while IFS= read -r bespoke; do
+  if [ -n "$bespoke" ] && [[ ! "$bespoke" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "melange.bespoke contains unsafe characters: '${bespoke}'" >&2
     exit 1
   fi
-done
+done < <(printf '%s' "$bespoke_json" | jq -r '.[]')
+
+if [ -n "$upstream" ] && [[ ! "$upstream" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "melange.upstream contains unsafe characters: '${upstream}'" >&2
+  exit 1
+fi
+
+if [ -n "$upstream" ] && [ "$bespoke_json" != '[]' ]; then
+  echo "melange block has both upstream and bespoke set — choose one" >&2
+  exit 1
+fi
 for field_name in env_file build_option; do
   field_val="${!field_name}"
   if [[ "$field_val" == *$'\n'* ]]; then
@@ -38,7 +49,7 @@ done
 
 {
   echo "needed=${needed}"
-  echo "bespoke=${bespoke}"
+  echo "bespoke_json=${bespoke_json}"
   echo "upstream=${upstream}"
   echo "env_file=${env_file}"
   echo "build_option=${build_option}"

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       needed: ${{ steps.check.outputs.needed }}
+      bespoke_json: ${{ steps.check.outputs.bespoke_json }}
       env_file: ${{ steps.check.outputs.env_file }}
       build_option: ${{ steps.check.outputs.build_option }}
     steps:
@@ -86,20 +87,29 @@ jobs:
             exit 0
           fi
 
+          raw_bespoke=$(yq -o=json ".types.\"${INPUT_TYPE}\".melange.bespoke // []" "$image_yaml")
           upstream=$(yq -r ".types.\"${INPUT_TYPE}\".melange.upstream // \"\"" "$image_yaml")
-          bespoke=$(yq -r ".types.\"${INPUT_TYPE}\".melange.bespoke // \"\"" "$image_yaml")
           env_file=$(yq -r ".types.\"${INPUT_TYPE}\".melange.env-file // \"\"" "$image_yaml")
           build_option=$(yq -r ".types.\"${INPUT_TYPE}\".melange.build-option // \"\"" "$image_yaml")
 
+          bespoke_json=$(printf '%s' "$raw_bespoke" | jq -c 'if type == "array" then . elif . == null or . == "" then [] else [.] end')
+
           # Require exactly one source
-          if [ -z "$upstream" ] && [ -z "$bespoke" ]; then
+          if [ -z "$upstream" ] && [ "$bespoke_json" = '[]' ]; then
             echo "melange block present but neither upstream nor bespoke is set" >&2
             exit 1
           fi
-          if [ -n "$upstream" ] && [ -n "$bespoke" ]; then
+          if [ -n "$upstream" ] && [ "$bespoke_json" != '[]' ]; then
             echo "melange block has both upstream and bespoke set — choose one" >&2
             exit 1
           fi
+
+          while IFS= read -r bespoke; do
+            if [[ ! "$bespoke" =~ ^[A-Za-z0-9._-]+$ ]]; then
+              echo "melange.bespoke contains unsafe characters: '${bespoke}'" >&2
+              exit 1
+            fi
+          done < <(printf '%s' "$bespoke_json" | jq -r '.[]')
 
           # Guard scalar fields: reject multi-line values (yq emits sequences/maps with newlines)
           for field_name in env_file build_option; do
@@ -113,19 +123,19 @@ jobs:
           {
             echo "needed=true"
             echo "upstream=${upstream}"
-            echo "bespoke=${bespoke}"
+            echo "bespoke_json=${bespoke_json}"
             echo "env_file=${env_file}"
             echo "build_option=${build_option}"
           } >> "$GITHUB_OUTPUT"
-          echo "Melange build needed: upstream=${upstream} bespoke=${bespoke}"
+          echo "Melange build needed: upstream=${upstream} bespoke=${bespoke_json}"
 
       - name: Resolve melange YAML source
         if: steps.check.outputs.needed == 'true'
         env:
           UPSTREAM: ${{ steps.check.outputs.upstream }}
-          BESPOKE: ${{ steps.check.outputs.bespoke }}
+          BESPOKE_JSON: ${{ steps.check.outputs.bespoke_json }}
         run: |
-          mkdir -p melange-work
+          mkdir -p melange-work/specs
 
           commit=$(jq -r '.wolfi_commit' packages/upstream.lock.json)
           if [ "$commit" = "null" ] || [ -z "$commit" ]; then
@@ -133,8 +143,13 @@ jobs:
             exit 1
           fi
 
-          if [ -n "$BESPOKE" ]; then
-            cp "packages/bespoke/${BESPOKE}" melange-work/build.yaml
+          if [ "$BESPOKE_JSON" != '[]' ]; then
+            while IFS= read -r bespoke; do
+              spec_dir="melange-work/specs/${bespoke}"
+              rm -rf "$spec_dir"
+              mkdir -p "$spec_dir"
+              cp "packages/bespoke/${bespoke}" "$spec_dir/build.yaml"
+            done < <(printf '%s' "$BESPOKE_JSON" | jq -r '.[]')
           elif [ -n "$UPSTREAM" ]; then
             file=$(jq -r --arg pkg "$UPSTREAM" '.packages[$pkg].file' packages/upstream.lock.json)
             expected_sha=$(jq -r --arg pkg "$UPSTREAM" '.packages[$pkg].sha256' packages/upstream.lock.json)
@@ -148,14 +163,17 @@ jobs:
             fi
             url="https://raw.githubusercontent.com/wolfi-dev/os/${commit}/${file}"
             echo "Fetching upstream melange YAML: ${url}"
-            curl -fsSL "$url" -o melange-work/build.yaml.tmp
-            actual_sha=$(sha256sum melange-work/build.yaml.tmp | awk '{print $1}')
+            spec_dir="melange-work/specs/${UPSTREAM}"
+            rm -rf "$spec_dir"
+            mkdir -p "$spec_dir"
+            curl -fsSL "$url" -o "$spec_dir/build.yaml.tmp"
+            actual_sha=$(sha256sum "$spec_dir/build.yaml.tmp" | awk '{print $1}')
             if [ "$actual_sha" != "$expected_sha" ]; then
               echo "sha256 mismatch for ${UPSTREAM}: expected ${expected_sha}, got ${actual_sha}" >&2
-              rm -f melange-work/build.yaml.tmp
+              rm -f "$spec_dir/build.yaml.tmp"
               exit 1
             fi
-            mv melange-work/build.yaml.tmp melange-work/build.yaml
+            mv "$spec_dir/build.yaml.tmp" "$spec_dir/build.yaml"
           fi
 
           echo "Fetching wolfi pipelines/ at commit ${commit}"
@@ -185,8 +203,7 @@ jobs:
           cp -r "$tmp_wolfi/pipelines" melange-work/pipelines
           if [ -n "$UPSTREAM" ]; then
             if [ -d "$tmp_wolfi/${UPSTREAM}" ]; then
-              cp -r "$tmp_wolfi/${UPSTREAM}/." melange-work/
-              echo "Copied ${UPSTREAM}/ companion files into melange-work/"
+              cp -r "$tmp_wolfi/${UPSTREAM}/." "$spec_dir/"
             fi
           fi
 
@@ -250,29 +267,38 @@ jobs:
         run: |
           chmod 600 melange-work/melange.rsa
 
-          MELANGE_ARGS=(
-            build melange-work/build.yaml
-            --arch "${{ matrix.arch }}"
-            --signing-key melange-work/melange.rsa
-            --out-dir packages/repo
-            --repository-append https://packages.wolfi.dev/os
-            --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-            --runner docker
-          )
-
-          if [ -d melange-work/pipelines ]; then
-            MELANGE_ARGS+=(--pipeline-dirs melange-work/pipelines)
+          shopt -s nullglob
+          builds=(melange-work/specs/*/build.yaml)
+          if [ ${#builds[@]} -eq 0 ]; then
+            echo "No melange build YAMLs staged in melange-work/specs" >&2
+            exit 1
           fi
 
-          if [ -n "$ENV_FILE" ]; then
-            MELANGE_ARGS+=(--env-file "packages/overrides/${ENV_FILE}")
-          fi
-          if [ -n "$BUILD_OPTION" ]; then
-            MELANGE_ARGS+=(--build-option "$BUILD_OPTION")
-          fi
+          for build_yaml in "${builds[@]}"; do
+            MELANGE_ARGS=(
+              build "$build_yaml"
+              --arch "${{ matrix.arch }}"
+              --signing-key melange-work/melange.rsa
+              --out-dir packages/repo
+              --repository-append https://packages.wolfi.dev/os
+              --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+              --runner docker
+            )
 
-          echo "Running: melange ${MELANGE_ARGS[*]}"
-          melange "${MELANGE_ARGS[@]}"
+            if [ -d melange-work/pipelines ]; then
+              MELANGE_ARGS+=(--pipeline-dirs melange-work/pipelines)
+            fi
+
+            if [ -n "$ENV_FILE" ]; then
+              MELANGE_ARGS+=(--env-file "packages/overrides/${ENV_FILE}")
+            fi
+            if [ -n "$BUILD_OPTION" ]; then
+              MELANGE_ARGS+=(--build-option "$BUILD_OPTION")
+            fi
+
+            echo "Running: melange ${MELANGE_ARGS[*]}"
+            melange "${MELANGE_ARGS[@]}"
+          done
 
           echo "Built packages:"
           find packages/repo -type f -name '*.apk'

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -160,6 +160,12 @@ jobs:
           - image: golang
             version: "1.24"
             type: fips
+          - image: haproxy
+            version: "3.0"
+            type: fips
+          - image: haproxy
+            version: "3.1"
+            type: fips
           - image: node
             version: "22"
             type: dev
@@ -190,21 +196,48 @@ jobs:
       - name: Build verity CLI
         run: go build -o verity .
 
+      - name: Check if melange build needed
+        id: melange-check
+        env:
+          IMAGE: ${{ matrix.image }}
+          TYPE: ${{ matrix.type }}
+        run: .github/scripts/melange-check.sh
+
+      - name: Build melange package
+        if: steps.melange-check.outputs.needed == 'true'
+        env:
+          UPSTREAM: ${{ steps.melange-check.outputs.upstream }}
+          BESPOKE_JSON: ${{ steps.melange-check.outputs.bespoke_json }}
+          ENV_FILE: ${{ steps.melange-check.outputs.env_file }}
+          BUILD_OPTION: ${{ steps.melange-check.outputs.build_option }}
+        run: .github/scripts/melange-build.sh
+
       - name: Generate apko config and build image (local, no push)
         run: |
-          ./verity integer discover --gen-dir ./gen
+          if [ "${{ steps.melange-check.outputs.needed }}" != "true" ]; then
+            ./verity integer build \
+              --image ${{ matrix.image }} \
+              --version ${{ matrix.version }} \
+              --type ${{ matrix.type }} \
+              --output image.tar \
+              --arch amd64
+          else
+            ./verity integer discover --gen-dir ./gen
 
-          config="gen/${{ matrix.image }}/${{ matrix.version }}/${{ matrix.type }}.apko.yaml"
-          if [ ! -f "$config" ]; then
-            echo "Config not found: $config" >&2
-            exit 1
+            config="gen/${{ matrix.image }}/${{ matrix.version }}/${{ matrix.type }}.apko.yaml"
+            if [ ! -f "$config" ]; then
+              echo "Config not found: $config" >&2
+              exit 1
+            fi
+
+            apko build \
+              --arch amd64 \
+              --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
+              --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
+              "$config" \
+              "${{ matrix.image }}:smoke-test" \
+              "$GITHUB_WORKSPACE/image.tar"
           fi
-
-          apko build \
-            --arch amd64 \
-            "$config" \
-            "${{ matrix.image }}:smoke-test" \
-            "$GITHUB_WORKSPACE/image.tar"
 
       - name: Trivy vulnerability scan
         run: |
@@ -377,7 +410,7 @@ jobs:
         if: steps.melange-check.outputs.needed == 'true'
         env:
           UPSTREAM: ${{ steps.melange-check.outputs.upstream }}
-          BESPOKE: ${{ steps.melange-check.outputs.bespoke }}
+          BESPOKE_JSON: ${{ steps.melange-check.outputs.bespoke_json }}
           ENV_FILE: ${{ steps.melange-check.outputs.env_file }}
           BUILD_OPTION: ${{ steps.melange-check.outputs.build_option }}
         run: .github/scripts/melange-build.sh

--- a/cmd/integer_validate.go
+++ b/cmd/integer_validate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"
@@ -167,40 +168,39 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 	bespokeRefs := 0
 	for typeName := range def.Types {
 		tmpl := def.Types[typeName]
-		if tmpl.Melange == nil || tmpl.Melange.Bespoke == "" {
+		if tmpl.Melange == nil || len(tmpl.Melange.Bespoke) == 0 {
 			continue
 		}
-		bespokeFile := tmpl.Melange.Bespoke
-		referenced[bespokeFile] = defPath
-		bespokeRefs++
+		for _, bespokeFile := range tmpl.Melange.Bespoke {
+			referenced[bespokeFile] = defPath
+			bespokeRefs++
 
-		// Defer the per-file reads to the post-loop summary when the
-		// entire bespoke directory is missing — see the function comment.
-		if !dirExists {
-			continue
-		}
+			if !dirExists {
+				continue
+			}
 
-		bespokePath := filepath.Join(bespokeDir, bespokeFile)
-		pkgName, berr := readBespokePackageName(bespokePath)
-		if berr != nil {
-			fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
-				defPath, typeName, bespokeFile, berr)
-			failures++
-			continue
-		}
-		if pkgName == "" {
-			fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: missing package.name\n",
-				defPath, typeName, bespokeFile)
-			failures++
-			continue
-		}
-		if !slices.Contains(tmpl.Packages, pkgName) {
-			fmt.Fprintf(os.Stderr,
-				"FAIL %s type %q: bespoke package.name %q not in apko packages: %v "+
-					"(apko will fail with 'not in indexes' at publish time)\n",
-				defPath, typeName, pkgName, tmpl.Packages)
-			failures++
-			continue
+			bespokePath := filepath.Join(bespokeDir, bespokeFile)
+			pkgName, berr := readBespokePackageName(bespokePath)
+			if berr != nil {
+				fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
+					defPath, typeName, bespokeFile, berr)
+				failures++
+				continue
+			}
+			if pkgName == "" {
+				fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: missing package.name\n",
+					defPath, typeName, bespokeFile)
+				failures++
+				continue
+			}
+			if !tmplPackageMatchesBespoke(def, typeName, tmpl.Packages, pkgName) {
+				fmt.Fprintf(os.Stderr,
+					"FAIL %s type %q: bespoke package.name %q not satisfiable by apko packages %v "+
+						"for any declared version of this type (apko will fail with 'not in indexes' at publish time)\n",
+					defPath, typeName, pkgName, tmpl.Packages)
+				failures++
+				continue
+			}
 		}
 	}
 
@@ -212,6 +212,26 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 	}
 
 	return failures
+}
+
+func tmplPackageMatchesBespoke(def *intconfig.ImageDef, typeName string, packages []string, pkgName string) bool {
+	if slices.Contains(packages, pkgName) {
+		return true
+	}
+	for _, pkg := range packages {
+		if !strings.Contains(pkg, "{{version}}") {
+			continue
+		}
+		for version, meta := range def.Versions {
+			if slices.Contains(meta.SkipTypes, typeName) {
+				continue
+			}
+			if strings.ReplaceAll(pkg, "{{version}}", version) == pkgName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // isExistingDir returns true iff path is a non-empty string and refers to

--- a/cmd/integer_validate_test.go
+++ b/cmd/integer_validate_test.go
@@ -131,6 +131,40 @@ package:
   epoch: 0
 `
 
+const intTestHaproxyImageYAML = `
+name: haproxy
+description: "HAProxy"
+upstream:
+  package: haproxy
+types:
+  default:
+    base: wolfi-base
+    packages: ["haproxy-{{version}}"]
+    entrypoint: /usr/bin/haproxy
+    melange:
+      bespoke:
+        - haproxy-3.0.yaml
+        - haproxy-3.1.yaml
+versions:
+  "3.0": {}
+  "3.1": {}
+  "3.2": {}
+`
+
+const intTestHaproxy30BespokeYAML = `
+package:
+  name: haproxy-3.0
+  version: "3.0.24"
+  epoch: 0
+`
+
+const intTestHaproxy31BespokeYAML = `
+package:
+  name: haproxy-3.1
+  version: "3.1.17"
+  epoch: 0
+`
+
 // TestIntegerValidateCommand_BespokeOK exercises the happy path: an image
 // declares melange.bespoke and a matching packages/bespoke/<file>.yaml exists
 // whose package.name matches the apko packages: constraint.
@@ -140,6 +174,24 @@ func TestIntegerValidateCommand_BespokeOK(t *testing.T) {
 
 	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
 	intWriteFile(t, filepath.Join(bespokeDir, "popeye.yaml"), intTestPopeyeBespokeYAML)
+
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "validate",
+		"--config", cfgPath,
+		"--images-dir", imagesDir,
+		"--bespoke-dir", bespokeDir,
+	})
+	assert.NoError(t, err)
+}
+
+func TestIntegerValidateCommand_BespokeVersionTemplateOK(t *testing.T) {
+	imagesDir, cfgPath := intSetupCmdImages(t)
+	intWriteFile(t, filepath.Join(imagesDir, "haproxy.yaml"), intTestHaproxyImageYAML)
+
+	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
+	intWriteFile(t, filepath.Join(bespokeDir, "haproxy-3.0.yaml"), intTestHaproxy30BespokeYAML)
+	intWriteFile(t, filepath.Join(bespokeDir, "haproxy-3.1.yaml"), intTestHaproxy31BespokeYAML)
 
 	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
 	err := root.Run(context.Background(), []string{
@@ -182,6 +234,25 @@ func TestIntegerValidateCommand_BespokeNameMismatch(t *testing.T) {
 
 	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
 	intWriteFile(t, filepath.Join(bespokeDir, "popeye.yaml"), intTestMismatchedBespokeYAML)
+
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "validate",
+		"--config", cfgPath,
+		"--images-dir", imagesDir,
+		"--bespoke-dir", bespokeDir,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errIntegerValidationFailed)
+}
+
+func TestIntegerValidateCommand_BespokeVersionTemplateMismatch(t *testing.T) {
+	imagesDir, cfgPath := intSetupCmdImages(t)
+	intWriteFile(t, filepath.Join(imagesDir, "haproxy.yaml"), intTestHaproxyImageYAML)
+
+	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
+	intWriteFile(t, filepath.Join(bespokeDir, "haproxy-3.0.yaml"), intTestHaproxy30BespokeYAML)
+	intWriteFile(t, filepath.Join(bespokeDir, "haproxy-3.1.yaml"), intTestMismatchedBespokeYAML)
 
 	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
 	err := root.Run(context.Background(), []string{

--- a/cmd/opensearch_dashboards_config_test.go
+++ b/cmd/opensearch_dashboards_config_test.go
@@ -22,9 +22,9 @@ func TestOpenSearchDashboardsImageUsesConfigScrubbingEntrypoint(t *testing.T) {
 	assert.Equal(t, "/usr/local/bin/verity-opensearch-dashboards-entrypoint", tmpl.Entrypoint)
 	assert.True(t, slices.Contains(tmpl.Packages, "verity-opensearch-dashboards-config"))
 	require.NotNil(t, tmpl.Melange)
-	assert.Equal(t, "verity-opensearch-dashboards-config.yaml", tmpl.Melange.Bespoke)
+	assert.Equal(t, "verity-opensearch-dashboards-config.yaml", tmpl.Melange.Bespoke.First())
 
-	bespoke, err := os.ReadFile(filepath.Join(repo, "packages", "bespoke", tmpl.Melange.Bespoke))
+	bespoke, err := os.ReadFile(filepath.Join(repo, "packages", "bespoke", tmpl.Melange.Bespoke.First()))
 	require.NoError(t, err)
 	text := string(bespoke)
 	assert.Contains(t, text, "name: verity-opensearch-dashboards-config")

--- a/images/haproxy.yaml
+++ b/images/haproxy.yaml
@@ -8,6 +8,10 @@ types:
     base: wolfi-base
     packages: ["haproxy-{{version}}", "libssl3"]
     entrypoint: "haproxy -f /etc/haproxy/haproxy.cfg"
+    melange:
+      bespoke:
+        - "haproxy-3.0.yaml"
+        - "haproxy-3.1.yaml"
     paths:
       - {path: /etc/haproxy, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /var/lib/haproxy, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
@@ -22,7 +26,10 @@ types:
       OPENSSL_MODULES: /usr/lib/ossl-modules
       OPENSSL_CONF: /etc/ssl/openssl-fips.cnf
     melange:
-      bespoke: "openssl-provider-fips.yaml"
+      bespoke:
+        - "haproxy-3.0.yaml"
+        - "haproxy-3.1.yaml"
+        - "openssl-provider-fips.yaml"
     paths:
       - {path: /etc/haproxy, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /var/lib/haproxy, type: directory, uid: 65532, gid: 65532, permissions: 0o755}

--- a/internal/integer/config/fips_validation_test.go
+++ b/internal/integer/config/fips_validation_test.go
@@ -60,7 +60,7 @@ func TestValidateFIPSProfile_acceptsOpenSSLWithProviderBase(t *testing.T) {
 					"OPENSSL_MODULES": "/usr/lib/ossl-modules",
 					"OPENSSL_CONF":    "/etc/ssl/openssl-fips.cnf",
 				},
-				Melange: &config.MelangeSpec{Bespoke: "openssl-provider-fips.yaml"},
+				Melange: &config.MelangeSpec{Bespoke: config.StringList{"openssl-provider-fips.yaml"}},
 			},
 		},
 	}
@@ -95,7 +95,7 @@ func TestValidateFIPSProfile_rejectsOpenSSLWrapperWithoutCommand(t *testing.T) {
 					"OPENSSL_MODULES": "/usr/lib/ossl-modules",
 					"OPENSSL_CONF":    "/etc/ssl/openssl-fips.cnf",
 				},
-				Melange: &config.MelangeSpec{Bespoke: "openssl-provider-fips.yaml"},
+				Melange: &config.MelangeSpec{Bespoke: config.StringList{"openssl-provider-fips.yaml"}},
 			},
 		},
 	}

--- a/internal/integer/config/loader.go
+++ b/internal/integer/config/loader.go
@@ -149,7 +149,7 @@ func validateOpenSSLFIPS(image, typeName string, tmpl *TypeTemplate) error {
 	if tmpl.Base != "wolfi-fips" {
 		return fmt.Errorf("image %q type %q profile %q base %q: %w", image, typeName, tmpl.FIPSProfile, tmpl.Base, ErrInvalidFIPSBase)
 	}
-	if !hasPackage(tmpl, "openssl-provider-fips") || tmpl.Melange == nil || tmpl.Melange.Bespoke != "openssl-provider-fips.yaml" {
+	if !hasPackage(tmpl, "openssl-provider-fips") || tmpl.Melange == nil || !tmpl.Melange.Bespoke.Contains("openssl-provider-fips.yaml") {
 		return fmt.Errorf("image %q type %q profile %q: %w", image, typeName, tmpl.FIPSProfile, ErrUnsupportedFIPSProfile)
 	}
 	command, ok := strings.CutPrefix(tmpl.Entrypoint, "/usr/bin/openssl-fips-entrypoint ")
@@ -189,14 +189,16 @@ func validateMelange(image, typeName string, m *MelangeSpec) error {
 	if m == nil {
 		return nil
 	}
-	if m.Upstream != "" && m.Bespoke != "" {
+	if m.Upstream != "" && len(m.Bespoke) > 0 {
 		return fmt.Errorf("image %q type %q: %w", image, typeName, ErrMelangeSourceConflict)
 	}
-	if m.Upstream == "" && m.Bespoke == "" {
+	if m.Upstream == "" && len(m.Bespoke) == 0 {
 		return fmt.Errorf("image %q type %q: %w", image, typeName, ErrMelangeNoSource)
 	}
-	if err := validateFilename(image, typeName, "bespoke", m.Bespoke); err != nil {
-		return err
+	for _, bespoke := range m.Bespoke {
+		if err := validateFilename(image, typeName, "bespoke", bespoke); err != nil {
+			return err
+		}
 	}
 	if err := validateFilename(image, typeName, "env-file", m.EnvFile); err != nil {
 		return err

--- a/internal/integer/config/loader_test.go
+++ b/internal/integer/config/loader_test.go
@@ -117,6 +117,28 @@ func TestLoadImage(t *testing.T) {
 	assert.True(t, v24.Latest)
 }
 
+func TestLoadImage_AllowsAliasedBespokeListEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "aliased.yaml", `
+name: custom
+description: "Custom image"
+upstream:
+  package: custom
+types:
+  default:
+    base: wolfi-base
+    melange:
+      bespoke:
+        - &spec custom.melange.yaml
+        - *spec
+`)
+
+	def, err := config.LoadImage(path)
+	require.NoError(t, err)
+	require.NotNil(t, def.Types["default"].Melange)
+	assert.Equal(t, config.StringList{"custom.melange.yaml", "custom.melange.yaml"}, def.Types["default"].Melange.Bespoke)
+}
+
 func TestValidate(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		def := &config.ImageDef{
@@ -237,7 +259,7 @@ func TestValidate(t *testing.T) {
 				"default": {
 					Base: "wolfi-base",
 					Melange: &config.MelangeSpec{
-						Bespoke: "custom.melange.yaml",
+						Bespoke: config.StringList{"custom.melange.yaml"},
 					},
 				},
 			},
@@ -256,7 +278,7 @@ func TestValidate(t *testing.T) {
 					Environment: map[string]string{"GODEBUG": "fips140=on"},
 					Melange: &config.MelangeSpec{
 						Upstream: "caddy",
-						Bespoke:  "caddy.melange.yaml",
+						Bespoke:  config.StringList{"caddy.melange.yaml"},
 					},
 				},
 			},
@@ -291,7 +313,7 @@ func TestValidate(t *testing.T) {
 					Base:        "wolfi-base",
 					FIPSProfile: config.FIPSProfileGo,
 					Environment: map[string]string{"GODEBUG": "fips140=on"},
-					Melange:     &config.MelangeSpec{Bespoke: "../evil/caddy.yaml"},
+					Melange:     &config.MelangeSpec{Bespoke: config.StringList{"../evil/caddy.yaml"}},
 				},
 			},
 		}
@@ -328,7 +350,7 @@ func TestValidate(t *testing.T) {
 					Base:        "wolfi-base",
 					FIPSProfile: config.FIPSProfileGo,
 					Environment: map[string]string{"GODEBUG": "fips140=on"},
-					Melange:     &config.MelangeSpec{Bespoke: `subdir\caddy.yaml`},
+					Melange:     &config.MelangeSpec{Bespoke: config.StringList{`subdir\caddy.yaml`}},
 				},
 			},
 		}

--- a/internal/integer/config/types.go
+++ b/internal/integer/config/types.go
@@ -1,11 +1,85 @@
 package config
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
 
 // versionPlaceholder is the literal string substituted with concrete version
 // values when rendering apko configs. Mirrors apkindex.versionPlaceholder so
 // the helper below can stay independent of the apkindex package.
 const versionPlaceholder = "{{version}}"
+
+var (
+	errStringListItemNotScalar = errors.New("string list item must be a scalar string")
+	errStringListAliasNil      = errors.New("string list alias must reference a node")
+	errStringListNodeKind      = errors.New("string list value must be a string or string sequence")
+)
+
+type StringList []string
+
+func (s *StringList) UnmarshalYAML(node *yaml.Node) error {
+	resolved, err := resolveStringListNode(node)
+	if err != nil {
+		return err
+	}
+
+	switch resolved.Kind {
+	case 0:
+		*s = nil
+		return nil
+	case yaml.ScalarNode:
+		if resolved.Value == "" {
+			*s = nil
+			return nil
+		}
+		*s = StringList{resolved.Value}
+		return nil
+	case yaml.SequenceNode:
+		vals := make([]string, 0, len(resolved.Content))
+		for _, child := range resolved.Content {
+			resolvedChild, err := resolveStringListNode(child)
+			if err != nil {
+				return err
+			}
+			if resolvedChild.Kind != yaml.ScalarNode {
+				return fmt.Errorf("%w: yaml kind %d", errStringListItemNotScalar, resolvedChild.Kind)
+			}
+			if resolvedChild.Value != "" {
+				vals = append(vals, resolvedChild.Value)
+			}
+		}
+		*s = vals
+		return nil
+	default:
+		return fmt.Errorf("%w: yaml kind %d", errStringListNodeKind, resolved.Kind)
+	}
+}
+
+func resolveStringListNode(node *yaml.Node) (*yaml.Node, error) {
+	for node != nil && node.Kind == yaml.AliasNode {
+		if node.Alias == nil {
+			return nil, errStringListAliasNil
+		}
+		node = node.Alias
+	}
+	return node, nil
+}
+
+func (s StringList) First() string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0]
+}
+
+func (s StringList) Contains(value string) bool {
+	return slices.Contains(s, value)
+}
 
 // FIPSProfile records which cryptographic validation path a fips image type uses.
 type FIPSProfile string
@@ -143,9 +217,7 @@ type MelangeSpec struct {
 	// YAML is fetched from wolfi-dev/os at the pinned commit.
 	Upstream string `yaml:"upstream,omitempty"`
 
-	// Bespoke is a filename (without path) in packages/bespoke/. Used for
-	// packages that don't exist in Wolfi or need radical changes.
-	Bespoke string `yaml:"bespoke,omitempty"`
+	Bespoke StringList `yaml:"bespoke,omitempty"`
 
 	// EnvFile is a filename (without path) in packages/overrides/. Passed to
 	// melange build via --env-file to inject build-time environment variables

--- a/packages/bespoke/haproxy-3.0.yaml
+++ b/packages/bespoke/haproxy-3.0.yaml
@@ -1,0 +1,55 @@
+package:
+  name: haproxy-3.0
+  version: "3.0.24"
+  epoch: 0
+  description: Reliable, high performance TCP/HTTP load balancer
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - libssl3
+      - pcre2
+      - zlib
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - linux-headers
+      - openssl-dev
+      - pcre2-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.haproxy.org/download/3.0/src/haproxy-${{package.version}}.tar.gz
+      expected-sha256: a12fd4bf59a7780ad10fd5f1677a307c1ba3d18419fb6ffcfd4f408eff6ff927
+
+  - runs: |
+      make -j$(nproc) \
+        TARGET=linux-glibc \
+        USE_GETADDRINFO=1 \
+        USE_OPENSSL=1 \
+        USE_PCRE2=1 \
+        USE_ZLIB=1 \
+        PREFIX=/usr \
+        SBINDIR=/usr/bin
+      make \
+        TARGET=linux-glibc \
+        USE_GETADDRINFO=1 \
+        USE_OPENSSL=1 \
+        USE_PCRE2=1 \
+        USE_ZLIB=1 \
+        PREFIX=/usr \
+        SBINDIR=/usr/bin \
+        DESTDIR="${{targets.destdir}}" \
+        install-bin
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        haproxy -vv | grep -q "HAProxy version ${{package.version}}"

--- a/packages/bespoke/haproxy-3.1.yaml
+++ b/packages/bespoke/haproxy-3.1.yaml
@@ -1,0 +1,55 @@
+package:
+  name: haproxy-3.1
+  version: "3.1.17"
+  epoch: 0
+  description: Reliable, high performance TCP/HTTP load balancer
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - libssl3
+      - pcre2
+      - zlib
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - linux-headers
+      - openssl-dev
+      - pcre2-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.haproxy.org/download/3.1/src/haproxy-${{package.version}}.tar.gz
+      expected-sha256: 5f875a297032bb68f100363d034574694313a59fc5b699adf647063bbfe5e7a7
+
+  - runs: |
+      make -j$(nproc) \
+        TARGET=linux-glibc \
+        USE_GETADDRINFO=1 \
+        USE_OPENSSL=1 \
+        USE_PCRE2=1 \
+        USE_ZLIB=1 \
+        PREFIX=/usr \
+        SBINDIR=/usr/bin
+      make \
+        TARGET=linux-glibc \
+        USE_GETADDRINFO=1 \
+        USE_OPENSSL=1 \
+        USE_PCRE2=1 \
+        USE_ZLIB=1 \
+        PREFIX=/usr \
+        SBINDIR=/usr/bin \
+        DESTDIR="${{targets.destdir}}" \
+        install-bin
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        haproxy -vv | grep -q "HAProxy version ${{package.version}}"

--- a/scripts/melange_build_test.go
+++ b/scripts/melange_build_test.go
@@ -45,7 +45,7 @@ func TestMelangeBuildRejectsUnsafeBespokeValue(t *testing.T) {
 	repoRoot := t.TempDir()
 
 	output, err := runMelangeBuild(t, repoRoot, map[string]string{
-		"BESPOKE": "../evil.yaml",
+		"BESPOKE_JSON": `["../evil.yaml"]`,
 	})
 
 	require.Error(t, err)
@@ -57,7 +57,7 @@ func TestMelangeBuildFailsWhenBespokeFileMissing(t *testing.T) {
 	writeTempFile(t, filepath.Join(repoRoot, "packages", "upstream.lock.json"), `{"wolfi_commit":"abc123"}`)
 
 	output, err := runMelangeBuild(t, repoRoot, map[string]string{
-		"BESPOKE": "custom.yaml",
+		"BESPOKE_JSON": `["custom.yaml"]`,
 	})
 
 	require.Error(t, err)
@@ -70,7 +70,7 @@ func TestMelangeBuildFailsWhenBespokeWolfiCommitMissing(t *testing.T) {
 	writeTempFile(t, filepath.Join(repoRoot, "packages", "upstream.lock.json"), `{"wolfi_commit":null}`)
 
 	output, err := runMelangeBuild(t, repoRoot, map[string]string{
-		"BESPOKE": "custom.yaml",
+		"BESPOKE_JSON": `["custom.yaml"]`,
 	})
 
 	require.Error(t, err)


### PR DESCRIPTION
## Summary
- root cause: Wolfi never published public `haproxy-3.0` or `haproxy-3.1` APKs, so apko could not solve those declared streams
- add bespoke HAProxy 3.0/3.1 melange recipes and allow image types/workflows to build multiple bespoke APKs into one local repo
- wire haproxy default/fips to those bespoke streams and add PR smoke coverage for haproxy 3.0/3.1 fips

## Verification
- `go test ./...`
- `make lint-workflows`
- `make lint-yaml`
- `./verity integer validate`
- local end-to-end: bespoke melange build + apko builds for haproxy 3.0/3.1 default and fips all passed

Closes #585
Closes #586

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `haproxy` 3.0/3.1 builds by adding bespoke `melange` recipes and enabling multi-bespoke builds in `integer` and CI. Default and FIPS `haproxy` images now target these streams and only build a local repo when needed.

- **Bug Fixes**
  - Added `haproxy-3.0.yaml` and `haproxy-3.1.yaml` bespoke recipes to replace missing Wolfi APKs.
  - Wired `haproxy` default/FIPS types to these streams; added PR smoke tests for FIPS 3.0 and 3.1.
  - Validation now ensures templated packages like `haproxy-{{version}}` resolve to bespoke package names across declared versions to avoid `apko` resolution failures.

- **Refactors**
  - Multi-bespoke support: `MelangeSpec.Bespoke` is now a list (`StringList`); accepts scalar or array with `.First()`/`.Contains()`.
  - `melange-build.sh` and workflows stage multiple specs under `melange-work/specs` and build them all via `BESPOKE_JSON`; upstream builds use the same flow.
  - Stronger checks: forbid mixed upstream/bespoke, validate safe filenames, and require `openssl-provider-fips.yaml` for FIPS types; PR tests only use a local bespoke repo/key when needed.

<sup>Written for commit 1831e18963837ad3ced2097ceb027cd3e41305d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

