### PR TITLE
ci: scope integer smoke matrix

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -147,28 +147,53 @@ jobs:
       - name: Validate all image configs
         run: ./verity integer validate
 
+  # ── Detect Integer smoke scope ───────────────────────────────────────
+  detect-smoke-scope:
+    name: Detect smoke scope
+    needs: [changes, detect-changed-images]
+    if: needs.changes.outputs.integer == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scope.outputs.matrix }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Build smoke matrix
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGED_IMAGE_SMOKE_MATRIX: ${{ needs.detect-changed-images.outputs.smoke-matrix }}
+        run: |
+          changed_files=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" || true)
+
+          # Rare path: core Integer mechanism changed, so keep full representative smoke matrix.
+          # Common path: reuse detect-changed-images output so smoke and build share one source of truth.
+          if echo "$changed_files" | grep -Eq '^internal/integer/|^cmd/(integer|discover|scan).*\.go$|^\.github/scripts/(melange-check|melange-build)\.sh$|^\.github/workflows/(pr-test|integer-.*)\.yaml$|^integer\.yaml$'; then
+            matrix='{"include":[{"image":"golang","version":"1.24","type":"fips"},{"image":"haproxy","version":"3.0","type":"fips"},{"image":"haproxy","version":"3.1","type":"fips"},{"image":"node","version":"22","type":"dev"}]}'
+          else
+            matrix="$CHANGED_IMAGE_SMOKE_MATRIX"
+          fi
+
+          echo "$matrix" | jq .
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
   # ── Integer (Wolfi-based) smoke test ─────────────────────────────────
   integer-smoke-test:
     name: "Integer ${{ matrix.image }}:${{ matrix.version }}-${{ matrix.type }}"
-    needs: changes
+    needs: [changes, detect-smoke-scope]
     if: needs.changes.outputs.integer == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - image: golang
-            version: "1.24"
-            type: fips
-          - image: haproxy
-            version: "3.0"
-            type: fips
-          - image: haproxy
-            version: "3.1"
-            type: fips
-          - image: node
-            version: "22"
-            type: dev
+      matrix: ${{ fromJson(needs.detect-smoke-scope.outputs.matrix) }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -266,6 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
+      smoke-matrix: ${{ steps.detect.outputs.smoke-matrix }}
       has-changes: ${{ steps.detect.outputs.has-changes }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -306,8 +332,11 @@ jobs:
 
           if [ -z "$all_changed" ]; then
             echo "No image YAML files changed"
-            echo 'has-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            {
+              echo 'has-changes=false'
+              echo 'matrix={"include":[]}'
+              echo 'smoke-matrix={"include":[]}'
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -323,8 +352,11 @@ jobs:
             echo "Changed images: $names"
           else
             echo "No actionable changes"
-            echo 'has-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            {
+              echo 'has-changes=false'
+              echo 'matrix={"include":[]}'
+              echo 'smoke-matrix={"include":[]}'
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -342,10 +374,15 @@ jobs:
 
           if [ -z "$all" ] || [ "$all" = "null" ] || [ "$all" = "[]" ]; then
             echo "No discoverable images"
-            echo 'has-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            {
+              echo 'has-changes=false'
+              echo 'matrix={"include":[]}'
+              echo 'smoke-matrix={"include":[]}'
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          smoke_matrix=$(echo "$all" | jq -c 'map({image: .name, version: .version, type: .type}) | {include: .}')
 
           # Build matrix: pick the latest version per image+type.
           # sort_by(.version | split(".") | map(tonumber? // .)) handles numeric ordering.
@@ -361,8 +398,11 @@ jobs:
           count=$(echo "$matrix" | jq '.include | length')
           echo "Matrix: ${count} image builds"
           echo "$matrix" | jq .
-          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
-          echo 'has-changes=true' >> "$GITHUB_OUTPUT"
+          {
+            echo "matrix=${matrix}"
+            echo "smoke-matrix=${smoke_matrix}"
+            echo 'has-changes=true'
+          } >> "$GITHUB_OUTPUT"
 
   integer-build-changed:
     name: "Build ${{ matrix.image }}:${{ matrix.version }}-${{ matrix.type }}"


### PR DESCRIPTION
## Summary
- add a dedicated smoke-scope detector in `.github/workflows/pr-test.yaml`
- run smoke builds only for discovered image/version/type combos when a PR changes image definitions
- keep the representative full smoke matrix only for rare core Integer mechanism changes

## Validation
- `actionlint .github/workflows/pr-test.yaml`
- `yamllint -c .yamllint.yml .github/workflows/pr-test.yaml`
- `./verity integer validate`
- locally simulated image-only and core-change matrix selection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Integer smoke tests to only PR-affected images using a dynamic CI matrix, reusing build discovery and falling back to a small representative set when core Integer code or workflows change.

- **New Features**
  - Added a `detect-smoke-scope` job in `.github/workflows/pr-test.yaml` that builds a JSON smoke matrix from PR diffs, with a representative fallback on core/script/workflow changes.
  - Added a `smoke-matrix` output to `detect-changed-images`; smoke uses all discovered image/version/type combos, while build keeps the latest per image+type.
  - Updated `integer-smoke-test` to depend on `detect-smoke-scope` and load the scoped set via `fromJson(needs.detect-smoke-scope.outputs.matrix)`.

- **Bug Fixes**
  - Consolidated `$GITHUB_OUTPUT` writes and emit empty `matrix`/`smoke-matrix` on no-op changes to prevent workflow errors.

<sup>Written for commit 7996e8a9d0a4ee0dabf2038474e861f941672028. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

