### PR TITLE
fix: publish missing Copa target images

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -551,7 +551,7 @@ jobs:
         continue-on-error: true  # Report only — images publish even with CVEs
 
       - name: Resolve Trivy gate policy
-        id: trivy-gate
+        id: trivy-gate-postgres
         run: |
           case "${{ inputs.image }}:${{ inputs.version }}:${{ inputs.type }}" in
             postgres:14:fips)
@@ -568,11 +568,11 @@ jobs:
           esac
 
       - name: Enforce Trivy gate
-        if: steps.trivy-gate.outputs.enabled == 'true'
+        if: steps.trivy-gate-postgres.outputs.enabled == 'true'
         run: |
           findings=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' trivy-report.json)
           if [ "$findings" -ne 0 ]; then
-            echo "${{ steps.trivy-gate.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
+            echo "${{ steps.trivy-gate-postgres.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
             exit 1
           fi
 
@@ -585,7 +585,7 @@ jobs:
           retention-days: 30
 
       - name: Resolve Trivy gate policy
-        id: trivy-gate
+        id: trivy-gate-vault
         run: |
           case "${{ inputs.image }}:${{ inputs.type }}" in
             vault:default)
@@ -598,11 +598,11 @@ jobs:
           esac
 
       - name: Enforce Trivy gate
-        if: steps.trivy-gate.outputs.enabled == 'true'
+        if: steps.trivy-gate-vault.outputs.enabled == 'true'
         run: |
           findings=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' trivy-report.json)
           if [ "$findings" -ne 0 ]; then
-            echo "${{ steps.trivy-gate.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
+            echo "${{ steps.trivy-gate-vault.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
             exit 1
           fi
 

--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -524,18 +524,30 @@ jobs:
 
       - name: Compare with previous post-patch report
         id: compare
+        env:
+          IMAGE_NAME: ${{ inputs.image-name }}
+          SOURCE_TAG: ${{ needs.scan.outputs.source-tag }}
+          TARGET_REGISTRY: ${{ inputs.target-registry }}
         run: |
           # Extract sorted vuln IDs from both reports for comparison
           NEW_IDS=$(jq -r '[.Results[]?.Vulnerabilities // [] | .[] | .VulnerabilityID] | sort | .[]' post.json | sha256sum)
           PREV_IDS=$(jq -r '[.Results[]?.Vulnerabilities // [] | .[] | .VulnerabilityID] | sort | .[]' prev-post.json 2>/dev/null | sha256sum || echo "")
 
           PREV_EXISTED="${{ needs.scan.outputs.prev-report-exists }}"
+          FINAL_TAG="${TARGET_REGISTRY}/${IMAGE_NAME}:${SOURCE_TAG}"
 
-          if [ "$PREV_EXISTED" = "true" ] && [ "$NEW_IDS" = "$PREV_IDS" ]; then
-            echo "Vuln set unchanged — discarding new image (no-op)"
+
+          if crane digest "$FINAL_TAG" > /dev/null 2>&1; then
+            TARGET_EXISTS=true
+          else
+            TARGET_EXISTS=false
+          fi
+
+          if [ "$PREV_EXISTED" = "true" ] && [ "$NEW_IDS" = "$PREV_IDS" ] && [ "$TARGET_EXISTS" = "true" ]; then
+            echo "Vuln set unchanged and target exists — discarding new image (no-op)"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Vuln set changed (or first time) — publishing"
+            echo "First time, vuln set changed, or target missing — publishing"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/internal/discovery/discover.go
+++ b/internal/discovery/discover.go
@@ -32,12 +32,6 @@ type DiscoveredImage struct {
 //     re-patching chart images that already have an Integer/Wolfi rebuild
 //     stub at images/<name>.yaml. Logged as "excluded via --exclude-names".
 //
-//   - unpatchable: applies to BOTH standalone and chart-discovered images.
-//     Sourced from verity.yaml's unpatchableImages list — images we
-//     deliberately skip because they have no replacement we can patch
-//     (distroless without a rebuild, deprecated registry references, etc.).
-//     Logged as "in verity.yaml unpatchableImages" so operators can tell
-//     the two attribution paths apart.
 //
 // unpatchable is checked first; an image listed in both sets is skipped
 // with the unpatchable log line.
@@ -72,10 +66,6 @@ func DiscoverWithChartValues(
 			continue
 		}
 		for _, img := range imgs {
-			if isUnpatchable(&img, unpatchable) {
-				fmt.Fprintf(os.Stderr, "Skipping standalone image %q: name %q in verity.yaml unpatchableImages\n", img.Source, img.Name)
-				continue
-			}
 			key := img.Name + "|" + img.Source
 			if _, exists := seen[key]; !exists {
 				seen[key] = struct{}{}

--- a/internal/discovery/discover.go
+++ b/internal/discovery/discover.go
@@ -32,7 +32,6 @@ type DiscoveredImage struct {
 //     re-patching chart images that already have an Integer/Wolfi rebuild
 //     stub at images/<name>.yaml. Logged as "excluded via --exclude-names".
 //
-//
 // unpatchable is checked first; an image listed in both sets is skipped
 // with the unpatchable log line.
 func Discover(cfg *config.CopaConfig, targetRegistry string, overrides map[string]config.Override, excludeNames, unpatchable map[string]struct{}) ([]DiscoveredImage, error) {

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -814,12 +814,7 @@ func TestIsExcluded(t *testing.T) {
 	})
 }
 
-// Regression test for the review feedback that unpatchable entries from
-// verity.yaml were being merged into excludeNames and emitting the
-// "excluded via --exclude-names" log line, mis-attributing the source.
-// Discover() now takes unpatchable as a separate parameter and applies it
-// to BOTH standalone and chart-discovered images with a distinct skip path.
-func TestDiscover_UnpatchableStandalone(t *testing.T) {
+func TestDiscover_UnpatchableStandaloneStillIncluded(t *testing.T) {
 	cfg := &config.CopaConfig{
 		Target: config.TargetSpec{Registry: "ghcr.io/verity-org"},
 		Images: []config.ImageSpec{
@@ -845,8 +840,11 @@ func TestDiscover_UnpatchableStandalone(t *testing.T) {
 		t.Fatalf("Discover() error = %v", err)
 	}
 
-	if len(got) != 1 || got[0].Name != testNginxName {
-		t.Errorf("Discover() returned %v, want only [{nginx}]; unpatchable standalone leaked through", got)
+	if len(got) != 2 {
+		t.Fatalf("Discover() returned %v, want both standalone images", got)
+	}
+	if got[0].Name != "cert-manager/cert-manager-openshift-routes" || got[1].Name != testNginxName {
+		t.Errorf("Discover() returned %v, want unpatchable standalone preserved plus nginx", got)
 	}
 }
 

--- a/internal/preflight/check.go
+++ b/internal/preflight/check.go
@@ -23,6 +23,10 @@ var digestFn = func(ref string) (string, error) {
 	return crane.Digest(ref)
 }
 
+var targetDigestFn = func(ref string) (string, error) {
+	return crane.Digest(ref)
+}
+
 // extractTag returns the tag portion of a full image reference,
 // e.g. "mirror.gcr.io/library/nginx:1.29.3" yields "1.29.3".
 // Digest-pinned references (containing "@") return "" to signal
@@ -56,6 +60,12 @@ func checkCopaImage(img *discovery.DiscoveredImage, manifest Manifest) CheckResu
 	entry, exists := manifest[key]
 	if !exists {
 		return CheckResult{NeedsWork: true, Reason: key + ": first time (not in manifest)"}
+	}
+	if img.TargetRegistry != "" {
+		targetRef := strings.TrimRight(img.TargetRegistry, "/") + "/" + img.Name + ":" + tag
+		if _, err := targetDigestFn(targetRef); err != nil {
+			return CheckResult{NeedsWork: true, Reason: key + ": target image missing"}
+		}
 	}
 
 	currentDigest, err := digestFn(img.Source)

--- a/internal/preflight/check_test.go
+++ b/internal/preflight/check_test.go
@@ -104,17 +104,43 @@ func TestCheckCopaImage_UnchangedClean(t *testing.T) {
 		"nginx/1.29.3": {UpstreamDigest: testDigestSame, PatchedVulns: 0},
 	}
 	img := discovery.DiscoveredImage{
-		Name:   "nginx",
-		Source: "mirror.gcr.io/library/nginx:1.29.3",
+		Name:           "nginx",
+		Source:         "mirror.gcr.io/library/nginx:1.29.3",
+		TargetRegistry: "ghcr.io/verity-org",
 	}
 
 	origFn := digestFn
 	digestFn = func(_ string) (string, error) { return testDigestSame, nil }
 	defer func() { digestFn = origFn }()
+	origTargetFn := targetDigestFn
+	targetDigestFn = func(_ string) (string, error) { return testDigestSame, nil }
+	defer func() { targetDigestFn = origTargetFn }()
 
 	result := checkCopaImage(&img, manifest)
 	assert.False(t, result.NeedsWork)
 	assert.Contains(t, result.Reason, "unchanged")
+}
+
+func TestCheckCopaImage_MissingTargetForcesBuild(t *testing.T) {
+	manifest := Manifest{
+		"nginx/1.29.3": {UpstreamDigest: testDigestSame, PatchedVulns: 0},
+	}
+	img := discovery.DiscoveredImage{
+		Name:           "nginx",
+		Source:         "mirror.gcr.io/library/nginx:1.29.3",
+		TargetRegistry: "ghcr.io/verity-org",
+	}
+
+	origDigest := digestFn
+	digestFn = func(_ string) (string, error) { return testDigestSame, nil }
+	defer func() { digestFn = origDigest }()
+	origTarget := targetDigestFn
+	targetDigestFn = func(_ string) (string, error) { return "", assert.AnError }
+	defer func() { targetDigestFn = origTarget }()
+
+	result := checkCopaImage(&img, manifest)
+	assert.True(t, result.NeedsWork)
+	assert.Contains(t, result.Reason, "target image missing")
 }
 
 func TestCheckCopaImage_DigestRef(t *testing.T) {


### PR DESCRIPTION
## Summary
- heal missing Copa target tags when GHCR target refs are missing
- keep standalone discover coverage for cataloged images such as victoria-logs
- fix workflow lint so actionlint stays green

## Root cause
- `verity discover` treated `verity.yaml` `unpatchableImages` as a standalone-image skip, so `victoriametrics/victoria-logs` stopped dispatching patch runs even though it is still cataloged publicly
- scheduled preflight only compared upstream digest + stored vuln count; it did not verify the target GHCR tag still existed
- `patch-image.yaml` discarded rebuilt manifests when vuln IDs matched the previous report, even if the final target tag was missing

## Fix
- standalone discover now keeps cataloged Copa images in the publish set while chart-image unpatchable filtering stays in the chart path
- preflight forces rebuild when the target tag is missing from GHCR
- patch-image republishes when the target tag is missing, even if the vuln set is unchanged
- deduplicate `integer-build-image.yaml` step IDs so workflow lint passes again

## Validation
- `go test ./...`
- `go build -o verity .`
- `actionlint`
- `yamllint .github/workflows/patch-image.yaml .github/workflows/orchestrator.yaml .github/workflows/integer-build-image.yaml copa-config.yaml verity.yaml`
- `./verity discover --config copa-config.yaml --only "elastic/eck-operator,rabbitmqoperator/messaging-topology-operator,victoriametrics/victoria-logs,tensorflow/serving"`

Closes #580
Closes #581
Closes #582
Closes #583
Closes #584

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Copa target images by keeping cataloged standalone images in discovery and forcing rebuild/publish when GHCR target tags are missing. Also fixes workflow lint errors by deduplicating step IDs.

- **Bug Fixes**
  - Discovery: keep cataloged Copa images (e.g., `victoriametrics/victoria-logs`) in the publish set; unpatchable filtering remains in the chart path.
  - Preflight: rebuild when the GHCR target tag is missing.
  - `patch-image.yaml`: republish when the target tag is missing, even if the vuln set is unchanged.
  - CI: deduplicate step IDs in `integer-build-image.yaml` so `actionlint` stays green.

<sup>Written for commit 74458c6f0afe2252f2cfbd801f5f9eb091450388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

