### PR TITLE
fix(integer): bound golang default cmd for smoke

### DIFF
--- a/images/golang.yaml
+++ b/images/golang.yaml
@@ -8,6 +8,7 @@ types:
     base: wolfi-base
     packages: ["go-{{version}}", "build-base"]
     entrypoint: /usr/bin/go
+    cmd: version
     work-dir: /go/src
     environment:
       GOPATH: /go
@@ -20,6 +21,7 @@ types:
     base: wolfi-dev
     packages: ["go-{{version}}", "build-base", "git", "curl", "bash"]
     entrypoint: /usr/bin/go
+    cmd: version
     work-dir: /go/src
     environment:
       GOPATH: /go
@@ -33,6 +35,7 @@ types:
     fips-profile: go
     packages: ["go-{{version}}", "build-base"]
     entrypoint: /usr/bin/go
+    cmd: version
     work-dir: /go/src
     environment:
       GOPATH: /go

--- a/internal/integer/config/loader_test.go
+++ b/internal/integer/config/loader_test.go
@@ -28,6 +28,7 @@ types:
     base: wolfi-base
     packages: ["nodejs-{{version}}", "libstdc++"]
     entrypoint: /usr/bin/node
+    cmd: --version
     work-dir: /app
     environment:
       NODE_ENV: production
@@ -97,6 +98,7 @@ func TestLoadImage(t *testing.T) {
 	assert.Equal(t, "wolfi-base", dflt.Base)
 	assert.Equal(t, []string{"nodejs-{{version}}", "libstdc++"}, dflt.Packages)
 	assert.Equal(t, "/usr/bin/node", dflt.Entrypoint)
+	assert.Equal(t, "--version", dflt.Cmd)
 	assert.Equal(t, "/app", dflt.WorkDir)
 	assert.Equal(t, "production", dflt.Environment["NODE_ENV"])
 	require.Len(t, dflt.Paths, 1)

--- a/internal/integer/config/types.go
+++ b/internal/integer/config/types.go
@@ -200,6 +200,7 @@ type TypeTemplate struct {
 	FIPSProfile FIPSProfile       `yaml:"fips-profile,omitempty"`
 	Packages    []string          `yaml:"packages"`
 	Entrypoint  string            `yaml:"entrypoint,omitempty"`
+	Cmd         string            `yaml:"cmd,omitempty"`
 	WorkDir     string            `yaml:"work-dir,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
 	Paths       []PathDef         `yaml:"paths,omitempty"`

--- a/internal/integer/render/render.go
+++ b/internal/integer/render/render.go
@@ -34,6 +34,7 @@ type apkoConfig struct {
 	Include    string            `yaml:"include,omitempty"`
 	Contents   *apkoContents     `yaml:"contents,omitempty"`
 	Entrypoint *apkoEntrypoint   `yaml:"entrypoint,omitempty"`
+	Cmd        string            `yaml:"cmd,omitempty"`
 	WorkDir    string            `yaml:"work-dir,omitempty"`
 	Environ    map[string]string `yaml:"environment,omitempty"`
 	Paths      []apkoPath        `yaml:"paths,omitempty"`
@@ -87,6 +88,9 @@ func Config(tmpl *config.TypeTemplate, version, basePath string) ([]byte, error)
 	// Entrypoint.
 	if tmpl.Entrypoint != "" {
 		cfg.Entrypoint = &apkoEntrypoint{Command: sub(tmpl.Entrypoint, version)}
+	}
+	if tmpl.Cmd != "" {
+		cfg.Cmd = sub(tmpl.Cmd, version)
 	}
 
 	// Working directory.

--- a/internal/integer/render/render_test.go
+++ b/internal/integer/render/render_test.go
@@ -16,6 +16,7 @@ var nodeDefault = config.TypeTemplate{
 	Base:       "wolfi-base",
 	Packages:   []string{"nodejs-{{version}}", "libstdc++"},
 	Entrypoint: "/usr/bin/node",
+	Cmd:        "--version",
 	WorkDir:    "/app",
 	Environment: map[string]string{
 		"NODE_ENV": "production",
@@ -47,6 +48,7 @@ func TestConfig_VersionSubstitution(t *testing.T) {
 	ep, ok := cfg["entrypoint"].(map[string]any)
 	require.True(t, ok, "expected entrypoint key to be map[string]any")
 	assert.Equal(t, "/usr/bin/node", ep["command"])
+	assert.Equal(t, "--version", cfg["cmd"])
 
 	// work-dir
 	assert.Equal(t, "/app", cfg["work-dir"])
@@ -77,6 +79,7 @@ func TestConfig_DifferentVersions(t *testing.T) {
 	assert.True(t, strings.Contains(string(out22), "nodejs-22"))
 	assert.True(t, strings.Contains(string(out24), "nodejs-24"))
 	assert.False(t, strings.Contains(string(out22), "nodejs-24"))
+	assert.True(t, strings.Contains(string(out22), "cmd: --version"))
 }
 
 func TestConfig_VersionInEnv(t *testing.T) {


### PR DESCRIPTION
## Root cause

Public Integer smoke inspects OCI `Entrypoint` + `Cmd`. Verity Integer image config could express `entrypoint`, but not OCI `cmd`, so golang rendered as `Entrypoint=["/usr/bin/go"]` and `Cmd=null` for every default/dev stream. The golang image itself was otherwise intentional; missing default args made the smoke harness treat it as unbounded/broken.

## Fix

- add generic Integer `cmd` support to config loading and apko rendering
- set golang default/dev/fips to `cmd: version`, preserving `docker run <image> build/test/...` overrides while making the no-arg default bounded
- add loader/render regression coverage for the new field

## Validation

- `go test ./...`
- built `golang:1.26-dev` locally via `verity integer build`
- verified `docker image inspect` now reports `Entrypoint=["/usr/bin/go"] Cmd=["version"]`
- verified `docker run golang:1.26-dev` prints `go version ...`
- verified discovered golang `default` + `dev` configs for 1.20-1.26 all render `cmd: version`

Closes #672
Closes #673
Closes #674
Closes #675
Closes #676
Closes #677
Closes #678
Closes #679
Closes #680
Closes #681
Closes #682
Closes #683
Closes #684
Closes #685

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add generic cmd support and set Go images to use cmd: version, so smoke treats them as bounded. Running the image with no args now prints the Go version, while explicit args still override.

- **New Features**
  - Support cmd in Integer config and apko rendering (with version substitution).
  - Added loader and renderer tests for cmd.

- **Bug Fixes**
  - Set Go default/dev/FIPS images to cmd: version.
  - Smoke no longer flags Go images as unbounded; docker inspect shows Entrypoint ["/usr/bin/go"] and Cmd ["version"].

<sup>Written for commit 892f113b0135385d18c49220addac2b336d0ca3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

