### PR TITLE
fix(integer): rebuild istio default streams

### DIFF
--- a/.github/scripts/melange-check.sh
+++ b/.github/scripts/melange-check.sh
@@ -8,14 +8,42 @@ set -euo pipefail
 : "${IMAGE:?IMAGE is required}"
 : "${TYPE:?TYPE is required}"
 
+resolve_version_template() {
+  local value="$1"
+
+  if [[ "$value" == *"{{version}}"* ]]; then
+    if [ -z "${VERSION:-}" ]; then
+      echo "melange value ${value} contains {{version}} but VERSION is not set" >&2
+      exit 1
+    fi
+    value=${value//\{\{version\}\}/$VERSION}
+  fi
+
+  printf '%s' "$value"
+}
+
 image_yaml="images/${IMAGE}.yaml"
 
 raw_bespoke=$(yq -o=json ".types.\"${TYPE}\".melange.bespoke // []" "$image_yaml")
-upstream=$(yq -r ".types.\"${TYPE}\".melange.upstream // \"\"" "$image_yaml")
-env_file=$(yq -r ".types.\"${TYPE}\".melange.env-file // \"\"" "$image_yaml")
-build_option=$(yq -r ".types.\"${TYPE}\".melange.build-option // \"\"" "$image_yaml")
+upstream=$(resolve_version_template "$(yq -r ".types.\"${TYPE}\".melange.upstream // \"\"" "$image_yaml")")
+env_file=$(resolve_version_template "$(yq -r ".types.\"${TYPE}\".melange.env-file // \"\"" "$image_yaml")")
+build_option=$(resolve_version_template "$(yq -r ".types.\"${TYPE}\".melange.build-option // \"\"" "$image_yaml")")
 
-bespoke_json=$(printf '%s' "$raw_bespoke" | jq -c 'if type == "array" then . elif . == null or . == "" then [] else [.] end')
+bespoke_json=$(printf '%s' "$raw_bespoke" | jq -c --arg version "${VERSION:-}" '
+  def resolve:
+    if type != "string" then .
+    elif contains("{{version}}") then
+      if $version == "" then error("melange.bespoke contains {{version}} but VERSION is not set")
+      else gsub("\\{\\{version\\}\\}"; $version)
+      end
+    else .
+    end;
+
+  if type == "array" then map(resolve)
+  elif . == null or . == "" then []
+  else [resolve]
+  end
+')
 
 if [ "$bespoke_json" != '[]' ] || [ -n "$upstream" ]; then
   needed=true

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -76,58 +76,10 @@ jobs:
       - name: Check if melange build needed
         id: check
         env:
-          INPUT_IMAGE: ${{ inputs.image }}
-          INPUT_TYPE: ${{ inputs.type }}
-        run: |
-          image_yaml="images/${INPUT_IMAGE}.yaml"
-          melange_block=$(yq -e ".types.\"${INPUT_TYPE}\".melange" "$image_yaml" 2>/dev/null) || true
-          if [ -z "$melange_block" ] || [ "$melange_block" = "null" ]; then
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-            echo "Melange build not needed for ${INPUT_IMAGE}:${INPUT_TYPE}"
-            exit 0
-          fi
-
-          raw_bespoke=$(yq -o=json ".types.\"${INPUT_TYPE}\".melange.bespoke // []" "$image_yaml")
-          upstream=$(yq -r ".types.\"${INPUT_TYPE}\".melange.upstream // \"\"" "$image_yaml")
-          env_file=$(yq -r ".types.\"${INPUT_TYPE}\".melange.env-file // \"\"" "$image_yaml")
-          build_option=$(yq -r ".types.\"${INPUT_TYPE}\".melange.build-option // \"\"" "$image_yaml")
-
-          bespoke_json=$(printf '%s' "$raw_bespoke" | jq -c 'if type == "array" then . elif . == null or . == "" then [] else [.] end')
-
-          # Require exactly one source
-          if [ -z "$upstream" ] && [ "$bespoke_json" = '[]' ]; then
-            echo "melange block present but neither upstream nor bespoke is set" >&2
-            exit 1
-          fi
-          if [ -n "$upstream" ] && [ "$bespoke_json" != '[]' ]; then
-            echo "melange block has both upstream and bespoke set — choose one" >&2
-            exit 1
-          fi
-
-          while IFS= read -r bespoke; do
-            if [[ ! "$bespoke" =~ ^[A-Za-z0-9._-]+$ ]]; then
-              echo "melange.bespoke contains unsafe characters: '${bespoke}'" >&2
-              exit 1
-            fi
-          done < <(printf '%s' "$bespoke_json" | jq -r '.[]')
-
-          # Guard scalar fields: reject multi-line values (yq emits sequences/maps with newlines)
-          for field_name in env_file build_option; do
-            field_val="${!field_name}"
-            if [[ "$field_val" == *$'\n'* ]]; then
-              echo "melange.${field_name//_/-} must be a scalar string, got multi-line value" >&2
-              exit 1
-            fi
-          done
-
-          {
-            echo "needed=true"
-            echo "upstream=${upstream}"
-            echo "bespoke_json=${bespoke_json}"
-            echo "env_file=${env_file}"
-            echo "build_option=${build_option}"
-          } >> "$GITHUB_OUTPUT"
-          echo "Melange build needed: upstream=${upstream} bespoke=${bespoke_json}"
+          IMAGE: ${{ inputs.image }}
+          TYPE: ${{ inputs.type }}
+          VERSION: ${{ inputs.version }}
+        run: .github/scripts/melange-check.sh
 
       - name: Resolve melange YAML source
         if: steps.check.outputs.needed == 'true'
@@ -562,6 +514,10 @@ jobs:
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=postgres 15 fips" >> "$GITHUB_OUTPUT"
               ;;
+            istio-install-cni:*:default|istio-pilot:*:default|istio-proxyv2:*:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
+              ;;
             *)
               echo "enabled=false" >> "$GITHUB_OUTPUT"
               ;;
@@ -591,6 +547,10 @@ jobs:
             vault:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=vault default" >> "$GITHUB_OUTPUT"
+              ;;
+            istio-install-cni:default|istio-pilot:default|istio-proxyv2:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=${{ inputs.image }} default" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "enabled=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -226,6 +226,7 @@ jobs:
         env:
           IMAGE: ${{ matrix.image }}
           TYPE: ${{ matrix.type }}
+          VERSION: ${{ matrix.version }}
         run: .github/scripts/melange-check.sh
 
       - name: Build melange package

--- a/cmd/integer_validate.go
+++ b/cmd/integer_validate.go
@@ -172,34 +172,44 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 			continue
 		}
 		for _, bespokeFile := range tmpl.Melange.Bespoke {
-			referenced[bespokeFile] = defPath
-			bespokeRefs++
-
-			if !dirExists {
-				continue
-			}
-
-			bespokePath := filepath.Join(bespokeDir, bespokeFile)
-			pkgName, berr := readBespokePackageName(bespokePath)
-			if berr != nil {
+			resolvedFiles, rerr := resolveBespokeFiles(def, typeName, bespokeFile)
+			if rerr != nil {
 				fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
-					defPath, typeName, bespokeFile, berr)
+					defPath, typeName, bespokeFile, rerr)
 				failures++
 				continue
 			}
-			if pkgName == "" {
-				fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: missing package.name\n",
-					defPath, typeName, bespokeFile)
-				failures++
-				continue
-			}
-			if !tmplPackageMatchesBespoke(def, typeName, tmpl.Packages, pkgName) {
-				fmt.Fprintf(os.Stderr,
-					"FAIL %s type %q: bespoke package.name %q not satisfiable by apko packages %v "+
-						"for any declared version of this type (apko will fail with 'not in indexes' at publish time)\n",
-					defPath, typeName, pkgName, tmpl.Packages)
-				failures++
-				continue
+
+			for _, resolvedFile := range resolvedFiles {
+				referenced[resolvedFile] = defPath
+				bespokeRefs++
+
+				if !dirExists {
+					continue
+				}
+
+				bespokePath := filepath.Join(bespokeDir, resolvedFile)
+				pkgName, berr := readBespokePackageName(bespokePath)
+				if berr != nil {
+					fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
+						defPath, typeName, resolvedFile, berr)
+					failures++
+					continue
+				}
+				if pkgName == "" {
+					fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: missing package.name\n",
+						defPath, typeName, resolvedFile)
+					failures++
+					continue
+				}
+				if !tmplPackageMatchesBespoke(def, typeName, tmpl.Packages, pkgName) {
+					fmt.Fprintf(os.Stderr,
+						"FAIL %s type %q: bespoke package.name %q not satisfiable by apko packages %v "+
+							"for any declared version of this type (apko will fail with 'not in indexes' at publish time)\n",
+						defPath, typeName, pkgName, tmpl.Packages)
+					failures++
+					continue
+				}
 			}
 		}
 	}
@@ -212,6 +222,36 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 	}
 
 	return failures
+}
+
+func resolveBespokeFiles(def *intconfig.ImageDef, typeName, bespokeFile string) ([]string, error) {
+	if !strings.Contains(bespokeFile, "{{version}}") {
+		return []string{bespokeFile}, nil
+	}
+
+	versions := make([]string, 0, len(def.Versions))
+	for version, meta := range def.Versions {
+		if slices.Contains(meta.SkipTypes, typeName) {
+			continue
+		}
+		versions = append(versions, version)
+	}
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("contains {{version}} but type %q has no declared versions to resolve", typeName)
+	}
+
+	apkindex.SortVersions(versions)
+	resolved := make([]string, 0, len(versions))
+	seen := make(map[string]struct{}, len(versions))
+	for _, version := range versions {
+		name := strings.ReplaceAll(bespokeFile, "{{version}}", version)
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		resolved = append(resolved, name)
+	}
+	return resolved, nil
 }
 
 func tmplPackageMatchesBespoke(def *intconfig.ImageDef, typeName string, packages []string, pkgName string) bool {

--- a/cmd/integer_validate_test.go
+++ b/cmd/integer_validate_test.go
@@ -142,13 +142,10 @@ types:
     packages: ["haproxy-{{version}}"]
     entrypoint: /usr/bin/haproxy
     melange:
-      bespoke:
-        - haproxy-3.0.yaml
-        - haproxy-3.1.yaml
+      bespoke: "haproxy-{{version}}.yaml"
 versions:
   "3.0": {}
   "3.1": {}
-  "3.2": {}
 `
 
 const intTestHaproxy30BespokeYAML = `

--- a/images/istio-install-cni.yaml
+++ b/images/istio-install-cni.yaml
@@ -8,6 +8,14 @@ types:
     base: wolfi-base
     packages: ["istio-install-cni-{{version}}"]
     entrypoint: /usr/bin/install-cni
+    melange:
+      bespoke: "istio-install-cni-{{version}}.yaml"
 
 versions:
-  "1": {}
+  "1":
+    latest: true
+  "1.26": {}
+  "1.27": {}
+  "1.28": {}
+  "1.29": {}
+  "1.30": {}

--- a/images/istio-pilot.yaml
+++ b/images/istio-pilot.yaml
@@ -8,6 +8,13 @@ types:
     base: wolfi-base
     packages: ["istio-pilot-discovery-{{version}}"]
     entrypoint: /usr/bin/pilot-discovery
+    melange:
+      bespoke: "istio-pilot-discovery-{{version}}.yaml"
 
 versions:
-  "1": {}
+  "1.26": {}
+  "1.27": {}
+  "1.28": {}
+  "1.29": {}
+  "1.30":
+    latest: true

--- a/images/istio-proxyv2.yaml
+++ b/images/istio-proxyv2.yaml
@@ -8,6 +8,15 @@ types:
     base: wolfi-base
     packages: ["istio-envoy-{{version}}", "istio-pilot-agent-{{version}}"]
     entrypoint: /usr/bin/pilot-agent
+    melange:
+      bespoke: "istio-pilot-agent-{{version}}.yaml"
 
 versions:
-  "1": {}
+  "1":
+    latest: true
+  "1.25": {}
+  "1.26": {}
+  "1.27": {}
+  "1.28": {}
+  "1.29": {}
+  "1.30": {}

--- a/internal/integer/discovery/discover.go
+++ b/internal/integer/discovery/discover.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/verity-org/verity/internal/integer/apkindex"
 	"github.com/verity-org/verity/internal/integer/config"
 	"github.com/verity-org/verity/internal/integer/render"
@@ -39,6 +41,12 @@ type Options struct {
 	// GenDir is the directory where generated apko YAML files are written.
 	// Defaults to a system temp directory if empty.
 	GenDir string
+}
+
+type bespokeTagPackageFile struct {
+	Package struct {
+		Version string `yaml:"version"`
+	} `yaml:"package"`
 }
 
 // DiscoverFromFiles walks imagesDir recursively for image *.yaml files
@@ -149,17 +157,20 @@ func expandImage(def *config.ImageDef, imagesDir, registry string, pkgs []apkind
 	for _, v := range versions {
 		renderVersion := ResolveStreamRenderVersion(def, pkgs, v)
 
-		// Resolve full version from APKINDEX for semver tag expansion. Use
-		// the aliased stem so semver cascade tags ("1.17", "1.17.5") still
-		// expand correctly when the declared stream is a floating-major.
-		fullVersion := apkindex.ResolveFullVersion(pkgs, resolutionPattern, renderVersion)
-		tags := DeriveTags(v, latestVersion, fullVersion)
-
 		for typeName := range def.Types {
 			if ShouldSkipType(def, v, typeName) {
 				continue
 			}
 			tmpl := def.Types[typeName]
+
+			// Resolve full version from APKINDEX for semver tag expansion. Use
+			// the aliased stem so semver cascade tags ("1.17", "1.17.5") still
+			// expand correctly when the declared stream is a floating-major.
+			fullVersion := apkindex.ResolveFullVersion(pkgs, resolutionPattern, renderVersion)
+			if bespokeVersion, ok := resolveSingleBespokeVersion(imagesDir, &tmpl, v); ok {
+				fullVersion = bespokeVersion
+			}
+			tags := DeriveTags(v, latestVersion, fullVersion)
 
 			out, err := render.Config(&tmpl, renderVersion, basePath)
 			if err != nil {
@@ -195,6 +206,32 @@ func expandImage(def *config.ImageDef, imagesDir, registry string, pkgs []apkind
 	})
 
 	return results, nil
+}
+
+func resolveSingleBespokeVersion(imagesDir string, tmpl *config.TypeTemplate, version string) (string, bool) {
+	if tmpl == nil || tmpl.Melange == nil || len(tmpl.Melange.Bespoke) != 1 {
+		return "", false
+	}
+
+	bespokeFile := tmpl.Melange.Bespoke[0]
+	if strings.Contains(bespokeFile, "{{version}}") {
+		bespokeFile = strings.ReplaceAll(bespokeFile, "{{version}}", version)
+	}
+
+	bespokePath := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke", bespokeFile)
+	data, err := os.ReadFile(bespokePath)
+	if err != nil {
+		return "", false
+	}
+
+	var pkgFile bespokeTagPackageFile
+	if err := yaml.Unmarshal(data, &pkgFile); err != nil {
+		return "", false
+	}
+	if pkgFile.Package.Version == "" {
+		return "", false
+	}
+	return pkgFile.Package.Version, true
 }
 
 // ShouldSkipType reports whether a type should be omitted for a specific

--- a/internal/integer/discovery/discover_test.go
+++ b/internal/integer/discovery/discover_test.go
@@ -570,6 +570,70 @@ func TestDiscoverFromFiles_FullSemverTags(t *testing.T) {
 	}
 }
 
+func TestDiscoverFromFiles_BespokeVersionOverridesSemverTags(t *testing.T) {
+	const istioYAML = `
+name: istio-pilot
+description: "Istio Pilot"
+upstream:
+  package: "istio-pilot-discovery-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["istio-pilot-discovery-{{version}}"]
+    entrypoint: /usr/bin/pilot-discovery
+    melange:
+      bespoke: "istio-pilot-discovery-{{version}}.yaml"
+versions:
+  "1":
+    latest: true
+  "1.26": {}
+  "1.30": {}
+`
+	const bespoke126 = `
+package:
+  name: istio-pilot-discovery-1.26
+  version: "1.26.8"
+  epoch: 4
+`
+	const bespoke1 = `
+package:
+  name: istio-pilot-discovery-1.30
+  version: "1.30.2"
+  epoch: 0
+`
+	const bespoke130 = `
+package:
+  name: istio-pilot-discovery-1.30
+  version: "1.30.2"
+  epoch: 0
+`
+
+	imagesDir := setupImages(t, map[string]string{"istio-pilot.yaml": istioYAML})
+	writeFile(t, filepath.Dir(imagesDir), filepath.Join("packages", "bespoke", "istio-pilot-discovery-1.26.yaml"), bespoke126)
+	writeFile(t, filepath.Dir(imagesDir), filepath.Join("packages", "bespoke", "istio-pilot-discovery-1.yaml"), bespoke1)
+	writeFile(t, filepath.Dir(imagesDir), filepath.Join("packages", "bespoke", "istio-pilot-discovery-1.30.yaml"), bespoke130)
+	genDir := t.TempDir()
+
+	pkgs := []apkindex.Package{
+		{Name: "istio-pilot-discovery-1.26", Version: "1.26.4-r1"},
+		{Name: "istio-pilot-discovery-1.30", Version: "1.30.1-r0"},
+	}
+
+	imgs, err := discovery.DiscoverFromFiles(opts(imagesDir, genDir, pkgs))
+	require.NoError(t, err)
+
+	got := map[string][]string{}
+	for _, img := range imgs {
+		if img.Type == typeDefault {
+			got[img.Version] = img.Tags
+		}
+	}
+
+	assert.Equal(t, []string{"1", "1.30", "1.30.2"}, got["1"])
+	assert.Equal(t, []string{"1.26", "1.26.8"}, got["1.26"])
+	assert.Equal(t, []string{"1.30", "1.30.2", "latest"}, got["1.30"])
+}
+
 func TestDiscoverFromFiles_UnversionedLatestGuard(t *testing.T) {
 	// Unversioned package (caddy-like) with explicit version stream "2".
 	// ResolveVersions drops auto-discovered "latest" when explicit versions

--- a/packages/bespoke/istio-install-cni-1.26.yaml
+++ b/packages/bespoke/istio-install-cni-1.26.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-install-cni-1.26
+  version: "1.26.8"
+  epoch: 4
+  description: Istio CNI installer
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: ebd05d044ab3e139f304ea26dc9b8263d53c2aeb
+  - uses: go/build
+    with:
+      packages: ./cni/cmd/install-cni
+      output: install-cni
+  - uses: strip

--- a/packages/bespoke/istio-install-cni-1.27.yaml
+++ b/packages/bespoke/istio-install-cni-1.27.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-install-cni-1.27
+  version: "1.27.9"
+  epoch: 2
+  description: Istio CNI installer
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: cea9e4a2fda24daea7dbca5115fd42b99f05bb1c
+  - uses: go/build
+    with:
+      packages: ./cni/cmd/install-cni
+      output: install-cni
+  - uses: strip

--- a/packages/bespoke/istio-install-cni-1.28.yaml
+++ b/packages/bespoke/istio-install-cni-1.28.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-install-cni-1.28
+  version: "1.28.7"
+  epoch: 3
+  description: Istio CNI installer
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 8841aa2300644a6f2086a0d20b1ec1699387d4db
+  - uses: go/build
+    with:
+      packages: ./cni/cmd/install-cni
+      output: install-cni
+  - uses: strip

--- a/packages/bespoke/istio-install-cni-1.29.yaml
+++ b/packages/bespoke/istio-install-cni-1.29.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-install-cni-1.29
+  version: "1.29.5"
+  epoch: 0
+  description: Istio CNI installer
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: f31fd6420e773538b031d4d6c9a770f33ee4144a
+  - uses: go/build
+    with:
+      packages: ./cni/cmd/install-cni
+      output: install-cni
+  - uses: strip

--- a/packages/bespoke/istio-install-cni-1.30.yaml
+++ b/packages/bespoke/istio-install-cni-1.30.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-install-cni-1.30
+  version: "1.30.2"
+  epoch: 0
+  description: Istio CNI installer
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 4e213fa7bafe4e932c3b3bb1b97dd022e7bc9583
+  - uses: go/build
+    with:
+      packages: ./cni/cmd/install-cni
+      output: install-cni
+  - uses: strip

--- a/packages/bespoke/istio-install-cni-1.yaml
+++ b/packages/bespoke/istio-install-cni-1.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-install-cni-1.30
+  version: "1.30.2"
+  epoch: 0
+  description: Istio CNI installer
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 4e213fa7bafe4e932c3b3bb1b97dd022e7bc9583
+  - uses: go/build
+    with:
+      packages: ./cni/cmd/install-cni
+      output: install-cni
+  - uses: strip

--- a/packages/bespoke/istio-pilot-agent-1.25.yaml
+++ b/packages/bespoke/istio-pilot-agent-1.25.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-agent-1.25
+  version: "1.25.5"
+  epoch: 5
+  description: Istio pilot agent
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 06c353b5cfea54b71b42af1e5cae4d592eae718f
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+  - uses: strip

--- a/packages/bespoke/istio-pilot-agent-1.26.yaml
+++ b/packages/bespoke/istio-pilot-agent-1.26.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-agent-1.26
+  version: "1.26.8"
+  epoch: 4
+  description: Istio pilot agent
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: ebd05d044ab3e139f304ea26dc9b8263d53c2aeb
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+  - uses: strip

--- a/packages/bespoke/istio-pilot-agent-1.27.yaml
+++ b/packages/bespoke/istio-pilot-agent-1.27.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-agent-1.27
+  version: "1.27.9"
+  epoch: 2
+  description: Istio pilot agent
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: cea9e4a2fda24daea7dbca5115fd42b99f05bb1c
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+  - uses: strip

--- a/packages/bespoke/istio-pilot-agent-1.28.yaml
+++ b/packages/bespoke/istio-pilot-agent-1.28.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-agent-1.28
+  version: "1.28.7"
+  epoch: 3
+  description: Istio pilot agent
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 8841aa2300644a6f2086a0d20b1ec1699387d4db
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+  - uses: strip

--- a/packages/bespoke/istio-pilot-agent-1.29.yaml
+++ b/packages/bespoke/istio-pilot-agent-1.29.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-agent-1.29
+  version: "1.29.5"
+  epoch: 0
+  description: Istio pilot agent
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: f31fd6420e773538b031d4d6c9a770f33ee4144a
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+  - uses: strip

--- a/packages/bespoke/istio-pilot-agent-1.30.yaml
+++ b/packages/bespoke/istio-pilot-agent-1.30.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-agent-1.30
+  version: "1.30.2"
+  epoch: 0
+  description: Istio pilot agent
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 4e213fa7bafe4e932c3b3bb1b97dd022e7bc9583
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+  - uses: strip

--- a/packages/bespoke/istio-pilot-agent-1.yaml
+++ b/packages/bespoke/istio-pilot-agent-1.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-agent-1.30
+  version: "1.30.2"
+  epoch: 0
+  description: Istio pilot agent
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 4e213fa7bafe4e932c3b3bb1b97dd022e7bc9583
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+  - uses: strip

--- a/packages/bespoke/istio-pilot-discovery-1.26.yaml
+++ b/packages/bespoke/istio-pilot-discovery-1.26.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-discovery-1.26
+  version: "1.26.8"
+  epoch: 4
+  description: Istio pilot discovery service
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: ebd05d044ab3e139f304ea26dc9b8263d53c2aeb
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-discovery
+      output: pilot-discovery
+  - uses: strip

--- a/packages/bespoke/istio-pilot-discovery-1.27.yaml
+++ b/packages/bespoke/istio-pilot-discovery-1.27.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-discovery-1.27
+  version: "1.27.9"
+  epoch: 2
+  description: Istio pilot discovery service
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: cea9e4a2fda24daea7dbca5115fd42b99f05bb1c
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-discovery
+      output: pilot-discovery
+  - uses: strip

--- a/packages/bespoke/istio-pilot-discovery-1.28.yaml
+++ b/packages/bespoke/istio-pilot-discovery-1.28.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-discovery-1.28
+  version: "1.28.7"
+  epoch: 3
+  description: Istio pilot discovery service
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 8841aa2300644a6f2086a0d20b1ec1699387d4db
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-discovery
+      output: pilot-discovery
+  - uses: strip

--- a/packages/bespoke/istio-pilot-discovery-1.29.yaml
+++ b/packages/bespoke/istio-pilot-discovery-1.29.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-discovery-1.29
+  version: "1.29.5"
+  epoch: 0
+  description: Istio pilot discovery service
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: f31fd6420e773538b031d4d6c9a770f33ee4144a
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-discovery
+      output: pilot-discovery
+  - uses: strip

--- a/packages/bespoke/istio-pilot-discovery-1.30.yaml
+++ b/packages/bespoke/istio-pilot-discovery-1.30.yaml
@@ -1,0 +1,31 @@
+package:
+  name: istio-pilot-discovery-1.30
+  version: "1.30.2"
+  epoch: 0
+  description: Istio pilot discovery service
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 4e213fa7bafe4e932c3b3bb1b97dd022e7bc9583
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-discovery
+      output: pilot-discovery
+  - uses: strip


### PR DESCRIPTION
## Summary
- rebuild Istio default Integer streams from bespoke source packages for install-cni, pilot, and proxyv2
- resolve version-templated `melange.bespoke` references in validation/workflows and derive tags from bespoke recipe versions
- enforce zero HIGH/CRITICAL Trivy gates for the Istio default image family in `integer-build-image.yaml`

## Root cause
Wolfi's published Istio Go packages lagged the Wolfi secdb fix levels and upstream Istio patch streams, so Integer builds for `istio-install-cni`, `istio-pilot`, and `istio-proxyv2` pulled stale vulnerable packages for 1.25-1.30. Integer discovery also derived patch tags from Wolfi APKINDEX even when bespoke recipes built newer versions, which would have published mismatched tags without this fix.

## Before / after HIGH+CRITICAL counts
- `istio-install-cni`: `1.26 33→0`, `1.27 31→0`, `1.28 11→0`, `1.29 0→0`, `1.30 0→0`, `1 0→0` (`1` now aliases `1.30.2`)
- `istio-pilot`: `1.26 33→0`, `1.27 31→0`, `1.28 11→0`, `1.29 2→0`, `1.30 0→0`
- `istio-proxyv2`: `1.25 2→0`, `1.26 33→0`, `1.27 31→0`, `1.28 11→0`, `1.29 2→0`, `1.30 0→0`, `1 0→0` (`1` now aliases `1.30.2`)

## Verification
- `go test ./...`
- `./verity integer validate`
- `actionlint`
- `yamllint` on changed workflow/image/bespoke YAML files
- manual CLI QA: `./verity integer validate --help`, `./verity integer discover --only istio-pilot --gen-dir ./gen`, bad-path `./verity integer build --image istio-pilot --version 1.26 --type nope`
- manual `apko` + `trivy` rescans for all affected concrete versions and the `1` aliases

Closes #706
Closes #707
Closes #708
Closes #709
Closes #710
Closes #711
Closes #712
Closes #713
Closes #714
Closes #715
Closes #716
Closes #717
Closes #718
Closes #719
Closes #720
Closes #721
Closes #722
Closes #723


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt Istio default streams from bespoke recipes for `istio-install-cni`, `istio-pilot`, and `istio-proxyv2`, fixed version/tag resolution, and gated builds to 0 HIGH/CRITICAL in Trivy.

- **New Features**
  - Added bespoke `melange` recipes for Istio 1.25–1.30 and wired images via `melange.bespoke: "<name>-{{version}}.yaml"`.
  - Discovery derives semver tags from the bespoke `package.version`; `1` aliases updated to 1.30.2 where applicable.

- **Bug Fixes**
  - Resolved `{{version}}` placeholders in `melange` fields across validation and CI to prevent stale/missing builds.
  - Enforced a Trivy gate of zero HIGH/CRITICAL for Istio default images; all affected streams now pass.

<sup>Written for commit b854ecfede2900d129252d02616e1bc702f967c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

