### PR TITLE
fix(integer): gate stale-zero trivy sweep

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -566,6 +566,56 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve Trivy gate policy
+        id: trivy-gate-rebuildable-sweep
+        run: |
+          case "${{ inputs.image }}:${{ inputs.version }}:${{ inputs.type }}" in
+            cloudflared:2025:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=cloudflared 2025 default" >> "$GITHUB_OUTPUT"
+              ;;
+            conftest:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=conftest 0 default" >> "$GITHUB_OUTPUT"
+              ;;
+            filebrowser:2:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=filebrowser 2 default" >> "$GITHUB_OUTPUT"
+              ;;
+            harbor-cli:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=harbor-cli 0 default" >> "$GITHUB_OUTPUT"
+              ;;
+            k9s:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=k9s 0 default" >> "$GITHUB_OUTPUT"
+              ;;
+            mailpit:1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=mailpit 1 default" >> "$GITHUB_OUTPUT"
+              ;;
+            rclone:1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=rclone 1 default" >> "$GITHUB_OUTPUT"
+              ;;
+            trufflehog:3:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=trufflehog 3 default" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "enabled=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Enforce Trivy gate
+        if: steps.trivy-gate-rebuildable-sweep.outputs.enabled == 'true'
+        run: |
+          findings=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' trivy-report.json)
+          if [ "$findings" -ne 0 ]; then
+            echo "${{ steps.trivy-gate-rebuildable-sweep.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
+            exit 1
+          fi
+
       # ── Sign & attest ──────────────────────────────────────────────────────
 
       - name: Sign image with cosign (keyless)

--- a/images/istio-install-cni.yaml
+++ b/images/istio-install-cni.yaml
@@ -9,7 +9,13 @@ types:
     packages: ["istio-install-cni-{{version}}"]
     entrypoint: /usr/bin/install-cni
     melange:
-      bespoke: "istio-install-cni-{{version}}.yaml"
+      bespoke:
+        - "istio-install-cni-1.yaml"
+        - "istio-install-cni-1.26.yaml"
+        - "istio-install-cni-1.27.yaml"
+        - "istio-install-cni-1.28.yaml"
+        - "istio-install-cni-1.29.yaml"
+        - "istio-install-cni-1.30.yaml"
 
 versions:
   "1":

--- a/images/istio-pilot.yaml
+++ b/images/istio-pilot.yaml
@@ -9,7 +9,12 @@ types:
     packages: ["istio-pilot-discovery-{{version}}"]
     entrypoint: /usr/bin/pilot-discovery
     melange:
-      bespoke: "istio-pilot-discovery-{{version}}.yaml"
+      bespoke:
+        - "istio-pilot-discovery-1.26.yaml"
+        - "istio-pilot-discovery-1.27.yaml"
+        - "istio-pilot-discovery-1.28.yaml"
+        - "istio-pilot-discovery-1.29.yaml"
+        - "istio-pilot-discovery-1.30.yaml"
 
 versions:
   "1.26": {}

--- a/images/istio-proxyv2.yaml
+++ b/images/istio-proxyv2.yaml
@@ -9,7 +9,14 @@ types:
     packages: ["istio-envoy-{{version}}", "istio-pilot-agent-{{version}}"]
     entrypoint: /usr/bin/pilot-agent
     melange:
-      bespoke: "istio-pilot-agent-{{version}}.yaml"
+      bespoke:
+        - "istio-pilot-agent-1.yaml"
+        - "istio-pilot-agent-1.25.yaml"
+        - "istio-pilot-agent-1.26.yaml"
+        - "istio-pilot-agent-1.27.yaml"
+        - "istio-pilot-agent-1.28.yaml"
+        - "istio-pilot-agent-1.29.yaml"
+        - "istio-pilot-agent-1.30.yaml"
 
 versions:
   "1":


### PR DESCRIPTION
## Summary
- gate verified zero-HIGH/CRITICAL integer images in `integer-build-image.yaml`
- restore explicit Istio bespoke file lists so `./verity integer validate` stays green after rebase
- document blocked pure-APK issues and queue clear bespoke families separately

## Verified stale-zero closures
- Closes #652
- Closes #654
- Closes #668
- Closes #703
- Closes #725
- Closes #786
- Closes #819
- Closes #860

## Not closed here
- upstream-blocked pure-APK issues were commented with current vs required Wolfi revisions
- bespoke-source families were commented and left open for the expensive rebuild pass

## Validation
- `./verity integer validate`
- `actionlint .github/workflows/integer-build-image.yaml`
- `yamllint .github/workflows/integer-build-image.yaml images/istio-install-cni.yaml images/istio-pilot.yaml images/istio-proxyv2.yaml`
- `python3 .github/scripts/validate-integer-build-image-workflow.py`
- local `./verity integer build` + Trivy for processed families

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a zero HIGH/CRITICAL Trivy gate for selected rebuildable images and restores explicit Istio bespoke file lists to keep validation green. This tightens the stale-zero sweep and prevents regressions after rebases.

- **New Features**
  - Added Trivy gate in `.github/workflows/integer-build-image.yaml` for selected images (cloudflared:2025, conftest:0, filebrowser:2, harbor-cli:0, k9s:0, mailpit:1, rclone:1, trufflehog:3); the job fails if any HIGH/CRITICAL is found in `trivy-report.json`.

- **Bug Fixes**
  - Restored explicit bespoke lists in `images/istio-install-cni.yaml`, `images/istio-pilot.yaml`, and `images/istio-proxyv2.yaml` so `./verity integer validate` stays green.

<sup>Written for commit 661e5723da66e2fd69c5dfdbb192828da5a5852a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

