### PR TITLE
fix(integer): gate stale-zero trivy sweep 2

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -570,6 +570,38 @@ jobs:
         id: trivy-gate-rebuildable-sweep
         run: |
           case "${{ inputs.image }}:${{ inputs.version }}:${{ inputs.type }}" in
+            alertmanager:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=alertmanager 0 default" >> "$GITHUB_OUTPUT"
+              ;;
+            apisix-ingress-controller:1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=apisix-ingress-controller 1 default" >> "$GITHUB_OUTPUT"
+              ;;
+            argo-workflow-controller:3:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=argo-workflow-controller 3 default" >> "$GITHUB_OUTPUT"
+              ;;
+            azure-workload-identity-webhook:1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=azure-workload-identity-webhook 1 default" >> "$GITHUB_OUTPUT"
+              ;;
+            bank-vaults:1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=bank-vaults 1 default" >> "$GITHUB_OUTPUT"
+              ;;
+            boring-registry:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=boring-registry 0 default" >> "$GITHUB_OUTPUT"
+              ;;
+            cert-manager-istio-csr:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=cert-manager-istio-csr 0 default" >> "$GITHUB_OUTPUT"
+              ;;
+            cilium-cli:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=cilium-cli 0 default" >> "$GITHUB_OUTPUT"
+              ;;
             cloudflared:2025:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=cloudflared 2025 default" >> "$GITHUB_OUTPUT"
@@ -586,6 +618,18 @@ jobs:
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=harbor-cli 0 default" >> "$GITHUB_OUTPUT"
               ;;
+            cortex:1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=cortex 1 default" >> "$GITHUB_OUTPUT"
+              ;;
+            external-secrets:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=external-secrets 0 default" >> "$GITHUB_OUTPUT"
+              ;;
+            hydra:2:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=hydra 2 default" >> "$GITHUB_OUTPUT"
+              ;;
             k9s:0:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=k9s 0 default" >> "$GITHUB_OUTPUT"
@@ -594,13 +638,37 @@ jobs:
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=mailpit 1 default" >> "$GITHUB_OUTPUT"
               ;;
+            openbao:2:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=openbao 2 default" >> "$GITHUB_OUTPUT"
+              ;;
+            opentelemetry-collector:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=opentelemetry-collector 0 default" >> "$GITHUB_OUTPUT"
+              ;;
             rclone:1:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=rclone 1 default" >> "$GITHUB_OUTPUT"
               ;;
+            spicedb:1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=spicedb 1 default" >> "$GITHUB_OUTPUT"
+              ;;
+            tempo:2:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=tempo 2 default" >> "$GITHUB_OUTPUT"
+              ;;
+            thanos:0:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=thanos 0 default" >> "$GITHUB_OUTPUT"
+              ;;
             trufflehog:3:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=trufflehog 3 default" >> "$GITHUB_OUTPUT"
+              ;;
+            velero:1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=velero 1 default" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "enabled=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- gate 17 stale-zero Integer Trivy families in integer-build-image workflow
- close stale open issues proven zero by fresh apko+Trivy on current main
- leave 32 non-zero families open with blocked triage comments documenting current -> required Wolfi revisions

## Validation
- actionlint
- yamllint -c .yamllint.yml .github/workflows/integer-build-image.yaml
- ./verity integer validate
- fresh apko+Trivy sweep across 49 live pure-APK issue families

Closes #610
Closes #611
Closes #613
Closes #623
Closes #624
Closes #626
Closes #644
Closes #647
Closes #655
Closes #666
Closes #705
Closes #796
Closes #803
Closes #827
Closes #841
Closes #850
Closes #862

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated 17 stale-zero Trivy scan families in the `integer-build-image` workflow to cut rebuildable sweep noise and close proven-zero issues. Left 32 non-zero families open with triage notes pointing to required Wolfi revisions.

- **New Features**
  - Added gating in `trivy-gate-rebuildable-sweep` for 17 families (e.g., `alertmanager:0`, `apisix-ingress-controller:1`, `argo-workflow-controller:3`, `hydra:2`, `thanos:0`, `velero:1`).
  - For these inputs, the step now emits `enabled=true` with a clear `label`; all others default to `enabled=false`.

<sup>Written for commit 6ea40a0994e406e38a00f03bb26e2010eb53d7df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

