### PR TITLE
fix(copa): drop unpatchable targets + refine standalone mappings

### DIFF
--- a/cmd/integer_validate.go
+++ b/cmd/integer_validate.go
@@ -16,7 +16,10 @@ import (
 	intconfig "github.com/verity-org/verity/internal/integer/config"
 )
 
-var errIntegerValidationFailed = errors.New("validation failed")
+var (
+	errIntegerValidationFailed    = errors.New("validation failed")
+	errMissingDeclaredVersionType = errors.New("contains {{version}} but type has no declared versions to resolve")
+)
 
 // bespokePkgFile is the minimal subset of a melange yaml needed to verify the
 // package name. Other fields (environment, pipeline, etc.) are intentionally
@@ -237,7 +240,7 @@ func resolveBespokeFiles(def *intconfig.ImageDef, typeName, bespokeFile string) 
 		versions = append(versions, version)
 	}
 	if len(versions) == 0 {
-		return nil, fmt.Errorf("contains {{version}} but type %q has no declared versions to resolve", typeName)
+		return nil, fmt.Errorf("%w: %q", errMissingDeclaredVersionType, typeName)
 	}
 
 	apkindex.SortVersions(versions)

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -270,19 +270,6 @@ images:
   #  MONITORING & OBSERVABILITY
   # ============================================================================
 
-  # -- VictoriaMetrics --
-  - name: "victoriametrics/victoria-logs"
-    image: "quay.io/victoriametrics/victoria-logs"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 1
-    # Go binary built with -trimpath (no VCS info in binary).
-    # OCI label points to monorepo (wrong directory at older tags).
-    # goVcsUrl overrides to the correct standalone source repo.
-    goVcsUrl: "https://github.com/VictoriaMetrics/VictoriaLogs"
-
   # -- Prometheus ecosystem --
 
   - name: "prometheus/prometheus"

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -234,15 +234,6 @@ images:
       pattern: '^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$'
       maxTags: 3
 
-  - name: "aws/eks-distro/kubernetes/kube-proxy"
-    image: "public.ecr.aws/eks-distro/kubernetes/kube-proxy"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$'
-      maxTags: 3
-      exclude: ["v1.36.0-eks-1-36-2"]
-
   - name: "aws/eks-distro/kubernetes-csi/node-driver-registrar"
     image: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
     platforms: ["linux/amd64", "linux/arm64"]

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -270,6 +270,19 @@ images:
   #  MONITORING & OBSERVABILITY
   # ============================================================================
 
+  # -- VictoriaMetrics --
+  - name: "victoriametrics/victoria-logs"
+    image: "quay.io/victoriametrics/victoria-logs"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 1
+    # Go binary built with -trimpath (no VCS info in binary).
+    # OCI label points to monorepo (wrong directory at older tags).
+    # goVcsUrl overrides to the correct standalone source repo.
+    goVcsUrl: "https://github.com/VictoriaMetrics/VictoriaLogs"
+
   # -- Prometheus ecosystem --
 
   - name: "prometheus/prometheus"

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -519,7 +519,6 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		{name: "aws/eks-distro/coredns/coredns", image: "public.ecr.aws/eks-distro/coredns/coredns", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
 		{name: "aws/eks-distro/kubernetes/kube-apiserver", image: "public.ecr.aws/eks-distro/kubernetes/kube-apiserver", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
 		{name: "aws/eks-distro/kubernetes/kube-scheduler", image: "public.ecr.aws/eks-distro/kubernetes/kube-scheduler", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
-		{name: "aws/eks-distro/kubernetes/kube-proxy", image: "public.ecr.aws/eks-distro/kubernetes/kube-proxy", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
 		{name: "aws/eks-distro/kubernetes-csi/node-driver-registrar", image: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
 		{name: "prometheus/mysqld-exporter", image: "quay.io/prometheus/mysqld-exporter", pattern: `^v\d+\.\d+\.\d+$`},
 		{name: "datadog/agent", image: "docker.io/datadog/agent", pattern: `^\d+\.\d+\.\d+$`},
@@ -542,7 +541,7 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		}
 	}
 
-	removed := []string{"spiffe/spiffe-helper", "tektoncd/cli", "kubeflow/spark-operator"}
+	removed := []string{"spiffe/spiffe-helper", "tektoncd/cli", "kubeflow/spark-operator", "aws/eks-distro/kubernetes/kube-proxy"}
 	for _, name := range removed {
 		if _, ok := byName[name]; ok {
 			t.Errorf("config still contains removed unsupported image %q", name)

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -541,6 +541,14 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		}
 	}
 
+	defaultBackend, ok := byName["kubernetes/ingress-nginx/defaultbackend"]
+	if !ok {
+		t.Fatal("config missing kubernetes/ingress-nginx/defaultbackend")
+	}
+	if got := strings.Join(defaultBackend.Tags.Exclude, ","); got != "1.0,1.1,1.2" {
+		t.Errorf("defaultbackend exclude = %q, want %q", got, "1.0,1.1,1.2")
+	}
+
 	removed := []string{"spiffe/spiffe-helper", "tektoncd/cli", "kubeflow/spark-operator", "aws/eks-distro/kubernetes/kube-proxy"}
 	for _, name := range removed {
 		if _, ok := byName[name]; ok {

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -332,12 +332,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "public.ecr.aws/eks-distro/kubernetes/kube-scheduler",
       },
       {
-        name: "aws/eks-distro/kubernetes/kube-proxy",
-        label: "eks-distro-kube-proxy",
-        source: "copa",
-        upstream: "public.ecr.aws/eks-distro/kubernetes/kube-proxy",
-      },
-      {
         name: "aws/eks-distro/kubernetes-csi/node-driver-registrar",
         label: "eks-distro-csi-node-driver-registrar",
         source: "copa",


### PR DESCRIPTION
## Summary
Post-[#866](https://github.com/verity-org/verity/pull/866) Copa/catalog cleanup PR.

- keep `victoriametrics/victoria-logs` publishable in standalone discovery + site catalog
- tighten legacy `defaultbackend` selection so PR Copa smoke picks only real patchable tags
- drop `aws/eks-distro/kubernetes/kube-proxy` from the Copa set under current Copa/EKS tooling-image behavior
- keep the standalone-source regression test aligned with the actual catalog/config state

## Why this is follow-up work
[#866](https://github.com/verity-org/verity/pull/866) merged its 24 standalone-prefix fixes, but the post-merge Copa matrix still exposed a few target-selection problems in the standalone Copa set.

## Target-by-target dispositions
- `victoriametrics/victoria-logs`: restored to `copa-config.yaml` + `site/src/data/full-catalog.ts` so it stays publishable, matching [#865](https://github.com/verity-org/verity/pull/865) / [#583](https://github.com/verity-org/verity/issues/583)
- `kubernetes/ingress-nginx/defaultbackend`: exclude `1.0`, `1.1`, `1.2` because those legacy refs resolve to non-patchable manifest-v1 images in current CI/Copa flow; `1.3+` remains patchable
- `aws/eks-distro/kubernetes/kube-proxy`: removed from the Copa set because current Copa fails on these images with Amazon Linux tooling-image resolution (`invalid reference format`) across selected tags; this is a genuine current unpatchable target, not a hidden patchable CVE
- `kubeflow/spark-operator`: removed from the standalone Copa set because current Copa leaves fixable non-Go CVEs after the Go-manager fallback path, so it is not a clean patch target today

## Validation
- `go test ./...`
- `go build -o verity .`
- `cd site && npm run lint && npm run format:check`
- `actionlint`
- `yamllint copa-config.yaml verity.yaml .github/workflows`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the Copa catalog to drop unpatchable images and tighten tag mappings so smoke tests only target patchable tags. Also standardizes an integer validation error for clearer checks.

- **Bug Fixes**
  - Removed `aws/eks-distro/kubernetes/kube-proxy` from Copa and the site catalog due to unpatchable image refs under current tooling.
  - Excluded `1.0`, `1.1`, `1.2` for `kubernetes/ingress-nginx/defaultbackend` to avoid legacy, non-patchable tags.
  - Restored `victoriametrics/victoria-logs` to standalone discovery and the site catalog to keep it publishable.
  - Synced the standalone-source regression test with the catalog (checks defaultbackend exclusions and removed `kubeflow/spark-operator` and `aws/eks-distro/kubernetes/kube-proxy`).
  - Added `errMissingDeclaredVersionType` and `%w` wrapping in integer validation to make error handling consistent.

<sup>Written for commit fdddb9e27da8a42d91cdccd7c7199cffcf452096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

