### PR TITLE
fix(integer): gate stale-zero trivy sweep 3

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -598,6 +598,14 @@ jobs:
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=cert-manager-istio-csr 0 default" >> "$GITHUB_OUTPUT"
               ;;
+            cert-manager-cainjector:1.20:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=cert-manager-cainjector 1.20 default" >> "$GITHUB_OUTPUT"
+              ;;
+            cert-manager-controller:1.20:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=cert-manager-controller 1.20 default" >> "$GITHUB_OUTPUT"
+              ;;
             cilium-cli:0:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=cilium-cli 0 default" >> "$GITHUB_OUTPUT"
@@ -638,6 +646,10 @@ jobs:
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=mailpit 1 default" >> "$GITHUB_OUTPUT"
               ;;
+            mariadb:10.11:default|mariadb:11.4:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
+              ;;
             openbao:2:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=openbao 2 default" >> "$GITHUB_OUTPUT"
@@ -657,6 +669,10 @@ jobs:
             tempo:2:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=tempo 2 default" >> "$GITHUB_OUTPUT"
+              ;;
+            traefik:3.7:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=traefik 3.7 default" >> "$GITHUB_OUTPUT"
               ;;
             thanos:0:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- gate current stale-zero Integer targets in the shared Trivy workflow
- close maintained zero-HIGH/CRITICAL issues for cert-manager, mariadb, and traefik
- leave remaining families open with per-issue triage comments for blocked/bespoke follow-up

## Validation
- make lint-workflows
- make lint-yaml
- fresh local `./verity integer build` + Trivy probes for:
  - cert-manager-cainjector:1.20-default
  - cert-manager-controller:1.20-default
  - mariadb:10.11-default
  - mariadb:11.4-default
  - traefik:3.7-default

Closes #641
Closes #643
Closes #787
Closes #789
Closes #856


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the current zero‑vuln Integer images in the shared Trivy workflow to keep them at zero and prevent regressions: `cert-manager-cainjector` 1.20, `cert-manager-controller` 1.20, `mariadb` 10.11/11.4, and `traefik` 3.7. Also closes the maintained zero‑HIGH/CRITICAL issue threads for `cert-manager`, `mariadb`, and `traefik`.

<sup>Written for commit 1e703a57e2c1269a7ce89e51aa347fcdfd63b64f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

