### PR TITLE
fix(integer): rebuild and gate telegraf default images

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -514,7 +514,7 @@ jobs:
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=postgres 15 fips" >> "$GITHUB_OUTPUT"
               ;;
-            istio-install-cni:*:default|istio-pilot:*:default|istio-proxyv2:*:default)
+            istio-install-cni:*:default|istio-pilot:*:default|istio-proxyv2:*:default|telegraf:1.34:default|telegraf:1.35:default|telegraf:1.36:default|telegraf:1.37:default|telegraf:1.38:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
               ;;

--- a/images/telegraf.yaml
+++ b/images/telegraf.yaml
@@ -8,6 +8,13 @@ types:
     base: wolfi-base
     packages: ["telegraf-{{version}}"]
     entrypoint: /usr/bin/telegraf
+    melange:
+      bespoke:
+        - telegraf-1.34.yaml
+        - telegraf-1.35.yaml
+        - telegraf-1.36.yaml
+        - telegraf-1.37.yaml
+        - telegraf-1.38.yaml
     paths:
       - {path: /etc/telegraf, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
@@ -25,5 +32,14 @@ types:
       env-file: "fips.env"
 
 versions:
+  "1.34":
+    skip-types: [fips]
+  "1.35":
+    skip-types: [fips]
+  "1.36":
+    skip-types: [fips]
   "1.37":
     skip-types: [fips]  # GOFIPS140 compilation exceeds GHA timeout; re-enable with larger runner
+  "1.38":
+    latest: true
+    skip-types: [fips]

--- a/packages/bespoke/telegraf-1.34.yaml
+++ b/packages/bespoke/telegraf-1.34.yaml
@@ -1,0 +1,39 @@
+package:
+  name: telegraf-1.34
+  version: "1.34.4"
+  epoch: 99
+  description: "Telegraf rebuilt from source for zero-CVE Integer images"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/influxdata/telegraf
+      tag: v${{package.version}}
+  - runs: |
+      mkdir -p "${{targets.contextdir}}/usr/bin"
+      mkdir -p "${{targets.contextdir}}/etc/telegraf/telegraf.d"
+      go build -trimpath -ldflags="-s -w -X github.com/influxdata/telegraf/internal.Version=${{package.version}}" -o "${{targets.contextdir}}/usr/bin/telegraf" ./cmd/telegraf
+      "${{targets.contextdir}}/usr/bin/telegraf" --sample-config > "${{targets.contextdir}}/etc/telegraf/telegraf.conf"
+      rm -rf .cache "${HOME}/.cache"
+
+test:
+  pipeline:
+    - runs: |
+        telegraf --version
+        telegraf --help

--- a/packages/bespoke/telegraf-1.35.yaml
+++ b/packages/bespoke/telegraf-1.35.yaml
@@ -1,0 +1,39 @@
+package:
+  name: telegraf-1.35
+  version: "1.35.4"
+  epoch: 99
+  description: "Telegraf rebuilt from source for zero-CVE Integer images"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/influxdata/telegraf
+      tag: v${{package.version}}
+  - runs: |
+      mkdir -p "${{targets.contextdir}}/usr/bin"
+      mkdir -p "${{targets.contextdir}}/etc/telegraf/telegraf.d"
+      go build -trimpath -ldflags="-s -w -X github.com/influxdata/telegraf/internal.Version=${{package.version}}" -o "${{targets.contextdir}}/usr/bin/telegraf" ./cmd/telegraf
+      "${{targets.contextdir}}/usr/bin/telegraf" --sample-config > "${{targets.contextdir}}/etc/telegraf/telegraf.conf"
+      rm -rf .cache "${HOME}/.cache"
+
+test:
+  pipeline:
+    - runs: |
+        telegraf --version
+        telegraf --help

--- a/packages/bespoke/telegraf-1.36.yaml
+++ b/packages/bespoke/telegraf-1.36.yaml
@@ -1,0 +1,39 @@
+package:
+  name: telegraf-1.36
+  version: "1.36.4"
+  epoch: 99
+  description: "Telegraf rebuilt from source for zero-CVE Integer images"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/influxdata/telegraf
+      tag: v${{package.version}}
+  - runs: |
+      mkdir -p "${{targets.contextdir}}/usr/bin"
+      mkdir -p "${{targets.contextdir}}/etc/telegraf/telegraf.d"
+      go build -trimpath -ldflags="-s -w -X github.com/influxdata/telegraf/internal.Version=${{package.version}}" -o "${{targets.contextdir}}/usr/bin/telegraf" ./cmd/telegraf
+      "${{targets.contextdir}}/usr/bin/telegraf" --sample-config > "${{targets.contextdir}}/etc/telegraf/telegraf.conf"
+      rm -rf .cache "${HOME}/.cache"
+
+test:
+  pipeline:
+    - runs: |
+        telegraf --version
+        telegraf --help

--- a/packages/bespoke/telegraf-1.37.yaml
+++ b/packages/bespoke/telegraf-1.37.yaml
@@ -1,0 +1,39 @@
+package:
+  name: telegraf-1.37
+  version: "1.37.3"
+  epoch: 99
+  description: "Telegraf rebuilt from source for zero-CVE Integer images"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/influxdata/telegraf
+      tag: v${{package.version}}
+  - runs: |
+      mkdir -p "${{targets.contextdir}}/usr/bin"
+      mkdir -p "${{targets.contextdir}}/etc/telegraf/telegraf.d"
+      go build -trimpath -ldflags="-s -w -X github.com/influxdata/telegraf/internal.Version=${{package.version}}" -o "${{targets.contextdir}}/usr/bin/telegraf" ./cmd/telegraf
+      "${{targets.contextdir}}/usr/bin/telegraf" --sample-config > "${{targets.contextdir}}/etc/telegraf/telegraf.conf"
+      rm -rf .cache "${HOME}/.cache"
+
+test:
+  pipeline:
+    - runs: |
+        telegraf --version
+        telegraf --help

--- a/packages/bespoke/telegraf-1.38.yaml
+++ b/packages/bespoke/telegraf-1.38.yaml
@@ -1,0 +1,39 @@
+package:
+  name: telegraf-1.38
+  version: "1.38.4"
+  epoch: 99
+  description: "Telegraf rebuilt from source for zero-CVE Integer images"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/influxdata/telegraf
+      tag: v${{package.version}}
+  - runs: |
+      mkdir -p "${{targets.contextdir}}/usr/bin"
+      mkdir -p "${{targets.contextdir}}/etc/telegraf/telegraf.d"
+      go build -trimpath -ldflags="-s -w -X github.com/influxdata/telegraf/internal.Version=${{package.version}}" -o "${{targets.contextdir}}/usr/bin/telegraf" ./cmd/telegraf
+      "${{targets.contextdir}}/usr/bin/telegraf" --sample-config > "${{targets.contextdir}}/etc/telegraf/telegraf.conf"
+      rm -rf .cache "${HOME}/.cache"
+
+test:
+  pipeline:
+    - runs: |
+        telegraf --version
+        telegraf --help


### PR DESCRIPTION
## Summary

Rebuild telegraf default Integer images from source for 1.34-1.38 and add them to the shared zero-HIGH/CRITICAL Trivy gate.

Closes [#834](https://github.com/verity-org/verity/issues/834)
Closes [#835](https://github.com/verity-org/verity/issues/835)
Closes [#836](https://github.com/verity-org/verity/issues/836)
Closes [#837](https://github.com/verity-org/verity/issues/837)
Closes [#838](https://github.com/verity-org/verity/issues/838)

## Root cause

`images/telegraf.yaml` default builds were still consuming upstream Wolfi `telegraf-*` packages. Those package lines remained vulnerable for 1.34-1.37, and telegraf was not covered by the shared Integer Trivy gate in `.github/workflows/integer-build-image.yaml`, so zero-CVE drift was not enforced.

## Fix

- add bespoke source-build melange recipes for `telegraf-1.34` through `telegraf-1.38`
- wire telegraf default images to those bespoke recipes
- declare telegraf 1.34-1.38 default in the shared Integer Trivy gate

## Before / after

Local Integer build + Trivy results:

| version | before HIGH/CRITICAL | after HIGH/CRITICAL |
| --- | ---: | ---: |
| 1.34 | 2 | 0 |
| 1.35 | 17 | 0 |
| 1.36 | 30 | 0 |
| 1.37 | 27 | 0 |
| 1.38 | 0 | 0 |

## Validation

- `go test ./...`
- `./verity integer validate`
- `actionlint`
- `yamllint -c .yamllint.yml .`
- local `go run . integer build` + Trivy for telegraf 1.34, 1.35, 1.36, 1.37, 1.38 default: all `0 HIGH / 0 CRITICAL`
- manual QA: ran built telegraf container through `--version`, `--help`, and bad flag path

## Gate

Telegraf default family now fails Integer publish if any HIGH/CRITICAL finding returns for 1.34-1.38.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt default `telegraf` Integer images (1.34–1.38) from source and added them to the shared zero-HIGH/CRITICAL Trivy gate to enforce zero-CVE publishes.

- Bug Fixes
  - Added bespoke melange recipes for `telegraf-1.34`–`1.38` with static Go build and sample config.
  - Pointed `images/telegraf.yaml` to these recipes; set 1.38 as latest; skipped `fips` builds for 1.34–1.38.
  - Updated `.github/workflows/integer-build-image.yaml` to gate `telegraf:1.34`–`1.38` defaults.
  - Local Trivy: all 1.34–1.38 now 0 HIGH / 0 CRITICAL.

<sup>Written for commit 0498c5e58b51f9ac0339d2b4d27c4771b8b0f2e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

