### PR TITLE
fix(integer): clear loki and mimir trivy CVEs

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -630,6 +630,10 @@ jobs:
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=cortex 1 default" >> "$GITHUB_OUTPUT"
               ;;
+            loki:3.5:default|loki:3.6:default|loki:3.7:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
+              ;;
             external-secrets:0:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=external-secrets 0 default" >> "$GITHUB_OUTPUT"
@@ -645,6 +649,10 @@ jobs:
             mailpit:1:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"
               echo "label=mailpit 1 default" >> "$GITHUB_OUTPUT"
+              ;;
+            mimir:3.0:default|mimir:3.1:default)
+              echo "enabled=true" >> "$GITHUB_OUTPUT"
+              echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
               ;;
             mariadb:10.11:default|mariadb:11.4:default)
               echo "enabled=true" >> "$GITHUB_OUTPUT"

--- a/images/loki.yaml
+++ b/images/loki.yaml
@@ -8,6 +8,10 @@ types:
     base: wolfi-base
     packages: ["loki-{{version}}"]
     entrypoint: /usr/bin/loki
+    melange:
+      bespoke:
+        - "loki-3.5.yaml"
+        - "loki-3.6.yaml"
     paths:
       - {path: /etc/loki, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /var/lib/loki, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
@@ -31,3 +35,6 @@ versions:
     skip-types: [fips]
   "3.6":
     skip-types: [fips]  # GOFIPS140 compilation exceeds GHA timeout; re-enable with larger runner
+  "3.7":
+    latest: true
+    skip-types: [fips]

--- a/images/mimir.yaml
+++ b/images/mimir.yaml
@@ -31,3 +31,5 @@ types:
 
 versions:
   "3.0": {}
+  "3.1":
+    latest: true

--- a/packages/bespoke/loki-3.5.yaml
+++ b/packages/bespoke/loki-3.5.yaml
@@ -1,0 +1,41 @@
+package:
+  name: loki-3.5
+  version: "3.5.12"
+  epoch: 99
+  description: Grafana Loki log aggregation system
+  copyright:
+    - license: AGPL-3.0-only
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grafana/loki
+      tag: v${{package.version}}
+      expected-commit: 3b305e3fe11a23c02ba34eb0382e06d5df0e3e07
+
+  - uses: go/build
+    with:
+      packages: ./cmd/loki
+      output: loki
+      ldflags: |
+        -X github.com/grafana/loki/v3/pkg/util/build.Version=${{package.version}}
+        -X github.com/grafana/loki/v3/pkg/util/build.Revision=$(git rev-parse HEAD)
+        -X github.com/grafana/loki/v3/pkg/util/build.Branch=v${{package.version}}
+
+test:
+  pipeline:
+    - runs: |
+        loki --version >/dev/null 2>&1 || loki -version >/dev/null

--- a/packages/bespoke/loki-3.6.yaml
+++ b/packages/bespoke/loki-3.6.yaml
@@ -1,0 +1,41 @@
+package:
+  name: loki-3.6
+  version: "3.6.12"
+  epoch: 99
+  description: Grafana Loki log aggregation system
+  copyright:
+    - license: AGPL-3.0-only
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grafana/loki
+      tag: v${{package.version}}
+      expected-commit: a25e0d91117416439be4998d3c714e48cd7e5a2b
+
+  - uses: go/build
+    with:
+      packages: ./cmd/loki
+      output: loki
+      ldflags: |
+        -X github.com/grafana/loki/v3/pkg/util/build.Version=${{package.version}}
+        -X github.com/grafana/loki/v3/pkg/util/build.Revision=$(git rev-parse HEAD)
+        -X github.com/grafana/loki/v3/pkg/util/build.Branch=v${{package.version}}
+
+test:
+  pipeline:
+    - runs: |
+        loki --version >/dev/null 2>&1 || loki -version >/dev/null


### PR DESCRIPTION
## Summary

- rebuild Loki 3.5/3.6 default streams from source on fixed upstream patch tags
- refresh declared zero-CVE streams for Loki 3.7 and Mimir 3.0/3.1
- gate all fixed Loki/Mimir default variants in integer Trivy sweep

## Root cause

- published `loki:3.5-default` and `loki:3.6-default` still carried HIGH/CRITICAL findings after a fresh Wolfi rebuild, so package refresh alone was not enough
- fresh Wolfi rebuilds for `loki:3.7-default`, `mimir:3.0-default`, and `mimir:3.1-default` already scanned clean; those streams were missing/ungated in repo config

## Fix

- route Loki default 3.5/3.6 through bespoke melange builds:
  - `loki-3.5` -> upstream tag `v3.5.12`
  - `loki-3.6` -> upstream tag `v3.6.12`
- declare `loki` 3.7 as latest stream
- declare `mimir` 3.1 as latest stream
- enforce zero HIGH/CRITICAL gate for:
  - `loki:3.5-default`
  - `loki:3.6-default`
  - `loki:3.7-default`
  - `mimir:3.0-default`
  - `mimir:3.1-default`

## Before / after

| Variant | Before | After |
| --- | ---: | ---: |
| loki:3.5-default | 12 HIGH/CRITICAL | 0 |
| loki:3.6-default | 16 HIGH/CRITICAL | 0 |
| loki:3.7-default | 2 HIGH/CRITICAL | 0 |
| mimir:3.0-default | 2 HIGH/CRITICAL | 0 |
| mimir:3.1-default | 1 HIGH/CRITICAL | 0 |

## Validation

- `go test ./...`
- `./verity integer validate`
- `actionlint`
- `yamllint .`
- local CLI QA in tmux:
  - `./verity integer validate --help`
  - `./verity integer validate`
  - bad input: `./verity integer build --image nope ...` returns expected missing-image error
- targeted local Trivy scans on built tarballs:
  - `loki 3.5 default` -> 0
  - `loki 3.6 default` -> 0
  - `loki 3.7 default` -> 0
  - `mimir 3.0 default` -> 0
  - `mimir 3.1 default` -> 0

Closes #783
Closes #784
Closes #785
Closes #791
Closes #792


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt `loki` 3.5/3.6 from fixed upstream tags and refreshed `loki` 3.7 and `mimir` 3.0/3.1 streams to clear all Trivy HIGH/CRITICAL CVEs. CI now gates these default variants to enforce zero HIGH/CRITICAL findings.

- **Bug Fixes**
  - Rebuilt `loki` 3.5/3.6 from source via bespoke recipes pinned to v3.5.12 and v3.6.12.
  - Marked `loki` 3.7 and `mimir` 3.1 as latest streams; refreshed clean builds.
  - Updated CI to include and gate `loki` 3.5/3.6/3.7 and `mimir` 3.0/3.1 in the Trivy sweep (zero HIGH/CRITICAL required).

<sup>Written for commit 541d2fded06a075ac4bff16ea5a9bd7ed2604e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

