### PR TITLE
ci(integer): gate publish on zero HIGH/CRITICAL — never publish an image with CVEs

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -428,13 +428,21 @@ jobs:
           # unlike inline workflow bash. Build the image LOCALLY and Trivy-scan
           # it here; if HIGH/CRITICAL CVEs are found this step FAILS and the
           # publish step below never runs. Verity never uploads an image with a CVE.
-          ./verity integer build \
-            --image "$INPUT_IMAGE" \
-            --version "$INPUT_VERSION" \
-            --type "$INPUT_TYPE" \
-            --arch amd64 \
-            --fail-on-severity HIGH,CRITICAL \
-            --output gate.tar
+          # Gate BOTH published arches (publish pushes amd64+arm64). apko build
+          # and trivy scan assemble/read packages without executing arch
+          # binaries, so no QEMU is needed. If EITHER arch has HIGH/CRITICAL
+          # CVEs, this step fails and the multi-arch publish below never runs.
+          for gate_arch in amd64 arm64; do
+            echo "::group::Trivy publish gate ($gate_arch)"
+            ./verity integer build \
+              --image "$INPUT_IMAGE" \
+              --version "$INPUT_VERSION" \
+              --type "$INPUT_TYPE" \
+              --arch "$gate_arch" \
+              --fail-on-severity HIGH,CRITICAL \
+              --output "gate-$gate_arch.tar"
+            echo "::endgroup::"
+          done
 
       - name: Build and publish multi-arch image
         id: build

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -416,6 +416,26 @@ jobs:
 
       # ── Build ──────────────────────────────────────────────────────────────
 
+      # ── Zero-CVE publish gate: build locally & scan BEFORE any push ──────────
+      - name: Trivy publish gate (not clean, no go)
+        env:
+          INPUT_IMAGE: ${{ inputs.image }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TYPE: ${{ inputs.type }}
+        run: |
+          # The verity binary owns this gate (cmd/integer_build.go
+          # integerTrivyGate) — it is unit-tested and cannot silently regress,
+          # unlike inline workflow bash. Build the image LOCALLY and Trivy-scan
+          # it here; if HIGH/CRITICAL CVEs are found this step FAILS and the
+          # publish step below never runs. Verity never uploads an image with a CVE.
+          ./verity integer build \
+            --image "$INPUT_IMAGE" \
+            --version "$INPUT_VERSION" \
+            --type "$INPUT_TYPE" \
+            --arch amd64 \
+            --fail-on-severity HIGH,CRITICAL \
+            --output gate.tar
+
       - name: Build and publish multi-arch image
         id: build
         env:

--- a/cmd/integer_build.go
+++ b/cmd/integer_build.go
@@ -64,6 +64,10 @@ var integerBuildCmd = &cli.Command{
 			Usage: "Wolfi APKINDEX URL",
 			Value: apkindex.DefaultAPKINDEXURL,
 		},
+		&cli.StringFlag{
+			Name:  "fail-on-severity",
+			Usage: "Comma-separated Trivy severities that fail the build before publish (e.g. HIGH,CRITICAL). Empty disables the gate.",
+		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		imageName := cmd.String("image")
@@ -152,7 +156,14 @@ var integerBuildCmd = &cli.Command{
 		output := cmd.String("output")
 		arch := cmd.String("arch")
 		fmt.Fprintf(os.Stderr, "Building %s:%s-%s (%s) → %s\n", imageName, version, typeName, arch, output)
-		return integerRunApkoBuild(ctx, tmp.Name(), output, arch, extraRepos, extraKeyrings)
+		if err := integerRunApkoBuild(ctx, tmp.Name(), output, arch, extraRepos, extraKeyrings); err != nil {
+			return err
+		}
+		if sev := cmd.String("fail-on-severity"); sev != "" {
+			fmt.Fprintf(os.Stderr, "Trivy gate: scanning %s for %s CVEs before publish\n", output, sev)
+			return integerTrivyGate(ctx, output, sev)
+		}
+		return nil
 	},
 }
 
@@ -236,6 +247,31 @@ func integerRunApkoBuild(ctx context.Context, configFile, output, arch string, e
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("apko build failed: %w", err)
+	}
+	return nil
+}
+
+
+// integerTrivyGate scans a locally-built image tarball and returns a non-nil
+// error if Trivy finds vulnerabilities at any of the comma-separated
+// severities. This is the publish gate: the caller MUST stop before pushing
+// the image when this returns an error ("not clean, no go").
+func integerTrivyGate(ctx context.Context, tarPath, severity string) error {
+	trivyPath, err := exec.LookPath("trivy")
+	if err != nil {
+		return fmt.Errorf("trivy not found in PATH (install via mise): %w", err)
+	}
+	c := exec.CommandContext(ctx, trivyPath, "image",
+		"--input", tarPath,
+		"--exit-code", "1",
+		"--severity", severity,
+		"--vuln-type", "os,library",
+		"--format", "table",
+	)
+	c.Stdout = os.Stderr
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("trivy gate: image has %s vulnerabilities — refusing to publish: %w", severity, err)
 	}
 	return nil
 }

--- a/cmd/integer_build_test.go
+++ b/cmd/integer_build_test.go
@@ -529,3 +529,25 @@ versions:
 		})
 	}
 }
+
+
+func intFakeTrivy(t *testing.T, exitCode int) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	script := filepath.Join(tmpDir, "trivy")
+	content := "#!/bin/sh\nexit " + string(rune('0'+exitCode)) + "\n"
+	require.NoError(t, os.WriteFile(script, []byte(content), 0o755))
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+}
+
+func TestIntegerTrivyGate_Clean(t *testing.T) {
+	intFakeTrivy(t, 0)
+	require.NoError(t, integerTrivyGate(context.Background(), "image.tar", "HIGH,CRITICAL"))
+}
+
+func TestIntegerTrivyGate_Findings(t *testing.T) {
+	intFakeTrivy(t, 1)
+	err := integerTrivyGate(context.Background(), "image.tar", "HIGH,CRITICAL")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to publish")
+}


### PR DESCRIPTION
## Why
The nightly Integer build (`integer-build-image.yaml`) published images **even when they had HIGH/CRITICAL CVEs** — its only Trivy step was `--exit-code 0` + `continue-on-error: true` ("Report only — images publish even with CVEs"). That contradicts Verity's zero-CVE claim. Prior PRs *claimed* to add a nightly gate, but those lived as inline workflow bash and silently vanished across rebases.

## What
Per maintainer directive (*"not clean? no go; open issue and never upload an image with a CVE"*):

1. **Gate lives in the tested binary** — `verity integer build --fail-on-severity HIGH,CRITICAL` builds the image locally, Trivy-scans it, and returns a non-zero error on findings (`cmd/integer_build.go: integerTrivyGate`). Covered by unit tests (`TestIntegerTrivyGate_Clean`, `TestIntegerTrivyGate_Findings`). It **cannot silently regress** the way inline YAML did.
2. **Nightly runs the gate before publish** — new step *"Trivy publish gate (not clean, no go)"* runs the gated build; a failure stops the job so the **publish step never runs**. Logic moves *out* of YAML into tested Go.

## Validation
`go build`, `go test ./cmd`, `go vet`, `actionlint` all pass.

## Important notes / follow-ups
- The nightly only runs on schedule/dispatch, so this gate first executes on the next scheduled run — **recommend a manual `workflow_dispatch` to validate the melange/build interaction** before relying on it.
- **Make the PR-test `Integer <image>` check a REQUIRED status** in branch protection — it already enforces `trivy --exit-code 1` on PRs but is currently non-required (so admin-merge bypasses it).
- Continue thinning the 800-line workflow: move annotation injection + multi-arch publish orchestration into the binary too ("build the catalog, update or fail").

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents publishing Integer images with HIGH/CRITICAL CVEs. The zero-CVE gate now lives in the `verity` binary and runs in nightly before any push, scanning both amd64 and arm64.

- **Bug Fixes**
  - Added a gated build to `verity integer build` via `--fail-on-severity HIGH,CRITICAL`; builds locally, scans with Trivy, exits non-zero on findings.
  - Updated the nightly workflow to run this gate before multi-arch publish and to scan both amd64 and arm64; a failed scan blocks publishing.
  - Added unit tests for the gate to avoid regressions.

<sup>Written for commit ec0d4e0c6f4525a37483ce8c755c6b6b431cbddf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

