### PR TITLE
docs+config: adopt Copa-first remediation policy

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -4,10 +4,12 @@ kind: PatchConfig
 # Standalone images to patch. Chart-sourced images are declared in Chart.yaml
 # (dependencies:) and picked up automatically by `verity discover`.
 #
-# NOTE: Basic core images (node, python, golang, nginx, postgres, etc.) are
-# maintained as Wolfi-based rebuilds (previously in github.com/verity-org/integer, now consolidated).
-# Only complex upstream images that cannot be trivially rebuilt from Wolfi
-# packages belong here.
+# REMEDIATION POLICY: Copa-first (see docs/product/remediation-policy.md).
+# Copa-patching the upstream image is the DEFAULT path — max compatibility, and
+# Copa can apply distro-patched packages a Wolfi rebuild can't. A Wolfi/bespoke
+# Integer rebuild is the LAST RESORT (only when Copa can't reach zero
+# HIGH/CRITICAL, or a minimal-attack-surface / FIPS variant is required).
+# The publish gate withholds any image that isn't clean on both arches.
 target:
   registry: "ghcr.io/verity-org"
 

--- a/docs/product/remediation-policy.md
+++ b/docs/product/remediation-policy.md
@@ -1,0 +1,50 @@
+# Remediation Policy — Copa-first
+
+## Invariant
+
+**Verity never publishes an image with a HIGH/CRITICAL CVE.**
+
+This is enforced in CI, not aspirational: the Integer build gates publish on a
+local Trivy scan of every arch (`verity integer build --fail-on-severity
+HIGH,CRITICAL`, wired into `integer-build-image.yaml`). Not clean → no publish.
+If an image cannot be made clean, it is **withheld** and a tracking issue is
+opened instead.
+
+## Remediation ordering
+
+When an image has fixable CVEs, remediate in this order:
+
+1. **Copa-patch the upstream image — the default, first choice.**
+   In-place OS/app-package patching of the *real upstream image* (see the
+   Discover → Scan → Patch → Sign → Publish pipeline in the README). Preferred
+   because:
+   - **Maximum compatibility** — it's the vendor's actual image, patched, so
+     runtime behavior, layout, entrypoints, and integrations match upstream.
+   - Copa can apply **distro-patched packages** that a from-scratch Wolfi
+     rebuild often cannot (the fix exists upstream even when Wolfi's APK is
+     stale).
+
+2. **Wolfi / bespoke Integer rebuild — last resort.**
+   A from-scratch hardened rebuild from Wolfi packages (+ bespoke melange
+   source builds). Use **only** when:
+   - Copa cannot reach zero HIGH/CRITICAL (no upstream package fix available,
+     statically-linked vulnerable libraries, distroless base Copa can't patch),
+     **or**
+   - a minimal-attack-surface / FIPS hardened variant is explicitly required.
+
+## Consequence
+
+- If **Copa** clears the CVEs → ship the Copa-patched variant (the supported
+  path). Any CVE-laden Integer variant of the same image is withheld by the
+  gate.
+- If **neither** Copa nor a bespoke rebuild can clear the CVEs → the image is
+  **not published**; a tracking issue stays open until upstream (or Wolfi)
+  ships a fix. This is honest exposure, not a silent vulnerable release.
+
+## Note
+
+This **supersedes** the earlier guidance in `copa-config.yaml` that treated
+Wolfi rebuilds as the default and Copa as the fallback for "images that cannot
+be trivially rebuilt from Wolfi." The ordering is now the reverse: Copa-first
+for compatibility and breadth of coverage, Wolfi/bespoke as the deliberate
+last resort.


### PR DESCRIPTION
Formalizes the maintainer's remediation ordering.

**Copa-first** (was Wolfi-first):
1. **Copa-patch the upstream image** — default. Max compatibility (it's the real vendor image, patched) and Copa can apply distro-patched packages a from-scratch Wolfi rebuild can't.
2. **Wolfi/bespoke Integer rebuild** — last resort (Copa can't reach zero HIGH/CRITICAL, or a minimal-surface/FIPS variant is wanted).

Pairs with the zero-CVE publish gate (#881): if neither path can clear an image, it is **withheld** and tracked by an issue — never shipped with a CVE.

- New: `docs/product/remediation-policy.md`
- Updated: the `copa-config.yaml` header note (reverses the old Wolfi-first guidance).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts a Copa-first remediation policy: default to Copa-patching upstream images; use Wolfi/bespoke Integer rebuilds only as a last resort. Updates `copa-config.yaml` guidance and adds `docs/product/remediation-policy.md`, aligned with the zero‑CVE publish gate (withhold images that can’t be cleared).

<sup>Written for commit a271682f105db3ced89cf7f27f778af0131c928d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

