### PR TITLE
copa: Copa-first coverage for grafana, argocd, calico family

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -445,3 +445,92 @@ images:
       maxTags: 3
     goVcsUrl: "https://github.com/ollama/ollama"
     goVcsTagPrefix: "v"
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 1) — Go-app families whose Wolfi Integer
+  #  variants are withheld by the zero-CVE publish gate (#881). Copa patches the
+  #  upstream vendor image (OS packages + Go binary via goVcsUrl) for max
+  #  compatibility. See docs/product/remediation-policy.md.
+  # ============================================================================
+  - name: "grafana/grafana"
+    image: "docker.io/grafana/grafana"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/grafana/grafana"
+    goVcsTagPrefix: "v"
+
+  - name: "argoproj/argocd"
+    image: "quay.io/argoproj/argocd"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/argoproj/argo-cd"
+
+  - name: "calico/apiserver"
+    image: "docker.io/calico/apiserver"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/projectcalico/calico"
+
+  - name: "calico/cni"
+    image: "docker.io/calico/cni"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/projectcalico/calico"
+
+  - name: "calico/csi"
+    image: "docker.io/calico/csi"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/projectcalico/calico"
+
+  - name: "calico/kube-controllers"
+    image: "docker.io/calico/kube-controllers"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/projectcalico/calico"
+
+  - name: "calico/node-driver-registrar"
+    image: "docker.io/calico/node-driver-registrar"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/projectcalico/calico"
+
+  - name: "calico/key-cert-provisioner"
+    image: "docker.io/calico/key-cert-provisioner"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/projectcalico/calico"
+
+  - name: "calico/typha"
+    image: "docker.io/calico/typha"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/projectcalico/calico"


### PR DESCRIPTION
First **Copa-first** remediation batch (policy #882). These Integer/Wolfi families ship HIGH/CRITICAL CVEs and are now **withheld** by the zero-CVE publish gate (#881). Rather than bespoke-rebuild them (last resort), add the real **upstream vendor images** to `copa-config.yaml` so the Copa pipeline patches + publishes clean `-patched` variants (max compatibility; `goVcsUrl` lets Copa patch the Go binaries, not just OS packages).

Upstream refs + tags **verified with `crane`**:
| Family | Upstream | addresses |
|---|---|---|
| grafana | docker.io/grafana/grafana | #690–#695 |
| argocd | quay.io/argoproj/argocd | #616–#620 |
| calico/apiserver | docker.io/calico/apiserver | #629,#630 |
| calico/cni | docker.io/calico/cni | #631,#632 |
| calico/csi | docker.io/calico/csi | #633,#634 |
| calico/kube-controllers | docker.io/calico/kube-controllers | #637 |
| calico/node-driver-registrar | docker.io/calico/node-driver-registrar | #638 |
| calico/key-cert-provisioner | docker.io/calico/key-cert-provisioner | #635,#636 |
| calico/typha | docker.io/calico/typha | #639 |

**No `Closes`** — the withheld Integer issues close only once the Copa pipeline publishes a confirmed clean patched variant. yamllint + go build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copa-first coverage for `grafana/grafana`, `argoproj/argocd`, and the Calico family so the Copa pipeline patches upstream images and publishes clean `-patched` variants. This unblocks the zero-CVE gate for these families without bespoke rebuilds.

- **New Features**
  - Added upstream vendor images to `copa-config.yaml` with `linux/amd64` and `linux/arm64` support and conservative tag patterns (max 3).
  - Set `goVcsUrl` (and `goVcsTagPrefix` where needed) so Copa patches Go binaries in addition to OS packages.
  - Coverage: `grafana/grafana`, `argoproj/argocd`, `calico/{apiserver,cni,csi,kube-controllers,node-driver-registrar,key-cert-provisioner,typha}`.

<sup>Written for commit 5d9767f496c7e847c692f19ac466e46f1129f457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

