### PR TITLE
copa: Copa-first coverage batch 2 (keycloak, opensearch, cluster-autoscaler, kube-state-metrics, karpenter)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -534,3 +534,51 @@ images:
       pattern: '^v\d+\.\d+\.\d+$'
       maxTags: 3
     goVcsUrl: "https://github.com/projectcalico/calico"
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 2) — more withheld families. OS-package Copa for
+  #  all; goVcsUrl added only where image-tag == VCS-tag (confident). Go-binary
+  #  patching for the trickier tag schemes (cluster-autoscaler, karpenter) is a
+  #  follow-up. See docs/product/remediation-policy.md.
+  # ============================================================================
+  - name: "keycloak/keycloak"
+    image: "quay.io/keycloak/keycloak"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "opensearchproject/opensearch"
+    image: "docker.io/opensearchproject/opensearch"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "kube-state-metrics/kube-state-metrics"
+    image: "registry.k8s.io/kube-state-metrics/kube-state-metrics"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/kubernetes/kube-state-metrics"
+
+  - name: "autoscaling/cluster-autoscaler"
+    image: "registry.k8s.io/autoscaling/cluster-autoscaler"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "karpenter/controller"
+    image: "public.ecr.aws/karpenter/controller"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3


### PR DESCRIPTION
Second **Copa-first** coverage batch (policy #882, gate #881). Adds upstream vendor images so the Copa pipeline patches withheld Integer families.

| Family | Upstream | goVcs | addresses |
|---|---|---|---|
| keycloak | quay.io/keycloak/keycloak | OS-only (Java) | #730–#733 |
| opensearch | docker.io/opensearchproject/opensearch | OS-only (Java) | #800,#801 |
| kube-state-metrics | registry.k8s.io/kube-state-metrics/kube-state-metrics | ✅ Go | #735 |
| cluster-autoscaler | registry.k8s.io/autoscaling/cluster-autoscaler | follow-up | #653 |
| karpenter | public.ecr.aws/karpenter/controller | follow-up | #729 |

Refs+tags crane-verified. `goVcsUrl` (Go-binary patching) added only where image-tag==VCS-tag; cluster-autoscaler/karpenter need a VCS-tag-mapping follow-up (their github tags don't match image tags). No `Closes` — issues close when the Copa pipeline publishes a confirmed clean variant. yamllint + go build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copa-first coverage batch 2 by onboarding upstream images for `keycloak`, `opensearch`, `kube-state-metrics`, `cluster-autoscaler`, and `karpenter`. This lets the Copa pipeline patch and publish clean variants for these withheld families.

- **New Features**
  - Configure upstream images (amd64/arm64, regex tag filters, max 3 tags): `quay.io/keycloak/keycloak`, `docker.io/opensearchproject/opensearch`, `registry.k8s.io/kube-state-metrics/kube-state-metrics`, `registry.k8s.io/autoscaling/cluster-autoscaler`, `public.ecr.aws/karpenter/controller`.
  - Enable Go-binary patching via `goVcsUrl` for `kube-state-metrics`. Follow-up needed for `cluster-autoscaler` and `karpenter` due to non-matching image/VCS tags.

<sup>Written for commit 638ef86ffc583f08d6f57edb7634952f2fd45c1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

