### PR TITLE
copa: Copa-first coverage batch 3 (cert-manager, crossplane, dex, jaeger, temporal)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -582,3 +582,64 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 3) — Go-app families, all with verified
+  #  goVcsUrl mappings. See docs/product/remediation-policy.md.
+  # ============================================================================
+  - name: "jetstack/cert-manager-controller"
+    image: "quay.io/jetstack/cert-manager-controller"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/cert-manager/cert-manager"
+
+  - name: "jetstack/cert-manager-cainjector"
+    image: "quay.io/jetstack/cert-manager-cainjector"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/cert-manager/cert-manager"
+
+  - name: "crossplane/crossplane"
+    image: "docker.io/crossplane/crossplane"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/crossplane/crossplane"
+
+  - name: "dexidp/dex"
+    image: "ghcr.io/dexidp/dex"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/dexidp/dex"
+
+  - name: "jaegertracing/jaeger"
+    image: "docker.io/jaegertracing/jaeger"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/jaegertracing/jaeger"
+    goVcsTagPrefix: "v"
+
+  - name: "temporalio/server"
+    image: "docker.io/temporalio/server"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/temporalio/temporal"
+    goVcsTagPrefix: "v"


### PR DESCRIPTION
Third Copa-first batch (policy #882, gate #881). Go-app families, all with verified `goVcsUrl` (Copa patches OS + Go binary):

| Family | Upstream | addresses |
|---|---|---|
| cert-manager-controller | quay.io/jetstack/cert-manager-controller | #643 |
| cert-manager-cainjector | quay.io/jetstack/cert-manager-cainjector | #641 |
| crossplane | docker.io/crossplane/crossplane | #657 |
| dex | ghcr.io/dexidp/dex | #660 |
| jaeger | docker.io/jaegertracing/jaeger | #724 |
| temporal | docker.io/temporalio/server | #842 |

crane-verified refs+tags. Deferred: teleport (ref needs locating), sonarqube (non-semver LTS tag scheme). No `Closes` — issues close when Copa publishes a confirmed clean variant. yamllint + go build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copa-first coverage batch 3 for Go apps (cert-manager, crossplane, dex, jaeger, temporal) so Copa can patch the OS and Go binary using verified `goVcsUrl` mappings. Aligns with remediation policy #882 and gate #881.

- **New Features**
  - `quay.io/jetstack/cert-manager-controller` → `https://github.com/cert-manager/cert-manager` (tags `^v\d+\.\d+\.\d+$`)
  - `quay.io/jetstack/cert-manager-cainjector` → `https://github.com/cert-manager/cert-manager` (tags `^v\d+\.\d+\.\d+$`)
  - `docker.io/crossplane/crossplane` → `https://github.com/crossplane/crossplane` (tags `^v\d+\.\d+\.\d+$`)
  - `ghcr.io/dexidp/dex` → `https://github.com/dexidp/dex` (tags `^v\d+\.\d+\.\d+$`)
  - `docker.io/jaegertracing/jaeger` → `https://github.com/jaegertracing/jaeger` (tags `^\d+\.\d+\.\d+$`, `goVcsTagPrefix: "v"`)
  - `docker.io/temporalio/server` → `https://github.com/temporalio/temporal` (tags `^\d+\.\d+\.\d+$`, `goVcsTagPrefix: "v"`)
  - All entries: platforms `linux/amd64` and `linux/arm64`, `maxTags: 3`. Crane-verified refs/tags.

<sup>Written for commit 37641f5261318e391707bc148e0ff62f981be4a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

