### PR TITLE
copa: Copa-first coverage batch 4 (traefik, argo-rollouts, argo-workflows, cilium, kaniko, buildah)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -643,3 +643,62 @@ images:
       maxTags: 3
     goVcsUrl: "https://github.com/temporalio/temporal"
     goVcsTagPrefix: "v"
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 4) — Go-app families. goVcsUrl mappings
+  #  (image-tag == VCS-tag). See docs/product/remediation-policy.md.
+  # ============================================================================
+  - name: "library/traefik"
+    image: "docker.io/library/traefik"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/traefik/traefik"
+
+  - name: "argoproj/argo-rollouts"
+    image: "quay.io/argoproj/argo-rollouts"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/argoproj/argo-rollouts"
+
+  - name: "argoproj/argocli"
+    image: "quay.io/argoproj/argocli"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/argoproj/argo-workflows"
+
+  - name: "cilium/cilium"
+    image: "quay.io/cilium/cilium"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/cilium/cilium"
+
+  - name: "kaniko-project/executor"
+    image: "gcr.io/kaniko-project/executor"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/GoogleContainerTools/kaniko"
+
+  - name: "buildah/stable"
+    image: "quay.io/buildah/stable"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/containers/buildah"


### PR DESCRIPTION
Fourth Copa-first batch (policy #882, gate #881). Go-app families with verified `goVcsUrl`:

| Family | Upstream | addresses |
|---|---|---|
| traefik | docker.io/library/traefik | #852-#855 |
| argo-rollouts | quay.io/argoproj/argo-rollouts | #612 |
| argo-workflows | quay.io/argoproj/argocli | #613/#614 |
| cilium | quay.io/cilium/cilium | #648 |
| kaniko | gcr.io/kaniko-project/executor | #728 |
| buildah | quay.io/buildah/stable | #627 |

crane-verified. Deferred: linkerd (ref needs locating). No `Closes` — close on confirmed clean Copa variant. yamllint + go build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copa-first coverage for six Go-based images by mapping image tags to upstream Go VCS tags and scanning only semver releases. This enables source-verified remediation on `linux/amd64` and `linux/arm64`, limited to the latest three tags.

- **New Features**
  - Mapped goVcsUrl for: `docker.io/library/traefik`, `quay.io/argoproj/argo-rollouts`, `quay.io/argoproj/argocli`, `quay.io/cilium/cilium`, `gcr.io/kaniko-project/executor`, `quay.io/buildah/stable`.
  - Enforced tag pattern `^v\d+\.\d+\.\d+$` with `maxTags: 3` on both platforms.

<sup>Written for commit ec9915eb1fab61f8ba19f7efb178a3f4f3a8a008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

