### PR TITLE
copa: Copa-first coverage batch 5 (teleport, step-ca, kube-vip, vcluster, grafana-alloy, argocd-image-updater, cadvisor, pulumi)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -702,3 +702,83 @@ images:
       pattern: '^v\d+\.\d+\.\d+$'
       maxTags: 3
     goVcsUrl: "https://github.com/containers/buildah"
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 5) — Go-app families. See
+  #  docs/product/remediation-policy.md.
+  # ============================================================================
+  - name: "gravitational/teleport-distroless"
+    image: "public.ecr.aws/gravitational/teleport-distroless"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/gravitational/teleport"
+    goVcsTagPrefix: "v"
+
+  - name: "smallstep/step-ca"
+    image: "docker.io/smallstep/step-ca"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/smallstep/certificates"
+    goVcsTagPrefix: "v"
+
+  - name: "kube-vip/kube-vip"
+    image: "ghcr.io/kube-vip/kube-vip"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/kube-vip/kube-vip"
+
+  - name: "loft-sh/vcluster"
+    image: "ghcr.io/loft-sh/vcluster"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/loft-sh/vcluster"
+    goVcsTagPrefix: "v"
+
+  - name: "grafana/alloy"
+    image: "docker.io/grafana/alloy"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/grafana/alloy"
+
+  - name: "argoprojlabs/argocd-image-updater"
+    image: "quay.io/argoprojlabs/argocd-image-updater"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/argoproj-labs/argocd-image-updater"
+
+  - name: "cadvisor/cadvisor"
+    image: "gcr.io/cadvisor/cadvisor"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/google/cadvisor"
+
+  - name: "pulumi/pulumi"
+    image: "docker.io/pulumi/pulumi"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/pulumi/pulumi"


### PR DESCRIPTION
Fifth Copa-first batch (policy #882, gate #881). Go-app families with verified `goVcsUrl`.

| Family | Upstream | addresses |
|---|---|---|
| teleport | public.ecr.aws/gravitational/teleport-distroless | #839,#840 |
| step-ca | docker.io/smallstep/step-ca | #832 |
| kube-vip | ghcr.io/kube-vip/kube-vip | #736 |
| vcluster | ghcr.io/loft-sh/vcluster | #861 |
| grafana-alloy | docker.io/grafana/alloy | #689 |
| argocd-image-updater | quay.io/argoprojlabs/argocd-image-updater | #615 |
| cadvisor | gcr.io/cadvisor/cadvisor | #628 |
| pulumi | docker.io/pulumi/pulumi | #818 |

crane-verified. No `Closes` \u2014 close on confirmed clean Copa variant. yamllint + go build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copa-first coverage for eight Go-based images—`gravitational/teleport-distroless`, `smallstep/step-ca`, `kube-vip/kube-vip`, `loft-sh/vcluster`, `grafana/alloy`, `argoprojlabs/argocd-image-updater`, `cadvisor/cadvisor`, `pulumi/pulumi`—with verified `goVcsUrl` and linux/amd64 + linux/arm64 support to enable Copa variants. crane-verified; yamllint and go build pass.

- **New Features**
  - Tag strategy: semver patterns with `maxTags: 3`; `goVcsTagPrefix: "v"` for `teleport`, `step-ca`, and `vcluster`; v-prefixed image tags where applicable.

<sup>Written for commit e3ed37036b7beebc5bb7d59a5db9f1326061c863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

