### PR TITLE
copa: Copa-first coverage batch 6 (skaffold, tflint, skopeo, chartmuseum, argo workflow-controller, terragrunt, haproxy-ingress)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -782,3 +782,73 @@ images:
       pattern: '^v\d+\.\d+\.\d+$'
       maxTags: 3
     goVcsUrl: "https://github.com/pulumi/pulumi"
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 6) — Go-app families. See
+  #  docs/product/remediation-policy.md.
+  # ============================================================================
+  - name: "k8s-skaffold/skaffold"
+    image: "gcr.io/k8s-skaffold/skaffold"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/GoogleContainerTools/skaffold"
+
+  - name: "terraform-linters/tflint"
+    image: "ghcr.io/terraform-linters/tflint"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/terraform-linters/tflint"
+
+  - name: "skopeo/stable"
+    image: "quay.io/skopeo/stable"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/containers/skopeo"
+
+  - name: "helm/chartmuseum"
+    image: "ghcr.io/helm/chartmuseum"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/chartmuseum/chartmuseum"
+
+  - name: "argoproj/workflow-controller"
+    image: "quay.io/argoproj/workflow-controller"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/argoproj/argo-workflows"
+
+  - name: "alpine/terragrunt"
+    image: "docker.io/alpine/terragrunt"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/gruntwork-io/terragrunt"
+    goVcsTagPrefix: "v"
+
+  - name: "haproxytech/kubernetes-ingress"
+    image: "ghcr.io/haproxytech/kubernetes-ingress"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/haproxytech/kubernetes-ingress"
+    goVcsTagPrefix: "v"


### PR DESCRIPTION
Sixth Copa-first batch (policy #882, gate #881). Go-app families with verified `goVcsUrl`.

| Family | Upstream | addresses |
|---|---|---|
| skaffold | gcr.io/k8s-skaffold/skaffold | #823 |
| tflint | ghcr.io/terraform-linters/tflint | #849 |
| skopeo | quay.io/skopeo/stable | #824 |
| chartmuseum | ghcr.io/helm/chartmuseum | #645 |
| argo-workflow-controller | quay.io/argoproj/workflow-controller | #613 |
| terragrunt | docker.io/alpine/terragrunt | #847 |
| haproxy-ingress | ghcr.io/haproxytech/kubernetes-ingress | #696 |

crane-verified. No `Closes` — close on confirmed clean Copa variant. yamllint + go build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copa-first coverage (batch 6) for seven Go image families, mapping images to repos and semver tag patterns to enable safe Copa variants on linux/amd64 and linux/arm64. Aligns with policy #882 and gate #881; covers `gcr.io/k8s-skaffold/skaffold`, `ghcr.io/terraform-linters/tflint`, `quay.io/skopeo/stable`, `ghcr.io/helm/chartmuseum`, `quay.io/argoproj/workflow-controller`, `docker.io/alpine/terragrunt`, `ghcr.io/haproxytech/kubernetes-ingress`.

- **New Features**
  - Added `goVcsUrl` for each family and set `maxTags: 3`.
  - Enforced semver tag patterns (`^v\d+\.\d+\.\d+$` or `^\d+\.\d+\.\d+$` as needed).
  - Set platforms to `linux/amd64` and `linux/arm64`.
  - Added `goVcsTagPrefix: "v"` for `alpine/terragrunt` and `haproxytech/kubernetes-ingress`.

<sup>Written for commit 5c122b306c60d8f4f61ffd44b5bab82ec8bc258c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

