### PR TITLE
copa: Copa-first coverage batch 7 (mlflow, airflow, opensearch-dashboards, kafka, zookeeper)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -852,3 +852,48 @@ images:
       maxTags: 3
     goVcsUrl: "https://github.com/haproxytech/kubernetes-ingress"
     goVcsTagPrefix: "v"
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 7) — Python (Copa patches pip) + JVM/Node apps
+  #  (Copa patches OS packages). See docs/product/remediation-policy.md.
+  # ============================================================================
+  - name: "mlflow/mlflow"
+    image: "ghcr.io/mlflow/mlflow"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "apache/airflow"
+    image: "docker.io/apache/airflow"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "opensearchproject/opensearch-dashboards"
+    image: "docker.io/opensearchproject/opensearch-dashboards"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "apache/kafka"
+    image: "docker.io/apache/kafka"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "library/zookeeper"
+    image: "docker.io/library/zookeeper"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3


### PR DESCRIPTION
Seventh Copa-first batch. Python apps (Copa patches pip packages) + JVM/Node apps (Copa patches OS packages):

| Family | Upstream | addresses |
|---|---|---|
| mlflow | ghcr.io/mlflow/mlflow | #793 |
| airflow | docker.io/apache/airflow | #609 |
| opensearch-dashboards | docker.io/opensearchproject/opensearch-dashboards | #799 |
| kafka | docker.io/apache/kafka | #726,#727 |
| zookeeper | docker.io/library/zookeeper | #864 |

crane-verified. No `Closes` — close on confirmed clean Copa variant. yamllint + go build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copa-first coverage (batch 7) in `copa-config.yaml` for `mlflow/mlflow`, `apache/airflow`, `opensearchproject/opensearch-dashboards`, `apache/kafka`, and `library/zookeeper`.

Targets `linux/amd64` and `linux/arm64`. Limits tags to semver (mlflow `^v\d+\.\d+\.\d+$`, others `^\d+\.\d+\.\d+$`) with `maxTags: 3`. Python images get pip patching; JVM/Node images get OS patching.

<sup>Written for commit c82e0799c5d6b5491a1902b3bcb59c10ccaacc23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

