### PR TITLE
copa: Copa-first coverage batch 8 (final: postgres, trivy, helm, newrelic, pgbouncer, sonarqube)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -897,3 +897,61 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 8, final) — remaining coverable families.
+  #  Go tools get goVcsUrl; DB/JVM/agent get OS-package Copa. See
+  #  docs/product/remediation-policy.md.
+  # ============================================================================
+  - name: "library/postgres"
+    image: "docker.io/library/postgres"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+$'
+      maxTags: 3
+
+  - name: "aquasecurity/trivy"
+    image: "ghcr.io/aquasecurity/trivy"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/aquasecurity/trivy"
+    goVcsTagPrefix: "v"
+
+  - name: "alpine/helm"
+    image: "docker.io/alpine/helm"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/helm/helm"
+    goVcsTagPrefix: "v"
+
+  - name: "newrelic/infrastructure-bundle"
+    image: "docker.io/newrelic/infrastructure-bundle"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "edoburu/pgbouncer"
+    image: "docker.io/edoburu/pgbouncer"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "library/sonarqube"
+    image: "docker.io/library/sonarqube"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3


### PR DESCRIPTION
Final Copa-first coverage batch. crane-verified upstreams.

| Family | Upstream | addresses |
|---|---|---|
| postgres | docker.io/library/postgres | #805-808 |
| trivy | ghcr.io/aquasecurity/trivy | #859 |
| helm | docker.io/alpine/helm | #704 |
| newrelic | docker.io/newrelic/infrastructure-bundle | #795 |
| pgbouncer | docker.io/edoburu/pgbouncer | #804 |
| sonarqube | docker.io/library/sonarqube | #826 |

Genuinely uncovered (documented-blocked, no clean/Go-patchable upstream): kubectl (no standalone image), falco (kernel/eBPF), linkerd (proxy ref unresolved), cert-manager-cmctl, crossplane-crank. yamllint + go build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Copa-first coverage for the final batch of images: Postgres, Trivy, Helm, New Relic infrastructure-bundle, PgBouncer, and SonarQube. Sets platforms, tag patterns, and source mapping for Go tools to complete coverage.

- **New Features**
  - Added `docker.io/library/postgres`, `ghcr.io/aquasecurity/trivy`, `docker.io/alpine/helm`, `docker.io/newrelic/infrastructure-bundle`, `docker.io/edoburu/pgbouncer`, `docker.io/library/sonarqube`
  - Platforms: `linux/amd64`, `linux/arm64`
  - Tag patterns with `maxTags: 3` (Postgres uses `^\d+\.\d+$`; others use `^\d+\.\d+\.\d+$`)
  - Added `goVcsUrl` and `goVcsTagPrefix: "v"` for `trivy` and `helm`

<sup>Written for commit 4064ad0d61c2fcc28cdfbb0368d23110aa8d3eb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

