### PR TITLE
copa: Copa-first coverage batch 9 (kubectl, linkerd, eks-pod-identity, crossplane-crank)

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -955,3 +955,50 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
+
+
+  # ============================================================================
+  #  Copa-first coverage (batch 9) — final fixable CVE tail.
+  #  kubectl: canonical registry.k8s.io image, Go-source patched.
+  #  linkerd: Rust proxy, OS-package Copa (edge channel).
+  #  eks-pod-identity-agent + crossplane(crank): Go-source patched.
+  #  Not covered (documented-blocked): cert-manager-cmctl (upstream quay image
+  #  inaccessible/deprecated), falco (kernel/eBPF module).
+  # ============================================================================
+  - name: "kubectl"
+    image: "registry.k8s.io/kubectl"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v1\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/kubernetes/kubernetes"
+    goVcsTagPrefix: ""
+
+  - name: "linkerd/proxy"
+    image: "cr.l5d.io/linkerd/proxy"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^edge-2[0-9]\.\d+\.\d+$'
+      maxTags: 3
+
+  - name: "eks/eks-pod-identity-agent"
+    image: "public.ecr.aws/eks/eks-pod-identity-agent"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/aws/eks-pod-identity-agent"
+    goVcsTagPrefix: "v"
+
+  - name: "crossplane/crank"
+    image: "docker.io/crossplane/crossplane"
+    platforms: ["linux/amd64", "linux/arm64"]
+    tags:
+      strategy: "pattern"
+      pattern: '^v\d+\.\d+\.\d+$'
+      maxTags: 3
+    goVcsUrl: "https://github.com/crossplane/crossplane"
+    goVcsTagPrefix: ""


### PR DESCRIPTION
Final fixable CVE tail — closes the CVE backlog for coverable families.

| Family | Upstream (crane-verified) | Patch | Closes |
|---|---|---|---|
| kubectl | registry.k8s.io/kubectl | Go-source | #738-746 (9) |
| linkerd | cr.l5d.io/linkerd/proxy (edge) | OS-package (Rust proxy) | #777 |
| eks-pod-identity-agent | public.ecr.aws/eks/eks-pod-identity-agent | Go-source | #621 |
| crossplane-crank | docker.io/crossplane/crossplane | Go-source | #656 |

Documented-blocked (no action — no clean upstream / kernel dependency):
- cert-manager-cmctl #642 — quay.io/jetstack/cert-manager-cmctl inaccessible/deprecated
- falco #667/#325 — kernel/eBPF module, not a container-layer CVE

yamllint + go build pass. copa entries 91 -> 95.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Copa coverage for `kubectl`, `linkerd/proxy`, `eks/eks-pod-identity-agent`, and `crossplane/crank` to patch the last fixable CVEs and close the coverage backlog. `cert-manager-cmctl` and `falco` remain documented‑blocked due to upstream/kernel constraints.

- New Features
  - Added `kubectl` (image: `registry.k8s.io/kubectl`) — Go-source patched.
  - Added `linkerd/proxy` (image: `cr.l5d.io/linkerd/proxy`) — OS-package coverage for the Rust proxy (edge channel).
  - Added `eks/eks-pod-identity-agent` (image: `public.ecr.aws/eks/eks-pod-identity-agent`) — Go-source patched.
  - Added `crossplane/crank` (image: `docker.io/crossplane/crossplane`) — Go-source patched.

<sup>Written for commit de983e6e6194c65243f1840817ac435102e315bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

