### PR TITLE
copa: fix runtime app remediation paths

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -764,17 +764,6 @@ images:
       maxTags: 3
     goVcsUrl: "https://github.com/google/cadvisor"
 
-  - name: "pulumi/pulumi"
-    image: "docker.io/pulumi/pulumi"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^3\.(249|25[0-9])\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/pulumi/pulumi"
-    goVcsTagPrefix: "v"
-
-
   # ============================================================================
   #  Copa-first coverage (batch 6) — Go-app families. See
   #  docs/product/remediation-policy.md.

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -715,6 +715,7 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
+      exclude: ["18.9.0", "18.9.1"]
     goVcsUrl: "https://github.com/gravitational/teleport"
     goVcsTagPrefix: "v"
 
@@ -779,9 +780,10 @@ images:
     platforms: ["linux/amd64", "linux/arm64"]
     tags:
       strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
+      pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
     goVcsUrl: "https://github.com/pulumi/pulumi"
+    goVcsTagPrefix: "v"
 
 
   # ============================================================================
@@ -873,6 +875,7 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
+      exclude: ["3.2.0"]
 
   - name: "opensearchproject/opensearch-dashboards"
     image: "docker.io/opensearchproject/opensearch-dashboards"
@@ -960,7 +963,9 @@ images:
   # ============================================================================
   #  Copa-first coverage (batch 9) — final fixable CVE tail.
   #  kubectl: canonical registry.k8s.io image, Go-source patched.
-  #  linkerd: Rust proxy, OS-package Copa (edge channel).
+  #  linkerd/proxy moved off Copa: upstream now declares Wolfi and Copa rejects
+  #  that osType outright (`unsupported osType wolfi specified`). Keep catalog
+  #  coverage on the Integer side instead of burning patch jobs.
   #  eks-pod-identity-agent + crossplane(crank): Go-source patched.
   #  Not covered (documented-blocked): cert-manager-cmctl (upstream quay image
   #  inaccessible/deprecated), falco (kernel/eBPF module).
@@ -974,14 +979,6 @@ images:
       maxTags: 3
     goVcsUrl: "https://github.com/kubernetes/kubernetes"
     goVcsTagPrefix: ""
-
-  - name: "linkerd/proxy"
-    image: "cr.l5d.io/linkerd/proxy"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^edge-2[0-9]\.\d+\.\d+$'
-      maxTags: 3
 
   - name: "eks/eks-pod-identity-agent"
     image: "public.ecr.aws/eks/eks-pod-identity-agent"
@@ -1072,15 +1069,9 @@ images:
     goVcsUrl: "https://github.com/goss-org/goss"
     goVcsTagPrefix: ""
 
-  - name: "earthly/earthly"
-    image: "docker.io/earthly/earthly"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/earthly/earthly"
-    goVcsTagPrefix: ""
+  # earthly moved off Copa: current patch runs explode with repeated apt-layer
+  # solver failures on both arches, while the bespoke Integer build already
+  # produces a clean receipt for v0.8.16.
 
   - name: "caddy"
     image: "docker.io/library/caddy"

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -715,7 +715,7 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
-      exclude: ["18.9.0", "18.9.1"]
+      exclude: ["18.8.2", "18.9.0", "18.9.1"]
     goVcsUrl: "https://github.com/gravitational/teleport"
     goVcsTagPrefix: "v"
 
@@ -782,6 +782,7 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
+      exclude: ["3.248.0"]
     goVcsUrl: "https://github.com/pulumi/pulumi"
     goVcsTagPrefix: "v"
 
@@ -875,7 +876,7 @@ images:
       strategy: "pattern"
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
-      exclude: ["3.2.0"]
+      exclude: ["3.1.8", "3.2.0"]
 
   - name: "opensearchproject/opensearch-dashboards"
     image: "docker.io/opensearchproject/opensearch-dashboards"

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -713,8 +713,9 @@ images:
     platforms: ["linux/amd64", "linux/arm64"]
     tags:
       strategy: "pattern"
-      pattern: '^18\.9\.[2-9]\d*$'
+      pattern: '^18\.9\.\d+$'
       maxTags: 3
+      exclude: ["18.9.0", "18.9.1"]
     goVcsUrl: "https://github.com/gravitational/teleport"
     goVcsTagPrefix: "v"
 

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -708,17 +708,6 @@ images:
   #  Copa-first coverage (batch 5) — Go-app families. See
   #  docs/product/remediation-policy.md.
   # ============================================================================
-  - name: "gravitational/teleport-distroless"
-    image: "public.ecr.aws/gravitational/teleport-distroless"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^18\.9\.\d+$'
-      maxTags: 3
-      exclude: ["18.9.0", "18.9.1"]
-    goVcsUrl: "https://github.com/gravitational/teleport"
-    goVcsTagPrefix: "v"
-
   - name: "smallstep/step-ca"
     image: "docker.io/smallstep/step-ca"
     platforms: ["linux/amd64", "linux/arm64"]

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -713,9 +713,8 @@ images:
     platforms: ["linux/amd64", "linux/arm64"]
     tags:
       strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
+      pattern: '^18\.9\.[2-9]\d*$'
       maxTags: 3
-      exclude: ["18.8.2", "18.9.0", "18.9.1"]
     goVcsUrl: "https://github.com/gravitational/teleport"
     goVcsTagPrefix: "v"
 
@@ -780,9 +779,8 @@ images:
     platforms: ["linux/amd64", "linux/arm64"]
     tags:
       strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
+      pattern: '^3\.(249|25[0-9])\.\d+$'
       maxTags: 3
-      exclude: ["3.248.0"]
     goVcsUrl: "https://github.com/pulumi/pulumi"
     goVcsTagPrefix: "v"
 
@@ -874,9 +872,8 @@ images:
     platforms: ["linux/amd64", "linux/arm64"]
     tags:
       strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
+      pattern: '^3\.2\.[1-9]\d*$'
       maxTags: 3
-      exclude: ["3.1.8", "3.2.0"]
 
   - name: "opensearchproject/opensearch-dashboards"
     image: "docker.io/opensearchproject/opensearch-dashboards"

--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -867,14 +867,6 @@ images:
       pattern: '^v\d+\.\d+\.\d+$'
       maxTags: 3
 
-  - name: "apache/airflow"
-    image: "docker.io/apache/airflow"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^3\.2\.[1-9]\d*$'
-      maxTags: 3
-
   - name: "opensearchproject/opensearch-dashboards"
     image: "docker.io/opensearchproject/opensearch-dashboards"
     platforms: ["linux/amd64", "linux/arm64"]

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -839,7 +839,7 @@ export const fullCatalog: FullCatalogCategory[] = [
     id: "data",
     label: "Data & ML",
     images: [
-      { name: "apache/airflow", source: "copa", upstream: "mirror.gcr.io/apache/airflow" },
+      { name: "airflow", source: "integer" },
       { name: "mlflow/mlflow", label: "mlflow", source: "copa", upstream: "ghcr.io/mlflow/mlflow" },
       { name: "temporal", source: "integer" },
       { name: "meilisearch", source: "integer" },

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -622,6 +622,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "buildah", source: "integer" },
       { name: "podman", source: "integer" },
       { name: "pulumi", source: "integer" },
+      { name: "earthly", source: "integer" },
       { name: "argo-workflows", source: "integer" },
       { name: "argo-rollouts", source: "integer" },
       { name: "gomplate", source: "integer" },

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -697,12 +697,7 @@ export const fullCatalog: FullCatalogCategory[] = [
         integerName: "spire-agent",
         upstream: "ghcr.io/spiffe/spire-agent",
       },
-      {
-        name: "gravitational/teleport",
-        label: "teleport",
-        source: "copa",
-        upstream: "quay.io/gravitational/teleport",
-      },
+      { name: "teleport", source: "integer" },
       {
         name: "openbao/openbao",
         label: "openbao",


### PR DESCRIPTION
Fix runtime-app remediation paths from the overnight CVE pass while preserving the remediation ladder: Copa first, Integer fallback only where Copa cannot produce a viable patched image.

Changes:
- `earthly/earthly`: remove from Copa; existing Integer/bespoke image is clean and now appears in the site catalog.
- `apache/airflow`: remove from Copa; current upstream tags still fail Copa patching, so use the existing Wolfi-based Integer image.
- `gravitational/teleport-distroless`: remove from Copa; patch jobs are flaky/failing, so use the existing Wolfi-based Integer image.
- `pulumi/pulumi`: remove from Copa; current tags still fail Copa patching, so use the existing Wolfi-based Integer image.
- `linkerd/proxy`: remove from Copa; Copa rejects upstream Wolfi (`unsupported osType wolfi specified`), so leave Integer as fallback.

Expected issue impact after the next Integer/catalog run:
- [#818](https://github.com/verity-org/verity/issues/818), [#609](https://github.com/verity-org/verity/issues/609), [#839](https://github.com/verity-org/verity/issues/839), [#840](https://github.com/verity-org/verity/issues/840), and [#777](https://github.com/verity-org/verity/issues/777) should be judged by Integer receipts rather than Copa patch jobs.

Validation:
- `yamllint copa-config.yaml`
- `go test ./internal/discovery ./internal/config ./internal/integer/config`
- `go build .`
- `npm --prefix site test`
- `npm --prefix site build`

PR checks are green and review threads are resolved.
