### PR TITLE
fix(integer): restrict explicit teleport streams

### DIFF
--- a/cmd/integer_build.go
+++ b/cmd/integer_build.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/urfave/cli/v3"
@@ -120,6 +121,8 @@ var integerBuildCmd = &cli.Command{
 			if err != nil {
 				return err
 			}
+		} else if !slices.Contains(discovery.ResolveVersions(def, pkgs), version) {
+			return fmt.Errorf("image %q version %q not defined for build: %w", imageName, version, errIntegerVariantNotFound)
 		}
 
 		extraRepos, extraKeyrings, err := integerPrepareMelangeBuild(ctx, tmpl.Melange)
@@ -250,7 +253,6 @@ func integerRunApkoBuild(ctx context.Context, configFile, output, arch string, e
 	}
 	return nil
 }
-
 
 // integerTrivyGate scans a locally-built image tarball and returns a non-nil
 // error if Trivy finds vulnerabilities at any of the comma-separated

--- a/cmd/integer_build_melange.go
+++ b/cmd/integer_build_melange.go
@@ -18,7 +18,7 @@ const (
 	integerMelangeKeyPath = "melange-work/melange.rsa.pub"
 )
 
-func integerPrepareMelangeBuild(ctx context.Context, melange *intconfig.MelangeSpec) (repos []string, keyrings []string, err error) {
+func integerPrepareMelangeBuild(ctx context.Context, melange *intconfig.MelangeSpec) (repos, keyrings []string, err error) {
 	if melange == nil {
 		return nil, nil, nil
 	}

--- a/cmd/integer_build_melange.go
+++ b/cmd/integer_build_melange.go
@@ -18,7 +18,7 @@ const (
 	integerMelangeKeyPath = "melange-work/melange.rsa.pub"
 )
 
-func integerPrepareMelangeBuild(ctx context.Context, melange *intconfig.MelangeSpec) ([]string, []string, error) {
+func integerPrepareMelangeBuild(ctx context.Context, melange *intconfig.MelangeSpec) (repos []string, keyrings []string, err error) {
 	if melange == nil {
 		return nil, nil, nil
 	}

--- a/cmd/integer_build_melange_test.go
+++ b/cmd/integer_build_melange_test.go
@@ -25,7 +25,11 @@ func TestIntegerPrepareMelangeBuild_RunsScriptAndReturnsRepoAndKey(t *testing.T)
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(repoRoot))
-	t.Cleanup(func() { require.NoError(t, os.Chdir(wd)) })
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
 
 	repos, keyrings, err := integerPrepareMelangeBuild(context.Background(), &intconfig.MelangeSpec{
 		Bespoke:     intconfig.StringList{"custom.yaml"},

--- a/cmd/integer_build_melange_test.go
+++ b/cmd/integer_build_melange_test.go
@@ -25,7 +25,7 @@ func TestIntegerPrepareMelangeBuild_RunsScriptAndReturnsRepoAndKey(t *testing.T)
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(repoRoot))
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	t.Cleanup(func() { require.NoError(t, os.Chdir(wd)) })
 
 	repos, keyrings, err := integerPrepareMelangeBuild(context.Background(), &intconfig.MelangeSpec{
 		Bespoke:     intconfig.StringList{"custom.yaml"},

--- a/cmd/integer_build_test.go
+++ b/cmd/integer_build_test.go
@@ -129,6 +129,44 @@ func TestIntegerResolveLatestVersion_NoVersions(t *testing.T) {
 	assert.Contains(t, err.Error(), "no versions found")
 }
 
+func TestIntegerBuildCommand_RejectsUndeclaredVersionWhenAutoDiscoveryDisabled(t *testing.T) {
+	const yamlBody = `
+name: teleport
+upstream:
+  package: "teleport-{{version}}"
+  auto-discover: false
+types:
+  default:
+    base: wolfi-base
+    packages: ["teleport-{{version}}"]
+    entrypoint: /usr/bin/teleport start
+versions:
+  "18.6": {}
+`
+	dir := t.TempDir()
+	imagesDir := filepath.Join(dir, "images")
+	baseDir := filepath.Join(imagesDir, "_base")
+	require.NoError(t, os.MkdirAll(baseDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "wolfi-base.yaml"), []byte("# base\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(imagesDir, "teleport.yaml"), []byte(yamlBody), 0o644))
+
+	srv := intMakeAPKINDEXServer(t, "P:teleport-17\nV:17.7.8-r0\n\nP:teleport-18\nV:18.6.6-r0\n\nP:teleport-18.6\nV:18.6.6-r0\n\n")
+	t.Setenv("PATH", "")
+
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "build",
+		"--image", "teleport",
+		"--version", "18",
+		"--type", "default",
+		"--images-dir", imagesDir,
+		"--apkindex-url", srv.URL,
+		"--output", filepath.Join(dir, "image.tar"),
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errIntegerVariantNotFound)
+}
+
 // intCapturingApko installs a fake `apko` on PATH that copies its config-file
 // argument to capturePath and exits 0. The capture path's parent directory is
 // created if needed. The fake mirrors the real apko CLI surface used by
@@ -529,7 +567,6 @@ versions:
 		})
 	}
 }
-
 
 func intFakeTrivy(t *testing.T, exitCode int) {
 	t.Helper()

--- a/images/teleport.yaml
+++ b/images/teleport.yaml
@@ -2,6 +2,7 @@ name: teleport
 description: "Teleport access platform — Wolfi rebuild targets upstream CVEs"
 upstream:
   package: "teleport-{{version}}"
+  auto-discover: false
 
 types:
   default:

--- a/internal/integer/config/types.go
+++ b/internal/integer/config/types.go
@@ -187,7 +187,12 @@ func (d *ImageDef) VersionedPackagePattern() string {
 // If Package contains no "{{version}}", the package is unversioned and only
 // a single "latest" version is built.
 type Upstream struct {
-	Package string `yaml:"package"`
+	Package      string `yaml:"package"`
+	AutoDiscover *bool  `yaml:"auto-discover,omitempty"`
+}
+
+func (u Upstream) AutoDiscoveryEnabled() bool {
+	return u.AutoDiscover == nil || *u.AutoDiscover
 }
 
 // TypeTemplate is the apko config template for one build type (default, dev, fips, …).

--- a/internal/integer/discovery/discover.go
+++ b/internal/integer/discovery/discover.go
@@ -260,7 +260,7 @@ func ResolveVersions(def *config.ImageDef, pkgs []apkindex.Package) []string {
 	seen := make(map[string]bool)
 
 	// Auto-discover from APKINDEX.
-	if len(pkgs) > 0 {
+	if def.Upstream.AutoDiscoveryEnabled() && len(pkgs) > 0 {
 		for _, v := range apkindex.DiscoverVersions(pkgs, def.Upstream.Package) {
 			seen[v] = true
 		}

--- a/internal/integer/discovery/discover_test.go
+++ b/internal/integer/discovery/discover_test.go
@@ -400,6 +400,36 @@ versions:
 	assert.Equal(t, []string{"3.9"}, fipsVersions, "only explicit version should get fips")
 }
 
+func TestDiscoverFromFiles_AutoDiscoveryDisabledUsesExplicitVersionsOnly(t *testing.T) {
+	const teleportYAML = `
+name: teleport
+description: "Teleport"
+upstream:
+  package: "teleport-{{version}}"
+  auto-discover: false
+types:
+  default:
+    base: wolfi-base
+    packages: ["teleport-{{version}}"]
+    entrypoint: /usr/bin/teleport start
+versions:
+  "18.6": {}
+`
+	imagesDir := setupImages(t, map[string]string{"teleport.yaml": teleportYAML})
+	genDir := t.TempDir()
+	pkgs := []apkindex.Package{
+		{Name: "teleport-17", Version: "17.7.8-r0"},
+		{Name: "teleport-18", Version: "18.6.6-r0"},
+		{Name: "teleport-18.6", Version: "18.6.6-r0"},
+	}
+
+	imgs, err := discovery.DiscoverFromFiles(opts(imagesDir, genDir, pkgs))
+	require.NoError(t, err)
+	require.Len(t, imgs, 1)
+	assert.Equal(t, "18.6", imgs[0].Version)
+	assert.Equal(t, typeDefault, imgs[0].Type)
+}
+
 func TestDiscoverFromFiles_ReviewFIPSProfileSkipped(t *testing.T) {
 	const reviewYAML = `
 name: review-only


### PR DESCRIPTION
Fixes stale Teleport streams leaking into Integer discovery/build.

Root cause:
- `images/teleport.yaml` intentionally only declares `18.6`, but auto-discovery merged APKINDEX streams and exposed `17`/`18`.
- Manual dispatches for `teleport:17` and `teleport:18` then rendered stale packages and failed Trivy with HIGH/CRITICAL findings.

Changes:
- Add `upstream.auto-discover: false` for Teleport.
- Make discovery respect explicit-only image definitions.
- Make `integer build --version` reject undeclared versions when auto-discovery is disabled.
- Add regression tests for discovery and build rejection.

Validation:
- `yamllint images/teleport.yaml`
- `go test ./cmd ./internal/...`
- `go build ./...`
- Manual: `go run . integer discover --only teleport` emits only `teleport:18.6-default`; `go run . integer build --image teleport --version 18 ...` rejects undeclared version.

Note: touched test files are pre-existing oversized files; this PR adds focused regression coverage only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits Teleport to the explicitly declared 18.6 stream and blocks stale 17/18 from discovery or build. Discovery now respects `upstream.auto-discover: false`, the build command rejects undeclared versions, and tests/lint cleanup were hardened.

- **Bug Fixes**
  - Set `upstream.auto-discover: false` in `images/teleport.yaml` to allow only 18.6.
  - Discovery skips APKINDEX-derived versions when auto-discovery is disabled.
  - `integer build --version` fails for versions not declared in the image file.
  - Adds tests for explicit-only discovery and build rejection.
  - Hardens test cleanup and function signatures to satisfy lints/CI.

- **Migration**
  - Only dispatch Teleport builds for `teleport:18.6-*`.
  - Remove workflows or jobs targeting `teleport:17` or `teleport:18`.

<sup>Written for commit 00b3ddcc6e928c288507b7b8d73e4a9592ad6cb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

