### PR TITLE
fix(integer): add bespoke linkerd CLI package

### DIFF
--- a/images/linkerd.yaml
+++ b/images/linkerd.yaml
@@ -6,7 +6,7 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["linkerd2-cli=25.12.3-r1"]
+    packages: ["linkerd2-cli=25.12.3-r99"]
     entrypoint: /usr/bin/linkerd
     melange:
       bespoke: "linkerd2-cli-25.yaml"

--- a/images/linkerd.yaml
+++ b/images/linkerd.yaml
@@ -1,13 +1,15 @@
 name: linkerd
-description: "Linkerd service mesh CLI — Wolfi rebuild for zero-CVE base"
+description: "Linkerd service mesh CLI — bespoke 25.x Wolfi rebuild for zero-CVE base"
 upstream:
   package: linkerd2-cli
 
 types:
   default:
     base: wolfi-base
-    packages: ["linkerd2-cli"]
+    packages: ["linkerd2-cli=25.12.3-r1"]
     entrypoint: /usr/bin/linkerd
+    melange:
+      bespoke: "linkerd2-cli-25.yaml"
 
 versions:
   "25": {}

--- a/packages/bespoke/linkerd2-cli-25.yaml
+++ b/packages/bespoke/linkerd2-cli-25.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2-cli
   version: "25.12.3"
-  epoch: 1
+  epoch: 99
   description: "Linkerd CLI"
   copyright:
     - license: Apache-2.0

--- a/packages/bespoke/linkerd2-cli-25.yaml
+++ b/packages/bespoke/linkerd2-cli-25.yaml
@@ -1,0 +1,42 @@
+package:
+  name: linkerd2-cli
+  version: "25.12.3"
+  epoch: 1
+  description: "Linkerd CLI"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+
+pipeline:
+  - runs: |
+      case "$(uname -m)" in
+        x86_64)
+          url="https://github.com/linkerd/linkerd2/releases/download/edge-${{package.version}}/linkerd2-cli-edge-${{package.version}}-linux-amd64"
+          sha="ef536e1d2efa8cb5e02e45c9baf5ed83fdfbc8c17403259af989dd8c88049b31"
+          ;;
+        aarch64)
+          url="https://github.com/linkerd/linkerd2/releases/download/edge-${{package.version}}/linkerd2-cli-edge-${{package.version}}-linux-arm64"
+          sha="69c4e6a8275204d1a77dd33c4a60ee00aab27f62915db34e121e3cd97eb46e6e"
+          ;;
+        *)
+          exit 1
+          ;;
+      esac
+      curl -fsSL "$url" -o linkerd
+      printf '%s  %s\n' "$sha" linkerd | sha256sum -c -
+      install -Dm755 linkerd "${{targets.contextdir}}/usr/bin/linkerd"
+
+test:
+  pipeline:
+    - runs: |
+        linkerd version --client | grep -F edge-${{package.version}}
+        linkerd --help


### PR DESCRIPTION
Adds a bespoke Linkerd CLI package for the Integer fallback path.

Root cause:
- `linkerd:25-default` failed the Trivy publish gate on the Wolfi `linkerd2-cli` package.
- Current Wolfi package drifted/skewed across arches; Copa is not viable for upstream Linkerd because the image declares Wolfi and Copa rejects it.

Changes:
- `images/linkerd.yaml`: pin default type to bespoke `linkerd2-cli=25.12.3-r1`.
- `packages/bespoke/linkerd2-cli-25.yaml`: package official `edge-25.12.3` release binaries with per-arch sha256 verification.

Validation:
- `yamllint images/linkerd.yaml packages/bespoke/linkerd2-cli-25.yaml`
- `go test ./cmd ./internal/...`
- `go build ./...`
- Agent manually built amd64/arm64 images and Trivy returned clean for `HIGH,CRITICAL`.

Expected to close [#777](https://github.com/verity-org/verity/issues/777) after CI confirms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Trivy gate for the Linkerd image by shipping a bespoke CLI and pinning `linkerd2-cli=25.12.3-r99` to outrank upstream Wolfi. Aligns amd64/arm64 builds and unblocks the Integer fallback path (will close #777 once CI passes).

- **Bug Fixes**
  - Set image default to `linkerd2-cli=25.12.3-r99` and wired `melange.bespoke` to `linkerd2-cli-25.yaml` to bypass Wolfi drift/Copa rejection; epoch bumped to outrank upstream.
  - Confirmed clean Trivy scans on amd64/arm64 for HIGH and CRITICAL.

- **Dependencies**
  - Added `packages/bespoke/linkerd2-cli-25.yaml` to package upstream `edge-25.12.3` binaries with per-arch sha256 verification and minimal runtime deps.

<sup>Written for commit 73b0c8d3164e4c2e74fbdd1deea6852fb3b3847a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

