### PR TITLE
fix: route chart wrappers and sign melange indexes

### DIFF
--- a/.github/scripts/melange-build.sh
+++ b/.github/scripts/melange-build.sh
@@ -147,3 +147,11 @@ fi
 for build_yaml in "${builds[@]}"; do
   build_one "$build_yaml"
 done
+
+cp melange-work/melange.rsa.pub packages/repo/
+
+for index in packages/repo/*/APKINDEX.tar.gz; do
+  [ -f "$index" ] || continue
+  echo "Signing APKINDEX: $index"
+  melange sign-index --signing-key melange-work/melange.rsa "$index" --force
+done

--- a/verity.yaml
+++ b/verity.yaml
@@ -99,6 +99,8 @@ chartValues:
   # false` via `mimir.structuredConfig` — the chart's documented hook
   # for overriding the rendered text-config.
   mimir-distributed:
+    image.repository: ghcr.io/verity-org/mimir
+    image.tag: "3.0"
     gateway.enabled: false
     kafka.enabled: false
     minio.enabled: false
@@ -164,6 +166,15 @@ chartValues:
     mimir.structuredConfig.alertmanager_storage.filesystem.dir: /data/storage-alertmanager
     mimir.structuredConfig.ruler_storage.backend: filesystem
     mimir.structuredConfig.ruler_storage.filesystem.dir: /data/storage-ruler
+
+  # traefik 41.0.1 leaves `image.registry`, `image.repository`, and `image.tag`
+  # null in values.yaml, so chart-gen cannot auto-detect the split registry+
+  # repository shape from defaults. Hard-set the wrapper values here so the
+  # rendered Deployment uses ghcr.io/verity-org/traefik:3.7.
+  traefik:
+    image.registry: ghcr.io
+    image.repository: verity-org/traefik
+    image.tag: "3.7"
 
   # tempo-distributed 1.61.3 defaults to a separate Memcached statefulset;
   # the minimal CI-friendly wrapper just runs the Tempo microservices


### PR DESCRIPTION
## Summary

- fix [#601](https://github.com/verity-org/verity/issues/601) by signing melange-produced `packages/repo/*/APKINDEX.tar.gz` and publishing `packages/repo/melange.rsa.pub`
- fix [#592](https://github.com/verity-org/verity/issues/592) by forcing the traefik wrapper chart to render `ghcr.io/verity-org/traefik:3.7`
- fix [#591](https://github.com/verity-org/verity/issues/591) by forcing the mimir-distributed wrapper chart to render `ghcr.io/verity-org/mimir:3.0`

## Validation

- `go test ./scripts -run "TestValidateAPKRepositoryRequiresSignedIndexAndPublicKey|TestMelangeBuild"`
- local wrapper packaging + `helm template` render now produce only:
  - `ghcr.io/verity-org/traefik:3.7`
  - `ghcr.io/verity-org/mimir:3.0`
- manual shell QA of `.github/scripts/melange-build.sh` with a fake melange binary produced:
  - `packages/repo/melange.rsa.pub`
  - signed `APKINDEX.tar.gz` containing `.SIGN.RSA.melange.rsa.pub`

## Remaining blockers

- [#503](https://github.com/verity-org/verity/issues/503): umbrella chart-image debt, not one safe generic fix. Next concrete slices remain per-image backlog work (`replacement-coverage` gaps like `cilium/cilium-envoy`, then exact-pin cleanup).
- [#372](https://github.com/verity-org/verity/issues/372): still blocked at `test/chart-integration/SKIPS.yaml:63` because kind lacks cilium's required capabilities; needs harness capability grants or an upstream CI-friendly probe-disable knob.
- [#325](https://github.com/verity-org/verity/issues/325): still blocked at `test/chart-integration/SKIPS.yaml:38` because falco's modern eBPF path fails on GHA without `CAP_BPF/CAP_PERFMON`; alternatives are manual plugin wiring or upstream driver-disabled support.
- [#551](https://github.com/verity-org/verity/issues/551): still blocked at `images/argocd.yaml:92` pending the upstream Go FIPS fix in a stable Go release and a Wolfi package bump.
- [#68](https://github.com/verity-org/verity/issues/68): dependency dashboard remains open; currently tracked renovate work still includes [#512](https://github.com/verity-org/verity/pull/512).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Signs melange-produced APK indexes and publishes the public key, and pins wrapper charts to Verity images for Traefik and Mimir. This fixes index verification and ensures manifests render `ghcr.io/verity-org/traefik:3.7` and `ghcr.io/verity-org/mimir:3.0`.

- **Bug Fixes**
  - Sign `packages/repo/*/APKINDEX.tar.gz` with `melange.rsa` and publish `packages/repo/melange.rsa.pub` to enable APK repository signature checks (fixes #601).
  - Hard-set Traefik chart values (`image.registry`, `image.repository`, `image.tag`) so the wrapper renders `ghcr.io/verity-org/traefik:3.7` (fixes #592).
  - Set Mimir-distributed `image.repository` and `image.tag` so the wrapper renders `ghcr.io/verity-org/mimir:3.0` (fixes #591).

<sup>Written for commit 5b8382d4420ef91ec8d32f2bcbf2144d8762e4ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

