### PR TITLE
copa: add bespoke pulumi recipe

### DIFF
--- a/images/pulumi.yaml
+++ b/images/pulumi.yaml
@@ -8,6 +8,9 @@ types:
     base: wolfi-base
     packages: ["pulumi"]
     entrypoint: /usr/bin/pulumi
+    melange:
+      bespoke:
+        - pulumi-3.yaml
 
 versions:
   "3": {}

--- a/packages/bespoke/pulumi-3.yaml
+++ b/packages/bespoke/pulumi-3.yaml
@@ -50,7 +50,7 @@ pipeline:
 
           SDKS= make install
           mv -v "${PULUMI_ROOT}"/bin/pulumi* "${{targets.contextdir}}/usr/bin"
-          chmod -R u+rwX .
+          chmod -R a+rwX .
       - uses: strip
     working-directory: ${{package.name}}
 

--- a/packages/bespoke/pulumi-3.yaml
+++ b/packages/bespoke/pulumi-3.yaml
@@ -50,6 +50,7 @@ pipeline:
 
           SDKS= make install
           mv -v "${PULUMI_ROOT}"/bin/pulumi* "${{targets.contextdir}}/usr/bin"
+          chmod -R u+rwX .
       - uses: strip
     working-directory: ${{package.name}}
 

--- a/packages/bespoke/pulumi-3.yaml
+++ b/packages/bespoke/pulumi-3.yaml
@@ -1,0 +1,67 @@
+package:
+  name: pulumi
+  version: "3.250.0"
+  epoch: 99
+  description: Infrastructure as Code in any programming language
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "8"
+    memory: 11Gi
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - coreutils
+      - go
+      - jq
+      - nodejs
+      - patch
+      - python-3.11
+      - python-3.11-dev
+      - uv
+      - yarn
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      destination: ${{package.name}}
+      expected-commit: 7549635909277a54490acc87186590b816762fd5
+      repository: https://github.com/pulumi/pulumi.git
+      tag: v${{package.version}}
+
+  - pipeline:
+      - runs: |
+          set -x
+
+          export PULUMI_VERSION="v${{package.version}}"
+          export PULUMI_ROOT="$(mktemp -d)"
+          export GOBIN="${PULUMI_ROOT}/bin"
+          mkdir -p "${{targets.contextdir}}/usr/bin" "${{targets.contextdir}}/usr/lib"
+
+          mkdir -p .make
+          touch .make/proto
+
+          SDKS= make install
+          mv -v "${PULUMI_ROOT}"/bin/pulumi* "${{targets.contextdir}}/usr/bin"
+      - uses: strip
+    working-directory: ${{package.name}}
+
+test:
+  pipeline:
+    - name: Verify Pulumi installation
+      runs: |
+        pulumi version | grep ${{package.version}}
+        pulumi --help
+
+update:
+  enabled: true
+  github:
+    identifier: pulumi/pulumi
+    strip-prefix: v


### PR DESCRIPTION
## Summary
- add bespoke melange recipe for `pulumi:3-default` and wire it into `images/pulumi.yaml`
- keep post-rebase Integer validation green by unpinning `linkerd2-cli` so bespoke package resolution stays satisfiable
- refs [#818](https://github.com/verity-org/verity/issues/818) without closing it before merge/publish

## Testing
- `./verity integer validate`
- `sudo env "PATH=$PATH:/home/omer/.local/share/mise/installs/trivy/0.70.0" TMPDIR="$PWD/.tmp" ./verity integer build --image pulumi --version 3 --type default --arch amd64 --fail-on-severity HIGH,CRITICAL --output gate-amd64.tar`
- `sudo env "PATH=$PATH:/home/omer/.local/share/mise/installs/trivy/0.70.0" TMPDIR="$PWD/.tmp" melange build melange-work/specs/pulumi-3.yaml/build.yaml --arch aarch64 --signing-key melange-work/melange.rsa --out-dir packages/repo --repository-append https://packages.wolfi.dev/os --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub --runner docker --pipeline-dirs melange-work/pipelines`
- `sudo env "PATH=$PATH:/home/omer/.local/share/mise/installs/trivy/0.70.0" ./verity integer discover --gen-dir ./gen`
- `sudo env "PATH=$PATH:/home/omer/.local/share/mise/installs/trivy/0.70.0" apko build --arch arm64 --repository-append "$PWD/packages/repo" --keyring-append "$PWD/melange-work/melange.rsa.pub" gen/pulumi/3/default.apko.yaml integer:local gate-arm64-manual.tar`
- `sudo env "PATH=$PATH:/home/omer/.local/share/mise/installs/trivy/0.70.0" trivy image --input gate-arm64-manual.tar --exit-code 1 --severity HIGH,CRITICAL --vuln-type os,library`

## Results
- amd64 tar built and Trivy HIGH/CRITICAL clean
- arm64 tar built from workflow-equivalent aarch64 melange + apko path and Trivy HIGH/CRITICAL clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bespoke `melange` recipe to build `pulumi` v3.250.0 from source, wires it into the `pulumi:3-default` image, and exposes workspace metadata so Integer can discover and build it. Refs #818.

- **New Features**
  - Adds `packages/bespoke/pulumi-3.yaml` to build `pulumi` 3.250.0 from source with CGO disabled, pins the upstream tag/commit, runs basic tests, installs binaries to `/usr/bin`, and enables update checks.
  - Updates `images/pulumi.yaml` to include `melange.bespoke: pulumi-3.yaml` and expose workspace metadata for `pulumi:3-default` (entrypoint `/usr/bin/pulumi`).

<sup>Written for commit f1936c06dc14335f0d728f295a32a168d01698a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

