### PR TITLE
fix(copa): target sonarqube community tag

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -924,9 +924,8 @@ images:
     image: "docker.io/library/sonarqube"
     platforms: ["linux/amd64", "linux/arm64"]
     tags:
-      strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
-      maxTags: 3
+      strategy: "list"
+      list: ["10-community"]
 
 
   # ============================================================================


### PR DESCRIPTION
## Summary
- switch SonarQube Copa discovery from stale numeric tags to real upstream `10-community`
- keep SonarQube on Copa-first path instead of dead `6.7.x` historical tags
- validate locally with `go build`, `go test ./...`, and `verity discover --only library/sonarqube`

## What changed
- `copa-config.yaml`: change `library/sonarqube` tag strategy from semver-pattern discovery to explicit `10-community`

## Validation
- `go build -o /tmp/opencode/verity .`
- `go test ./...`
- `/tmp/opencode/verity discover --config copa-config.yaml --charts-file /tmp/opencode/empty-chart.yaml --verity-config verity.yaml --only library/sonarqube`
  - resolves `docker.io/library/sonarqube:10-community`

## Blockers found while re-evaluating remaining CVE issues
- [#799](https://github.com/verity-org/verity/issues/799): `opensearch-dashboards:3.6.0` Copa blocked upstream. Latest patch runs fail because Amazon Linux repos serve lower-than-required package revisions (`graphite2`, `libcap`, `libsolv`, `openssl*`, `python3*`). Evidence: run [28732043260](https://github.com/verity-org/verity/actions/runs/28732043260).
- [#800](https://github.com/verity-org/verity/issues/800): `opensearch:2/3.x` Integer issue remains upstream-blocked on Wolfi per issue evidence; latest Copa run for `3.6.0` also fails because Amazon Linux repos serve lower-than-required `libcap`, `libsolv`, `openssl*`, `python3*` revisions. Evidence: run [28731936473](https://github.com/verity-org/verity/actions/runs/28731936473).
- [#801](https://github.com/verity-org/verity/issues/801): same OpenSearch 3.x blocker as above; no repo-side Copa/base override fix until upstream package repos publish required revisions.
- [#826](https://github.com/verity-org/verity/issues/826): previous SonarQube Copa config targeted wrong upstream train (`6.7.x`). This PR fixes discovery to the live `10-community` tag. Historical failed Copa evidence for stale config: run [28732073679](https://github.com/verity-org/verity/actions/runs/28732073679).

## Live follow-up validation dispatched
- `Patch library/sonarqube (docker.io/library/sonarqube:10-community)`: [28780218553](https://github.com/verity-org/verity/actions/runs/28780218553)
- `Patch library/sonarqube (docker.io/library/sonarqube:community)`: [28780220738](https://github.com/verity-org/verity/actions/runs/28780220738)
- `Patch library/sonarqube (docker.io/library/sonarqube:lts-community)`: [28780222464](https://github.com/verity-org/verity/actions/runs/28780222464)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SonarQube image discovery to target the active `10-community` tag instead of stale numeric tags, ensuring we pull the supported upstream image.

- **Bug Fixes**
  - Updated `copa-config.yaml` to use `list: ["10-community"]` for `docker.io/library/sonarqube` (replacing the semver pattern).
  - Keeps Copa on the current community release line and avoids `6.7.x`-era tags.

<sup>Written for commit cc93de3ad2a011c0f37359dc8c156c0ec7f6d483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

