### PR TITLE
fix(integer): rebuild airflow with bespoke package

### DIFF
--- a/cmd/integer_validate.go
+++ b/cmd/integer_validate.go
@@ -258,10 +258,10 @@ func resolveBespokeFiles(def *intconfig.ImageDef, typeName, bespokeFile string) 
 }
 
 func tmplPackageMatchesBespoke(def *intconfig.ImageDef, typeName string, packages []string, pkgName string) bool {
-	if slices.Contains(packages, pkgName) {
-		return true
-	}
 	for _, pkg := range packages {
+		if apkPackageName(pkg) == pkgName {
+			return true
+		}
 		if !strings.Contains(pkg, "{{version}}") {
 			continue
 		}
@@ -269,12 +269,20 @@ func tmplPackageMatchesBespoke(def *intconfig.ImageDef, typeName string, package
 			if slices.Contains(meta.SkipTypes, typeName) {
 				continue
 			}
-			if strings.ReplaceAll(pkg, "{{version}}", version) == pkgName {
+			if apkPackageName(strings.ReplaceAll(pkg, "{{version}}", version)) == pkgName {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func apkPackageName(pkg string) string {
+	idx := strings.IndexAny(pkg, "<>=~!")
+	if idx < 0 {
+		return pkg
+	}
+	return pkg[:idx]
 }
 
 // isExistingDir returns true iff path is a non-empty string and refers to

--- a/cmd/integer_validate_test.go
+++ b/cmd/integer_validate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -168,6 +169,23 @@ package:
 func TestIntegerValidateCommand_BespokeOK(t *testing.T) {
 	imagesDir, cfgPath := intSetupCmdImages(t)
 	intWriteFile(t, filepath.Join(imagesDir, "popeye.yaml"), intTestPopeyeImageYAML)
+
+	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
+	intWriteFile(t, filepath.Join(bespokeDir, "popeye.yaml"), intTestPopeyeBespokeYAML)
+
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "validate",
+		"--config", cfgPath,
+		"--images-dir", imagesDir,
+		"--bespoke-dir", bespokeDir,
+	})
+	assert.NoError(t, err)
+}
+
+func TestIntegerValidateCommand_BespokePackageConstraintOK(t *testing.T) {
+	imagesDir, cfgPath := intSetupCmdImages(t)
+	intWriteFile(t, filepath.Join(imagesDir, "popeye.yaml"), strings.ReplaceAll(intTestPopeyeImageYAML, `packages: ["popeye"]`, `packages: ["popeye=0.22.1-r99"]`))
 
 	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
 	intWriteFile(t, filepath.Join(bespokeDir, "popeye.yaml"), intTestPopeyeBespokeYAML)

--- a/images/airflow.yaml
+++ b/images/airflow.yaml
@@ -26,6 +26,8 @@ types:
       # in Jobs/Deployments and `sh` in exec probes, so PATH must include that
       # directory and the image must ship both shells.
       PATH: /opt/airflow/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    melange:
+      bespoke: "airflow-3.yaml"
     paths:
       # Keep absolute-path callers working while the chart uses PATH-based
       # `airflow` invocations.

--- a/internal/integer/config/airflow_image_test.go
+++ b/internal/integer/config/airflow_image_test.go
@@ -41,6 +41,9 @@ func TestAirflowImageExposesConsoleScriptsOnPath(t *testing.T) {
 	if tmpl.Environment["AIRFLOW_USER_HOME_DIR"] != "/opt/airflow" {
 		t.Fatalf("AIRFLOW_USER_HOME_DIR=%q want /opt/airflow for /entrypoint-based chart probes", tmpl.Environment["AIRFLOW_USER_HOME_DIR"])
 	}
+	if tmpl.Melange == nil || !tmpl.Melange.Bespoke.Contains("airflow-3.yaml") {
+		t.Fatalf("melange=%v want bespoke airflow-3.yaml rebuild for Trivy-clean airflow-3", tmpl.Melange)
+	}
 
 	foundSymlink := false
 	for _, p := range tmpl.Paths {

--- a/packages/bespoke/airflow-3.yaml
+++ b/packages/bespoke/airflow-3.yaml
@@ -1,0 +1,188 @@
+package:
+  name: airflow-3
+  version: "3.2.2"
+  epoch: 10
+  description: Apache Airflow workflow engine
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - aom-libs
+      - ca-certificates-bundle
+      - cairo
+      - coreutils
+      - fontconfig-config
+      - freetype
+      - fribidi
+      - gdbm
+      - glib
+      - glibc
+      - glibc-locale-posix
+      - graphite2
+      - graphviz
+      - harfbuzz
+      - keyutils
+      - keyutils-libs
+      - ld-linux
+      - libacl1
+      - libattr1
+      - libavif
+      - libbrotlicommon1
+      - libbrotlidec1
+      - libbsd
+      - libbz2-1
+      - libcrypt1
+      - libcrypto3
+      - libdav1d
+      - libexpat1
+      - libffi
+      - libfontconfig1
+      - libgcc
+      - libgd
+      - libice
+      - libjpeg-turbo
+      - libltdl
+      - libmd
+      - libpcre2-8-0
+      - libpng
+      - libselinux
+      - libsepol
+      - libsm
+      - libssl3
+      - libstdc++
+      - libudev
+      - libwebp
+      - libx11
+      - libxau
+      - libxcb
+      - libxcrypt
+      - libxdmcp
+      - libxext
+      - libxft
+      - libxpm
+      - libxrender
+      - libxt
+      - libzstd1
+      - mariadb-connector-c
+      - mpdecimal
+      - ncurses
+      - ncurses-terminfo-base
+      - netcat-openbsd
+      - pango
+      - pixman
+      - posix-libc-utils
+      - posix-libc-utils-bin
+      - py3-pip-wheel
+      - python-3.13
+      - python-3.13-base
+      - readline
+      - sqlite-libs
+      - tiff
+      - tzdata
+      - unixodbc
+      - wolfi-baselayout
+      - xz
+      - zlib
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - ca-certificates-bundle
+      - coreutils
+      - git
+      - libffi-dev
+      - libxml2-dev
+      - libxslt-dev
+      - linux-headers
+      - mariadb-connector-c-dev
+      - openssl-dev
+      - py3-pip
+      - py3-pip-wheel
+      - python-3.13
+      - python-3.13-dev
+      - sqlite-dev
+      - unixodbc-dev
+      - wolfi-base
+      - wolfi-baselayout
+  environment:
+    PIP_DISABLE_PIP_VERSION_CHECK: "1"
+    PYTHONDONTWRITEBYTECODE: "1"
+
+pipeline:
+  - runs: |
+      python3.13 -m venv "${{targets.destdir}}/opt/airflow"
+      "${{targets.destdir}}/opt/airflow/bin/pip" install --upgrade pip setuptools wheel
+      "${{targets.destdir}}/opt/airflow/bin/pip" install --no-compile \
+        "apache-airflow==${{package.version}}" \
+        "apache-airflow-providers-amazon==9.29.0" \
+        "apache-airflow-providers-celery==3.20.0" \
+        "apache-airflow-providers-cncf-kubernetes==10.17.1" \
+        "apache-airflow-providers-common-compat==1.15.0" \
+        "apache-airflow-providers-common-io==1.7.2" \
+        "apache-airflow-providers-common-sql==2.0.0" \
+        "apache-airflow-providers-docker==4.5.6" \
+        "apache-airflow-providers-elasticsearch==6.5.4" \
+        "apache-airflow-providers-fab==3.6.4" \
+        "apache-airflow-providers-ftp==3.15.0" \
+        "apache-airflow-providers-google==22.0.0" \
+        "apache-airflow-providers-grpc==3.9.4" \
+        "apache-airflow-providers-hashicorp==4.6.0" \
+        "apache-airflow-providers-http==6.0.2" \
+        "apache-airflow-providers-imap==3.11.3" \
+        "apache-airflow-providers-microsoft-azure==13.3.0" \
+        "apache-airflow-providers-mysql==6.6.0" \
+        "apache-airflow-providers-odbc==4.12.2" \
+        "apache-airflow-providers-openlineage==2.17.0" \
+        "apache-airflow-providers-postgres==6.7.0" \
+        "apache-airflow-providers-redis==4.4.4" \
+        "apache-airflow-providers-sendgrid==4.2.3" \
+        "apache-airflow-providers-sftp==5.8.2" \
+        "apache-airflow-providers-slack==9.10.0" \
+        "apache-airflow-providers-smtp==3.0.1" \
+        "apache-airflow-providers-snowflake==6.13.0" \
+        "apache-airflow-providers-sqlite==4.3.2" \
+        "apache-airflow-providers-ssh==5.0.2" \
+        "apache-airflow-providers-standard==1.13.1"
+      "${{targets.destdir}}/opt/airflow/bin/pip" install --no-compile --upgrade \
+        "joserfc==1.7.2" \
+        "litellm==1.83.7" \
+        "python-multipart==0.0.32" \
+        "starlette==1.3.1"
+      find "${{targets.destdir}}/opt/airflow/bin" -maxdepth 1 -type f -perm -u+x | while read -r script; do
+        if grep -q '^#!/home/build/melange-out/airflow-3/opt/airflow/bin/python' "$script"; then
+          sed -i '1s|^#!.*|#!/opt/airflow/bin/python3.13|' "$script"
+        fi
+      done
+      install -d "${{targets.destdir}}/opt/airflow" "${{targets.destdir}}/opt/airflow/dags" "${{targets.destdir}}/opt/airflow/logs" "${{targets.destdir}}/opt/airflow/plugins"
+      cat > "${{targets.destdir}}/entrypoint" <<'EOF'
+      #!/usr/bin/env bash
+      set -euo pipefail
+      export AIRFLOW_HOME="${AIRFLOW_HOME:-/opt/airflow}"
+      export AIRFLOW_USER_HOME_DIR="${AIRFLOW_USER_HOME_DIR:-/opt/airflow}"
+      for candidate in \
+        "/usr/lib/$(uname -m)-linux-gnu/libstdc++.so.6" \
+        /usr/lib/libstdc++.so.6 \
+        /usr/lib64/libstdc++.so.6; do
+        if [ -e "$candidate" ]; then
+          export LD_PRELOAD="$candidate"
+          break
+        fi
+      done
+      exec "$@"
+      EOF
+      chmod 0755 "${{targets.destdir}}/entrypoint"
+
+test:
+  environment:
+    contents:
+      packages:
+        - airflow-3
+        - bash
+  pipeline:
+    - runs: |
+        test -x /entrypoint
+        test -x /opt/airflow/bin/airflow
+        /opt/airflow/bin/airflow version | grep -q '^3\.2\.2$'
+        AIRFLOW_HOME=/opt/airflow AIRFLOW_USER_HOME_DIR=/opt/airflow /entrypoint bash -c 'exec /opt/airflow/bin/airflow version' | grep -q '^3\.2\.2$'


### PR DESCRIPTION
## Summary

- add bespoke `airflow-3` melange package and wire `images/airflow.yaml` to build from it
- rebuild Airflow on Python 3.13 so patched LiteLLM can install, while preserving `/opt/airflow` layout and `/entrypoint` surface
- lock test coverage on the bespoke package wiring in `internal/integer/config/airflow_image_test.go`

## Validation

- `yamllint images/airflow.yaml packages/bespoke/airflow-3.yaml`
- `go test ./internal/integer/config -run TestAirflowImageExposesConsoleScriptsOnPath`
- `go build ./...`
- `go run . integer build --image airflow --version 3 --type default --output /tmp/airflow-fixed.tar`
- `docker run --rm integer:local-amd64 sh -lc '/opt/airflow/bin/airflow version && AIRFLOW_HOME=/opt/airflow AIRFLOW_USER_HOME_DIR=/opt/airflow /entrypoint bash -c "exec /opt/airflow/bin/airflow version" && /opt/airflow/bin/airflow scheduler --help >/tmp/scheduler-help.txt && wc -l </tmp/scheduler-help.txt && /opt/airflow/bin/airflow db check-migrations --help >/tmp/db-help.txt && wc -l </tmp/db-help.txt'`
- `docker run --rm -v /tmp/airflow-fixed.tar:/scan.tar aquasec/trivy:0.69.3 image --input /scan.tar --severity HIGH,CRITICAL --format json` → 0 HIGH/CRITICAL findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the Airflow image from a bespoke `airflow-3` melange package on Python 3.13 to enable `litellm` while keeping the `/opt/airflow` layout and a stable `/entrypoint`. Also updates validation to handle version‑pinned apk packages when resolving bespoke wiring; the image remains Trivy‑clean (0 HIGH/CRITICAL).

- **Refactors**
  - Add `packages/bespoke/airflow-3.yaml`; pin `apache-airflow` 3.2.2 and providers; install `litellm` and companions; patch venv shebangs.
  - Wire `images/airflow.yaml` to the bespoke package and assert it in tests; update `integer validate` to match bespoke packages even when `packages:` include version constraints (e.g., `foo=1.2.3-r0`); keep PATH-based console scripts and `/entrypoint`.

<sup>Written for commit 1c5afa6e36a4bfe317937599bcc4f3f12db2f1f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

