### PR TITLE
ci(renovate): ungroup helm PRs, scope + gate chart-integration

### DIFF
--- a/.github/RENOVATE.md
+++ b/.github/RENOVATE.md
@@ -54,6 +54,9 @@ Custom manager tracks:
 - Go minor/patch updates
 - GitHub Actions patch updates
 - Security vulnerability fixes
+- Helm chart minor/patch updates — one PR per chart (never grouped), and
+  automerge is gated by the required "Chart Integration" check, which runs
+  the smoke test for exactly the bumped chart
 
 ⚠️ Requires review:
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,10 +83,9 @@
       "semanticCommitScope": "ci"
     },
     {
-      "description": "Helm chart dependencies",
+      "description": "Helm chart dependencies — one PR per chart (no groupName) so chart-integration tests exactly the bumped chart and a failure only blocks that chart's update",
       "matchManagers": ["helmv3"],
       "labels": ["helm", "dependencies"],
-      "groupName": "helm charts",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
     },

--- a/.github/workflows/chart-integration.yaml
+++ b/.github/workflows/chart-integration.yaml
@@ -12,16 +12,10 @@ on:
         required: false
         type: string
   pull_request:
-    paths:
-      - 'test/chart-integration/**'
-      - '.github/workflows/chart-integration.yaml'
-      - 'mise.toml'
-      - 'Makefile'
-      - 'Chart.yaml'
-      - 'verity.yaml'
-      - 'images/**'
-      - 'internal/chartgen/**'
-      - 'internal/discovery/**'
+    # No path filter: the "Chart Integration" gate job is a required status
+    # check, so it must report on EVERY PR. Scoping happens in discover-charts
+    # (changed-file grep -> chart matrix); PRs touching no chart-relevant
+    # paths get an empty matrix and the gate passes immediately.
   schedule:
     - cron: '0 5 * * *'
 
@@ -42,6 +36,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
+      strict: ${{ steps.build-matrix.outputs.strict }}
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -68,18 +63,18 @@ jobs:
           INPUT_CHART: ${{ github.event.inputs.chart }}
         run: |
           set -euo pipefail
+          strict=false
           if [[ -n "$INPUT_CHART" ]]; then
             charts="$INPUT_CHART"
           elif [[ "$EVENT_NAME" == "pull_request" ]]; then
             git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
-            if grep -Eq '^(test/chart-integration/|\.github/workflows/chart-integration\.yaml|mise\.toml|Makefile|Chart\.yaml|verity\.yaml|internal/chartgen/|internal/discovery/)' changed-files.txt; then
+            if grep -Eq '^(test/chart-integration/|\.github/workflows/chart-integration\.yaml|mise\.toml|Makefile|verity\.yaml|internal/chartgen/|internal/discovery/)' changed-files.txt; then
               charts="$(yq -r '.dependencies[].name' Chart.yaml)"
             elif grep -Eq '^images/_base/' changed-files.txt; then
               charts="$(yq -r '.dependencies[].name' Chart.yaml)"
-            elif grep -Eq '^images/.*\.ya?ml$' changed-files.txt; then
+            else
               mapfile -t chart_deps < <(yq -r '.dependencies[].name' Chart.yaml)
               mapfile -t chart_value_keys < <(yq -r '(.chartValues // {}) | keys[]' verity.yaml)
-              mapfile -t changed_images < <(sed -n 's|^images/\([^/]*\)\.ya\?ml$|\1|p' changed-files.txt | sort -u)
               declare -A chart_set=()
 
               norm() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]'; }
@@ -104,34 +99,54 @@ jobs:
                 return 0
               }
 
-              for image in "${changed_images[@]}"; do
-                image_re="$(printf '%s' "$image" | sed 's/[][(){}.^$?+*|\\/]/\\&/g')"
-                image_norm="$(norm "$image")"
-                match_chart_name "$image_norm"
-                for values_file in test/chart-integration/values/*.yaml; do
-                  if grep -Eq "verity-org/(.*/)?${image_re}([:@'\"[:space:]]|$)|\b${image_re}\b" "$values_file"; then
-                    add_chart "$(basename "$values_file" .yaml)"
+              if grep -q '^Chart\.yaml$' changed-files.txt; then
+                # Chart dependency bump (e.g. a Renovate helm PR): test ONLY
+                # the dependencies whose (name, version, repository) tuple was
+                # added or changed vs the base branch — not all ~53 charts.
+                # These scoped runs are strict: a failing shard must block the
+                # merge (see continue-on-error on chart-test).
+                strict=true
+                git show "$BASE_SHA:Chart.yaml" > base-Chart.yaml 2>/dev/null || : > base-Chart.yaml
+                { yq -r '.dependencies[] | [.name, .version, .repository] | @tsv' base-Chart.yaml 2>/dev/null || true; } | sort > base-deps.tsv
+                yq -r '.dependencies[] | [.name, .version, .repository] | @tsv' Chart.yaml | sort > head-deps.tsv
+                while IFS= read -r dep_name; do
+                  if [[ -n "$dep_name" ]]; then
+                    add_chart "$dep_name"
                   fi
+                done < <(comm -13 base-deps.tsv head-deps.tsv | cut -f1 | sort -u)
+              fi
+
+              if grep -Eq '^images/.*\.ya?ml$' changed-files.txt; then
+                mapfile -t changed_images < <(sed -n 's|^images/\([^/]*\)\.ya\?ml$|\1|p' changed-files.txt | sort -u)
+
+                for image in "${changed_images[@]}"; do
+                  image_re="$(printf '%s' "$image" | sed 's/[][(){}.^$?+*|\\/]/\\&/g')"
+                  image_norm="$(norm "$image")"
+                  match_chart_name "$image_norm"
+                  for values_file in test/chart-integration/values/*.yaml; do
+                    if grep -Eq "verity-org/(.*/)?${image_re}([:@'\"[:space:]]|$)|\b${image_re}\b" "$values_file"; then
+                      add_chart "$(basename "$values_file" .yaml)"
+                    fi
+                  done
+                  while IFS=$'\t' read -r _ replacement; do
+                    replacement_image="${replacement##*/}"
+                    replacement_norm="$(norm "$replacement_image")"
+                    if [[ "$replacement_norm" == "$image_norm" || "$replacement_norm" == "$image_norm"* || "$image_norm" == "$replacement_norm"* ]]; then
+                      match_chart_name "$replacement_norm"
+                    fi
+                  done < <(yq -r '(.replacements // {}) | to_entries[] | [.key, .value.image] | @tsv' verity.yaml)
                 done
-                while IFS=$'\t' read -r _ replacement; do
-                  replacement_image="${replacement##*/}"
-                  replacement_norm="$(norm "$replacement_image")"
-                  if [[ "$replacement_norm" == "$image_norm" || "$replacement_norm" == "$image_norm"* || "$image_norm" == "$replacement_norm"* ]]; then
-                    match_chart_name "$replacement_norm"
-                  fi
-                done < <(yq -r '(.replacements // {}) | to_entries[] | [.key, .value.image] | @tsv' verity.yaml)
-              done
+              fi
 
               charts="$(printf '%s\n' "${!chart_set[@]}" | sort)"
-            else
-              charts=""
             fi
           else
             charts="$(yq -r '.dependencies[].name' Chart.yaml)"
           fi
           json="$(printf '%s\n' "$charts" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
           echo "matrix=$json" >> "$GITHUB_OUTPUT"
-          echo "Discovered charts: $json"
+          echo "strict=$strict" >> "$GITHUB_OUTPUT"
+          echo "Discovered charts: $json (strict=$strict)"
 
   chart-test:
     name: ${{ matrix.chart }}
@@ -197,20 +212,23 @@ jobs:
 
       - name: Run chart smoke test
         id: smoke
-        # PR-strict policy (SCR-2026-04-30-001, Option E) is **DEFERRED**.
-        # Investigation while landing this PR revealed that ~30 of 41
-        # wrapper charts have chronic helm-install timeouts of the same
-        # class as kyverno's bug #254 (broken image refs / missing
-        # chartValues overrides), not just a missing-allowlist gap.
-        # Flipping strict mode today would surface ~30+ pre-existing
-        # chart-wrapper bugs as red shards on every PR, not the ~9
-        # genuine missing-allowlist cases the SCR anticipated. The
-        # typed-error infrastructure (`errAllowlistMissing`,
-        # `CollectNamespaceImages`, `classifyMissingAllowlist`) lands
-        # in this PR — ready to activate. A follow-up PR will flip
-        # the strictness once the chart-wrapper backlog clears.
+        # PR-strict policy (SCR-2026-04-30-001, Option E) is PARTIALLY active:
+        # - Chart.yaml dependency bumps (Renovate helm PRs) run only the
+        #   changed charts' shards and are STRICT (discover-charts emits
+        #   strict=true): a failing shard fails this job, which fails the
+        #   "Chart Integration" gate below and blocks (auto)merge. #905
+        #   merged while its chart tests were still running because nothing
+        #   gated the merge — this closes that hole for chart bumps.
+        # - All other PR shards stay lenient (continue-on-error) because
+        #   ~30 of the wrapper charts have chronic helm-install timeouts of
+        #   the same class as kyverno's bug #254 (broken image refs /
+        #   missing chartValues overrides). Flipping strict globally would
+        #   surface those as red shards on every PR. The typed-error
+        #   infrastructure (`errAllowlistMissing`, `CollectNamespaceImages`,
+        #   `classifyMissingAllowlist`) is ready — flip once the
+        #   chart-wrapper backlog clears.
         # Tracking issue: TBD (chart-wrapper backlog).
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: ${{ github.event_name == 'pull_request' && needs.discover-charts.outputs.strict != 'true' }}
         run: make chart-integration
 
       - name: Record shard outcome
@@ -265,3 +283,38 @@ jobs:
             _kind-logs-${{ matrix.chart }}
           retention-days: 7
           if-no-files-found: ignore
+
+  chart-integration-result:
+    name: Chart Integration
+    # Single stable-name aggregation gate for branch protection: matrix
+    # shard names vary per PR (one job per chart), so they can't be listed
+    # as required checks. This job is the required check. It runs on every
+    # PR — chart-test result "skipped" (empty matrix) counts as pass — so
+    # the check always reports and automerge can never bypass chart tests
+    # the way #905 did.
+    needs: [discover-charts, chart-test]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Aggregate chart shard results
+        env:
+          DISCOVER_RESULT: ${{ needs.discover-charts.result }}
+          TEST_RESULT: ${{ needs.chart-test.result }}
+        run: |
+          set -euo pipefail
+          echo "discover-charts: ${DISCOVER_RESULT}"
+          echo "chart-test: ${TEST_RESULT}"
+          if [[ "$DISCOVER_RESULT" != "success" ]]; then
+            echo "::error::discover-charts did not succeed"
+            exit 1
+          fi
+          if [[ "$TEST_RESULT" == "failure" || "$TEST_RESULT" == "cancelled" ]]; then
+            echo "::error::one or more chart shards failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

[#905](https://github.com/verity-org/verity/pull/905) (grouped bump of etcd + fluent-bit + traefik) **auto-merged at 17:49 UTC while `discover charts` was still IN_PROGRESS**. Root cause chain:

1. Renovate groups all helmv3 bumps into a single PR (`groupName: helm charts`)
2. A `Chart.yaml` change fans the chart-integration matrix out to **all 53 charts** instead of the bumped ones
3. Branch protection only requires `Unit Tests` / `Go Lint` / `Node Lint` / `Static Analysis` — all path-skipped on a Chart.yaml-only diff (skipped = satisfied) — and the chart-test smoke step is `continue-on-error` on PRs, so chart tests gate **nothing**

## Fixes

### 1. Renovate: one PR per helm chart
Dropped `groupName` from the helmv3 packageRule. Each chart bump gets its own PR, so a failing chart blocks only its own update.

### 2. chart-integration: test exactly the bumped chart(s)
`discover-charts` now diffs `Chart.yaml` between base and head and scopes the matrix to dependencies whose `(name, version, repository)` tuple was added/changed — replayed #905's diff locally: matrix = `["etcd","fluent-bit","traefik"]`, not 53 shards. Harness/infra changes (`test/chart-integration/`, workflow, `mise.toml`, `Makefile`, `verity.yaml`, `internal/chartgen|discovery/`, `images/_base/`) still run the full matrix.

### 3. Chart bumps are strict + a stable gate check
- Scoped Chart.yaml runs emit `strict=true`; `chart-test` drops `continue-on-error` for them — a failing shard fails the job. All other PR shards keep the lenient mode until the chart-wrapper backlog clears (unchanged policy, SCR-2026-04-30-001).
- New **`Chart Integration`** aggregation job (stable name — matrix shard names vary per PR so they can't be required checks). Path filter removed from the `pull_request` trigger so it reports on every PR; unrelated PRs get an empty matrix and pass in ~1 min.

## Follow-up required after merge (repo admin)

Add `Chart Integration` to required status checks — without this, automerge still won't wait:

```bash
gh api -X POST repos/verity-org/verity/branches/main/protection/required_status_checks/contexts \
  -f 'contexts[]=Chart Integration'
```

(Do this only after merge: the check must exist on PRs before it's required, and Renovate's rebase-when-behind picks it up automatically since `strict: true` is already set.)

## Validation

- Extracted the discover script from the workflow and executed it against a synthetic git repo with the real `Chart.yaml`/`verity.yaml`/values files — 9 cases: single bump → `["etcd"]` strict; #905 replay → 3 charts strict; unrelated file → `[]`; `Makefile` → 53 lenient; `images/etcd.yaml` → `["etcd"]` lenient; schedule → 53; metadata-only Chart.yaml → `[]`; new dep → `["brandnew"]` strict; dispatch w/ input → that chart
- `yamllint`, `actionlint`, `validate-chart-integration-workflow.py`, `jq` on renovate.json — all green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ungroups Helm chart Renovate PRs and adds a scoped, gated chart-integration so only changed charts run and merges wait for results. Prevents auto-merge while chart tests are still running.

- **New Features**
  - Added a stable “Chart Integration” aggregation job that runs on every PR and serves as the required gate; empty matrices pass quickly.
  - Scoped matrix: `discover-charts` diffs `Chart.yaml` and tests only dependencies whose `(name, version, repository)` changed; infra/harness paths still run the full matrix.
  - Chart bump runs are strict (`strict=true`): `continue-on-error` is disabled so a failing shard blocks merge.

- **Dependencies**
  - Removed `groupName` for `helmv3` in `renovate.json` to open one PR per chart, isolating failures.
  - Updated `.github/RENOVATE.md` to document the new behavior and gate.

- **Migration**
  - After merge, add “Chart Integration” to required status checks for the default branch.

<sup>Written for commit 048700e09f14c23791f351baa2f86ba514e2fd38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

