### PR TITLE
Revert "chore(deps): update helm charts"

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -83,7 +83,7 @@ dependencies:
     repository: "oci://ghcr.io/cloudpirates-io/helm-charts"
 
   - name: etcd
-    version: "0.8.2"
+    version: "0.8.1"
     repository: "oci://ghcr.io/cloudpirates-io/helm-charts"
 
   - name: velero
@@ -122,7 +122,7 @@ dependencies:
     repository: "https://charts.jenkins.io"
 
   - name: traefik
-    version: "41.0.2"
+    version: "41.0.1"
     repository: "https://traefik.github.io/charts"
 
   - name: alloy
@@ -222,7 +222,7 @@ dependencies:
     repository: "https://prometheus-community.github.io/helm-charts"
 
   - name: fluent-bit
-    version: "0.57.9"
+    version: "0.57.8"
     repository: "https://fluent.github.io/helm-charts"
 
   - name: cluster-autoscaler


### PR DESCRIPTION
Reverts verity-org/verity#905

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revert recent Helm chart bumps to restore known-good releases. Rolls back `etcd`, `traefik`, and `fluent-bit` to their previous stable versions.

- **Dependencies**
  - `etcd`: 0.8.2 → 0.8.1
  - `traefik`: 41.0.2 → 41.0.1
  - `fluent-bit`: 0.57.9 → 0.57.8

<sup>Written for commit eb40733ec284875fc5bb4107810b65baf7be1b7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

