### PR TITLE
fix(copa): remove dirty database catalog entries

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -66,39 +66,6 @@ images:
   #  DATABASES
   # ============================================================================
 
-  # MongoDB Community Server is only published with UBI-suffixed tags
-  # (no plain semver variants exist). Use -ubi9 for current RHEL UBI 9 base.
-  #
-  # Note on goVcsUrl: deliberately NOT set. The bundled Go CLI tools
-  # (mongostat, mongodump, ...) live in github.com/mongodb/mongo-tools, a
-  # separate repo whose tags are 100.x.x — independent of the server image
-  # tag (8.x.x-ubi9). discoverStandaloneImage always appends "@<imageTag>"
-  # to a non-empty goVcsUrl, so any value here would produce an invalid VCS
-  # ref like "mongo-tools@8.2.5-ubi9" and break copa's first patch attempt.
-  # Without goVcsUrl, the first attempt fails with copa's "no binaries were
-  # successfully rebuilt" message; patch-image.sh's broadened retry trigger
-  # then re-runs with --pkg-types os, which still patches OS-level CVEs in
-  # the UBI 9 base. Adding fixed-VCS-ref support is tracked separately.
-  - name: "mongodb/mongodb-community-server"
-    image: "quay.io/mongodb/mongodb-community-server"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+-ubi9$'
-      maxTags: 3
-
-  # cockroach binary lives at /cockroach/cockroach (non-standard path).
-  # Stripped with -trimpath, so buildinfo doesn't carry a VCS URL.
-  - name: "cockroachdb/cockroach"
-    image: "mirror.gcr.io/cockroachdb/cockroach"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/cockroachdb/cockroach"
-    goVcsTagPrefix: ""
-
   - name: "library/elasticsearch"
     image: "mirror.gcr.io/library/elasticsearch"
     platforms: ["linux/amd64", "linux/arm64"]

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -100,19 +100,7 @@ export const fullCatalog: FullCatalogCategory[] = [
     images: [
       { name: "postgres", source: "integer", variants: ["default", "fips"] },
       { name: "valkey", source: "integer", variants: ["default", "fips"] },
-      {
-        name: "mongodb/mongodb-community-server",
-        label: "mongodb",
-        source: "copa",
-        upstream: "quay.io/mongodb/mongodb-community-server",
-      },
       { name: "mariadb", source: "integer" },
-      {
-        name: "cockroachdb/cockroach",
-        label: "cockroachdb",
-        source: "copa",
-        upstream: "mirror.gcr.io/cockroachdb/cockroach",
-      },
       {
         name: "clickhouse/clickhouse-server",
         label: "clickhouse",

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -25,6 +25,7 @@ const base = import.meta.env.BASE_URL;
     <title>{title}</title>
     <meta name="description" content={description} />
     <meta name="theme-color" content="#060d12" />
+    <link rel="icon" href={`${base}logo.svg`} type="image/svg+xml" />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />


### PR DESCRIPTION
## Summary
- Remove mongodb and cockroachdb from Copa patch config and full catalog because live entries show HIGH/CRITICAL findings and local environment lacks Trivy/Copa to prove a clean patched rebuild.
- Keep zero-CVE invariant by removing dirty catalog surfaces instead of suppressing scans or publishing vulnerable variants.
- Add favicon link to the existing logo asset after browser QA exposed a favicon 404.

Fixes [#911](https://github.com/verity-org/verity/issues/911).
Fixes [#919](https://github.com/verity-org/verity/issues/919).

## Validation
- make lint-yaml
- make build
- go test ./...
- make integer-validate
- npm run test (site)
- npm run lint (site)
- npm run format:check (site)
- npm run build (site)
- Playwright/manual: /catalog/ lists neither mongodb nor cockroachdb; old detail routes return 404.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `mongodb/mongodb-community-server` and `cockroachdb/cockroach` from the `copa` patch config and site catalog to maintain a zero‑CVE policy, and added a favicon link to stop browser 404s. Fixes #911 and #919.

- **Bug Fixes**
  - Removed `mongodb/mongodb-community-server` and `cockroachdb/cockroach` from `copa-config.yaml` and `full-catalog` data; affected detail routes now 404 until clean rebuilds are verified.
  - Added `<link rel="icon" href="logo.svg">` in `BaseLayout.astro` to resolve missing favicon.

<sup>Written for commit 01df3523c3400dd35e04ad1337bb1df420189981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

