### PR TITLE
fix(site): withhold dirty k3s and cilium entries

### DIFF
--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -509,7 +509,6 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		{name: "kubernetes/ingress-nginx/controller", image: "registry.k8s.io/ingress-nginx/controller", pattern: `^v\d+\.\d+\.\d+$`},
 		{name: "kubernetes/ingress-nginx/defaultbackend", image: "registry.k8s.io/defaultbackend", pattern: `^\d+\.\d+$`},
 		{name: "emberstack/kubernetes-reflector", image: "ghcr.io/emberstack/kubernetes-reflector", pattern: `^\d+\.\d+\.\d+$`},
-		{name: "rancher/k3s", image: "mirror.gcr.io/rancher/k3s", pattern: `^v\d+\.\d+\.\d+-k3s\d+$`},
 		{name: "prometheus/mysqld-exporter", image: "quay.io/prometheus/mysqld-exporter", pattern: `^v\d+\.\d+\.\d+$`},
 		{name: "datadog/agent", image: "docker.io/datadog/agent", pattern: `^\d+\.\d+\.\d+$`},
 		{name: "datadog/cluster-agent", image: "docker.io/datadog/cluster-agent", pattern: `^\d+\.\d+\.\d+$`},
@@ -521,6 +520,8 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		{name: "aws/eks-distro/kubernetes/kube-apiserver", image: "public.ecr.aws/eks-distro/kubernetes/kube-apiserver", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
 		{name: "aws/eks-distro/kubernetes/kube-scheduler", image: "public.ecr.aws/eks-distro/kubernetes/kube-scheduler", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
 		{name: "aws/eks-distro/kubernetes-csi/node-driver-registrar", image: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
+		{name: "rancher/k3s", image: "mirror.gcr.io/rancher/k3s", pattern: `^v\d+\.\d+\.\d+-k3s\d+$`},
+		{name: "cilium/cilium", image: "quay.io/cilium/cilium", pattern: `^v\d+\.\d+\.\d+$`},
 	}
 
 	for _, tc := range append(kept, hiddenFromCatalog...) {

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -561,9 +561,9 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 			t.Errorf("config still contains removed unsupported image %q", name)
 		}
 	}
-	for _, name := range catalogWithheld {
-		if _, ok := byName[name]; !ok {
-			t.Errorf("config missing catalog-withheld image %q", name)
+	for _, tc := range hiddenFromCatalog {
+		if _, ok := byName[tc.name]; !ok {
+			t.Errorf("config missing catalog-withheld image %q", tc.name)
 		}
 	}
 

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -561,6 +561,11 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 			t.Errorf("config still contains removed unsupported image %q", name)
 		}
 	}
+	for _, name := range catalogWithheld {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("config missing catalog-withheld image %q", name)
+		}
+	}
 
 	catalog, err := os.ReadFile(repoCatalogPath)
 	if err != nil {

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -203,7 +203,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         integerName: "configmap-reload",
         upstream: "ghcr.io/jimmidyson/configmap-reload",
       },
-      { name: "rancher/k3s", label: "k3s", source: "copa", upstream: "mirror.gcr.io/rancher/k3s" },
       {
         name: "crossplane/crossplane",
         label: "crossplane",
@@ -269,13 +268,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         source: "integer",
         integerName: "istio-install-cni",
         upstream: "mirror.gcr.io/istio/install-cni",
-      },
-      {
-        name: "cilium/cilium",
-        label: "cilium-agent",
-        source: "integer",
-        integerName: "cilium",
-        upstream: "quay.io/cilium/cilium",
       },
       {
         name: "cilium/hubble-ui",


### PR DESCRIPTION
## Summary
- Withhold k3s and cilium-agent from the public site catalog while their latest advertised variants still have HIGH CVEs.
- Keep build/discovery configs intact so clean Copa/Integer rebuilds can re-enable them later.
- Update the standalone-source regression test to assert these dirty images remain withheld from the catalog.

Closes [#924](https://github.com/verity-org/verity/issues/924).
Closes [#927](https://github.com/verity-org/verity/issues/927).
Related: [#372](https://github.com/verity-org/verity/issues/372) remains a chart-integration/kind capability issue, not part of this catalog CVE fix.

## Validation
- `go test ./...`
- `npm run check --prefix site`
- `npm test --prefix site`
- `npm run build --prefix site`
- `./verity integer validate`
- Manual QA: generated `site/dist/catalog/rancher/k3s` and `site/dist/catalog/cilium/cilium` routes are absent after build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Withhold `rancher/k3s` and `cilium/cilium` from the public site catalog due to HIGH CVEs. Keep them discoverable so we can re-enable later. Tests now assert they stay discoverable and are absent from the built catalog.

- **Bug Fixes**
  - Removed `rancher/k3s` and `cilium/cilium` from `site/src/data/full-catalog.ts` so routes aren’t generated (closes #924, #927).
  - Fixed `TestRepoStandaloneSourceRegression_556_579` to explicitly assert these images remain in discovery config and are excluded from the built catalog.

<sup>Written for commit 6329b70ecaab34589f97d7b02eab129fb41568ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

