### PR TITLE
fix(site): route devtools to integer catalog

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -436,17 +436,6 @@ images:
       pattern: '^\d+\.\d+\.\d+$'
       maxTags: 3
 
-  - name: "ollama/ollama"
-    image: "mirror.gcr.io/ollama/ollama"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/ollama/ollama"
-    goVcsTagPrefix: "v"
-
-
   # ============================================================================
   #  Copa-first coverage (batch 1) — Go-app families whose Wolfi Integer
   #  variants are withheld by the zero-CVE publish gate (#881). Copa patches the
@@ -1015,16 +1004,6 @@ images:
     goVcsUrl: "https://github.com/google/go-containerregistry"
     goVcsTagPrefix: ""
 
-  - name: "wagoodman/dive"
-    image: "docker.io/wagoodman/dive"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/wagoodman/dive"
-    goVcsTagPrefix: ""
-
   - name: "goss-org/goss"
     image: "ghcr.io/goss-org/goss"
     platforms: ["linux/amd64", "linux/arm64"]
@@ -1140,14 +1119,6 @@ images:
 
   - name: "library/haproxy"
     image: "docker.io/library/haproxy"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
-      maxTags: 3
-
-  - name: "library/docker"
-    image: "docker.io/library/docker"
     platforms: ["linux/amd64", "linux/arm64"]
     tags:
       strategy: "pattern"

--- a/images/ollama.yaml
+++ b/images/ollama.yaml
@@ -1,0 +1,16 @@
+name: ollama
+description: "Ollama model runner — Wolfi rebuild replaces dirty upstream image"
+upstream:
+  package: ollama
+
+types:
+  default:
+    base: wolfi-base
+    packages: ["ollama"]
+    entrypoint: /usr/bin/ollama
+    cmd: serve
+    paths:
+      - {path: /root/.ollama, type: directory, uid: 0, gid: 0, permissions: 0o755}
+
+versions:
+  "0": {}

--- a/site/src/components/ImageCatalog.astro
+++ b/site/src/components/ImageCatalog.astro
@@ -39,12 +39,15 @@ for (const img of integerImages) {
 
 // Helper to get vulnerability summary for an image
 function getVulnSummary(image: FullCatalogImage): VulnSummary {
+  if (image.source !== "copa") {
+    return { total: 0, severityCounts: {} };
+  }
+
   const scanData = scanDataMap.get(image.name);
   if (scanData) {
     return scanData.afterVulns;
   }
-  // No scan data yet — treat as clean (integer images are built from scratch;
-  // copa images without scan data are either newly added or awaiting first scan)
+  // No scan data yet — copa images without scan data are newly added or awaiting first scan.
   return { total: 0, severityCounts: {} };
 }
 ---

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -773,12 +773,7 @@ export const fullCatalog: FullCatalogCategory[] = [
         source: "copa",
         upstream: "mirror.gcr.io/tensorflow/serving",
       },
-      {
-        name: "ollama/ollama",
-        label: "ollama",
-        source: "copa",
-        upstream: "mirror.gcr.io/ollama/ollama",
-      },
+      { name: "ollama/ollama", label: "ollama", source: "integer", integerName: "ollama" },
     ],
   },
 
@@ -803,12 +798,7 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "curl", source: "integer" },
       { name: "git", source: "integer" },
       { name: "docker-cli", source: "integer", variants: ["default", "fips"] },
-      {
-        name: "library/docker",
-        label: "docker-cli",
-        source: "copa",
-        upstream: "mirror.gcr.io/library/docker",
-      },
+      { name: "library/docker", label: "docker-cli", source: "integer", integerName: "docker-cli" },
       {
         name: "google/cloud-sdk",
         label: "google-cloud-sdk",
@@ -845,7 +835,7 @@ export const fullCatalog: FullCatalogCategory[] = [
         source: "copa",
         upstream: "ghcr.io/pendulum-project/ntpd-rs",
       },
-      { name: "wagoodman/dive", label: "dive", source: "copa", upstream: "ghcr.io/wagoodman/dive" },
+      { name: "wagoodman/dive", label: "dive", source: "integer", integerName: "dive" },
       { name: "crane", source: "integer", variants: ["default", "fips"] },
       { name: "grype", source: "integer" },
       { name: "coredns", source: "integer" },

--- a/site/src/pages/catalog/[...name].astro
+++ b/site/src/pages/catalog/[...name].astro
@@ -436,7 +436,29 @@ const hasFips =
   }
 
   {
-    image.source === "copa" && (
+    image.source === "integer" ? (
+      <div class="mb-8">
+        <h2 class="text-lg font-semibold mb-1 text-verity-text-primary">Vulnerability Scan</h2>
+        <div class="flex items-center gap-2 p-3 bg-green-950/20 border border-green-800/40 rounded-lg">
+          <svg
+            class="w-5 h-5 text-green-400 shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <p class="text-sm text-green-400">
+            0 HIGH/CRITICAL vulnerabilities allowed. Integer publish gate blocks images unless Trivy passes.
+          </p>
+        </div>
+      </div>
+    ) : (
       <div class="mb-8">
         <h2 class="text-lg font-semibold mb-1 text-verity-text-primary">Vulnerability Scan</h2>
         {!scanData ? (

--- a/site/src/pages/catalog/[...name].astro
+++ b/site/src/pages/catalog/[...name].astro
@@ -81,7 +81,7 @@ export function getStaticPaths() {
 
   for (const category of fullCatalog) {
     for (const image of category.images) {
-      const allScanData = scanDataByName.get(image.name) ?? [];
+      const allScanData = image.source === "copa" ? (scanDataByName.get(image.name) ?? []) : [];
       const scanData = allScanData[0];
 
       // Fetch integer version data for integer source images


### PR DESCRIPTION
## Summary
- remove dirty Copa catalog/build entries for [#915](https://github.com/verity-org/verity/issues/915), [#918](https://github.com/verity-org/verity/issues/918), and [#929](https://github.com/verity-org/verity/issues/929)
- route existing catalog URLs for `library/docker`, `wagoodman/dive`, and `ollama/ollama` to Integer/Wolfi images
- add Integer coverage for `ollama`
- show the Integer zero HIGH/CRITICAL publish-gate invariant on Integer catalog pages and avoid stale Copa scan data for Integer aliases

## Validation
- `go test ./...`
- `./verity integer validate --config integer.yaml`
- `./verity integer discover --config integer.yaml` confirms `ollama`, `docker-cli`, and `dive`
- `cd site && npm run build && npm run lint && npm run format:check`
- Playwright preview QA for `/catalog/library/docker/`, `/catalog/wagoodman/dive/`, `/catalog/ollama/ollama/`: all render Wolfi source, `0 HIGH/CRITICAL` gate text, no Copa page content, and correct `ghcr.io/verity-org/...` pull refs

## Notes
- Issues remain open until merged and live verified.
