### PR TITLE
fix(site): remove dirty Kubernetes catalog entries

### DIFF
--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -508,13 +508,8 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 	kept := []expectedEntry{
 		{name: "nginxinc/nginx-s3-gateway", image: "docker.io/nginxinc/nginx-s3-gateway", pattern: `^unprivileged-oss-\d{8}$`},
 		{name: "kubernetes/ingress-nginx/controller", image: "registry.k8s.io/ingress-nginx/controller", pattern: `^v\d+\.\d+\.\d+$`},
-		{name: "kubernetes/ingress-nginx/kube-webhook-certgen", image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen", pattern: `^v\d+\.\d+\.\d+$`},
 		{name: "kubernetes/ingress-nginx/defaultbackend", image: "registry.k8s.io/defaultbackend", pattern: `^\d+\.\d+$`},
-		{name: "kubernetes-sigs/external-dns", image: "registry.k8s.io/external-dns/external-dns", pattern: `^v\d+\.\d+\.\d+$`},
 		{name: "emberstack/kubernetes-reflector", image: "ghcr.io/emberstack/kubernetes-reflector", pattern: `^\d+\.\d+\.\d+$`},
-		{name: "kubernetes-sigs/secrets-store-csi-driver", image: "registry.k8s.io/csi-secrets-store/driver", pattern: `^v\d+\.\d+\.\d+$`},
-		{name: "googlecloudplatform/secrets-store-csi-driver-provider-gcp", image: "us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin", pattern: `^v\d+\.\d+\.\d+$`},
-		{name: "kubernetes-sigs/node-feature-discovery", image: "registry.k8s.io/nfd/node-feature-discovery", pattern: `^v\d+\.\d+\.\d+$`},
 		{name: "rancher/k3s", image: "mirror.gcr.io/rancher/k3s", pattern: `^v\d+\.\d+\.\d+-k3s\d+$`},
 		{name: "aws/eks-distro/coredns/coredns", image: "public.ecr.aws/eks-distro/coredns/coredns", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
 		{name: "aws/eks-distro/kubernetes/kube-apiserver", image: "public.ecr.aws/eks-distro/kubernetes/kube-apiserver", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
@@ -574,6 +569,19 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 	for _, name := range removed {
 		if strings.Contains(catalogText, `name: "`+name+`"`) {
 			t.Errorf("catalog still contains removed unsupported image %q", name)
+		}
+	}
+
+	removedFromFullCatalog := []string{
+		"kubernetes/ingress-nginx/kube-webhook-certgen",
+		"kubernetes-sigs/external-dns",
+		"kubernetes-sigs/secrets-store-csi-driver",
+		"googlecloudplatform/secrets-store-csi-driver-provider-gcp",
+		"kubernetes-sigs/node-feature-discovery",
+	}
+	for _, name := range removedFromFullCatalog {
+		if strings.Contains(catalogText, `name: "`+name+`"`) {
+			t.Errorf("catalog still contains dirty Copa-only image %q", name)
 		}
 	}
 }

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -92,12 +92,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "registry.k8s.io/ingress-nginx/controller",
       },
       {
-        name: "kubernetes/ingress-nginx/kube-webhook-certgen",
-        label: "kube-webhook-certgen",
-        source: "copa",
-        upstream: "registry.k8s.io/ingress-nginx/kube-webhook-certgen",
-      },
-      {
         name: "kubernetes/ingress-nginx/defaultbackend",
         label: "ingress-defaultbackend",
         source: "copa",
@@ -203,12 +197,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "ghcr.io/kubernetes/autoscaler/cluster-autoscaler",
       },
       {
-        name: "kubernetes-sigs/external-dns",
-        label: "external-dns",
-        source: "copa",
-        upstream: "registry.k8s.io/external-dns/external-dns",
-      },
-      {
         name: "kubernetes/kube-state-metrics/kube-state-metrics",
         label: "kube-state-metrics",
         source: "integer",
@@ -219,19 +207,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         label: "kubernetes-reflector",
         source: "copa",
         upstream: "ghcr.io/emberstack/kubernetes-reflector",
-      },
-      {
-        name: "kubernetes-sigs/secrets-store-csi-driver",
-        label: "secrets-store-csi-driver",
-        source: "copa",
-        upstream: "registry.k8s.io/csi-secrets-store/driver",
-      },
-      {
-        name: "googlecloudplatform/secrets-store-csi-driver-provider-gcp",
-        label: "secrets-store-csi-provider-gcp",
-        source: "copa",
-        upstream:
-          "us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin",
       },
       {
         name: "kiwigrid/k8s-sidecar",
@@ -245,12 +220,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         source: "integer",
         integerName: "configmap-reload",
         upstream: "ghcr.io/jimmidyson/configmap-reload",
-      },
-      {
-        name: "kubernetes-sigs/node-feature-discovery",
-        label: "node-feature-discovery",
-        source: "copa",
-        upstream: "registry.k8s.io/nfd/node-feature-discovery",
       },
       { name: "rancher/k3s", label: "k3s", source: "copa", upstream: "mirror.gcr.io/rancher/k3s" },
       {


### PR DESCRIPTION
## Summary
- Remove five dirty Kubernetes Copa-only entries from the public full catalog.
- Add regression coverage so the removed entries stay out of `site/src/data/full-catalog.ts`.

Closes [#916](https://github.com/verity-org/verity/issues/916).
Closes [#920](https://github.com/verity-org/verity/issues/920).
Closes [#923](https://github.com/verity-org/verity/issues/923).
Closes [#926](https://github.com/verity-org/verity/issues/926).
Closes [#928](https://github.com/verity-org/verity/issues/928).

## Verification
- `go test ./...`
- `npm run build`
- `npm run test`
- `npm run check`
- Headless Chrome QA: `/catalog/` renders; all five removed catalog paths return 404.
- Trivy investigation: latest upstream tags remain HIGH/CRITICAL dirty; attempted `external-dns:0.21` Integer build still reports 2 HIGH CVEs in `external-dns-0.21`, so no dirty fallback was adopted.