### PR TITLE
fix(catalog): remove dirty app entries

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -37,14 +37,6 @@ images:
   #  WEB SERVERS & PROXIES
   # ============================================================================
 
-  - name: "nginxinc/nginx-s3-gateway"
-    image: "docker.io/nginxinc/nginx-s3-gateway"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^unprivileged-oss-\d{8}$'
-      maxTags: 3
-
   - name: "kubernetes/ingress-nginx/controller"
     image: "registry.k8s.io/ingress-nginx/controller"
     platforms: ["linux/amd64", "linux/arm64"]
@@ -326,16 +318,6 @@ images:
       maxTags: 3
 
   # -- Grafana ecosystem --
-  - name: "grafana/promtail"
-    image: "mirror.gcr.io/grafana/promtail"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/grafana/loki"
-    goVcsTagPrefix: "v"
-
   # -- Agents --
   - name: "datadog/agent"
     image: "docker.io/datadog/agent"
@@ -394,14 +376,6 @@ images:
   # ============================================================================
   #  POLICY & COMPLIANCE
   # ============================================================================
-
-  - name: "kyverno/policy-reporter-ui"
-    image: "ghcr.io/kyverno/policy-reporter-ui"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
-      maxTags: 3
 
   - name: "openpolicyagent/gatekeeper"
     image: "mirror.gcr.io/openpolicyagent/gatekeeper"
@@ -462,15 +436,6 @@ images:
       maxTags: 3
     goVcsUrl: "https://github.com/grafana/grafana"
     goVcsTagPrefix: "v"
-
-  - name: "argoproj/argocd"
-    image: "quay.io/argoproj/argocd"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/argoproj/argo-cd"
 
   - name: "calico/apiserver"
     image: "docker.io/calico/apiserver"
@@ -838,14 +803,6 @@ images:
   #  Copa-first coverage (batch 7) — Python (Copa patches pip) + JVM/Node apps
   #  (Copa patches OS packages). See docs/product/remediation-policy.md.
   # ============================================================================
-  - name: "mlflow/mlflow"
-    image: "ghcr.io/mlflow/mlflow"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-
   - name: "opensearchproject/opensearch-dashboards"
     image: "docker.io/opensearchproject/opensearch-dashboards"
     platforms: ["linux/amd64", "linux/arm64"]

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -506,7 +506,6 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 	}
 
 	kept := []expectedEntry{
-		{name: "nginxinc/nginx-s3-gateway", image: "docker.io/nginxinc/nginx-s3-gateway", pattern: `^unprivileged-oss-\d{8}$`},
 		{name: "kubernetes/ingress-nginx/controller", image: "registry.k8s.io/ingress-nginx/controller", pattern: `^v\d+\.\d+\.\d+$`},
 		{name: "kubernetes/ingress-nginx/kube-webhook-certgen", image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen", pattern: `^v\d+\.\d+\.\d+$`},
 		{name: "kubernetes/ingress-nginx/defaultbackend", image: "registry.k8s.io/defaultbackend", pattern: `^\d+\.\d+$`},
@@ -524,7 +523,6 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		{name: "datadog/agent", image: "docker.io/datadog/agent", pattern: `^\d+\.\d+\.\d+$`},
 		{name: "datadog/cluster-agent", image: "docker.io/datadog/cluster-agent", pattern: `^\d+\.\d+\.\d+$`},
 		{name: "fluent/fluent-operator", image: "ghcr.io/fluent/fluent-operator/fluent-operator", pattern: `^v\d+\.\d+\.\d+$`},
-		{name: "kyverno/policy-reporter-ui", image: "ghcr.io/kyverno/policy-reporter-ui", pattern: `^\d+\.\d+\.\d+$`},
 		{name: "victoriametrics/victoria-logs", image: "quay.io/victoriametrics/victoria-logs", pattern: `^v\d+\.\d+\.\d+$`},
 	}
 
@@ -549,7 +547,15 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		t.Errorf("defaultbackend exclude = %q, want %q", got, "1.0,1.1,1.2")
 	}
 
-	removed := []string{"spiffe/spiffe-helper", "tektoncd/cli", "kubeflow/spark-operator", "aws/eks-distro/kubernetes/kube-proxy"}
+	removed := []string{
+		"spiffe/spiffe-helper",
+		"tektoncd/cli",
+		"kubeflow/spark-operator",
+		"aws/eks-distro/kubernetes/kube-proxy",
+		"nginxinc/nginx-s3-gateway",
+		"grafana/promtail",
+		"kyverno/policy-reporter-ui",
+	}
 	for _, name := range removed {
 		if _, ok := byName[name]; ok {
 			t.Errorf("config still contains removed unsupported image %q", name)

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -555,6 +555,8 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		"nginxinc/nginx-s3-gateway",
 		"grafana/promtail",
 		"kyverno/policy-reporter-ui",
+		"argoproj/argocd",
+		"mlflow/mlflow",
 	}
 	for _, name := range removed {
 		if _, ok := byName[name]; ok {

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -73,12 +73,6 @@ export const fullCatalog: FullCatalogCategory[] = [
       { name: "traefik", source: "integer" },
       { name: "envoy", source: "integer" },
       {
-        name: "nginxinc/nginx-s3-gateway",
-        label: "nginx-s3-gateway",
-        source: "copa",
-        upstream: "docker.io/nginxinc/nginx-s3-gateway",
-      },
-      {
         name: "jcmoraisjr/haproxy-ingress",
         label: "haproxy-ingress",
         source: "integer",
@@ -467,12 +461,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "quay.io/prometheuscommunity/elasticsearch-exporter",
       },
       {
-        name: "grafana/promtail",
-        label: "promtail",
-        source: "copa",
-        upstream: "mirror.gcr.io/grafana/promtail",
-      },
-      {
         name: "datadog/agent",
         label: "datadog-agent",
         source: "copa",
@@ -544,7 +532,7 @@ export const fullCatalog: FullCatalogCategory[] = [
     id: "cicd",
     label: "CI/CD & GitOps",
     images: [
-      { name: "argoproj/argocd", source: "copa", upstream: "quay.io/argoproj/argocd" },
+      { name: "argocd", source: "integer" },
       {
         name: "jenkins/jenkins",
         label: "jenkins",
@@ -701,12 +689,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         upstream: "ghcr.io/kyverno/reports-controller",
       },
       {
-        name: "kyverno/policy-reporter-ui",
-        label: "kyverno-policy-reporter-ui",
-        source: "copa",
-        upstream: "ghcr.io/kyverno/policy-reporter-ui",
-      },
-      {
         name: "openpolicyagent/gatekeeper",
         label: "gatekeeper",
         source: "copa",
@@ -762,7 +744,7 @@ export const fullCatalog: FullCatalogCategory[] = [
     label: "Data & ML",
     images: [
       { name: "airflow", source: "integer" },
-      { name: "mlflow/mlflow", label: "mlflow", source: "copa", upstream: "ghcr.io/mlflow/mlflow" },
+      { name: "mlflow", source: "integer" },
       { name: "temporal", source: "integer" },
       { name: "meilisearch", source: "integer" },
       { name: "qdrant", source: "integer" },


### PR DESCRIPTION
## Summary
- remove dirty low-demand Copa catalog entries: nginx-s3-gateway, promtail, kyverno policy-reporter UI
- switch app catalog ArgoCD and MLflow rows to existing Integer images
- update repository catalog regression test for removed entries

Addresses [#912](https://github.com/verity-org/verity/issues/912), [#913](https://github.com/verity-org/verity/issues/913), [#914](https://github.com/verity-org/verity/issues/914), [#930](https://github.com/verity-org/verity/issues/930), [#932](https://github.com/verity-org/verity/issues/932).

## Validation
- `go test ./...`
- `go build ./...`
- `npm --prefix site run check`
- `npm --prefix site run build`
- `go run . discover --config copa-config.yaml --charts-file Chart.yaml --verity-config verity.yaml` confirmed removed standalone targets stay absent (`removedHits=0`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove low-demand Copa entries and drop Copa variants of `argocd` and `mlflow`, switching the app catalog to `integer` images to cut CVE noise. Updates tests and site catalog accordingly. Addresses #912, #913, #914, #930, #932.

- **Bug Fixes**
  - Remove `nginxinc/nginx-s3-gateway`, `grafana/promtail`, `kyverno/policy-reporter-ui`, `argoproj/argocd`, `mlflow/mlflow` from `copa-config.yaml` and site catalog.
  - Switch `argocd` and `mlflow` to `integer` in the app catalog; extend discovery regression tests to cover these removals and migrations.

<sup>Written for commit a112ed3b4c6711b7e076d6a3cdeb8cca2e4b803c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

