### PR TITLE
fix(site): withhold dirty renovate entry until clean image exists

### DIFF
--- a/images/renovate.yaml
+++ b/images/renovate.yaml
@@ -13,4 +13,4 @@ types:
       - {path: /tmp/renovate, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
-  "40": {}
+  "43": {}

--- a/internal/discovery/discover_test.go
+++ b/internal/discovery/discover_test.go
@@ -522,6 +522,7 @@ func TestRepoStandaloneSourceRegression_556_579(t *testing.T) {
 		{name: "aws/eks-distro/kubernetes-csi/node-driver-registrar", image: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar", pattern: `^v\d+\.\d+\.\d+-eks-\d+-\d+-\d+$`},
 		{name: "rancher/k3s", image: "mirror.gcr.io/rancher/k3s", pattern: `^v\d+\.\d+\.\d+-k3s\d+$`},
 		{name: "cilium/cilium", image: "quay.io/cilium/cilium", pattern: `^v\d+\.\d+\.\d+$`},
+		{name: "renovatebot/renovate", image: "ghcr.io/renovatebot/renovate", pattern: `^\d+\.\d+\.\d+$`},
 	}
 
 	for _, tc := range append(kept, hiddenFromCatalog...) {

--- a/site/src/data/full-catalog.ts
+++ b/site/src/data/full-catalog.ts
@@ -464,12 +464,6 @@ export const fullCatalog: FullCatalogCategory[] = [
         source: "copa",
         upstream: "mirror.gcr.io/jenkins/jenkins",
       },
-      {
-        name: "renovatebot/renovate",
-        label: "renovate",
-        source: "copa",
-        upstream: "ghcr.io/renovatebot/renovate",
-      },
       { name: "kaniko", source: "integer" },
       { name: "flux", source: "integer" },
       { name: "gitea", source: "integer" },


### PR DESCRIPTION
## Summary
No clean renovate image is currently possible, so the catalog entry is withheld (recoverable):

| Path | State |
|---|---|
| Copa-patched `ghcr.io/renovatebot/renovate` | 7 CRITICAL / 178 HIGH post-patch — npm app-layer CVEs Copa cannot fix |
| Wolfi/Integer rebuild | 3 HIGH in the `renovate` package itself (CVE-2026-9697, CVE-2026-6734, CVE-2026-12151) — fixed in Wolfi advisory data (43.249.5-r2) but the apk is **not yet published** (404 on packages.wolfi.dev) |
| Bespoke | Building renovate's npm monorepo from source — not worth it |

## Changes
- Remove `renovatebot/renovate` from `site/src/data/full-catalog.ts`
- Add it to the `hiddenFromCatalog` regression list in `internal/discovery/discover_test.go` (stays in `copa-config.yaml` for recovery)
- Bump `images/renovate.yaml` version stream `40` → `43` so the nightly Integer build auto-publishes a clean image once Wolfi ships the fixed package

## Validation
- `go test ./...` green
- `go run . integer validate` — 334 configs valid
- `npm --prefix site test` + `npm --prefix site run build` green (326 pages)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily hide `renovatebot/renovate` from the site catalog to avoid surfacing a vulnerable image; add it to the hidden-from-catalog regression list for recovery. Bump the Integer version stream in `images/renovate.yaml` from `40` to `43` so nightly builds publish a clean image once the Wolfi fix ships.

<sup>Written for commit c70f12ac22f2697540f3d55905a1ddf12c372c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

