### PR TITLE
Fix nightly CI orchestration

### DIFF
--- a/.github/scripts/validate-ci-workflow.py
+++ b/.github/scripts/validate-ci-workflow.py
@@ -5,6 +5,7 @@ workflow = Path(".github/workflows/ci.yaml").read_text()
 required = [
     "^site/|^\\.github/workflows/ci\\.yaml$|^mise\\.toml$",
     "python3 .github/scripts/validate-ci-workflow.py",
+    "python3 .github/scripts/validate-nightly-workflows.py",
 ]
 
 missing = [needle for needle in required if needle not in workflow]

--- a/.github/scripts/validate-integer-build-image-workflow.py
+++ b/.github/scripts/validate-integer-build-image-workflow.py
@@ -42,6 +42,21 @@ def main() -> None:
         )
 
     require(
+        "--fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL" in workflow,
+        "Integer publish gate must fail on any Trivy vulnerability severity",
+    )
+    require(
+        "--exit-code 1" in workflow
+        and "--severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL" in workflow,
+        "Integer post-publish Trivy scan must fail on any vulnerability severity",
+    )
+    require(
+        "images publish even with CVEs" not in workflow
+        and "continue-on-error: true  # Report only" not in workflow,
+        "Integer Trivy scans must not be report-only",
+    )
+
+    require(
         'digest=$(bash .github/scripts/retry-registry-command.sh \\' in workflow,
         "digest retrieval must capture retry helper stdout",
     )

--- a/.github/scripts/validate-nightly-workflows.py
+++ b/.github/scripts/validate-nightly-workflows.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Guard nightly orchestration behavior that actionlint cannot express."""
+
+from pathlib import Path
+import sys
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        print(f"nightly workflow check failed: {message}", file=sys.stderr)
+        sys.exit(1)
+
+
+def uncomment(path: str) -> str:
+    return "\n".join(
+        line
+        for line in Path(path).read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+def main() -> None:
+    orchestrator = uncomment(".github/workflows/orchestrator.yaml")
+    chart_gen = uncomment(".github/workflows/chart-gen.yaml")
+    build_site = uncomment(".github/workflows/build-site.yaml")
+    chart_integration = uncomment(".github/workflows/chart-integration.yaml")
+    ci = uncomment(".github/workflows/ci.yaml")
+
+    require(
+        "for attempt in 1 2 3 4 5; do" in orchestrator
+        and "gh workflow run patch-image.yaml" in orchestrator
+        and 'if [ "$dispatched" -ne "$expected_count" ]; then' in orchestrator,
+        "Copa orchestrator dispatch must retry and verify all patch runs dispatched",
+    )
+    require(
+        "bash .github/scripts/wait-for-workflows.sh patch-image.yaml" in chart_gen
+        and "actions: read" in chart_gen,
+        "chart generation must wait for active patch-image producer runs",
+    )
+    require(
+        "bash .github/scripts/wait-for-workflows.sh patch-image.yaml integer-build-image.yaml chart-gen.yaml"
+        in build_site
+        and "actions: read" in build_site,
+        "site build must wait for active patch, Integer, and chart generation producer runs",
+    )
+    require(
+        "  schedule:" not in chart_integration,
+        "chart-integration must not also schedule itself beside workflow_run",
+    )
+    require(
+        "python3 .github/scripts/validate-nightly-workflows.py" in ci,
+        "CI must run the nightly workflow validator",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/validate-nightly-workflows.py
+++ b/.github/scripts/validate-nightly-workflows.py
@@ -2,6 +2,7 @@
 """Guard nightly orchestration behavior that actionlint cannot express."""
 
 from pathlib import Path
+import re
 import sys
 
 
@@ -11,20 +12,66 @@ def require(condition: bool, message: str) -> None:
         sys.exit(1)
 
 
+def uncomment_text(text: str) -> str:
+    lines: list[str] = []
+    block_parent_indent: int | None = None
+
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        if block_parent_indent is not None:
+            if stripped and indent <= block_parent_indent:
+                block_parent_indent = None
+            else:
+                lines.append(line)
+                continue
+
+        if stripped.startswith("#"):
+            continue
+
+        lines.append(line)
+        if re.search(r"(:|-\s*)\s*[|>][+-]?\s*(?:#.*)?$", line):
+            block_parent_indent = indent
+
+    return "\n".join(lines)
+
+
 def uncomment(path: str) -> str:
-    return "\n".join(
-        line
-        for line in Path(path).read_text(encoding="utf-8").splitlines()
-        if not line.lstrip().startswith("#")
+    return uncomment_text(Path(path).read_text(encoding="utf-8"))
+
+
+def self_test() -> None:
+    sample = """
+name: example
+# YAML comment
+jobs:
+  test:
+    steps:
+      - run: |
+          # shell comments inside block scalars must be preserved
+          #!/usr/bin/env bash
+          echo ok
+    # another YAML comment
+permissions: {}
+"""
+    got = uncomment_text(sample)
+    require("# YAML comment" not in got, "YAML comments should be stripped")
+    require(
+        "#!/usr/bin/env bash" in got and "# shell comments inside block scalars" in got,
+        "block-scalar shell comments should be preserved",
     )
+    require("# another YAML comment" not in got, "YAML comments after block scalars should be stripped")
 
 
 def main() -> None:
+    self_test()
     orchestrator = uncomment(".github/workflows/orchestrator.yaml")
     chart_gen = uncomment(".github/workflows/chart-gen.yaml")
     build_site = uncomment(".github/workflows/build-site.yaml")
     chart_integration = uncomment(".github/workflows/chart-integration.yaml")
     ci = uncomment(".github/workflows/ci.yaml")
+    wait_helper = Path(".github/scripts/wait-for-workflows.sh").read_text(encoding="utf-8")
 
     require(
         "for attempt in 1 2 3 4 5; do" in orchestrator
@@ -36,6 +83,12 @@ def main() -> None:
         "bash .github/scripts/wait-for-workflows.sh patch-image.yaml" in chart_gen
         and "actions: read" in chart_gen,
         "chart generation must wait for active patch-image producer runs",
+    )
+    require(
+        "--method GET" in wait_helper
+        and "--paginate" in wait_helper
+        and ".database_id" not in wait_helper,
+        "wait helper must use GET pagination and REST run ids",
     )
     require(
         "bash .github/scripts/wait-for-workflows.sh patch-image.yaml integer-build-image.yaml chart-gen.yaml"

--- a/.github/scripts/validate-wait-for-workflows.sh
+++ b/.github/scripts/validate-wait-for-workflows.sh
@@ -24,6 +24,20 @@ for required in "--method GET" "--paginate" "-f branch=main" "-f status=" "--jq"
   fi
 done
 
+status_arg_found=0
+for arg in "$@"; do
+  case "$arg" in
+    status=*)
+      echo "${arg#status=}" >> "${FAKE_GH_STATUSES:?}"
+      status_arg_found=1
+      ;;
+  esac
+done
+if [ "$status_arg_found" -ne 1 ]; then
+  echo "missing status field value" >&2
+  exit 1
+fi
+
 if [[ "$args" == *".database_id"* ]]; then
   echo "wait helper must use REST .id, not GraphQL .database_id" >&2
   exit 1
@@ -39,6 +53,7 @@ EOF
 chmod +x "$tmpdir/gh"
 
 FAKE_GH_CALLS="$tmpdir/calls" \
+FAKE_GH_STATUSES="$tmpdir/statuses" \
 PATH="$tmpdir:$PATH" \
 GITHUB_REPOSITORY="verity-org/verity" \
 WAIT_BRANCH="main" \
@@ -49,6 +64,10 @@ WAIT_INTERVAL_SECONDS=1 \
 
 if [ "$(wc -l < "$tmpdir/calls" | tr -d ' ')" -ne 4 ]; then
   echo "wait helper should query each active workflow status" >&2
+  exit 1
+fi
+if [ "$(sort -u "$tmpdir/statuses" | paste -sd, -)" != "in_progress,queued,requested,waiting" ]; then
+  echo "wait helper must query queued, in_progress, requested, and waiting statuses" >&2
   exit 1
 fi
 if ! grep -q "No active producer workflow runs remain." "$tmpdir/out"; then

--- a/.github/scripts/validate-wait-for-workflows.sh
+++ b/.github/scripts/validate-wait-for-workflows.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression checks for wait-for-workflows.sh behavior that shellcheck/actionlint
+# cannot prove.
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "$tmpdir/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=" $* "
+case "$args" in
+  *" api "*) ;;
+  *) echo "fake gh only supports api" >&2; exit 2 ;;
+esac
+
+for required in "--method GET" "--paginate" "-f branch=main" "-f status=" "--jq"; do
+  if [[ "$args" != *"$required"* ]]; then
+    echo "missing required gh api argument: $required" >&2
+    exit 1
+  fi
+done
+
+if [[ "$args" == *".database_id"* ]]; then
+  echo "wait helper must use REST .id, not GraphQL .database_id" >&2
+  exit 1
+fi
+if [[ "$args" != *".id"* ]]; then
+  echo "wait helper must print the REST run id" >&2
+  exit 1
+fi
+
+echo "call" >> "${FAKE_GH_CALLS:?}"
+exit 0
+EOF
+chmod +x "$tmpdir/gh"
+
+FAKE_GH_CALLS="$tmpdir/calls" \
+PATH="$tmpdir:$PATH" \
+GITHUB_REPOSITORY="verity-org/verity" \
+WAIT_BRANCH="main" \
+WAIT_LOOKBACK_HOURS=1 \
+WAIT_TIMEOUT_SECONDS=1 \
+WAIT_INTERVAL_SECONDS=1 \
+  bash .github/scripts/wait-for-workflows.sh patch-image.yaml > "$tmpdir/out"
+
+if [ "$(wc -l < "$tmpdir/calls" | tr -d ' ')" -ne 4 ]; then
+  echo "wait helper should query each active workflow status" >&2
+  exit 1
+fi
+if ! grep -q "No active producer workflow runs remain." "$tmpdir/out"; then
+  echo "wait helper should exit cleanly when no active runs are returned" >&2
+  exit 1
+fi
+
+echo "✓ wait-for-workflows validation passed"

--- a/.github/scripts/wait-for-workflows.sh
+++ b/.github/scripts/wait-for-workflows.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: wait-for-workflows.sh <workflow-file-or-name>..." >&2
+  exit 2
+fi
+
+BRANCH="${WAIT_BRANCH:-${GITHUB_REF_NAME:-main}}"
+LOOKBACK_HOURS="${WAIT_LOOKBACK_HOURS:-8}"
+TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-7200}"
+INTERVAL_SECONDS="${WAIT_INTERVAL_SECONDS:-60}"
+
+case "$LOOKBACK_HOURS" in
+  ''|*[!0-9]*|0*) echo "WAIT_LOOKBACK_HOURS must be a positive integer" >&2; exit 2 ;;
+esac
+case "$TIMEOUT_SECONDS" in
+  ''|*[!0-9]*|0*) echo "WAIT_TIMEOUT_SECONDS must be a positive integer" >&2; exit 2 ;;
+esac
+case "$INTERVAL_SECONDS" in
+  ''|*[!0-9]*|0*) echo "WAIT_INTERVAL_SECONDS must be a positive integer" >&2; exit 2 ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required" >&2
+  exit 2
+fi
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+cutoff="$(date -u -d "-${LOOKBACK_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ)"
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+
+echo "Waiting for active workflow runs on ${BRANCH} since ${cutoff}: $*"
+
+while true; do
+  active="$(
+    for workflow in "$@"; do
+      for status in queued in_progress requested waiting; do
+        gh api "repos/${repo}/actions/workflows/${workflow}/runs" \
+          -f branch="${BRANCH}" \
+          -f status="${status}" \
+          --jq ".workflow_runs[] | select(.created_at >= \"${cutoff}\") | [\"${workflow}\", .database_id, .status, .created_at, .html_url] | @tsv"
+      done
+    done | sort -u
+  )"
+
+  if [ -z "$active" ]; then
+    echo "No active producer workflow runs remain."
+    exit 0
+  fi
+
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "Timed out waiting for producer workflows:" >&2
+    printf '%s\n' "$active" >&2
+    exit 1
+  fi
+
+  echo "Still waiting for producer workflows:"
+  printf '%s\n' "$active"
+  sleep "$INTERVAL_SECONDS"
+done

--- a/.github/scripts/wait-for-workflows.sh
+++ b/.github/scripts/wait-for-workflows.sh
@@ -37,9 +37,11 @@ while true; do
     for workflow in "$@"; do
       for status in queued in_progress requested waiting; do
         gh api "repos/${repo}/actions/workflows/${workflow}/runs" \
+          --method GET \
+          --paginate \
           -f branch="${BRANCH}" \
           -f status="${status}" \
-          --jq ".workflow_runs[] | select(.created_at >= \"${cutoff}\") | [\"${workflow}\", .database_id, .status, .created_at, .html_url] | @tsv"
+          --jq ".workflow_runs[] | select(.created_at >= \"${cutoff}\") | [\"${workflow}\", .id, .status, .created_at, .html_url] | @tsv"
       done
     done | sort -u
   )"

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -17,6 +17,7 @@ permissions:
   packages: read
   pages: write
   id-token: write
+  actions: read
 
 env:
   TARGET_REGISTRY: ghcr.io/verity-org
@@ -41,6 +42,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
+
+      - name: Wait for nightly producers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WAIT_BRANCH: main
+        run: bash .github/scripts/wait-for-workflows.sh patch-image.yaml integer-build-image.yaml chart-gen.yaml
 
       - name: Checkout reports branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/chart-gen.yaml
+++ b/.github/workflows/chart-gen.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   packages: write
+  actions: read
 
 env:
   TARGET_REGISTRY: ghcr.io/verity-org
@@ -38,6 +39,12 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Wait for nightly patch producers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WAIT_BRANCH: ${{ github.ref_name }}
+        run: bash .github/scripts/wait-for-workflows.sh patch-image.yaml
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/chart-integration.yaml
+++ b/.github/workflows/chart-integration.yaml
@@ -16,8 +16,6 @@ on:
     # check, so it must report on EVERY PR. Scoping happens in discover-charts
     # (changed-file grep -> chart matrix); PRs touching no chart-relevant
     # paths get an empty matrix and the gate passes immediately.
-  schedule:
-    - cron: '0 5 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,6 +176,9 @@ jobs:
       - name: Validate chart-integration workflow guards
         run: python3 .github/scripts/validate-chart-integration-workflow.py
 
+      - name: Validate nightly workflow guards
+        run: python3 .github/scripts/validate-nightly-workflows.py
+
       - name: Validate CI workflow guards
         run: python3 .github/scripts/validate-ci-workflow.py
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,9 @@ jobs:
       - name: Validate CI workflow guards
         run: python3 .github/scripts/validate-ci-workflow.py
 
+      - name: Validate wait-for-workflows helper
+        run: bash .github/scripts/validate-wait-for-workflows.sh
+
       - name: Validate retry helpers
         run: bash .github/scripts/validate-retry-helpers.sh
 

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -426,12 +426,12 @@ jobs:
           # The verity binary owns this gate (cmd/integer_build.go
           # integerTrivyGate) — it is unit-tested and cannot silently regress,
           # unlike inline workflow bash. Build the image LOCALLY and Trivy-scan
-          # it here; if HIGH/CRITICAL CVEs are found this step FAILS and the
-          # publish step below never runs. Verity never uploads an image with a CVE.
+          # it here; if any CVEs are found this step FAILS and the publish step
+          # below never runs. Verity never uploads an Integer image with a CVE.
           # Gate BOTH published arches (publish pushes amd64+arm64). apko build
           # and trivy scan assemble/read packages without executing arch
-          # binaries, so no QEMU is needed. If EITHER arch has HIGH/CRITICAL
-          # CVEs, this step fails and the multi-arch publish below never runs.
+          # binaries, so no QEMU is needed. If EITHER arch has any CVEs, this
+          # step fails and the multi-arch publish below never runs.
           for gate_arch in amd64 arm64; do
             echo "::group::Trivy publish gate ($gate_arch)"
             ./verity integer build \
@@ -439,7 +439,7 @@ jobs:
               --version "$INPUT_VERSION" \
               --type "$INPUT_TYPE" \
               --arch "$gate_arch" \
-              --fail-on-severity HIGH,CRITICAL \
+              --fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
               --output "gate-$gate_arch.tar"
             echo "::endgroup::"
           done
@@ -522,13 +522,12 @@ jobs:
           PRIMARY_TAG: ${{ steps.gen.outputs.primary_tag }}
         run: |
           trivy image \
-            --exit-code 0 \
-            --severity CRITICAL,HIGH,MEDIUM,LOW \
+            --exit-code 1 \
+            --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
             --vuln-type os,library \
             --format json \
             --output trivy-report.json \
             "${INPUT_REGISTRY}/${INPUT_IMAGE}:${PRIMARY_TAG}"
-        continue-on-error: true  # Report only — images publish even with CVEs
 
       - name: Resolve Trivy gate policy
         id: trivy-gate-postgres

--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -258,7 +258,46 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGES: ${{ needs.discover.outputs.images }}
         run: |
-          echo "$IMAGES" | jq -c '.[]' | while IFS= read -r image; do
+          dispatch_patch() {
+            local name="$1"
+            local source="$2"
+            local registry="$3"
+            local platforms="$4"
+            local go_vcs_url="$5"
+
+            local dispatch_args=(
+              --repo "${{ github.repository }}"
+              --ref "${{ github.ref_name }}"
+              --field "image-name=${name}"
+              --field "source-ref=${source}"
+              --field "target-registry=${registry}"
+              --field "platforms=${platforms}"
+            )
+            if [ -n "${go_vcs_url}" ]; then
+              dispatch_args+=(--field "go-vcs-url=${go_vcs_url}")
+            fi
+
+            local attempt
+            for attempt in 1 2 3 4 5; do
+              if gh workflow run patch-image.yaml "${dispatch_args[@]}"; then
+                return 0
+              fi
+              if [ "$attempt" -lt 5 ]; then
+                local sleep_seconds=$((attempt * 10))
+                echo "Dispatch failed for ${name}: ${source} (attempt ${attempt}/5); retrying in ${sleep_seconds}s" >&2
+                sleep "${sleep_seconds}"
+              fi
+            done
+
+            echo "Failed to dispatch ${name}: ${source} after 5 attempts" >&2
+            return 1
+          }
+
+          jq -c '.[]' <<< "$IMAGES" > "$RUNNER_TEMP/patch-images.ndjson"
+          expected_count="${{ needs.discover.outputs.count }}"
+          dispatched=0
+
+          while IFS= read -r image; do
             NAME=$(echo "$image" | jq -r '.name')
             SOURCE=$(echo "$image" | jq -r '.source')
             REGISTRY=$(echo "$image" | jq -r '."target-registry"')
@@ -266,20 +305,15 @@ jobs:
             GO_VCS_URL=$(echo "$image" | jq -r '."go-vcs-url" // ""')
 
             echo "Dispatching patch for ${NAME}: ${SOURCE}..."
-            DISPATCH_ARGS=(
-              --repo "${{ github.repository }}"
-              --ref "${{ github.ref_name }}"
-              --field "image-name=${NAME}"
-              --field "source-ref=${SOURCE}"
-              --field "target-registry=${REGISTRY}"
-              --field "platforms=${PLATFORMS}"
-            )
-            if [ -n "${GO_VCS_URL}" ]; then
-              DISPATCH_ARGS+=(--field "go-vcs-url=${GO_VCS_URL}")
-            fi
-            gh workflow run patch-image.yaml "${DISPATCH_ARGS[@]}"
+            dispatch_patch "$NAME" "$SOURCE" "$REGISTRY" "$PLATFORMS" "$GO_VCS_URL"
+            dispatched=$((dispatched + 1))
 
             # Throttle to avoid GitHub API rate limits
             sleep 2
-          done
-          echo "✓ Dispatched ${{ needs.discover.outputs.count }} patch runs"
+          done < "$RUNNER_TEMP/patch-images.ndjson"
+
+          if [ "$dispatched" -ne "$expected_count" ]; then
+            echo "Dispatched ${dispatched}/${expected_count} patch runs; expected all discovered images to dispatch" >&2
+            exit 1
+          fi
+          echo "✓ Dispatched ${dispatched}/${expected_count} patch runs"

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ lint-workflows:
 	python3 .github/scripts/validate-integer-build-image-workflow.py
 	python3 .github/scripts/validate-chart-integration-workflow.py
 	python3 .github/scripts/validate-nightly-workflows.py
+	bash .github/scripts/validate-wait-for-workflows.sh
 	bash .github/scripts/validate-retry-helpers.sh
 
 # Lint YAML files

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ lint-workflows:
 	python3 .github/scripts/validate-patch-image-workflow.py
 	python3 .github/scripts/validate-integer-build-image-workflow.py
 	python3 .github/scripts/validate-chart-integration-workflow.py
+	python3 .github/scripts/validate-nightly-workflows.py
 	bash .github/scripts/validate-retry-helpers.sh
 
 # Lint YAML files


### PR DESCRIPTION
## Summary
- enforce Integer zero-CVE gates across all Trivy severities before publish and in the post-publish scan
- retry and count Copa patch workflow dispatches
- make downstream nightly consumers wait for active patch/build/chart producer workflows before reading registry/report state
- remove the duplicate scheduled chart-integration trigger and add validators for these nightly workflow guarantees

## Verification
- actionlint
- python3 .github/scripts/validate-patch-image-workflow.py && python3 .github/scripts/validate-integer-build-image-workflow.py && python3 .github/scripts/validate-chart-integration-workflow.py && python3 .github/scripts/validate-nightly-workflows.py && python3 .github/scripts/validate-ci-workflow.py && bash .github/scripts/validate-wait-for-workflows.sh && bash .github/scripts/validate-retry-helpers.sh
- mise exec -- shellcheck .github/scripts/*.sh scripts/*.sh
- bash -n .github/scripts/wait-for-workflows.sh .github/scripts/validate-wait-for-workflows.sh
- git diff --check