### PR TITLE
ci: move matrix planning into verity

### DIFF
--- a/.github/scripts/validate-chart-integration-workflow.py
+++ b/.github/scripts/validate-chart-integration-workflow.py
@@ -3,13 +3,14 @@ from pathlib import Path
 workflow = Path(".github/workflows/chart-integration.yaml").read_text()
 
 required = [
-    "image_re=\"$(printf '%s' \"$image\" | sed 's/[][(){}.^$?+*|\\\\/]/\\\\&/g')\"",
-    "${image_re}([:@'\\\"[:space:]]|$)|\\b${image_re}\\b",
+    "./verity ci plan \\",
+    "--kind chart \\",
+    "json=\"$(jq -c '[.matrix.include[].chart]' ci-plan.json)\"",
 ]
 
 missing = [needle for needle in required if needle not in workflow]
 if missing:
     raise SystemExit(f"chart-integration workflow guard missing: {missing}")
 
-if "${image}([:@'\\\"[:space:]]|$)|\\b${image}\\b" in workflow:
-    raise SystemExit("chart-integration workflow uses an unescaped image regex")
+if "grep -Eq \"verity-org/" in workflow:
+    raise SystemExit("chart-integration workflow must not rebuild chart/image matching in shell")

--- a/.github/scripts/validate-integer-build-image-workflow.py
+++ b/.github/scripts/validate-integer-build-image-workflow.py
@@ -34,7 +34,7 @@ def main() -> None:
         "Integer Build Image must use retrying GHCR login helper",
     )
 
-    for label in ("apko publish", "crane digest", "cosign sign"):
+    for label in ("apko publish", "crane copy", "crane digest", "cosign sign"):
         require(
             "bash .github/scripts/retry-registry-command.sh" in workflow
             and f'"{label}"' in workflow,
@@ -46,16 +46,21 @@ def main() -> None:
         "Integer publish gate must fail on any Trivy vulnerability severity",
     )
     require(
-        "--exit-code 1" in workflow
+        "STAGING_REF=" in workflow
+        and "trivy image \\" in workflow
+        and "--exit-code 1 \\" in workflow
         and "--severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL" in workflow,
-        "Integer post-publish Trivy scan must fail on any vulnerability severity",
+        "Integer publish must stage and enforce Trivy on the staged image before final tags",
     )
     require(
         "images publish even with CVEs" not in workflow
         and "continue-on-error: true  # Report only" not in workflow,
         "Integer Trivy scans must not be report-only",
     )
-
+    require(
+        workflow.index("--exit-code 1 \\") < workflow.index('"crane copy"'),
+        "Trivy staged-image gate must run before final crane copy promotion",
+    )
     require(
         'digest=$(bash .github/scripts/retry-registry-command.sh \\' in workflow,
         "digest retrieval must capture retry helper stdout",

--- a/.github/workflows/chart-integration.yaml
+++ b/.github/workflows/chart-integration.yaml
@@ -80,7 +80,7 @@ jobs:
             > ci-plan.json
 
           json="$(jq -c '[.matrix.include[].chart]' ci-plan.json)"
-          strict="$(jq -r '.strict' ci-plan.json)"
+          strict="$(jq -r '.strict // false' ci-plan.json)"
           echo "matrix=$json" >> "$GITHUB_OUTPUT"
           echo "strict=$strict" >> "$GITHUB_OUTPUT"
           echo "Discovered charts: $json (strict=$strict)"

--- a/.github/workflows/chart-integration.yaml
+++ b/.github/workflows/chart-integration.yaml
@@ -52,6 +52,9 @@ jobs:
           install: true
           cache: true
 
+      - name: Build verity
+        run: go build -o verity .
+
       - id: build-matrix
         name: Build chart matrix from Chart.yaml
         env:
@@ -61,87 +64,23 @@ jobs:
           INPUT_CHART: ${{ github.event.inputs.chart }}
         run: |
           set -euo pipefail
-          strict=false
-          if [[ -n "$INPUT_CHART" ]]; then
-            charts="$INPUT_CHART"
-          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+          : > changed-files.txt
+          printf 'dependencies: []\n' > base-Chart.yaml
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
             git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
-            if grep -Eq '^(test/chart-integration/|\.github/workflows/chart-integration\.yaml|mise\.toml|Makefile|verity\.yaml|internal/chartgen/|internal/discovery/)' changed-files.txt; then
-              charts="$(yq -r '.dependencies[].name' Chart.yaml)"
-            elif grep -Eq '^images/_base/' changed-files.txt; then
-              charts="$(yq -r '.dependencies[].name' Chart.yaml)"
-            else
-              mapfile -t chart_deps < <(yq -r '.dependencies[].name' Chart.yaml)
-              mapfile -t chart_value_keys < <(yq -r '(.chartValues // {}) | keys[]' verity.yaml)
-              declare -A chart_set=()
-
-              norm() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]'; }
-              add_chart() {
-                local chart="$1"
-                for dep in "${chart_deps[@]}"; do
-                  if [[ "$dep" == "$chart" ]]; then
-                    chart_set["$chart"]=1
-                  fi
-                done
-                return 0
-              }
-              match_chart_name() {
-                local image_norm="$1"
-                local chart chart_norm
-                for chart in "${chart_deps[@]}" "${chart_value_keys[@]}"; do
-                  chart_norm="$(norm "$chart")"
-                  if [[ "$image_norm" == "$chart_norm" || "$image_norm" == "$chart_norm"* || "$chart_norm" == "$image_norm"* ]]; then
-                    add_chart "$chart"
-                  fi
-                done
-                return 0
-              }
-
-              if grep -q '^Chart\.yaml$' changed-files.txt; then
-                # Chart dependency bump (e.g. a Renovate helm PR): test ONLY
-                # the dependencies whose (name, version, repository) tuple was
-                # added or changed vs the base branch — not all ~53 charts.
-                # These scoped runs are strict: a failing shard must block the
-                # merge (see continue-on-error on chart-test).
-                strict=true
-                git show "$BASE_SHA:Chart.yaml" > base-Chart.yaml 2>/dev/null || : > base-Chart.yaml
-                { yq -r '.dependencies[] | [.name, .version, .repository] | @tsv' base-Chart.yaml 2>/dev/null || true; } | sort > base-deps.tsv
-                yq -r '.dependencies[] | [.name, .version, .repository] | @tsv' Chart.yaml | sort > head-deps.tsv
-                while IFS= read -r dep_name; do
-                  if [[ -n "$dep_name" ]]; then
-                    add_chart "$dep_name"
-                  fi
-                done < <(comm -13 base-deps.tsv head-deps.tsv | cut -f1 | sort -u)
-              fi
-
-              if grep -Eq '^images/.*\.ya?ml$' changed-files.txt; then
-                mapfile -t changed_images < <(sed -n 's|^images/\([^/]*\)\.ya\?ml$|\1|p' changed-files.txt | sort -u)
-
-                for image in "${changed_images[@]}"; do
-                  image_re="$(printf '%s' "$image" | sed 's/[][(){}.^$?+*|\\/]/\\&/g')"
-                  image_norm="$(norm "$image")"
-                  match_chart_name "$image_norm"
-                  for values_file in test/chart-integration/values/*.yaml; do
-                    if grep -Eq "verity-org/(.*/)?${image_re}([:@'\"[:space:]]|$)|\b${image_re}\b" "$values_file"; then
-                      add_chart "$(basename "$values_file" .yaml)"
-                    fi
-                  done
-                  while IFS=$'\t' read -r _ replacement; do
-                    replacement_image="${replacement##*/}"
-                    replacement_norm="$(norm "$replacement_image")"
-                    if [[ "$replacement_norm" == "$image_norm" || "$replacement_norm" == "$image_norm"* || "$image_norm" == "$replacement_norm"* ]]; then
-                      match_chart_name "$replacement_norm"
-                    fi
-                  done < <(yq -r '(.replacements // {}) | to_entries[] | [.key, .value.image] | @tsv' verity.yaml)
-                done
-              fi
-
-              charts="$(printf '%s\n' "${!chart_set[@]}" | sort)"
-            fi
-          else
-            charts="$(yq -r '.dependencies[].name' Chart.yaml)"
+            git show "$BASE_SHA:Chart.yaml" > base-Chart.yaml 2>/dev/null || printf 'dependencies: []\n' > base-Chart.yaml
           fi
-          json="$(printf '%s\n' "$charts" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+
+          ./verity ci plan \
+            --kind chart \
+            --event-name "$EVENT_NAME" \
+            --input-chart "$INPUT_CHART" \
+            --changed-files changed-files.txt \
+            --base-charts-file base-Chart.yaml \
+            > ci-plan.json
+
+          json="$(jq -c '[.matrix.include[].chart]' ci-plan.json)"
+          strict="$(jq -r '.strict' ci-plan.json)"
           echo "matrix=$json" >> "$GITHUB_OUTPUT"
           echo "strict=$strict" >> "$GITHUB_OUTPUT"
           echo "Discovered charts: $json (strict=$strict)"

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -416,7 +416,7 @@ jobs:
 
       # ── Build ──────────────────────────────────────────────────────────────
 
-      # ── Zero-CVE publish gate: build locally & scan BEFORE any push ──────────
+      # ── Zero-CVE preflight gate: build locally & scan BEFORE any registry write
       - name: Trivy publish gate (not clean, no go)
         env:
           INPUT_IMAGE: ${{ inputs.image }}
@@ -426,12 +426,11 @@ jobs:
           # The verity binary owns this gate (cmd/integer_build.go
           # integerTrivyGate) — it is unit-tested and cannot silently regress,
           # unlike inline workflow bash. Build the image LOCALLY and Trivy-scan
-          # it here; if any CVEs are found this step FAILS and the publish step
-          # below never runs. Verity never uploads an Integer image with a CVE.
+          # it here; if any CVEs are found this step FAILS before staging or
+          # final promotion. Verity never uploads an Integer image with a CVE.
           # Gate BOTH published arches (publish pushes amd64+arm64). apko build
           # and trivy scan assemble/read packages without executing arch
-          # binaries, so no QEMU is needed. If EITHER arch has any CVEs, this
-          # step fails and the multi-arch publish below never runs.
+          # binaries, so no QEMU is needed.
           for gate_arch in amd64 arm64; do
             echo "::group::Trivy publish gate ($gate_arch)"
             ./verity integer build \
@@ -444,7 +443,7 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Build and publish multi-arch image
+      - name: Build, verify, and publish multi-arch image
         id: build
         env:
           INPUT_IMAGE: ${{ inputs.image }}
@@ -473,8 +472,14 @@ jobs:
             .annotations["org.opencontainers.image.created"]     = strenv(BUILD_TIMESTAMP)
           ' "$tmpconfig"
 
-          # Split refs into an array for safe expansion (one arg per ref).
-          read -ra REFSARR <<< "$REFS"
+          # Split final refs into an array for safe expansion (one arg per ref).
+          read -ra FINAL_REFS <<< "$REFS"
+
+          # Stage one run-scoped ref first. This lets Trivy scan the exact
+          # multi-arch image apko produced before any final user-facing tag is
+          # written, closing the rebuild drift gap between local tar scans and
+          # apko publish.
+          STAGING_REF="${INPUT_REGISTRY}/cache/${INPUT_IMAGE}:${PRIMARY_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
           # Build apko args — conditionally append local melange repo.
           APKO_ARGS=(
@@ -501,63 +506,33 @@ jobs:
             echo "Appending local melange repo to apko publish"
           fi
 
-          APKO_ARGS+=("$tmpconfig" "${REFSARR[@]}")
+          APKO_ARGS+=("$tmpconfig" "$STAGING_REF")
 
           bash .github/scripts/retry-registry-command.sh \
             "apko publish" \
             apko "${APKO_ARGS[@]}"
 
-          # Capture the digest of the published index for signing
-          digest=$(bash .github/scripts/retry-registry-command.sh \
-            "crane digest" \
-            crane digest "${INPUT_REGISTRY}/${INPUT_IMAGE}:${PRIMARY_TAG}")
-          echo "digest=$digest" >> "$GITHUB_OUTPUT"
-
-      # ── Security scan ──────────────────────────────────────────────────────
-
-      - name: Trivy vulnerability scan
-        env:
-          INPUT_IMAGE: ${{ inputs.image }}
-          INPUT_REGISTRY: ${{ inputs.registry }}
-          PRIMARY_TAG: ${{ steps.gen.outputs.primary_tag }}
-        run: |
           trivy image \
             --exit-code 1 \
             --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
             --vuln-type os,library \
             --format json \
             --output trivy-report.json \
-            "${INPUT_REGISTRY}/${INPUT_IMAGE}:${PRIMARY_TAG}"
+            "$STAGING_REF"
 
-      - name: Resolve Trivy gate policy
-        id: trivy-gate-postgres
-        run: |
-          case "${{ inputs.image }}:${{ inputs.version }}:${{ inputs.type }}" in
-            postgres:14:fips)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=postgres 14 fips" >> "$GITHUB_OUTPUT"
-              ;;
-            postgres:15:fips)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=postgres 15 fips" >> "$GITHUB_OUTPUT"
-              ;;
-            istio-install-cni:*:default|istio-pilot:*:default|istio-proxyv2:*:default|telegraf:1.34:default|telegraf:1.35:default|telegraf:1.36:default|telegraf:1.37:default|telegraf:1.38:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "enabled=false" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
+          for final_ref in "${FINAL_REFS[@]}"; do
+            bash .github/scripts/retry-registry-command.sh \
+              "crane copy" \
+              crane copy "$STAGING_REF" "$final_ref"
+          done
 
-      - name: Enforce Trivy gate
-        if: steps.trivy-gate-postgres.outputs.enabled == 'true'
-        run: |
-          findings=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' trivy-report.json)
-          if [ "$findings" -ne 0 ]; then
-            echo "${{ steps.trivy-gate-postgres.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
-            exit 1
-          fi
+          # Capture the digest of the clean promoted index for signing.
+          digest=$(bash .github/scripts/retry-registry-command.sh \
+            "crane digest" \
+            crane digest "${INPUT_REGISTRY}/${INPUT_IMAGE}:${PRIMARY_TAG}")
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      # ── Security scan ──────────────────────────────────────────────────────
 
       - name: Upload Trivy report
         if: always()
@@ -566,174 +541,6 @@ jobs:
           name: "trivy-${{ steps.gen.outputs.safe_image }}-${{ inputs.version }}-${{ inputs.type }}"
           path: trivy-report.json
           retention-days: 30
-
-      - name: Resolve Trivy gate policy
-        id: trivy-gate-vault
-        run: |
-          case "${{ inputs.image }}:${{ inputs.type }}" in
-            vault:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=vault default" >> "$GITHUB_OUTPUT"
-              ;;
-            istio-install-cni:default|istio-pilot:default|istio-proxyv2:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=${{ inputs.image }} default" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "enabled=false" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
-
-      - name: Enforce Trivy gate
-        if: steps.trivy-gate-vault.outputs.enabled == 'true'
-        run: |
-          findings=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' trivy-report.json)
-          if [ "$findings" -ne 0 ]; then
-            echo "${{ steps.trivy-gate-vault.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
-            exit 1
-          fi
-
-      - name: Resolve Trivy gate policy
-        id: trivy-gate-rebuildable-sweep
-        run: |
-          case "${{ inputs.image }}:${{ inputs.version }}:${{ inputs.type }}" in
-            alertmanager:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=alertmanager 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            apisix-ingress-controller:1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=apisix-ingress-controller 1 default" >> "$GITHUB_OUTPUT"
-              ;;
-            argo-workflow-controller:3:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=argo-workflow-controller 3 default" >> "$GITHUB_OUTPUT"
-              ;;
-            azure-workload-identity-webhook:1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=azure-workload-identity-webhook 1 default" >> "$GITHUB_OUTPUT"
-              ;;
-            bank-vaults:1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=bank-vaults 1 default" >> "$GITHUB_OUTPUT"
-              ;;
-            boring-registry:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=boring-registry 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            cert-manager-istio-csr:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=cert-manager-istio-csr 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            cert-manager-cainjector:1.20:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=cert-manager-cainjector 1.20 default" >> "$GITHUB_OUTPUT"
-              ;;
-            cert-manager-controller:1.20:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=cert-manager-controller 1.20 default" >> "$GITHUB_OUTPUT"
-              ;;
-            cilium-cli:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=cilium-cli 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            cloudflared:2025:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=cloudflared 2025 default" >> "$GITHUB_OUTPUT"
-              ;;
-            conftest:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=conftest 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            filebrowser:2:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=filebrowser 2 default" >> "$GITHUB_OUTPUT"
-              ;;
-            harbor-cli:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=harbor-cli 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            cortex:1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=cortex 1 default" >> "$GITHUB_OUTPUT"
-              ;;
-            loki:3.5:default|loki:3.6:default|loki:3.7:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
-              ;;
-            external-secrets:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=external-secrets 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            hydra:2:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=hydra 2 default" >> "$GITHUB_OUTPUT"
-              ;;
-            k9s:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=k9s 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            mailpit:1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=mailpit 1 default" >> "$GITHUB_OUTPUT"
-              ;;
-            mimir:3.0:default|mimir:3.1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
-              ;;
-            mariadb:10.11:default|mariadb:11.4:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=${{ inputs.image }} ${{ inputs.version }} default" >> "$GITHUB_OUTPUT"
-              ;;
-            openbao:2:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=openbao 2 default" >> "$GITHUB_OUTPUT"
-              ;;
-            opentelemetry-collector:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=opentelemetry-collector 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            rclone:1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=rclone 1 default" >> "$GITHUB_OUTPUT"
-              ;;
-            spicedb:1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=spicedb 1 default" >> "$GITHUB_OUTPUT"
-              ;;
-            tempo:2:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=tempo 2 default" >> "$GITHUB_OUTPUT"
-              ;;
-            traefik:3.7:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=traefik 3.7 default" >> "$GITHUB_OUTPUT"
-              ;;
-            thanos:0:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=thanos 0 default" >> "$GITHUB_OUTPUT"
-              ;;
-            trufflehog:3:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=trufflehog 3 default" >> "$GITHUB_OUTPUT"
-              ;;
-            velero:1:default)
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-              echo "label=velero 1 default" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "enabled=false" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
-
-      - name: Enforce Trivy gate
-        if: steps.trivy-gate-rebuildable-sweep.outputs.enabled == 'true'
-        run: |
-          findings=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH" or .Severity == "CRITICAL")] | length' trivy-report.json)
-          if [ "$findings" -ne 0 ]; then
-            echo "${{ steps.trivy-gate-rebuildable-sweep.outputs.label }} image must stay zero HIGH/CRITICAL, found ${findings}" >&2
-            exit 1
-          fi
 
       # ── Sign & attest ──────────────────────────────────────────────────────
 

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -328,81 +328,23 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Find image YAML files changed in this PR (use PR event SHAs)
-          all_changed=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" -- 'images/*.yaml' 'images/_base/*.yaml' || true)
+          git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
+          ./verity ci plan \
+            --kind integer-pr \
+            --changed-files changed-files.txt \
+            --gen-dir "$RUNNER_TEMP/integer-gen" \
+            > ci-plan.json
 
-          if [ -z "$all_changed" ]; then
-            echo "No image YAML files changed"
-            {
-              echo 'has-changes=false'
-              echo 'matrix={"include":[]}'
-              echo 'smoke-matrix={"include":[]}'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Check if base images changed (affects all images)
-          base_changed=$(echo "$all_changed" | grep '_base/' || true)
-          image_changed=$(echo "$all_changed" | grep -v '_base/' || true)
-
-          if [ -n "$base_changed" ]; then
-            echo "Base image files changed — discovering all images"
-            names=""  # empty = all
-          elif [ -n "$image_changed" ]; then
-            names=$(echo "$image_changed" | sed 's|images/||;s|\.yaml||' | paste -sd, || true)
-            echo "Changed images: $names"
-          else
-            echo "No actionable changes"
-            {
-              echo 'has-changes=false'
-              echo 'matrix={"include":[]}'
-              echo 'smoke-matrix={"include":[]}'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Discover version+type combos for changed images
-          DISCOVER_FLAGS=""
-          if [ -n "$names" ]; then
-            DISCOVER_FLAGS="--only $names"
-          fi
-
-          # shellcheck disable=SC2086
-          if ! all=$(./verity integer discover $DISCOVER_FLAGS); then
-            echo "::error::verity integer discover failed"
-            exit 1
-          fi
-
-          if [ -z "$all" ] || [ "$all" = "null" ] || [ "$all" = "[]" ]; then
-            echo "No discoverable images"
-            {
-              echo 'has-changes=false'
-              echo 'matrix={"include":[]}'
-              echo 'smoke-matrix={"include":[]}'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          smoke_matrix=$(echo "$all" | jq -c 'map({image: .name, version: .version, type: .type}) | {include: .}')
-
-          # Build matrix: pick the latest version per image+type.
-          # sort_by(.version | split(".") | map(tonumber? // .)) handles numeric ordering.
-          matrix=$(echo "$all" | jq -c '
-            [.[] | . + {_key: (.name + "-" + .type)}]
-            | sort_by(._key)
-            | group_by(._key)
-            | map(sort_by(.version | split(".") | map(tonumber? // .)) | last)
-            | map({image: .name, version: .version, type: .type})
-            | {include: .}
-          ')
-
-          count=$(echo "$matrix" | jq '.include | length')
+          matrix=$(jq -c '.matrix' ci-plan.json)
+          smoke_matrix=$(jq -c '.smokeMatrix' ci-plan.json)
+          has_changes=$(jq -r '.hasChanges' ci-plan.json)
+          count=$(jq '.include | length' <<< "$matrix")
           echo "Matrix: ${count} image builds"
           echo "$matrix" | jq .
           {
             echo "matrix=${matrix}"
             echo "smoke-matrix=${smoke_matrix}"
-            echo 'has-changes=true'
+            echo "has-changes=${has_changes}"
           } >> "$GITHUB_OUTPUT"
 
   integer-build-changed:
@@ -572,75 +514,24 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Check if copa-config.yaml was modified in this PR
-          if ! git diff --name-only "$BASE_SHA"..."$HEAD_SHA" | grep -q '^copa-config.yaml$'; then
-            echo "copa-config.yaml not changed — skipping"
-            echo 'has-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
+          git show "${BASE_SHA}":copa-config.yaml > base-copa-config.yaml 2>/dev/null || printf 'images: []\n' > base-copa-config.yaml
 
-          # Extract image names from old and new config
-          OLD_NAMES=$(git show "${BASE_SHA}":copa-config.yaml 2>/dev/null | yq -r '.images[].name' 2>/dev/null | sort || true)
-          NEW_NAMES=$(yq -r '.images[].name' copa-config.yaml | sort)
+          ./verity ci plan \
+            --kind copa-pr \
+            --changed-files changed-files.txt \
+            --base-copa-config base-copa-config.yaml \
+            --copa-config copa-config.yaml \
+            --target-registry "${TARGET_REGISTRY}" \
+            > ci-plan.json
 
-          # Find added image names
-          ADDED=$(comm -13 <(echo "$OLD_NAMES") <(echo "$NEW_NAMES") | paste -sd, || true)
-
-          # Find changed image entries (compare full data blocks).
-          # Use JSON output to ignore comment shifts: yq attributes leading
-          # comments to the next node, so removing an entry can make adjacent
-          # section headers re-attach to a sibling that didn't actually change.
-          CHANGED_NAMES=""
-          while IFS= read -r name; do
-            [ -z "$name" ] && continue
-            old_block=$(git show "${BASE_SHA}":copa-config.yaml 2>/dev/null | yq -o=json ".images[] | select(.name == \"$name\")" 2>/dev/null || true)
-            new_block=$(yq -o=json ".images[] | select(.name == \"$name\")" copa-config.yaml)
-            if [ "$old_block" != "$new_block" ]; then
-              CHANGED_NAMES="${CHANGED_NAMES:+$CHANGED_NAMES,}$name"
-            fi
-          done <<< "$NEW_NAMES"
-
-          FILTER="${ADDED}${ADDED:+${CHANGED_NAMES:+,}}${CHANGED_NAMES}"
-
-          if [ -z "$FILTER" ]; then
-            echo "No image entries changed in copa-config.yaml"
-            echo 'has-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Changed Copa images: $FILTER"
-
-          # Discover image+tag combos for changed images only
-          if ! all=$(./verity discover --config copa-config.yaml --only "$FILTER"); then
-            echo "::warning::verity discover failed for changed images"
-            echo 'has-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -z "$all" ] || [ "$all" = "null" ] || [ "$all" = "[]" ]; then
-            echo "No discoverable images"
-            echo 'has-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Build matrix: first tag per image name (one test per changed image)
-          matrix=$(echo "$all" | jq -c '
-            sort_by(.name)
-            | group_by(.name)
-            | map(first)
-            | map({name: .name, tag: (.source | split(":") | last)})
-            | {include: .}
-          ')
-
-          count=$(echo "$matrix" | jq '.include | length')
+          matrix=$(jq -c '.matrix' ci-plan.json)
+          has_changes=$(jq -r '.hasChanges' ci-plan.json)
+          count=$(jq '.include | length' <<< "$matrix")
           echo "Copa change matrix: ${count} images to test"
           echo "$matrix" | jq .
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
-          echo 'has-changes=true' >> "$GITHUB_OUTPUT"
+          echo "has-changes=${has_changes}" >> "$GITHUB_OUTPUT"
 
   copa-patching-changed:
     name: "Copa Patch: ${{ matrix.name }}:${{ matrix.tag }}"

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"github.com/verity-org/verity/internal/ci"
 	"github.com/verity-org/verity/internal/integer/apkindex"
 )
+
+var errUnknownPlanKind = errors.New("unknown plan kind")
 
 var CICommand = &cli.Command{
 	Name:  "ci",
@@ -53,7 +56,7 @@ func runCIPlan(_ context.Context, cmd *cli.Command) error {
 	var plan ci.Plan
 	switch cmd.String("kind") {
 	case "integer-pr":
-		plan, err = ci.PlanIntegerPR(ci.IntegerPROptions{
+		plan, err = ci.PlanIntegerPR(&ci.IntegerPROptions{
 			ChangedFiles: changed,
 			ConfigPath:   cmd.String("integer-config"),
 			ImagesDir:    cmd.String("images-dir"),
@@ -62,16 +65,14 @@ func runCIPlan(_ context.Context, cmd *cli.Command) error {
 			GenDir:       cmd.String("gen-dir"),
 		})
 	case "copa-pr":
-		plan, err = ci.PlanCopaPR(ci.CopaPROptions{
+		plan, err = ci.PlanCopaPR(&ci.CopaPROptions{
 			ChangedFiles:   changed,
 			BaseConfigPath: cmd.String("base-copa-config"),
 			HeadConfigPath: cmd.String("copa-config"),
 			TargetRegistry: cmd.String("target-registry"),
-			ChartsFile:     cmd.String("charts-file"),
-			VerityConfig:   cmd.String("verity-config"),
 		})
 	case "chart":
-		plan, err = ci.PlanCharts(ci.ChartOptions{
+		plan, err = ci.PlanCharts(&ci.ChartOptions{
 			EventName:      cmd.String("event-name"),
 			InputChart:     cmd.String("input-chart"),
 			ChangedFiles:   changed,
@@ -81,7 +82,7 @@ func runCIPlan(_ context.Context, cmd *cli.Command) error {
 			ValuesDir:      cmd.String("values-dir"),
 		})
 	default:
-		return fmt.Errorf("unknown plan kind %q", cmd.String("kind"))
+		return fmt.Errorf("%w %q", errUnknownPlanKind, cmd.String("kind"))
 	}
 	if err != nil {
 		return err

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/verity-org/verity/internal/ci"
+	"github.com/verity-org/verity/internal/integer/apkindex"
+)
+
+var CICommand = &cli.Command{
+	Name:  "ci",
+	Usage: "CI planning helpers",
+	Commands: []*cli.Command{
+		ciPlanCommand,
+	},
+}
+
+var ciPlanCommand = &cli.Command{
+	Name:  "plan",
+	Usage: "Emit a typed CI matrix plan as JSON",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "kind", Required: true, Usage: "Plan kind: integer-pr, copa-pr, chart"},
+		&cli.StringFlag{Name: "changed-files", Usage: "Path to newline-delimited changed files"},
+		&cli.StringFlag{Name: "event-name", Usage: "GitHub event name", Value: "pull_request"},
+		&cli.StringFlag{Name: "input-chart", Usage: "Single chart requested by workflow_dispatch"},
+		&cli.StringFlag{Name: "integer-config", Usage: "Path to integer.yaml", Value: "integer.yaml"},
+		&cli.StringFlag{Name: "images-dir", Usage: "Path to images/", Value: "images"},
+		&cli.StringFlag{Name: "apkindex-url", Usage: "Wolfi APKINDEX URL; empty disables online discovery", Value: apkindex.DefaultAPKINDEXURL},
+		&cli.StringFlag{Name: "cache-dir", Usage: "APKINDEX cache dir"},
+		&cli.StringFlag{Name: "gen-dir", Usage: "Generated apko config directory"},
+		&cli.StringFlag{Name: "base-copa-config", Usage: "Base copa-config.yaml for PR diffing"},
+		&cli.StringFlag{Name: "copa-config", Usage: "Head copa-config.yaml", Value: "copa-config.yaml"},
+		&cli.StringFlag{Name: "target-registry", Usage: "Target registry override"},
+		&cli.StringFlag{Name: "charts-file", Usage: "Head Chart.yaml", Value: "Chart.yaml"},
+		&cli.StringFlag{Name: "base-charts-file", Usage: "Base Chart.yaml for PR diffing"},
+		&cli.StringFlag{Name: "verity-config", Usage: "Path to verity.yaml", Value: "verity.yaml"},
+		&cli.StringFlag{Name: "values-dir", Usage: "Path to chart integration values", Value: "test/chart-integration/values"},
+	},
+	Action: runCIPlan,
+}
+
+func runCIPlan(_ context.Context, cmd *cli.Command) error {
+	changed, err := readChangedFiles(cmd.String("changed-files"))
+	if err != nil {
+		return err
+	}
+
+	var plan ci.Plan
+	switch cmd.String("kind") {
+	case "integer-pr":
+		plan, err = ci.PlanIntegerPR(ci.IntegerPROptions{
+			ChangedFiles: changed,
+			ConfigPath:   cmd.String("integer-config"),
+			ImagesDir:    cmd.String("images-dir"),
+			APKIndexURL:  cmd.String("apkindex-url"),
+			CacheDir:     cmd.String("cache-dir"),
+			GenDir:       cmd.String("gen-dir"),
+		})
+	case "copa-pr":
+		plan, err = ci.PlanCopaPR(ci.CopaPROptions{
+			ChangedFiles:   changed,
+			BaseConfigPath: cmd.String("base-copa-config"),
+			HeadConfigPath: cmd.String("copa-config"),
+			TargetRegistry: cmd.String("target-registry"),
+			ChartsFile:     cmd.String("charts-file"),
+			VerityConfig:   cmd.String("verity-config"),
+		})
+	case "chart":
+		plan, err = ci.PlanCharts(ci.ChartOptions{
+			EventName:      cmd.String("event-name"),
+			InputChart:     cmd.String("input-chart"),
+			ChangedFiles:   changed,
+			ChartsFile:     cmd.String("charts-file"),
+			BaseChartsFile: cmd.String("base-charts-file"),
+			VerityConfig:   cmd.String("verity-config"),
+			ValuesDir:      cmd.String("values-dir"),
+		})
+	default:
+		return fmt.Errorf("unknown plan kind %q", cmd.String("kind"))
+	}
+	if err != nil {
+		return err
+	}
+
+	out, err := ci.Marshal(plan)
+	if err != nil {
+		return fmt.Errorf("marshal ci plan: %w", err)
+	}
+	fmt.Fprintln(os.Stdout, string(out))
+	return nil
+}
+
+func readChangedFiles(path string) ([]string, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read changed files %q: %w", path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	files := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line = strings.TrimSpace(line); line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}

--- a/internal/ci/plan.go
+++ b/internal/ci/plan.go
@@ -24,11 +24,11 @@ type Matrix struct {
 }
 
 type Plan struct {
-	Kind        string `json:"kind"`
-	HasChanges  bool   `json:"hasChanges"`
-	Strict      bool   `json:"strict,omitempty"`
-	Matrix      Matrix `json:"matrix"`
-	SmokeMatrix Matrix `json:"smokeMatrix,omitempty"`
+	Kind        string  `json:"kind"`
+	HasChanges  bool    `json:"hasChanges"`
+	Strict      bool    `json:"strict,omitempty"`
+	Matrix      Matrix  `json:"matrix"`
+	SmokeMatrix *Matrix `json:"smokeMatrix,omitempty"`
 }
 
 type IntegerPROptions struct {
@@ -41,13 +41,10 @@ type IntegerPROptions struct {
 }
 
 type CopaPROptions struct {
-	ChangedFiles     []string
-	BaseConfigPath   string
-	HeadConfigPath   string
-	TargetRegistry   string
-	ChartsFile       string
-	VerityConfig     string
-	IntegerImagesDir string
+	ChangedFiles   []string
+	BaseConfigPath string
+	HeadConfigPath string
+	TargetRegistry string
 }
 
 type ChartOptions struct {
@@ -60,12 +57,14 @@ type ChartOptions struct {
 	ValuesDir      string
 }
 
-func PlanIntegerPR(opts IntegerPROptions) (Plan, error) {
+var apkindexFetch = apkindex.Fetch
+
+func PlanIntegerPR(opts *IntegerPROptions) (Plan, error) {
 	plan := Plan{Kind: "integer-pr"}
 	imageNames, allImages := changedIntegerImages(opts.ChangedFiles)
 	if !allImages && len(imageNames) == 0 {
 		plan.Matrix = Matrix{}
-		plan.SmokeMatrix = Matrix{}
+		plan.SmokeMatrix = &Matrix{}
 		return plan, nil
 	}
 
@@ -76,9 +75,10 @@ func PlanIntegerPR(opts IntegerPROptions) (Plan, error) {
 
 	var pkgs []apkindex.Package
 	if opts.APKIndexURL != "" {
-		pkgs, err = apkindex.Fetch(opts.APKIndexURL, defaultString(opts.CacheDir, os.TempDir()), apkindex.DefaultCacheMaxAge)
+		pkgs, err = apkindexFetch(opts.APKIndexURL, defaultString(opts.CacheDir, os.TempDir()), apkindex.DefaultCacheMaxAge)
 		if err != nil {
-			return plan, fmt.Errorf("fetch apkindex: %w", err)
+			fmt.Fprintf(os.Stderr, "warning: APKINDEX unavailable (%v) — using versions map only\n", err)
+			pkgs = nil
 		}
 	}
 
@@ -96,17 +96,18 @@ func PlanIntegerPR(opts IntegerPROptions) (Plan, error) {
 	}
 	if len(imgs) == 0 {
 		plan.Matrix = Matrix{}
-		plan.SmokeMatrix = Matrix{}
+		plan.SmokeMatrix = &Matrix{}
 		return plan, nil
 	}
 
 	plan.HasChanges = true
-	plan.SmokeMatrix = integerMatrix(imgs)
+	smokeMatrix := integerMatrix(imgs)
+	plan.SmokeMatrix = &smokeMatrix
 	plan.Matrix = latestIntegerMatrix(imgs)
 	return plan, nil
 }
 
-func PlanCopaPR(opts CopaPROptions) (Plan, error) {
+func PlanCopaPR(opts *CopaPROptions) (Plan, error) {
 	plan := Plan{Kind: "copa-pr"}
 	if !containsPath(opts.ChangedFiles, "copa-config.yaml") {
 		plan.Matrix = Matrix{}
@@ -141,7 +142,7 @@ func PlanCopaPR(opts CopaPROptions) (Plan, error) {
 	return plan, nil
 }
 
-func PlanCharts(opts ChartOptions) (Plan, error) {
+func PlanCharts(opts *ChartOptions) (Plan, error) {
 	plan := Plan{Kind: "chart"}
 	charts, err := copadiscovery.LoadChartsFile(defaultString(opts.ChartsFile, "Chart.yaml"))
 	if err != nil {
@@ -150,11 +151,12 @@ func PlanCharts(opts ChartOptions) (Plan, error) {
 	chartNames := chartNameSet(charts)
 
 	var selected []string
-	if strings.TrimSpace(opts.InputChart) != "" {
+	switch {
+	case strings.TrimSpace(opts.InputChart) != "":
 		selected = []string{strings.TrimSpace(opts.InputChart)}
-	} else if opts.EventName != "pull_request" {
+	case opts.EventName != "pull_request":
 		selected = sortedChartNames(chartNames)
-	} else {
+	default:
 		selected, plan.Strict, err = affectedCharts(opts, charts, chartNames)
 		if err != nil {
 			return plan, err
@@ -174,9 +176,8 @@ func changedIntegerImages(files []string) (names map[string]struct{}, all bool) 
 		switch {
 		case f == "integer.yaml", strings.HasPrefix(f, "images/_base/"):
 			all = true
-		case strings.HasPrefix(f, "images/") && strings.HasSuffix(f, ".yaml") && !strings.Contains(f, "/_base/"):
-			name := strings.TrimSuffix(strings.TrimPrefix(f, "images/"), ".yaml")
-			if name != "" {
+		default:
+			if name, ok := imageNameFromPath(f); ok {
 				names[name] = struct{}{}
 			}
 		}
@@ -198,7 +199,8 @@ func changedCopaNames(basePath, headPath string) (map[string]struct{}, error) {
 	}
 
 	names := map[string]struct{}{}
-	for name, img := range head {
+	for name := range head {
+		img := head[name]
 		if old, ok := base[name]; !ok || !reflect.DeepEqual(old, img) {
 			names[name] = struct{}{}
 		}
@@ -212,19 +214,19 @@ func loadCopaImages(path string) (map[string]config.ImageSpec, error) {
 		return nil, err
 	}
 	out := make(map[string]config.ImageSpec, len(cfg.Images))
-	for _, img := range cfg.Images {
+	for i := range cfg.Images {
+		img := cfg.Images[i]
 		out[img.Name] = img
 	}
 	return out, nil
 }
 
-func affectedCharts(opts ChartOptions, charts []config.ChartSpec, chartNames map[string]struct{}) ([]string, bool, error) {
+func affectedCharts(opts *ChartOptions, charts []config.ChartSpec, chartNames map[string]struct{}) (affected []string, strict bool, err error) {
 	if matchesAny(opts.ChangedFiles, broadChartPatterns()) || changedUnder(opts.ChangedFiles, "images/_base/") {
 		return sortedChartNames(chartNames), false, nil
 	}
 
 	selected := map[string]struct{}{}
-	strict := false
 	if containsPath(opts.ChangedFiles, "Chart.yaml") {
 		strict = true
 		changed, err := changedChartDependencies(opts.BaseChartsFile, defaultString(opts.ChartsFile, "Chart.yaml"))
@@ -435,15 +437,20 @@ func filterCopaByName(imgs []copadiscovery.DiscoveredImage, names map[string]str
 func changedImageNames(files []string) []string {
 	set := map[string]struct{}{}
 	for _, f := range files {
-		f = filepath.ToSlash(strings.TrimSpace(f))
-		if strings.HasPrefix(f, "images/") && strings.HasSuffix(f, ".yaml") && !strings.Contains(f, "/_base/") {
-			name := strings.TrimSuffix(strings.TrimPrefix(f, "images/"), ".yaml")
-			if name != "" {
-				set[name] = struct{}{}
-			}
+		if name, ok := imageNameFromPath(f); ok {
+			set[name] = struct{}{}
 		}
 	}
 	return sortedChartNames(set)
+}
+
+func imageNameFromPath(path string) (string, bool) {
+	path = filepath.ToSlash(strings.TrimSpace(path))
+	if !strings.HasPrefix(path, "images/") || !strings.HasSuffix(path, ".yaml") || strings.Contains(path, "/_base/") {
+		return "", false
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(path, "images/"), ".yaml")
+	return name, name != ""
 }
 
 func chartNameSet(charts []config.ChartSpec) map[string]struct{} {
@@ -555,7 +562,10 @@ func Marshal(plan Plan) ([]byte, error) {
 	if plan.Matrix.Include == nil {
 		plan.Matrix.Include = []map[string]string{}
 	}
-	if plan.SmokeMatrix.Include == nil && plan.Kind == "integer-pr" {
+	if plan.SmokeMatrix == nil && plan.Kind == "integer-pr" {
+		plan.SmokeMatrix = &Matrix{}
+	}
+	if plan.SmokeMatrix != nil && plan.SmokeMatrix.Include == nil {
 		plan.SmokeMatrix.Include = []map[string]string{}
 	}
 	return json.MarshalIndent(plan, "", "  ")

--- a/internal/ci/plan.go
+++ b/internal/ci/plan.go
@@ -1,0 +1,562 @@
+package ci
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/verity-org/verity/internal/config"
+	copadiscovery "github.com/verity-org/verity/internal/discovery"
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
+)
+
+type Matrix struct {
+	Include []map[string]string `json:"include"`
+}
+
+type Plan struct {
+	Kind        string `json:"kind"`
+	HasChanges  bool   `json:"hasChanges"`
+	Strict      bool   `json:"strict,omitempty"`
+	Matrix      Matrix `json:"matrix"`
+	SmokeMatrix Matrix `json:"smokeMatrix,omitempty"`
+}
+
+type IntegerPROptions struct {
+	ChangedFiles []string
+	ConfigPath   string
+	ImagesDir    string
+	APKIndexURL  string
+	CacheDir     string
+	GenDir       string
+}
+
+type CopaPROptions struct {
+	ChangedFiles     []string
+	BaseConfigPath   string
+	HeadConfigPath   string
+	TargetRegistry   string
+	ChartsFile       string
+	VerityConfig     string
+	IntegerImagesDir string
+}
+
+type ChartOptions struct {
+	EventName      string
+	InputChart     string
+	ChangedFiles   []string
+	ChartsFile     string
+	BaseChartsFile string
+	VerityConfig   string
+	ValuesDir      string
+}
+
+func PlanIntegerPR(opts IntegerPROptions) (Plan, error) {
+	plan := Plan{Kind: "integer-pr"}
+	imageNames, allImages := changedIntegerImages(opts.ChangedFiles)
+	if !allImages && len(imageNames) == 0 {
+		plan.Matrix = Matrix{}
+		plan.SmokeMatrix = Matrix{}
+		return plan, nil
+	}
+
+	cfg, err := intconfig.LoadConfig(defaultString(opts.ConfigPath, "integer.yaml"))
+	if err != nil {
+		return plan, fmt.Errorf("load integer config: %w", err)
+	}
+
+	var pkgs []apkindex.Package
+	if opts.APKIndexURL != "" {
+		pkgs, err = apkindex.Fetch(opts.APKIndexURL, defaultString(opts.CacheDir, os.TempDir()), apkindex.DefaultCacheMaxAge)
+		if err != nil {
+			return plan, fmt.Errorf("fetch apkindex: %w", err)
+		}
+	}
+
+	imgs, err := intdiscovery.DiscoverFromFiles(intdiscovery.Options{
+		ImagesDir: defaultString(opts.ImagesDir, "images"),
+		Registry:  cfg.Target.Registry,
+		Packages:  pkgs,
+		GenDir:    opts.GenDir,
+	})
+	if err != nil {
+		return plan, fmt.Errorf("discover integer images: %w", err)
+	}
+	if !allImages {
+		imgs = filterIntegerByName(imgs, imageNames)
+	}
+	if len(imgs) == 0 {
+		plan.Matrix = Matrix{}
+		plan.SmokeMatrix = Matrix{}
+		return plan, nil
+	}
+
+	plan.HasChanges = true
+	plan.SmokeMatrix = integerMatrix(imgs)
+	plan.Matrix = latestIntegerMatrix(imgs)
+	return plan, nil
+}
+
+func PlanCopaPR(opts CopaPROptions) (Plan, error) {
+	plan := Plan{Kind: "copa-pr"}
+	if !containsPath(opts.ChangedFiles, "copa-config.yaml") {
+		plan.Matrix = Matrix{}
+		return plan, nil
+	}
+
+	names, err := changedCopaNames(opts.BaseConfigPath, defaultString(opts.HeadConfigPath, "copa-config.yaml"))
+	if err != nil {
+		return plan, err
+	}
+	if len(names) == 0 {
+		plan.Matrix = Matrix{}
+		return plan, nil
+	}
+
+	cfg, err := copadiscovery.LoadConfig(defaultString(opts.HeadConfigPath, "copa-config.yaml"))
+	if err != nil {
+		return plan, fmt.Errorf("load copa config: %w", err)
+	}
+	cfg.Charts = nil
+	images, err := copadiscovery.DiscoverWithChartValues(cfg, opts.TargetRegistry, nil, nil, nil, nil)
+	if err != nil {
+		return plan, fmt.Errorf("discover copa images: %w", err)
+	}
+	images = filterCopaByName(images, names)
+	if len(images) == 0 {
+		plan.Matrix = Matrix{}
+		return plan, nil
+	}
+	plan.HasChanges = true
+	plan.Matrix = firstCopaTagMatrix(images)
+	return plan, nil
+}
+
+func PlanCharts(opts ChartOptions) (Plan, error) {
+	plan := Plan{Kind: "chart"}
+	charts, err := copadiscovery.LoadChartsFile(defaultString(opts.ChartsFile, "Chart.yaml"))
+	if err != nil {
+		return plan, fmt.Errorf("load charts: %w", err)
+	}
+	chartNames := chartNameSet(charts)
+
+	var selected []string
+	if strings.TrimSpace(opts.InputChart) != "" {
+		selected = []string{strings.TrimSpace(opts.InputChart)}
+	} else if opts.EventName != "pull_request" {
+		selected = sortedChartNames(chartNames)
+	} else {
+		selected, plan.Strict, err = affectedCharts(opts, charts, chartNames)
+		if err != nil {
+			return plan, err
+		}
+	}
+
+	selected = filterKnownCharts(selected, chartNames)
+	plan.HasChanges = len(selected) > 0
+	plan.Matrix = chartMatrix(selected)
+	return plan, nil
+}
+
+func changedIntegerImages(files []string) (names map[string]struct{}, all bool) {
+	names = map[string]struct{}{}
+	for _, f := range files {
+		f = filepath.ToSlash(strings.TrimSpace(f))
+		switch {
+		case f == "integer.yaml", strings.HasPrefix(f, "images/_base/"):
+			all = true
+		case strings.HasPrefix(f, "images/") && strings.HasSuffix(f, ".yaml") && !strings.Contains(f, "/_base/"):
+			name := strings.TrimSuffix(strings.TrimPrefix(f, "images/"), ".yaml")
+			if name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	}
+	return names, all
+}
+
+func changedCopaNames(basePath, headPath string) (map[string]struct{}, error) {
+	head, err := loadCopaImages(headPath)
+	if err != nil {
+		return nil, fmt.Errorf("load head copa config: %w", err)
+	}
+	base := map[string]config.ImageSpec{}
+	if basePath != "" {
+		base, err = loadCopaImages(basePath)
+		if err != nil {
+			return nil, fmt.Errorf("load base copa config: %w", err)
+		}
+	}
+
+	names := map[string]struct{}{}
+	for name, img := range head {
+		if old, ok := base[name]; !ok || !reflect.DeepEqual(old, img) {
+			names[name] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
+func loadCopaImages(path string) (map[string]config.ImageSpec, error) {
+	cfg, err := copadiscovery.LoadConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]config.ImageSpec, len(cfg.Images))
+	for _, img := range cfg.Images {
+		out[img.Name] = img
+	}
+	return out, nil
+}
+
+func affectedCharts(opts ChartOptions, charts []config.ChartSpec, chartNames map[string]struct{}) ([]string, bool, error) {
+	if matchesAny(opts.ChangedFiles, broadChartPatterns()) || changedUnder(opts.ChangedFiles, "images/_base/") {
+		return sortedChartNames(chartNames), false, nil
+	}
+
+	selected := map[string]struct{}{}
+	strict := false
+	if containsPath(opts.ChangedFiles, "Chart.yaml") {
+		strict = true
+		changed, err := changedChartDependencies(opts.BaseChartsFile, defaultString(opts.ChartsFile, "Chart.yaml"))
+		if err != nil {
+			return nil, false, err
+		}
+		for _, name := range changed {
+			if _, ok := chartNames[name]; ok {
+				selected[name] = struct{}{}
+			}
+		}
+	}
+
+	changedImages := changedImageNames(opts.ChangedFiles)
+	if len(changedImages) > 0 {
+		vc, err := copadiscovery.LoadVerityConfig(defaultString(opts.VerityConfig, "verity.yaml"))
+		if err != nil {
+			return nil, false, fmt.Errorf("load verity config: %w", err)
+		}
+		chartValueKeys := mapKeys(vc.ChartValues)
+		for _, image := range changedImages {
+			addFuzzyChartMatches(selected, normalize(image), charts, chartValueKeys, chartNames)
+			addValueFileMatches(selected, defaultString(opts.ValuesDir, filepath.Join("test", "chart-integration", "values")), image, chartNames)
+			addReplacementMatches(selected, image, vc.Replacements, charts, chartValueKeys, chartNames)
+		}
+	}
+
+	return sortedChartNames(selected), strict, nil
+}
+
+func changedChartDependencies(basePath, headPath string) ([]string, error) {
+	head, err := loadChartDepMap(headPath)
+	if err != nil {
+		return nil, fmt.Errorf("load head Chart.yaml: %w", err)
+	}
+	base := map[string]config.ChartSpec{}
+	if basePath != "" {
+		base, err = loadChartDepMap(basePath)
+		if err != nil {
+			return nil, fmt.Errorf("load base Chart.yaml: %w", err)
+		}
+	}
+	var changed []string
+	for name, dep := range head {
+		if old, ok := base[name]; !ok || old.Version != dep.Version || old.Repository != dep.Repository {
+			changed = append(changed, name)
+		}
+	}
+	sort.Strings(changed)
+	return changed, nil
+}
+
+func loadChartDepMap(path string) (map[string]config.ChartSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var file config.HelmChartFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, err
+	}
+	out := make(map[string]config.ChartSpec, len(file.Dependencies))
+	for _, dep := range file.Dependencies {
+		out[dep.Name] = dep
+	}
+	return out, nil
+}
+
+func addFuzzyChartMatches(selected map[string]struct{}, imageNorm string, charts []config.ChartSpec, chartValueKeys []string, chartNames map[string]struct{}) {
+	for _, chart := range charts {
+		chartNorm := normalize(chart.Name)
+		if imageNorm == chartNorm || strings.HasPrefix(imageNorm, chartNorm) || strings.HasPrefix(chartNorm, imageNorm) {
+			selected[chart.Name] = struct{}{}
+		}
+	}
+	for _, key := range chartValueKeys {
+		keyNorm := normalize(key)
+		if imageNorm == keyNorm || strings.HasPrefix(imageNorm, keyNorm) || strings.HasPrefix(keyNorm, imageNorm) {
+			if _, ok := chartNames[key]; ok {
+				selected[key] = struct{}{}
+			}
+		}
+	}
+}
+
+func addValueFileMatches(selected map[string]struct{}, valuesDir, image string, chartNames map[string]struct{}) {
+	entries, err := os.ReadDir(valuesDir)
+	if err != nil {
+		return
+	}
+	re := regexp.MustCompile(`verity-org/(.*/)?` + regexp.QuoteMeta(image) + `([:@"'\s]|$)|\b` + regexp.QuoteMeta(image) + `\b`)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		chart := strings.TrimSuffix(entry.Name(), ".yaml")
+		if _, ok := chartNames[chart]; !ok {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(valuesDir, entry.Name()))
+		if err == nil && re.Match(data) {
+			selected[chart] = struct{}{}
+		}
+	}
+}
+
+func addReplacementMatches(selected map[string]struct{}, image string, replacements map[string]config.Replacement, charts []config.ChartSpec, chartValueKeys []string, chartNames map[string]struct{}) {
+	imageNorm := normalize(image)
+	for _, repl := range replacements {
+		replImage := repl.Image
+		if idx := strings.LastIndex(replImage, "/"); idx >= 0 {
+			replImage = replImage[idx+1:]
+		}
+		replNorm := normalize(replImage)
+		if replNorm == imageNorm || strings.HasPrefix(replNorm, imageNorm) || strings.HasPrefix(imageNorm, replNorm) {
+			addFuzzyChartMatches(selected, replNorm, charts, chartValueKeys, chartNames)
+		}
+	}
+}
+
+func integerMatrix(imgs []intdiscovery.DiscoveredImage) Matrix {
+	include := make([]map[string]string, 0, len(imgs))
+	for _, img := range imgs {
+		include = append(include, map[string]string{
+			"image":   img.Name,
+			"version": img.Version,
+			"type":    img.Type,
+		})
+	}
+	return Matrix{Include: include}
+}
+
+func latestIntegerMatrix(imgs []intdiscovery.DiscoveredImage) Matrix {
+	latest := map[string]intdiscovery.DiscoveredImage{}
+	for _, img := range imgs {
+		key := img.Name + "\x00" + img.Type
+		prev, ok := latest[key]
+		if !ok || apkindex.VersionLess(prev.Version, img.Version) {
+			latest[key] = img
+		}
+	}
+	out := make([]intdiscovery.DiscoveredImage, 0, len(latest))
+	for _, img := range latest {
+		out = append(out, img)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		if out[i].Type != out[j].Type {
+			return out[i].Type < out[j].Type
+		}
+		return apkindex.VersionLess(out[i].Version, out[j].Version)
+	})
+	return integerMatrix(out)
+}
+
+func firstCopaTagMatrix(imgs []copadiscovery.DiscoveredImage) Matrix {
+	sort.Slice(imgs, func(i, j int) bool {
+		if imgs[i].Name != imgs[j].Name {
+			return imgs[i].Name < imgs[j].Name
+		}
+		return imgs[i].Source < imgs[j].Source
+	})
+	seen := map[string]struct{}{}
+	include := []map[string]string{}
+	for _, img := range imgs {
+		if _, ok := seen[img.Name]; ok {
+			continue
+		}
+		seen[img.Name] = struct{}{}
+		include = append(include, map[string]string{
+			"name": img.Name,
+			"tag":  sourceTag(img.Source),
+		})
+	}
+	return Matrix{Include: include}
+}
+
+func chartMatrix(charts []string) Matrix {
+	include := make([]map[string]string, 0, len(charts))
+	for _, chart := range charts {
+		include = append(include, map[string]string{"chart": chart})
+	}
+	return Matrix{Include: include}
+}
+
+func filterIntegerByName(imgs []intdiscovery.DiscoveredImage, names map[string]struct{}) []intdiscovery.DiscoveredImage {
+	out := imgs[:0]
+	for _, img := range imgs {
+		if _, ok := names[img.Name]; ok {
+			out = append(out, img)
+		}
+	}
+	return out
+}
+
+func filterCopaByName(imgs []copadiscovery.DiscoveredImage, names map[string]struct{}) []copadiscovery.DiscoveredImage {
+	out := imgs[:0]
+	for _, img := range imgs {
+		if _, ok := names[img.Name]; ok {
+			out = append(out, img)
+		}
+	}
+	return out
+}
+
+func changedImageNames(files []string) []string {
+	set := map[string]struct{}{}
+	for _, f := range files {
+		f = filepath.ToSlash(strings.TrimSpace(f))
+		if strings.HasPrefix(f, "images/") && strings.HasSuffix(f, ".yaml") && !strings.Contains(f, "/_base/") {
+			name := strings.TrimSuffix(strings.TrimPrefix(f, "images/"), ".yaml")
+			if name != "" {
+				set[name] = struct{}{}
+			}
+		}
+	}
+	return sortedChartNames(set)
+}
+
+func chartNameSet(charts []config.ChartSpec) map[string]struct{} {
+	set := make(map[string]struct{}, len(charts))
+	for _, chart := range charts {
+		set[chart.Name] = struct{}{}
+	}
+	return set
+}
+
+func filterKnownCharts(charts []string, known map[string]struct{}) []string {
+	out := charts[:0]
+	for _, chart := range charts {
+		if _, ok := known[chart]; ok {
+			out = append(out, chart)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedChartNames(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for name := range set {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func mapKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func broadChartPatterns() []*regexp.Regexp {
+	return []*regexp.Regexp{
+		regexp.MustCompile(`^test/chart-integration/`),
+		regexp.MustCompile(`^\.github/workflows/chart-integration\.yaml$`),
+		regexp.MustCompile(`^mise\.toml$`),
+		regexp.MustCompile(`^Makefile$`),
+		regexp.MustCompile(`^verity\.yaml$`),
+		regexp.MustCompile(`^internal/chartgen/`),
+		regexp.MustCompile(`^internal/discovery/`),
+	}
+}
+
+func matchesAny(files []string, patterns []*regexp.Regexp) bool {
+	for _, f := range files {
+		f = filepath.ToSlash(strings.TrimSpace(f))
+		for _, p := range patterns {
+			if p.MatchString(f) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func changedUnder(files []string, prefix string) bool {
+	for _, f := range files {
+		if strings.HasPrefix(filepath.ToSlash(strings.TrimSpace(f)), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPath(files []string, path string) bool {
+	for _, f := range files {
+		if filepath.ToSlash(strings.TrimSpace(f)) == path {
+			return true
+		}
+	}
+	return false
+}
+
+func normalize(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func sourceTag(ref string) string {
+	ref = strings.SplitN(ref, "@", 2)[0]
+	if idx := strings.LastIndex(ref, ":"); idx >= 0 && idx > strings.LastIndex(ref, "/") {
+		return ref[idx+1:]
+	}
+	return "latest"
+}
+
+func defaultString(v, fallback string) string {
+	if strings.TrimSpace(v) == "" {
+		return fallback
+	}
+	return v
+}
+
+func Marshal(plan Plan) ([]byte, error) {
+	if plan.Matrix.Include == nil {
+		plan.Matrix.Include = []map[string]string{}
+	}
+	if plan.SmokeMatrix.Include == nil && plan.Kind == "integer-pr" {
+		plan.SmokeMatrix.Include = []map[string]string{}
+	}
+	return json.MarshalIndent(plan, "", "  ")
+}

--- a/internal/ci/plan_test.go
+++ b/internal/ci/plan_test.go
@@ -1,0 +1,204 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTestFile(t *testing.T, path, body string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+}
+
+func setupIntegerPlanRepo(t *testing.T) (root string) {
+	t.Helper()
+	root = t.TempDir()
+	writeTestFile(t, filepath.Join(root, "integer.yaml"), `
+target:
+  registry: ghcr.io/test-org
+`)
+	for _, base := range []string{"wolfi-base", "wolfi-dev", "wolfi-fips"} {
+		writeTestFile(t, filepath.Join(root, "images", "_base", base+".yaml"), "# base\n")
+	}
+	writeTestFile(t, filepath.Join(root, "images", "node.yaml"), `
+name: node
+description: Node
+upstream:
+  package: nodejs-{{version}}
+types:
+  default:
+    base: wolfi-base
+    packages: ["nodejs-{{version}}"]
+  dev:
+    base: wolfi-dev
+    packages: ["nodejs-{{version}}", "npm"]
+versions:
+  "20": {}
+  "22": {}
+`)
+	writeTestFile(t, filepath.Join(root, "images", "curl.yaml"), `
+name: curl
+description: curl
+upstream:
+  package: curl
+types:
+  default:
+    base: wolfi-base
+    packages: ["curl"]
+versions:
+  latest:
+    latest: true
+`)
+	return root
+}
+
+func TestPlanIntegerPRChangedImageBuildsLatestAndSmokesAllCombos(t *testing.T) {
+	root := setupIntegerPlanRepo(t)
+
+	plan, err := PlanIntegerPR(IntegerPROptions{
+		ChangedFiles: []string{"images/node.yaml"},
+		ConfigPath:   filepath.Join(root, "integer.yaml"),
+		ImagesDir:    filepath.Join(root, "images"),
+		APKIndexURL:  "",
+		GenDir:       filepath.Join(root, "gen"),
+	})
+	require.NoError(t, err)
+
+	assert.True(t, plan.HasChanges)
+	assert.ElementsMatch(t, []map[string]string{
+		{"image": "node", "version": "22", "type": "default"},
+		{"image": "node", "version": "22", "type": "dev"},
+	}, plan.Matrix.Include)
+	assert.Len(t, plan.SmokeMatrix.Include, 4)
+}
+
+func TestPlanIntegerPREmptyWhenNoImageFilesChanged(t *testing.T) {
+	root := setupIntegerPlanRepo(t)
+
+	plan, err := PlanIntegerPR(IntegerPROptions{
+		ChangedFiles: []string{"README.md"},
+		ConfigPath:   filepath.Join(root, "integer.yaml"),
+		ImagesDir:    filepath.Join(root, "images"),
+		APKIndexURL:  "",
+		GenDir:       filepath.Join(root, "gen"),
+	})
+	require.NoError(t, err)
+
+	assert.False(t, plan.HasChanges)
+	assert.Empty(t, plan.Matrix.Include)
+	assert.Empty(t, plan.SmokeMatrix.Include)
+}
+
+func TestPlanCopaPRDiffsSemanticImageEntries(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base-copa.yaml")
+	head := filepath.Join(root, "copa.yaml")
+	writeTestFile(t, base, `
+target:
+  registry: ghcr.io/test-org
+images:
+  - name: library/nginx
+    image: mirror.gcr.io/library/nginx
+    tags:
+      strategy: list
+      list: ["1.28.0"]
+  - name: library/rabbitmq
+    image: mirror.gcr.io/library/rabbitmq
+    tags:
+      strategy: list
+      list: ["4.1.0"]
+`)
+	writeTestFile(t, head, `
+target:
+  registry: ghcr.io/test-org
+images:
+  - name: library/nginx
+    image: mirror.gcr.io/library/nginx
+    tags:
+      strategy: list
+      list: ["1.29.0"]
+  - name: library/rabbitmq
+    image: mirror.gcr.io/library/rabbitmq
+    tags:
+      strategy: list
+      list: ["4.1.0"]
+`)
+
+	plan, err := PlanCopaPR(CopaPROptions{
+		ChangedFiles:   []string{"copa-config.yaml"},
+		BaseConfigPath: base,
+		HeadConfigPath: head,
+		TargetRegistry: "ghcr.io/test-org",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, plan.HasChanges)
+	assert.Equal(t, []map[string]string{{"name": "library/nginx", "tag": "1.29.0"}}, plan.Matrix.Include)
+}
+
+func TestPlanChartsMarksChangedDependencyStrict(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base-Chart.yaml")
+	head := filepath.Join(root, "Chart.yaml")
+	writeTestFile(t, base, `
+dependencies:
+  - name: grafana
+    version: "10.0.0"
+    repository: "https://grafana.github.io/helm-charts"
+  - name: loki
+    version: "7.0.0"
+    repository: "https://grafana.github.io/helm-charts"
+`)
+	writeTestFile(t, head, `
+dependencies:
+  - name: grafana
+    version: "10.1.0"
+    repository: "https://grafana.github.io/helm-charts"
+  - name: loki
+    version: "7.0.0"
+    repository: "https://grafana.github.io/helm-charts"
+`)
+
+	plan, err := PlanCharts(ChartOptions{
+		EventName:      "pull_request",
+		ChangedFiles:   []string{"Chart.yaml"},
+		ChartsFile:     head,
+		BaseChartsFile: base,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, plan.Strict)
+	assert.Equal(t, []map[string]string{{"chart": "grafana"}}, plan.Matrix.Include)
+}
+
+func TestPlanChartsMapsChangedImageThroughValuesFile(t *testing.T) {
+	root := t.TempDir()
+	charts := filepath.Join(root, "Chart.yaml")
+	valuesDir := filepath.Join(root, "values")
+	writeTestFile(t, charts, `
+dependencies:
+  - name: grafana
+    version: "10.0.0"
+    repository: "https://grafana.github.io/helm-charts"
+  - name: loki
+    version: "7.0.0"
+    repository: "https://grafana.github.io/helm-charts"
+`)
+	writeTestFile(t, filepath.Join(valuesDir, "grafana.yaml"), "image: ghcr.io/verity-org/grafana:12\n")
+
+	plan, err := PlanCharts(ChartOptions{
+		EventName:    "pull_request",
+		ChangedFiles: []string{"images/grafana.yaml"},
+		ChartsFile:   charts,
+		ValuesDir:    valuesDir,
+	})
+	require.NoError(t, err)
+
+	assert.False(t, plan.Strict)
+	assert.Equal(t, []map[string]string{{"chart": "grafana"}}, plan.Matrix.Include)
+}

--- a/internal/ci/plan_test.go
+++ b/internal/ci/plan_test.go
@@ -1,13 +1,19 @@
 package ci
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
 )
+
+var errTemporaryAPKIndexOutage = errors.New("temporary apkindex outage")
 
 func writeTestFile(t *testing.T, path, body string) {
 	t.Helper()
@@ -60,7 +66,7 @@ versions:
 func TestPlanIntegerPRChangedImageBuildsLatestAndSmokesAllCombos(t *testing.T) {
 	root := setupIntegerPlanRepo(t)
 
-	plan, err := PlanIntegerPR(IntegerPROptions{
+	plan, err := PlanIntegerPR(&IntegerPROptions{
 		ChangedFiles: []string{"images/node.yaml"},
 		ConfigPath:   filepath.Join(root, "integer.yaml"),
 		ImagesDir:    filepath.Join(root, "images"),
@@ -80,7 +86,7 @@ func TestPlanIntegerPRChangedImageBuildsLatestAndSmokesAllCombos(t *testing.T) {
 func TestPlanIntegerPREmptyWhenNoImageFilesChanged(t *testing.T) {
 	root := setupIntegerPlanRepo(t)
 
-	plan, err := PlanIntegerPR(IntegerPROptions{
+	plan, err := PlanIntegerPR(&IntegerPROptions{
 		ChangedFiles: []string{"README.md"},
 		ConfigPath:   filepath.Join(root, "integer.yaml"),
 		ImagesDir:    filepath.Join(root, "images"),
@@ -92,6 +98,30 @@ func TestPlanIntegerPREmptyWhenNoImageFilesChanged(t *testing.T) {
 	assert.False(t, plan.HasChanges)
 	assert.Empty(t, plan.Matrix.Include)
 	assert.Empty(t, plan.SmokeMatrix.Include)
+}
+
+func TestPlanIntegerPRFallsBackWhenAPKIndexFetchFails(t *testing.T) {
+	root := setupIntegerPlanRepo(t)
+	originalFetch := apkindexFetch
+	apkindexFetch = func(string, string, time.Duration) ([]apkindex.Package, error) {
+		return nil, errTemporaryAPKIndexOutage
+	}
+	t.Cleanup(func() { apkindexFetch = originalFetch })
+
+	plan, err := PlanIntegerPR(&IntegerPROptions{
+		ChangedFiles: []string{"images/node.yaml"},
+		ConfigPath:   filepath.Join(root, "integer.yaml"),
+		ImagesDir:    filepath.Join(root, "images"),
+		APKIndexURL:  "https://example.invalid/APKINDEX.tar.gz",
+		GenDir:       filepath.Join(root, "gen"),
+	})
+	require.NoError(t, err)
+
+	assert.True(t, plan.HasChanges)
+	assert.ElementsMatch(t, []map[string]string{
+		{"image": "node", "version": "22", "type": "default"},
+		{"image": "node", "version": "22", "type": "dev"},
+	}, plan.Matrix.Include)
 }
 
 func TestPlanCopaPRDiffsSemanticImageEntries(t *testing.T) {
@@ -129,7 +159,7 @@ images:
       list: ["4.1.0"]
 `)
 
-	plan, err := PlanCopaPR(CopaPROptions{
+	plan, err := PlanCopaPR(&CopaPROptions{
 		ChangedFiles:   []string{"copa-config.yaml"},
 		BaseConfigPath: base,
 		HeadConfigPath: head,
@@ -164,7 +194,7 @@ dependencies:
     repository: "https://grafana.github.io/helm-charts"
 `)
 
-	plan, err := PlanCharts(ChartOptions{
+	plan, err := PlanCharts(&ChartOptions{
 		EventName:      "pull_request",
 		ChangedFiles:   []string{"Chart.yaml"},
 		ChartsFile:     head,
@@ -191,7 +221,7 @@ dependencies:
 `)
 	writeTestFile(t, filepath.Join(valuesDir, "grafana.yaml"), "image: ghcr.io/verity-org/grafana:12\n")
 
-	plan, err := PlanCharts(ChartOptions{
+	plan, err := PlanCharts(&ChartOptions{
 		EventName:    "pull_request",
 		ChangedFiles: []string{"images/grafana.yaml"},
 		ChartsFile:   charts,

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 			cmd.CatalogCommand,
 			cmd.DiscoverCommand,
 			cmd.IntegerCommand,
+			cmd.CICommand,
 			cmd.PreflightCommand,
 			cmd.ChartGenCommand,
 			cmd.PatchCommand,

--- a/mise.lock
+++ b/mise.lock
@@ -161,36 +161,36 @@ checksum = "sha256:fb78f814f68ab47266458f319ca7e642a303453ea25c8993a14eb9850c56e
 url = "https://github.com/google/go-containerregistry/releases/download/v0.21.6/go-containerregistry_Windows_x86_64.tar.gz"
 
 [[tools.go]]
-version = "1.26.4"
+version = "1.26.5"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
-url = "https://dl.google.com/go/go1.26.4.linux-arm64.tar.gz"
+checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-arm64-musl"]
-checksum = "sha256:ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
-url = "https://dl.google.com/go/go1.26.4.linux-arm64.tar.gz"
+checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
-url = "https://dl.google.com/go/go1.26.4.linux-amd64.tar.gz"
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
 
 [tools.go."platforms.linux-x64-musl"]
-checksum = "sha256:1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
-url = "https://dl.google.com/go/go1.26.4.linux-amd64.tar.gz"
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53"
-url = "https://dl.google.com/go/go1.26.4.darwin-arm64.tar.gz"
+checksum = "sha256:efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
+url = "https://dl.google.com/go/go1.26.5.darwin-arm64.tar.gz"
 
 [tools.go."platforms.macos-x64"]
-checksum = "sha256:05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d"
-url = "https://dl.google.com/go/go1.26.4.darwin-amd64.tar.gz"
+checksum = "sha256:6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
+url = "https://dl.google.com/go/go1.26.5.darwin-amd64.tar.gz"
 
 [tools.go."platforms.windows-x64"]
-checksum = "sha256:3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345"
-url = "https://dl.google.com/go/go1.26.4.windows-amd64.zip"
+checksum = "sha256:97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
+url = "https://dl.google.com/go/go1.26.5.windows-amd64.zip"
 
 [[tools."go:github.com/golangci/golangci-lint/v2/cmd/golangci-lint"]]
 version = "2.12.2"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Core tools
-go = "1.26.4"
+go = "1.26.5"
 node = { version = "24.16.0", postinstall = "corepack enable" }
 crane = "0.21.6"
 helm = "4.2.0"


### PR DESCRIPTION
## Summary
- add `verity ci plan` for typed Integer PR, Copa PR, and chart-integration matrix planning
- replace PR/chart matrix-selection shell with planner JSON consumers
- tighten Integer publish by staging the multi-arch image, Trivy-scanning that staged ref across all severities, then promoting with `crane copy`
- bump the pinned CI Go toolchain to `1.26.5` so `govulncheck` uses the fixed standard library

## Validation
- `mise x -- go test ./...`
- `mise x -- golangci-lint run --timeout=5m`
- `mise x -- govulncheck ./...`
- `go test ./...`
- `golangci-lint run --timeout=5m`
- `actionlint .github/workflows/pr-test.yaml .github/workflows/chart-integration.yaml .github/workflows/integer-build-image.yaml .github/workflows/ci.yaml .github/workflows/orchestrator.yaml .github/workflows/chart-gen.yaml .github/workflows/build-site.yaml`
- `yamllint -c .yamllint.yml .github/workflows/pr-test.yaml .github/workflows/chart-integration.yaml .github/workflows/integer-build-image.yaml`
- `python3 .github/scripts/validate-chart-integration-workflow.py`
- `python3 .github/scripts/validate-ci-workflow.py`
- `python3 .github/scripts/validate-integer-build-image-workflow.py`
- `python3 .github/scripts/validate-patch-image-workflow.py`
- `python3 .github/scripts/validate-nightly-workflows.py`
- `bash .github/scripts/validate-retry-helpers.sh`
- `bash .github/scripts/validate-wait-for-workflows.sh`
