### PR TITLE
feat: scan before nightly remediation

### DIFF
--- a/.github/scripts/validate-ci-workflow.py
+++ b/.github/scripts/validate-ci-workflow.py
@@ -6,6 +6,7 @@ required = [
     "^site/|^\\.github/workflows/ci\\.yaml$|^mise\\.toml$",
     "python3 .github/scripts/validate-ci-workflow.py",
     "python3 .github/scripts/validate-nightly-workflows.py",
+    "python3 .github/scripts/validate-pr-test-workflow.py",
 ]
 
 missing = [needle for needle in required if needle not in workflow]

--- a/.github/scripts/validate-nightly-workflows.py
+++ b/.github/scripts/validate-nightly-workflows.py
@@ -67,6 +67,7 @@ permissions: {}
 def main() -> None:
     self_test()
     orchestrator = uncomment(".github/workflows/orchestrator.yaml")
+    integer_orchestrator = uncomment(".github/workflows/integer-orchestrator.yaml")
     chart_gen = uncomment(".github/workflows/chart-gen.yaml")
     build_site = uncomment(".github/workflows/build-site.yaml")
     chart_integration = uncomment(".github/workflows/chart-integration.yaml")
@@ -74,10 +75,20 @@ def main() -> None:
     wait_helper = Path(".github/scripts/wait-for-workflows.sh").read_text(encoding="utf-8")
 
     require(
-        "for attempt in 1 2 3 4 5; do" in orchestrator
-        and "gh workflow run patch-image.yaml" in orchestrator
-        and 'if [ "$dispatched" -ne "$expected_count" ]; then' in orchestrator,
-        "Copa orchestrator dispatch must retry and verify all patch runs dispatched",
+        "nightly plan" in orchestrator
+        and "--family copa" in orchestrator
+        and "nightly dispatch" in orchestrator
+        and "--family copa" in orchestrator
+        and "gh workflow run patch-image.yaml" not in orchestrator,
+        "Copa orchestrator must plan dirty targets and dispatch through verity nightly, not shell gh loops",
+    )
+    require(
+        "nightly plan" in integer_orchestrator
+        and "--family integer" in integer_orchestrator
+        and "nightly dispatch" in integer_orchestrator
+        and "--family integer" in integer_orchestrator
+        and "gh workflow run integer-build-image.yaml" not in integer_orchestrator,
+        "Integer orchestrator must scan published targets and dispatch through verity nightly, not shell gh loops",
     )
     require(
         "bash .github/scripts/wait-for-workflows.sh patch-image.yaml" in chart_gen

--- a/.github/scripts/validate-nightly-workflows.py
+++ b/.github/scripts/validate-nightly-workflows.py
@@ -91,6 +91,11 @@ def main() -> None:
         "Integer orchestrator must scan published targets and dispatch through verity nightly, not shell gh loops",
     )
     require(
+        'IMAGES: ${{ needs.discover.outputs.images }}' not in integer_orchestrator
+        and "__IMAGES_JSON_EOF__" in integer_orchestrator,
+        "Integer orchestrator must not pass the large dispatch matrix through an environment variable",
+    )
+    require(
         "bash .github/scripts/wait-for-workflows.sh patch-image.yaml" in chart_gen
         and "actions: read" in chart_gen,
         "chart generation must wait for active patch-image producer runs",

--- a/.github/scripts/validate-pr-test-workflow.py
+++ b/.github/scripts/validate-pr-test-workflow.py
@@ -18,12 +18,12 @@ def main() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     require(
-        "^cmd/(ci|integer|discover|scan).*\\.go$" in workflow,
-        "Integer scope must include cmd/ci*.go because verity ci plan feeds Integer PR jobs",
+        "^cmd/(ci|integer|nightly|discover|scan).*\\.go$" in workflow,
+        "Integer scope must include cmd/ci*.go and cmd/nightly*.go because those commands feed Integer PR jobs",
     )
     require(
-        "^cmd/(ci|patch|discover|scan).*\\.go$" in workflow,
-        "Copa scope must include cmd/ci*.go because verity ci plan feeds Copa PR jobs",
+        "^cmd/(ci|nightly|patch|discover|scan).*\\.go$" in workflow,
+        "Copa scope must include cmd/ci*.go and cmd/nightly*.go because those commands feed Copa PR jobs",
     )
     require(
         "pr-test-result:" in workflow and "name: PR Test" in workflow,

--- a/.github/scripts/validate-pr-test-workflow.py
+++ b/.github/scripts/validate-pr-test-workflow.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Guard PR Test scoping behavior that actionlint cannot express."""
+
+from pathlib import Path
+import sys
+
+
+WORKFLOW = Path(".github/workflows/pr-test.yaml")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        print(f"pr-test workflow check failed: {message}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    require(
+        "^cmd/(ci|integer|discover|scan).*\\.go$" in workflow,
+        "Integer scope must include cmd/ci*.go because verity ci plan feeds Integer PR jobs",
+    )
+    require(
+        "^cmd/(ci|patch|discover|scan).*\\.go$" in workflow,
+        "Copa scope must include cmd/ci*.go because verity ci plan feeds Copa PR jobs",
+    )
+    require(
+        "pr-test-result:" in workflow and "name: PR Test" in workflow,
+        "PR Test must expose a stable aggregate gate for branch protection",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,6 +179,9 @@ jobs:
       - name: Validate nightly workflow guards
         run: python3 .github/scripts/validate-nightly-workflows.py
 
+      - name: Validate PR Test workflow guards
+        run: python3 .github/scripts/validate-pr-test-workflow.py
+
       - name: Validate CI workflow guards
         run: python3 .github/scripts/validate-ci-workflow.py
 

--- a/.github/workflows/integer-orchestrator.yaml
+++ b/.github/workflows/integer-orchestrator.yaml
@@ -179,9 +179,13 @@ jobs:
       - name: Dispatch integer-build-image.yaml for each image
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGES: ${{ needs.discover.outputs.images }}
         run: |
-          printf '%s' "$IMAGES" > "$RUNNER_TEMP/images.json"
+          # Keep the large all-image matrix out of env/argv. GitHub-hosted
+          # Linux runners can reject oversized environment entries before the
+          # shell starts, which breaks forced all-image Integer dispatches.
+          cat > "$RUNNER_TEMP/images.json" <<'__IMAGES_JSON_EOF__'
+          ${{ needs.discover.outputs.images }}
+          __IMAGES_JSON_EOF__
           ./verity nightly dispatch \
             --family integer \
             --input "$RUNNER_TEMP/images.json" \

--- a/.github/workflows/integer-orchestrator.yaml
+++ b/.github/workflows/integer-orchestrator.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Build verity CLI
         run: go build -o verity .
 
-      - name: Discover image×version×type combos
+      - name: Plan dirty image×version×type combos
         id: discover
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -119,29 +119,31 @@ jobs:
           DETECT_FILTER: ${{ needs.detect.outputs.filter }}
           DISPATCH_IMAGE: ${{ github.event.inputs.image }}
         run: |
-          DISCOVER_ARGS=()
+          PLAN_ARGS=(
+            nightly plan
+            --family integer
+            --output images.json
+            --github-output "$GITHUB_OUTPUT"
+          )
 
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            DISCOVER_ARGS+=(--preflight true --github-repo "${{ github.repository }}")
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$DISPATCH_IMAGE" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$DISPATCH_IMAGE" ]; then
             # Validate dispatch input matches safe pattern
             if [[ ! "$DISPATCH_IMAGE" =~ ^[a-z0-9][a-z0-9./_-]*$ ]]; then
               echo "Invalid image name: ${DISPATCH_IMAGE}" >&2
               exit 1
             fi
-            DISCOVER_ARGS+=(--only "$DISPATCH_IMAGE")
-          elif [ "${{ github.event_name }}" = "push" ] && [ "$DETECT_MODE" = "filter" ] && [ -n "$DETECT_FILTER" ]; then
-            DISCOVER_ARGS+=(--only "$DETECT_FILTER")
+            PLAN_ARGS+=(--only "$DISPATCH_IMAGE")
           fi
 
-          all=$(./verity integer discover "${DISCOVER_ARGS[@]}")
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PLAN_ARGS+=(--force)
+          elif [ "${{ github.event_name }}" = "push" ] && [ "$DETECT_MODE" = "filter" ] && [ -n "$DETECT_FILTER" ]; then
+            PLAN_ARGS+=(--only "$DETECT_FILTER" --force)
+          fi
 
-          count=$(echo "$all" | jq 'length')
-          echo "count=${count}" >> "$GITHUB_OUTPUT"
-          echo "images=$(echo "$all" | jq -c .)" >> "$GITHUB_OUTPUT"
-
-          echo "✓ Discovered ${count} image+version+type combos"
-          echo "$all" | jq -r '.[] | "  - \(.name):\(.version)-\(.type) → \(.registry)/\(.name):\(.tags[0])"'
+          ./verity "${PLAN_ARGS[@]}"
+          echo "✓ Planned $(jq 'length' images.json) Integer remediation run(s)"
+          jq -r '.[] | "  - \(.name):\(.version)-\(.type) → \(.registry)/\(.name):\(.tags[0])"' images.json
 
   dispatch:
     name: Dispatch builds
@@ -154,85 +156,34 @@ jobs:
         with:
           egress-policy: audit
 
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/dev/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-${{ runner.os }}-
+
+      - name: Build verity CLI
+        run: go build -o verity .
+
       - name: Dispatch integer-build-image.yaml for each image
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGES: ${{ needs.discover.outputs.images }}
         run: |
-          # Write images JSON to a temp file instead of an env var to avoid
-          # E2BIG (argv+env > ~2MB / per-string > 128KB) when the matrix is large.
-          # Heredoc with quoted delimiter disables shell expansion of the body,
-          # tolerating any JSON content (including apostrophes) safely.
-          cat > "$RUNNER_TEMP/images.json" <<'__IMAGES_JSON_EOF__'
-          ${{ needs.discover.outputs.images }}
-          __IMAGES_JSON_EOF__
-          dispatch_build() {
-            local name="$1"
-            local version="$2"
-            local type="$3"
-            local tags="$4"
-            local registry="$5"
-
-            local attempt
-            for attempt in 1 2 3 4 5; do
-              if gh workflow run integer-build-image.yaml \
-                --repo "${{ github.repository }}" \
-                --ref "${{ github.ref_name }}" \
-                --field "image=${name}" \
-                --field "version=${version}" \
-                --field "type=${type}" \
-                --field "tags=${tags}" \
-                --field "registry=${registry}"; then
-                return 0
-              fi
-
-              # GitHub can return secondary-rate-limit or transient
-              # 5xx/transport failures when hundreds of workflow_dispatch
-              # calls are made in one job. Retry with bounded backoff so
-              # one transient dispatch does not fail the entire nightly.
-              if [ "$attempt" -lt 5 ]; then
-                local sleep_seconds=$((attempt * 10))
-                echo "Dispatch failed for ${name}:${version}-${type} (attempt ${attempt}/5); retrying in ${sleep_seconds}s" >&2
-                sleep "${sleep_seconds}"
-              fi
-            done
-
-            echo "Failed to dispatch ${name}:${version}-${type} after 5 attempts" >&2
-            return 1
-          }
-
-          jq -c '.[]' "$RUNNER_TEMP/images.json" > "$RUNNER_TEMP/images.ndjson"
-
-          expected_count="${{ needs.discover.outputs.count }}"
-          dispatched=0
-          while IFS= read -r image; do
-            NAME=$(echo "$image" | jq -r '.name')
-            VERSION=$(echo "$image" | jq -r '.version')
-            TYPE=$(echo "$image" | jq -r '.type')
-            TAGS=$(echo "$image" | jq -r '[.tags[]] | join(",")')
-            REGISTRY=$(echo "$image" | jq -r '.registry')
-
-            # Validate field values before shell interpolation
-            for field in "$NAME" "$VERSION" "$TYPE" "$REGISTRY"; do
-              if [[ ! "$field" =~ ^[a-zA-Z0-9][a-zA-Z0-9.:/_-]*$ ]]; then
-                echo "Unsafe field value rejected: ${field}" >&2
-                exit 1
-              fi
-            done
-            if [[ ! "$TAGS" =~ ^[a-zA-Z0-9.,_-]+$ ]]; then
-              echo "Unsafe tags value rejected: ${TAGS}" >&2
-              exit 1
-            fi
-
-            echo "Dispatching build for ${NAME}:${VERSION}-${TYPE}..."
-            dispatch_build "$NAME" "$VERSION" "$TYPE" "$TAGS" "$REGISTRY"
-            dispatched=$((dispatched + 1))
-
-            # Throttle to avoid GitHub API rate limits
-            sleep 2
-          done < "$RUNNER_TEMP/images.ndjson"
-
-          if [ "$dispatched" -ne "$expected_count" ]; then
-            echo "Dispatched ${dispatched}/${expected_count} build runs; expected all discovered images to dispatch" >&2
-            exit 1
-          fi
-          echo "✓ Dispatched ${dispatched}/${expected_count} build runs"
+          printf '%s' "$IMAGES" > "$RUNNER_TEMP/images.json"
+          ./verity nightly dispatch \
+            --family integer \
+            --input "$RUNNER_TEMP/images.json" \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}"

--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -22,7 +22,7 @@ on:
         required: false
         default: ""
       preflight:
-        description: "Skip images that don't need work per the preflight manifest (unchanged upstream digest AND zero remaining vulnerabilities in the previously-patched image); may still rebuild when digests change or any vulns are present"
+        description: "Scan published targets first and dispatch only missing, scan-failing, or vulnerable images instead of forcing the selected image set"
         required: false
         type: boolean
         default: false
@@ -189,7 +189,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Discover images
+      - name: Plan dirty images
         id: discover
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -197,19 +197,14 @@ jobs:
           DETECT_FILTER: ${{ needs.detect.outputs.filter }}
           DISPATCH_IMAGE: ${{ github.event.inputs.image }}
         run: |
-          DISCOVER_ARGS=(
+          PLAN_ARGS=(
+            nightly plan
+            --family copa
             --config copa-config.yaml
             --target-registry "${TARGET_REGISTRY}"
+            --output images.json
+            --github-output "$GITHUB_OUTPUT"
           )
-
-          # --preflight and --only are orthogonal: --preflight uses the
-          # manifest to skip images that don't need work (unchanged upstream
-          # digest AND zero remaining vulns in the previously-patched
-          # image); --only controls which images are considered. They
-          # compose, so split them into independent blocks.
-          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event.inputs.preflight }}" = "true" ]; then
-            DISCOVER_ARGS+=(--preflight --github-repo "${{ github.repository }}")
-          fi
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$DISPATCH_IMAGE" ]; then
             # Validate dispatch input matches safe pattern
@@ -217,26 +212,20 @@ jobs:
               echo "Invalid image name: ${DISPATCH_IMAGE}" >&2
               exit 1
             fi
-            DISCOVER_ARGS+=(--only "$DISPATCH_IMAGE")
-          elif [ "${{ github.event_name }}" = "push" ] && [ "$DETECT_MODE" = "filter" ] && [ -n "$DETECT_FILTER" ]; then
-            DISCOVER_ARGS+=(--only "$DETECT_FILTER")
+            PLAN_ARGS+=(--only "$DISPATCH_IMAGE")
           fi
 
-          # Derive Integer/Wolfi image names to exclude from chart discovery.
-          # Chart-discovered images that share a name with an Integer image are
-          # skipped because the Wolfi rebuild is the preferred zero-CVE variant.
-          EXCLUDE_NAMES=$(find images -name '*.yaml' -not -path 'images/_base/*' -printf '%P\n' 2>/dev/null | sed 's/\.yaml$//' | paste -sd, || true)
-          DISCOVER_ARGS+=(--exclude-names "${EXCLUDE_NAMES}")
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.preflight }}" != "true" ]; then
+            PLAN_ARGS+=(--force)
+          elif [ "${{ github.event_name }}" = "push" ] && [ "$DETECT_MODE" = "filter" ] && [ -n "$DETECT_FILTER" ]; then
+            PLAN_ARGS+=(--only "$DETECT_FILTER" --force)
+          fi
 
-          ./verity discover "${DISCOVER_ARGS[@]}" > images.json
-
-          COUNT=$(jq 'length' images.json)
-          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
-          echo "images=$(jq -c . images.json)" >> "$GITHUB_OUTPUT"
-          echo "✓ Discovered ${COUNT} image+tag combos"
+          ./verity "${PLAN_ARGS[@]}"
+          echo "✓ Planned $(jq 'length' images.json) Copa remediation run(s)"
           jq -r '.[] | "  - \(.name): \(.source)"' images.json
 
-  # ── Job 3: Dispatch one patch-image.yaml run per image+tag ─────────
+  # ── Job 4: Dispatch one patch-image.yaml run per dirty image+tag ───
   dispatch:
     name: Dispatch Patches
     needs: discover
@@ -253,67 +242,34 @@ jobs:
         with:
           egress-policy: audit
 
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/dev/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-${{ runner.os }}-
+
+      - name: Build verity
+        run: go build -o verity .
+
       - name: Dispatch patch-image.yaml for each image
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGES: ${{ needs.discover.outputs.images }}
         run: |
-          dispatch_patch() {
-            local name="$1"
-            local source="$2"
-            local registry="$3"
-            local platforms="$4"
-            local go_vcs_url="$5"
-
-            local dispatch_args=(
-              --repo "${{ github.repository }}"
-              --ref "${{ github.ref_name }}"
-              --field "image-name=${name}"
-              --field "source-ref=${source}"
-              --field "target-registry=${registry}"
-              --field "platforms=${platforms}"
-            )
-            if [ -n "${go_vcs_url}" ]; then
-              dispatch_args+=(--field "go-vcs-url=${go_vcs_url}")
-            fi
-
-            local attempt
-            for attempt in 1 2 3 4 5; do
-              if gh workflow run patch-image.yaml "${dispatch_args[@]}"; then
-                return 0
-              fi
-              if [ "$attempt" -lt 5 ]; then
-                local sleep_seconds=$((attempt * 10))
-                echo "Dispatch failed for ${name}: ${source} (attempt ${attempt}/5); retrying in ${sleep_seconds}s" >&2
-                sleep "${sleep_seconds}"
-              fi
-            done
-
-            echo "Failed to dispatch ${name}: ${source} after 5 attempts" >&2
-            return 1
-          }
-
-          jq -c '.[]' <<< "$IMAGES" > "$RUNNER_TEMP/patch-images.ndjson"
-          expected_count="${{ needs.discover.outputs.count }}"
-          dispatched=0
-
-          while IFS= read -r image; do
-            NAME=$(echo "$image" | jq -r '.name')
-            SOURCE=$(echo "$image" | jq -r '.source')
-            REGISTRY=$(echo "$image" | jq -r '."target-registry"')
-            PLATFORMS=$(echo "$image" | jq -r '.platforms')
-            GO_VCS_URL=$(echo "$image" | jq -r '."go-vcs-url" // ""')
-
-            echo "Dispatching patch for ${NAME}: ${SOURCE}..."
-            dispatch_patch "$NAME" "$SOURCE" "$REGISTRY" "$PLATFORMS" "$GO_VCS_URL"
-            dispatched=$((dispatched + 1))
-
-            # Throttle to avoid GitHub API rate limits
-            sleep 2
-          done < "$RUNNER_TEMP/patch-images.ndjson"
-
-          if [ "$dispatched" -ne "$expected_count" ]; then
-            echo "Dispatched ${dispatched}/${expected_count} patch runs; expected all discovered images to dispatch" >&2
-            exit 1
-          fi
-          echo "✓ Dispatched ${dispatched}/${expected_count} patch runs"
+          printf '%s' "$IMAGES" > "$RUNNER_TEMP/patch-images.json"
+          ./verity nightly dispatch \
+            --family copa \
+            --input "$RUNNER_TEMP/patch-images.json" \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}"

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -5,26 +5,6 @@ name: PR Test
 
 on:
   pull_request:
-    paths:
-      - 'copa-config.yaml'
-      - 'images/**'
-      - 'integer.yaml'
-      - '.github/workflows/pr-test.yaml'
-      - '.github/workflows/patch-image.yaml'
-      - '.github/workflows/integer-*.yaml'
-      - 'internal/integer/**'
-      - 'cmd/integer*.go'
-      - 'cmd/patch*.go'
-      - 'cmd/discover*.go'
-      - 'cmd/scan*.go'
-      - 'internal/patch/**'
-      - '.github/scripts/patch-image.sh'
-      - '.github/scripts/scan-before.sh'
-      - '.github/scripts/verify-patched.sh'
-      - '.github/scripts/read-catalog-entry.sh'
-      - '.github/scripts/melange-check.sh'
-      - '.github/scripts/melange-build.sh'
-      - '.github/actions/setup-binaries/**'
 
 permissions:
   contents: read
@@ -756,3 +736,96 @@ jobs:
             before.json
             after.json
           retention-days: 7
+
+  pr-test-result:
+    name: PR Test
+    needs:
+      - changes
+      - discover
+      - validate
+      - detect-changed-images
+      - detect-smoke-scope
+      - integer-smoke-test
+      - integer-build-changed
+      - detect-copa-changes
+      - copa-patching-changed
+      - copa-patching-regression
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate PR test results
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          INTEGER: ${{ needs.changes.outputs.integer }}
+          COPA: ${{ needs.changes.outputs.copa }}
+          DISCOVER_RESULT: ${{ needs.discover.result }}
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          DETECT_INTEGER_RESULT: ${{ needs.detect-changed-images.result }}
+          DETECT_SMOKE_RESULT: ${{ needs.detect-smoke-scope.result }}
+          INTEGER_SMOKE_RESULT: ${{ needs.integer-smoke-test.result }}
+          INTEGER_BUILD_RESULT: ${{ needs.integer-build-changed.result }}
+          DETECT_COPA_RESULT: ${{ needs.detect-copa-changes.result }}
+          COPA_CHANGED_RESULT: ${{ needs.copa-patching-changed.result }}
+          COPA_REGRESSION_RESULT: ${{ needs.copa-patching-regression.result }}
+        run: |
+          echo "changes: ${CHANGES_RESULT}"
+          echo "integer: ${INTEGER}"
+          echo "copa: ${COPA}"
+          echo "discover: ${DISCOVER_RESULT}"
+          echo "validate: ${VALIDATE_RESULT}"
+          echo "detect-changed-images: ${DETECT_INTEGER_RESULT}"
+          echo "detect-smoke-scope: ${DETECT_SMOKE_RESULT}"
+          echo "integer-smoke-test: ${INTEGER_SMOKE_RESULT}"
+          echo "integer-build-changed: ${INTEGER_BUILD_RESULT}"
+          echo "detect-copa-changes: ${DETECT_COPA_RESULT}"
+          echo "copa-patching-changed: ${COPA_CHANGED_RESULT}"
+          echo "copa-patching-regression: ${COPA_REGRESSION_RESULT}"
+
+          require_success() {
+            local name="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::${name} did not succeed: ${result}"
+              exit 1
+            fi
+          }
+
+          allow_success_or_skipped() {
+            local name="$1"
+            local result="$2"
+            case "$result" in
+              success|skipped) ;;
+              *)
+                echo "::error::${name} did not succeed or skip cleanly: ${result}"
+                exit 1
+                ;;
+            esac
+          }
+
+          require_success "changes" "$CHANGES_RESULT"
+
+          if [ "$INTEGER" = "true" ]; then
+            require_success "validate" "$VALIDATE_RESULT"
+            require_success "detect-changed-images" "$DETECT_INTEGER_RESULT"
+            require_success "detect-smoke-scope" "$DETECT_SMOKE_RESULT"
+            allow_success_or_skipped "integer-smoke-test" "$INTEGER_SMOKE_RESULT"
+            allow_success_or_skipped "integer-build-changed" "$INTEGER_BUILD_RESULT"
+          else
+            allow_success_or_skipped "validate" "$VALIDATE_RESULT"
+            allow_success_or_skipped "detect-changed-images" "$DETECT_INTEGER_RESULT"
+            allow_success_or_skipped "detect-smoke-scope" "$DETECT_SMOKE_RESULT"
+            allow_success_or_skipped "integer-smoke-test" "$INTEGER_SMOKE_RESULT"
+            allow_success_or_skipped "integer-build-changed" "$INTEGER_BUILD_RESULT"
+          fi
+
+          if [ "$COPA" = "true" ]; then
+            require_success "discover" "$DISCOVER_RESULT"
+            require_success "detect-copa-changes" "$DETECT_COPA_RESULT"
+            allow_success_or_skipped "copa-patching-changed" "$COPA_CHANGED_RESULT"
+            require_success "copa-patching-regression" "$COPA_REGRESSION_RESULT"
+          else
+            allow_success_or_skipped "discover" "$DISCOVER_RESULT"
+            allow_success_or_skipped "detect-copa-changes" "$DETECT_COPA_RESULT"
+            allow_success_or_skipped "copa-patching-changed" "$COPA_CHANGED_RESULT"
+            allow_success_or_skipped "copa-patching-regression" "$COPA_REGRESSION_RESULT"
+          fi

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -36,13 +36,13 @@ jobs:
         run: |
           git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
 
-          if grep -Eq '^images/|^integer\.yaml$|^internal/integer/|^cmd/(ci|integer|discover|scan).*\.go$|^\.github/scripts/(melange-check|melange-build)\.sh$|^\.github/workflows/(pr-test|integer-.*)\.yaml$' changed-files.txt; then
+          if grep -Eq '^images/|^integer\.yaml$|^internal/integer/|^cmd/(ci|integer|nightly|discover|scan).*\.go$|^\.github/scripts/(melange-check|melange-build)\.sh$|^\.github/workflows/(pr-test|integer-.*)\.yaml$' changed-files.txt; then
             echo 'integer=true' >> "$GITHUB_OUTPUT"
           else
             echo 'integer=false' >> "$GITHUB_OUTPUT"
           fi
 
-          if grep -Eq '^copa-config\.yaml$|^internal/patch/|^cmd/(ci|patch|discover|scan).*\.go$|^\.github/scripts/(patch-image|scan-before|verify-patched|read-catalog-entry)\.sh$|^\.github/workflows/(pr-test|patch-image)\.yaml$|^\.github/actions/setup-binaries/' changed-files.txt; then
+          if grep -Eq '^copa-config\.yaml$|^internal/patch/|^cmd/(ci|nightly|patch|discover|scan).*\.go$|^\.github/scripts/(patch-image|scan-before|verify-patched|read-catalog-entry)\.sh$|^\.github/workflows/(pr-test|patch-image)\.yaml$|^\.github/actions/setup-binaries/' changed-files.txt; then
             echo 'copa=true' >> "$GITHUB_OUTPUT"
           else
             echo 'copa=false' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -174,9 +174,10 @@ jobs:
         run: |
           changed_files=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" || true)
 
-          # Rare path: core Integer mechanism changed, so keep full representative smoke matrix.
+          # Rare path: core Integer build mechanics changed, so keep full representative smoke matrix.
+          # Orchestrator-only changes still validate config but do not need image smoke builds.
           # Common path: reuse detect-changed-images output so smoke and build share one source of truth.
-          if echo "$changed_files" | grep -Eq '^internal/integer/|^cmd/(integer|discover|scan).*\.go$|^\.github/scripts/(melange-check|melange-build)\.sh$|^\.github/workflows/(pr-test|integer-.*)\.yaml$|^integer\.yaml$'; then
+          if echo "$changed_files" | grep -Eq '^internal/integer/|^cmd/(integer|discover|scan).*\.go$|^\.github/scripts/(melange-check|melange-build)\.sh$|^\.github/workflows/(pr-test|integer-build-image)\.yaml$|^integer\.yaml$'; then
             matrix='{"include":[{"image":"golang","version":"1.24","type":"fips"},{"image":"haproxy","version":"3.0","type":"fips"},{"image":"haproxy","version":"3.1","type":"fips"},{"image":"node","version":"22","type":"dev"}]}'
           else
             matrix="$CHANGED_IMAGE_SMOKE_MATRIX"

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -36,13 +36,13 @@ jobs:
         run: |
           git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
 
-          if grep -Eq '^images/|^integer\.yaml$|^internal/integer/|^cmd/(integer|discover|scan).*\.go$|^\.github/scripts/(melange-check|melange-build)\.sh$|^\.github/workflows/(pr-test|integer-.*)\.yaml$' changed-files.txt; then
+          if grep -Eq '^images/|^integer\.yaml$|^internal/integer/|^cmd/(ci|integer|discover|scan).*\.go$|^\.github/scripts/(melange-check|melange-build)\.sh$|^\.github/workflows/(pr-test|integer-.*)\.yaml$' changed-files.txt; then
             echo 'integer=true' >> "$GITHUB_OUTPUT"
           else
             echo 'integer=false' >> "$GITHUB_OUTPUT"
           fi
 
-          if grep -Eq '^copa-config\.yaml$|^internal/patch/|^cmd/(patch|discover|scan).*\.go$|^\.github/scripts/(patch-image|scan-before|verify-patched|read-catalog-entry)\.sh$|^\.github/workflows/(pr-test|patch-image)\.yaml$|^\.github/actions/setup-binaries/' changed-files.txt; then
+          if grep -Eq '^copa-config\.yaml$|^internal/patch/|^cmd/(ci|patch|discover|scan).*\.go$|^\.github/scripts/(patch-image|scan-before|verify-patched|read-catalog-entry)\.sh$|^\.github/workflows/(pr-test|patch-image)\.yaml$|^\.github/actions/setup-binaries/' changed-files.txt; then
             echo 'copa=true' >> "$GITHUB_OUTPUT"
           else
             echo 'copa=false' >> "$GITHUB_OUTPUT"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,6 +102,7 @@ Commands:
   catalog     Generate site catalog JSON from patch reports
   discover    Enumerate image+tag combos from copa-config.yaml, Chart.yaml, and verity.yaml
   integer     Build and manage Wolfi-based OCI images from source (subcommand group)
+  nightly     Plan and dispatch scan-first nightly remediation
   preflight   Manage preflight manifest for build skipping
   chart-gen   Generate and push patched wrapper Helm charts from Chart.yaml
   patch       Patch a single image via Copa (imported as a library)
@@ -172,6 +173,26 @@ produce identical output. Requires `GH_TOKEN` or
 | `--tag` | *(required)* | Image tag |
 | `--upstream-digest` | | Upstream image digest (`sha256:…`) |
 | `--patched-vulns` | `0` | Count of vulnerabilities remaining after patching. The CLI flag's help text calls these "fixable". This CLI is not currently invoked by the workflows — today `patch-image.yaml` updates `preflight-manifest.json` inline via `gh api` + `jq`, writing the raw Trivy post-patch count from `post.json` (no `--ignore-unfixed`, so the value includes unfixable CVEs) — but the CLI exists as a programmatic alternative |
+
+### `verity nightly`
+
+Go-owned scheduled orchestration. `nightly plan` discovers the intended
+published image set, scans the already-published Verity tag with the current
+Trivy database, and emits a dispatch matrix containing only dirty targets.
+Dirty means the published target is missing, cannot be scanned, or currently
+has one or more vulnerabilities. `nightly dispatch` sends that matrix to the
+appropriate GitHub Actions workflow through the Actions REST API.
+
+| Subcommand | Purpose |
+| --- | --- |
+| `nightly plan --family copa` | Discover Copa/chart targets, scan `target-registry/name:tag`, emit dirty `patch-image.yaml` inputs |
+| `nightly plan --family integer` | Discover Integer image/version/type targets, scan each published `registry/name:tag`, emit dirty `integer-build-image.yaml` inputs |
+| `nightly dispatch --family copa` | Dispatch dirty Copa targets to `patch-image.yaml` |
+| `nightly dispatch --family integer` | Dispatch dirty Integer targets to `integer-build-image.yaml` |
+
+Manual dispatches and push-triggered image-definition changes may pass
+`--force` to rebuild the selected target set without scan skipping. Scheduled
+runs do not force; they scan first.
 
 ### `verity integer`
 
@@ -334,19 +355,22 @@ Ten GitHub Actions workflows cover patching, Wolfi rebuilds, chart generation,
 site deployment, and PR validation. Nightly runs are scheduled in sequence:
 
 ```text
-02:00 UTC — orchestrator.yaml            (Copa patching dispatcher)
-03:00 UTC — integer-orchestrator.yaml    (Wolfi rebuild dispatcher)
+02:00 UTC — orchestrator.yaml            (Copa scan planner + patch dispatcher)
+03:00 UTC — integer-orchestrator.yaml    (Integer scan planner + rebuild dispatcher)
 04:00 UTC — chart-gen.yaml               (Helm wrapper generation)
 05:00 UTC — build-site.yaml              (catalog assembly + site deploy)
 ```
 
 ### `orchestrator.yaml` — Copa dispatcher
 
-Runs `verity discover` against `copa-config.yaml`, `Chart.yaml`, and
-`verity.yaml`, then dispatches one `patch-image.yaml` run per image+tag.
-Fire-and-forget — does NOT wait for per-image runs to complete. This keeps the
-dispatcher fast and lets each image patch in its own isolated workflow with its
-own logs and artifacts.
+Runs `verity nightly plan --family copa` against `copa-config.yaml`,
+`Chart.yaml`, and `verity.yaml`. The planner scans each already-published
+patched target with the current Trivy database and emits only images that are
+missing, scan-failing, or vulnerable. The workflow then runs
+`verity nightly dispatch --family copa`, which dispatches one `patch-image.yaml`
+run per dirty image+tag. Fire-and-forget — does NOT wait for per-image runs to
+complete. This keeps remediation isolated while avoiding nightly rebuilds for
+clean images.
 
 Triggers: nightly cron `0 2 * * *`, push to `main` touching
 `copa-config.yaml`/`Chart.yaml`/`verity.yaml`, and `workflow_dispatch` with an
@@ -355,7 +379,7 @@ optional `image` input to patch a single image on demand.
 ### `patch-image.yaml` — reusable per-image lifecycle
 
 ```text
-┌──────────┐   scan-before.sh: Pre-patch Trivy (or skip on preflight hit)
+┌──────────┐   Pre-patch Trivy plus existing-target scan
 │   scan   │
 └────┬─────┘
      ▼
@@ -375,11 +399,15 @@ patching path inline — see `pr-test.yaml` below.
 
 ### `integer-orchestrator.yaml` + `integer-build-image.yaml`
 
-The Integer dispatcher offsets itself one hour after Copa (03:00 UTC) to avoid
-resource contention. It runs `verity integer discover` to build a matrix of
-(image × version × variant) combinations, then dispatches
-`integer-build-image.yaml` per entry. Each per-image build runs apko + melange,
-pushes to the target registry, and captures a post-build Trivy scan.
+The Integer dispatcher offsets itself one hour after Copa (03:00 UTC). It runs
+`verity nightly plan --family integer`, which discovers all
+image × version × variant combinations but scans the already-published tags
+before dispatching. Clean published Integer images are skipped. Missing,
+scan-failing, or vulnerable tags dispatch that image/version/type to
+`integer-build-image.yaml`.
+Each dispatched build runs apko + melange/bespoke package builds when required,
+gates both arches with Trivy before publish, pushes to the target registry, and
+captures a post-build Trivy scan.
 
 ### `chart-gen.yaml`
 
@@ -450,7 +478,7 @@ documented in full in
   bare-name chart args (dex), and charts whose Helm template hardcodes
   `args:` (opensearch-dashboards).
 
-### Skip Detection (Preflight)
+### Skip Detection And Nightly Scan Planning
 
 `verity preflight` maintains a manifest on the `reports` branch that records
 each published image's upstream digest and post-patch vulnerability count
@@ -459,6 +487,12 @@ does not pass `--ignore-unfixed`). When `verity discover --preflight` runs,
 images whose upstream digest hasn't changed AND whose recorded vulnerability
 count is zero are skipped — avoiding unnecessary rebuilds, registry churn,
 and signing traffic.
+
+Scheduled workflows now default to `verity nightly plan` instead of preflight
+manifest-only skipping. The planner scans published Copa and Integer targets
+with the current Trivy database every night. That catches fresh CVEs discovered
+after yesterday's report even when the upstream tag digest has not changed.
+Only dirty targets are dispatched for patching/rebuild.
 
 ## Site Architecture
 
@@ -484,14 +518,16 @@ Cron triggers cascade across the night: Copa at 02:00 UTC, Integer at 03:00,
 chart-gen at 04:00, site build at 05:00.
 
 For **Copa-patched images**, whether an image actually re-publishes on a given
-run depends on the skip checks (see Skip Detection above) plus whether the
-post-patch Trivy vulnerability-ID set has changed since the previous
-published report on the `reports` branch — a change, including the appearance
-of a previously-unseen unfixable CVE, triggers a new push.
+run depends on the nightly scan planner plus `patch-image.yaml`'s own scan and
+post-patch comparison. A clean published image is skipped. A missing,
+scan-failing, or vulnerable published image is dispatched to the patch flow.
 
 For **Integer (Wolfi) images**, the build runs on a schedule or when
-`images/<name>.yaml` changes; there is no vuln-ID-set delta comparison, so
-rebuilt images are published whenever the build succeeds.
+`images/<name>.yaml` changes. Scheduled runs scan the currently-published
+Integer tags and rebuild only missing, scan-failing, or vulnerable targets.
+Push-triggered changes to `images/` or `integer.yaml` force the
+selected image definitions through the rebuild path so config/source changes
+are published even when the previous image was clean.
 
 ### Dependency Updates (Renovate)
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ go build -o verity .
 ./verity catalog     # Generate site catalog JSON from scan reports
 ./verity discover    # Enumerate image+tag combos (Copa + charts)
 ./verity integer     # Build/validate Wolfi-based Integer images (subcommand group)
+./verity nightly     # Scan published images and dispatch dirty nightly remediation
 ./verity preflight   # Manage preflight manifest for build skipping
 ./verity chart-gen   # Generate patched Helm wrapper charts
 

--- a/cmd/nightly.go
+++ b/cmd/nightly.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +29,23 @@ import (
 const (
 	nightlyFamilyCopa    = "copa"
 	nightlyFamilyInteger = "integer"
+)
+
+var (
+	errUnsupportedNightlyFamily = errors.New("unsupported nightly family")
+	errMissingGitHubToken       = errors.New("GH_TOKEN or GITHUB_TOKEN is required for workflow dispatch")
+	errSourceTagUnavailable     = errors.New("source ref is digest-pinned or tagless")
+	errMissingTargetRegistry    = errors.New("target registry missing")
+	errMissingIntegerTags       = errors.New("integer image has no tags")
+	errNoNonEmptyIntegerTags    = errors.New("integer image has no non-empty tags")
+	errMissingIntegerRegistry   = errors.New("registry missing for integer image")
+	errGitHubDispatchStatus     = errors.New("github dispatch returned non-success status")
+
+	craneDigest        = crane.Digest
+	dispatchRetrySleep = time.Sleep
+	githubAPIBaseURL   = "https://api.github.com"
+	githubHTTPClient   = http.DefaultClient
+	trivyVulnCountFor  = nightlyTrivyVulnCount
 )
 
 // NightlyCommand owns scheduled scan/dispatch decisions. It deliberately keeps
@@ -65,10 +82,7 @@ var nightlyPlanCmd = &cli.Command{
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		family := cmd.String("family")
 		force := cmd.Bool("force")
-		parallel := cmd.Int("parallel")
-		if parallel < 1 {
-			parallel = 1
-		}
+		parallel := max(cmd.Int("parallel"), 1)
 
 		var data []byte
 		var count int
@@ -77,6 +91,9 @@ var nightlyPlanCmd = &cli.Command{
 		case nightlyFamilyCopa:
 			var items []discovery.DiscoveredImage
 			items, err = nightlyPlanCopa(ctx, cmd, force, parallel)
+			if err != nil {
+				return err
+			}
 			if items == nil {
 				items = []discovery.DiscoveredImage{}
 			}
@@ -85,13 +102,16 @@ var nightlyPlanCmd = &cli.Command{
 		case nightlyFamilyInteger:
 			var items []intdiscovery.DiscoveredImage
 			items, err = nightlyPlanInteger(ctx, cmd, force, parallel)
+			if err != nil {
+				return err
+			}
 			if items == nil {
 				items = []intdiscovery.DiscoveredImage{}
 			}
 			count = len(items)
 			data, err = json.Marshal(items)
 		default:
-			return fmt.Errorf("unsupported --family %q; want %q or %q", family, nightlyFamilyCopa, nightlyFamilyInteger)
+			return fmt.Errorf("%w: %q; want %q or %q", errUnsupportedNightlyFamily, family, nightlyFamilyCopa, nightlyFamilyInteger)
 		}
 		if err != nil {
 			return err
@@ -133,7 +153,7 @@ var nightlyDispatchCmd = &cli.Command{
 			case nightlyFamilyInteger:
 				workflow = "integer-build-image.yaml"
 			default:
-				return fmt.Errorf("unsupported --family %q", cmd.String("family"))
+				return fmt.Errorf("%w: %q", errUnsupportedNightlyFamily, cmd.String("family"))
 			}
 		}
 		token := os.Getenv("GH_TOKEN")
@@ -141,7 +161,7 @@ var nightlyDispatchCmd = &cli.Command{
 			token = os.Getenv("GITHUB_TOKEN")
 		}
 		if token == "" {
-			return errors.New("GH_TOKEN or GITHUB_TOKEN is required for workflow dispatch")
+			return errMissingGitHubToken
 		}
 
 		inputs, err := nightlyDispatchInputs(cmd.String("family"), cmd.String("input"))
@@ -200,7 +220,7 @@ func nightlyPlanCopa(ctx context.Context, cmd *cli.Command, force bool, parallel
 	images = filterCopaImagesByName(images, cmd.String("only"))
 
 	return filterDirty(ctx, images, parallel, func(img discovery.DiscoveredImage) ([]nightlyScanTarget, string, error) {
-		targetRef, err := copaTargetRef(img)
+		targetRef, err := copaTargetRef(&img)
 		if err != nil {
 			return nil, "", err
 		}
@@ -219,8 +239,8 @@ func nightlyPlanInteger(ctx context.Context, cmd *cli.Command, force bool, paral
 	}
 
 	var pkgs []apkindex.Package
-	if url := cmd.String("apkindex-url"); url != "" {
-		pkgs, err = apkindex.Fetch(url, cmd.String("cache-dir"), apkindex.DefaultCacheMaxAge)
+	if apkIndexURL := cmd.String("apkindex-url"); apkIndexURL != "" {
+		pkgs, err = apkindex.Fetch(apkIndexURL, cmd.String("cache-dir"), apkindex.DefaultCacheMaxAge)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: APKINDEX unavailable (%v) — using versions map only\n", err)
 		}
@@ -241,7 +261,7 @@ func nightlyPlanInteger(ctx context.Context, cmd *cli.Command, force bool, paral
 	images = filterIntegerImagesByName(images, cmd.String("only"))
 
 	return filterDirty(ctx, images, parallel, func(img intdiscovery.DiscoveredImage) ([]nightlyScanTarget, string, error) {
-		targetRefs, err := integerTargetRefs(img)
+		targetRefs, err := integerTargetRefs(&img)
 		if err != nil {
 			return nil, "", err
 		}
@@ -317,7 +337,7 @@ func scanPublishedTargets(ctx context.Context, targets []nightlyScanTarget) scan
 		if target.label == "" {
 			target.label = target.ref
 		}
-		digest, err := crane.Digest(target.ref)
+		digest, err := craneDigest(target.ref)
 		if err != nil {
 			return scanDecision{dirty: true, reason: target.label + " missing or digest lookup failed: " + err.Error()}
 		}
@@ -326,7 +346,7 @@ func scanPublishedTargets(ctx context.Context, targets []nightlyScanTarget) scan
 		}
 		seenDigests[digest] = struct{}{}
 
-		count, err := nightlyTrivyVulnCount(ctx, target.ref)
+		count, err := trivyVulnCountFor(ctx, target.ref)
 		if err != nil {
 			return scanDecision{dirty: true, reason: target.label + " scan failed: " + err.Error()}
 		}
@@ -362,33 +382,33 @@ func nightlyTrivyVulnCount(ctx context.Context, ref string) (int, error) {
 	return count, nil
 }
 
-func copaTargetRef(img discovery.DiscoveredImage) (string, error) {
+func copaTargetRef(img *discovery.DiscoveredImage) (string, error) {
 	tag := sourceTag(img.Source)
 	if tag == "" {
-		return "", fmt.Errorf("source ref %q is digest-pinned or tagless; cannot derive target tag", img.Source)
+		return "", fmt.Errorf("%w: %q; cannot derive target tag", errSourceTagUnavailable, img.Source)
 	}
 	if img.TargetRegistry == "" {
-		return "", fmt.Errorf("target registry missing for %q", img.Name)
+		return "", fmt.Errorf("%w for %q", errMissingTargetRegistry, img.Name)
 	}
 	return strings.TrimRight(img.TargetRegistry, "/") + "/" + img.Name + ":" + tag, nil
 }
 
-func integerTargetRef(img intdiscovery.DiscoveredImage) (string, error) {
+func integerTargetRef(img *intdiscovery.DiscoveredImage) (string, error) {
 	if len(img.Tags) == 0 {
-		return "", fmt.Errorf("integer image %s:%s-%s has no tags", img.Name, img.Version, img.Type)
+		return "", fmt.Errorf("%w: %s:%s-%s", errMissingIntegerTags, img.Name, img.Version, img.Type)
 	}
 	if img.Registry == "" {
-		return "", fmt.Errorf("registry missing for integer image %s:%s-%s", img.Name, img.Version, img.Type)
+		return "", fmt.Errorf("%w: %s:%s-%s", errMissingIntegerRegistry, img.Name, img.Version, img.Type)
 	}
 	return strings.TrimRight(img.Registry, "/") + "/" + img.Name + ":" + img.Tags[0], nil
 }
 
-func integerTargetRefs(img intdiscovery.DiscoveredImage) ([]nightlyScanTarget, error) {
+func integerTargetRefs(img *intdiscovery.DiscoveredImage) ([]nightlyScanTarget, error) {
 	if len(img.Tags) == 0 {
-		return nil, fmt.Errorf("integer image %s:%s-%s has no tags", img.Name, img.Version, img.Type)
+		return nil, fmt.Errorf("%w: %s:%s-%s", errMissingIntegerTags, img.Name, img.Version, img.Type)
 	}
 	if img.Registry == "" {
-		return nil, fmt.Errorf("registry missing for integer image %s:%s-%s", img.Name, img.Version, img.Type)
+		return nil, fmt.Errorf("%w: %s:%s-%s", errMissingIntegerRegistry, img.Name, img.Version, img.Type)
 	}
 	base := strings.TrimRight(img.Registry, "/") + "/" + img.Name
 	targets := make([]nightlyScanTarget, 0, len(img.Tags))
@@ -399,7 +419,7 @@ func integerTargetRefs(img intdiscovery.DiscoveredImage) ([]nightlyScanTarget, e
 		}
 	}
 	if len(targets) == 0 {
-		return nil, fmt.Errorf("integer image %s:%s-%s has no non-empty tags", img.Name, img.Version, img.Type)
+		return nil, fmt.Errorf("%w: %s:%s-%s", errNoNonEmptyIntegerTags, img.Name, img.Version, img.Type)
 	}
 	return targets, nil
 }
@@ -437,8 +457,16 @@ func appendGitHubMatrixOutput(path string, count int, data []byte) error {
 	if err != nil {
 		return fmt.Errorf("opening GitHub output %s: %w", path, err)
 	}
-	defer f.Close()
-	if _, err := fmt.Fprintf(f, "count=%d\nimages<<__VERITY_NIGHTLY_JSON__\n%s\n__VERITY_NIGHTLY_JSON__\n", count, data); err != nil {
+	return appendGitHubMatrixOutputTo(f, path, count, data)
+}
+
+func appendGitHubMatrixOutputTo(w io.WriteCloser, path string, count int, data []byte) (retErr error) {
+	defer func() {
+		if cerr := w.Close(); cerr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("closing GitHub output %s: %w", path, cerr))
+		}
+	}()
+	if _, err := fmt.Fprintf(w, "count=%d\nimages<<__VERITY_NIGHTLY_JSON__\n%s\n__VERITY_NIGHTLY_JSON__\n", count, data); err != nil {
 		return fmt.Errorf("writing GitHub output %s: %w", path, err)
 	}
 	return nil
@@ -486,7 +514,7 @@ func nightlyDispatchInputs(family, inputPath string) ([]map[string]string, error
 		}
 		return out, nil
 	default:
-		return nil, fmt.Errorf("unsupported --family %q", family)
+		return nil, fmt.Errorf("%w: %q", errUnsupportedNightlyFamily, family)
 	}
 }
 
@@ -501,7 +529,7 @@ func dispatchWorkflow(ctx context.Context, token, repo, workflow, ref string, in
 	if err != nil {
 		return fmt.Errorf("marshalling dispatch body: %w", err)
 	}
-	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/actions/workflows/%s/dispatches", repo, url.PathEscape(workflow))
+	endpoint := fmt.Sprintf("%s/repos/%s/actions/workflows/%s/dispatches", strings.TrimRight(githubAPIBaseURL, "/"), repo, neturl.PathEscape(workflow))
 	var lastErr error
 	for attempt := 1; attempt <= retries; attempt++ {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
@@ -513,22 +541,39 @@ func dispatchWorkflow(ctx context.Context, token, repo, workflow, ref string, in
 		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 		req.Header.Set("Content-Type", "application/json")
 
-		resp, err := http.DefaultClient.Do(req)
-		if err == nil && resp != nil && resp.Body != nil {
-			defer resp.Body.Close()
-		}
-		if err == nil && resp.StatusCode == http.StatusNoContent {
-			return nil
-		}
-		if err != nil {
+		resp, err := githubHTTPClient.Do(req)
+		switch {
+		case err != nil:
 			lastErr = err
-		} else {
-			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-			lastErr = fmt.Errorf("github dispatch returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		case resp.StatusCode == http.StatusNoContent:
+			if resp.Body != nil {
+				if cerr := resp.Body.Close(); cerr != nil {
+					return fmt.Errorf("closing github dispatch response: %w", cerr)
+				}
+			}
+			return nil
+		default:
+			lastErr = githubDispatchResponseError(resp)
 		}
 		if attempt < retries {
-			time.Sleep(time.Duration(attempt*10) * time.Second)
+			dispatchRetrySleep(time.Duration(attempt*10) * time.Second)
 		}
 	}
 	return fmt.Errorf("dispatching %s after %d attempt(s): %w", workflow, retries, lastErr)
+}
+
+func githubDispatchResponseError(resp *http.Response) error {
+	if resp.Body == nil {
+		return fmt.Errorf("%w: %s", errGitHubDispatchStatus, resp.Status)
+	}
+	responseBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	closeErr := resp.Body.Close()
+	switch {
+	case readErr != nil:
+		return fmt.Errorf("reading github dispatch error response: %w", readErr)
+	case closeErr != nil:
+		return fmt.Errorf("closing github dispatch error response: %w", closeErr)
+	default:
+		return fmt.Errorf("%w: %s: %s", errGitHubDispatchStatus, resp.Status, strings.TrimSpace(string(responseBody)))
+	}
 }

--- a/cmd/nightly.go
+++ b/cmd/nightly.go
@@ -1,0 +1,534 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/urfave/cli/v3"
+
+	"github.com/verity-org/verity/internal/discovery"
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
+)
+
+const (
+	nightlyFamilyCopa    = "copa"
+	nightlyFamilyInteger = "integer"
+)
+
+// NightlyCommand owns scheduled scan/dispatch decisions. It deliberately keeps
+// orchestration policy in Go so workflows only install tools and invoke verity.
+var NightlyCommand = &cli.Command{
+	Name:  "nightly",
+	Usage: "Plan and dispatch nightly remediation from current vulnerability scans",
+	Commands: []*cli.Command{
+		nightlyPlanCmd,
+		nightlyDispatchCmd,
+	},
+}
+
+var nightlyPlanCmd = &cli.Command{
+	Name:  "plan",
+	Usage: "Scan published Verity images and emit only dirty remediation targets",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "family", Usage: "Image family to plan: copa or integer", Required: true},
+		&cli.StringFlag{Name: "config", Usage: "Path to copa-config.yaml", Value: "copa-config.yaml"},
+		&cli.StringFlag{Name: "charts-file", Usage: "Path to Chart.yaml", Value: "Chart.yaml"},
+		&cli.StringFlag{Name: "verity-config", Usage: "Path to verity.yaml", Value: "verity.yaml"},
+		&cli.StringFlag{Name: "integer-config", Usage: "Path to integer.yaml", Value: "integer.yaml"},
+		&cli.StringFlag{Name: "images-dir", Usage: "Path to images/", Value: "images"},
+		&cli.StringFlag{Name: "target-registry", Usage: "Target registry override"},
+		&cli.StringFlag{Name: "apkindex-url", Usage: "Wolfi APKINDEX URL", Value: apkindex.DefaultAPKINDEXURL},
+		&cli.StringFlag{Name: "cache-dir", Usage: "APKINDEX cache dir"},
+		&cli.StringFlag{Name: "gen-dir", Usage: "Generated apko config directory"},
+		&cli.StringFlag{Name: "only", Usage: "Comma-separated image names to consider"},
+		&cli.IntFlag{Name: "parallel", Usage: "Number of concurrent target scans", Value: 6},
+		&cli.BoolFlag{Name: "force", Usage: "Bypass scan skip and emit every considered target"},
+		&cli.StringFlag{Name: "output", Usage: "Write dispatch matrix JSON to this file"},
+		&cli.StringFlag{Name: "github-output", Usage: "Append count/images outputs to this GitHub output file"},
+	},
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		family := cmd.String("family")
+		force := cmd.Bool("force")
+		parallel := cmd.Int("parallel")
+		if parallel < 1 {
+			parallel = 1
+		}
+
+		var data []byte
+		var count int
+		var err error
+		switch family {
+		case nightlyFamilyCopa:
+			var items []discovery.DiscoveredImage
+			items, err = nightlyPlanCopa(ctx, cmd, force, parallel)
+			if items == nil {
+				items = []discovery.DiscoveredImage{}
+			}
+			count = len(items)
+			data, err = json.Marshal(items)
+		case nightlyFamilyInteger:
+			var items []intdiscovery.DiscoveredImage
+			items, err = nightlyPlanInteger(ctx, cmd, force, parallel)
+			if items == nil {
+				items = []intdiscovery.DiscoveredImage{}
+			}
+			count = len(items)
+			data, err = json.Marshal(items)
+		default:
+			return fmt.Errorf("unsupported --family %q; want %q or %q", family, nightlyFamilyCopa, nightlyFamilyInteger)
+		}
+		if err != nil {
+			return err
+		}
+
+		if out := cmd.String("output"); out != "" {
+			if err := os.WriteFile(out, data, 0o644); err != nil {
+				return fmt.Errorf("writing %s: %w", out, err)
+			}
+		}
+		if ghOut := cmd.String("github-output"); ghOut != "" {
+			if err := appendGitHubMatrixOutput(ghOut, count, data); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintln(os.Stdout, string(data))
+		return nil
+	},
+}
+
+var nightlyDispatchCmd = &cli.Command{
+	Name:  "dispatch",
+	Usage: "Dispatch a nightly remediation matrix through the GitHub Actions API",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "family", Usage: "Image family to dispatch: copa or integer", Required: true},
+		&cli.StringFlag{Name: "input", Usage: "Dispatch matrix JSON file", Required: true},
+		&cli.StringFlag{Name: "repo", Usage: "GitHub repository owner/name", Required: true},
+		&cli.StringFlag{Name: "ref", Usage: "Git ref for workflow dispatch", Required: true},
+		&cli.StringFlag{Name: "workflow", Usage: "Workflow file name; defaults from --family"},
+		&cli.IntFlag{Name: "retries", Usage: "Dispatch retries per item", Value: 5},
+		&cli.DurationFlag{Name: "throttle", Usage: "Delay between successful dispatches", Value: 2 * time.Second},
+	},
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		workflow := cmd.String("workflow")
+		if workflow == "" {
+			switch cmd.String("family") {
+			case nightlyFamilyCopa:
+				workflow = "patch-image.yaml"
+			case nightlyFamilyInteger:
+				workflow = "integer-build-image.yaml"
+			default:
+				return fmt.Errorf("unsupported --family %q", cmd.String("family"))
+			}
+		}
+		token := os.Getenv("GH_TOKEN")
+		if token == "" {
+			token = os.Getenv("GITHUB_TOKEN")
+		}
+		if token == "" {
+			return errors.New("GH_TOKEN or GITHUB_TOKEN is required for workflow dispatch")
+		}
+
+		inputs, err := nightlyDispatchInputs(cmd.String("family"), cmd.String("input"))
+		if err != nil {
+			return err
+		}
+		for i, in := range inputs {
+			if err := dispatchWorkflow(ctx, token, cmd.String("repo"), workflow, cmd.String("ref"), in, cmd.Int("retries")); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Dispatched %d/%d to %s\n", i+1, len(inputs), workflow)
+			if i+1 < len(inputs) && cmd.Duration("throttle") > 0 {
+				time.Sleep(cmd.Duration("throttle"))
+			}
+		}
+		fmt.Fprintf(os.Stderr, "✓ Dispatched %d %s remediation run(s)\n", len(inputs), cmd.String("family"))
+		return nil
+	},
+}
+
+func nightlyPlanCopa(ctx context.Context, cmd *cli.Command, force bool, parallel int) ([]discovery.DiscoveredImage, error) {
+	cfg, err := discovery.LoadConfig(cmd.String("config"))
+	if err != nil {
+		return nil, fmt.Errorf("loading copa config: %w", err)
+	}
+	charts, err := discovery.LoadChartsFile(cmd.String("charts-file"))
+	if err != nil {
+		return nil, fmt.Errorf("loading charts file: %w", err)
+	}
+	cfg.Charts = append(cfg.Charts, charts...)
+	vc, err := discovery.LoadVerityConfig(cmd.String("verity-config"))
+	if err != nil {
+		return nil, fmt.Errorf("loading verity config: %w", err)
+	}
+
+	overrides := maps.Clone(cfg.Overrides)
+	if overrides == nil {
+		overrides = maps.Clone(vc.Overrides)
+	} else {
+		maps.Copy(overrides, vc.Overrides)
+	}
+	unpatchable := make(map[string]struct{}, len(vc.UnpatchableImages))
+	for _, n := range vc.UnpatchableImages {
+		if n = strings.TrimSpace(n); n != "" {
+			unpatchable[n] = struct{}{}
+		}
+	}
+	excludeNames, err := integerImageNames(cmd.String("images-dir"))
+	if err != nil {
+		return nil, err
+	}
+	images, err := discovery.DiscoverWithChartValues(cfg, cmd.String("target-registry"), overrides, vc.ChartValues, excludeNames, unpatchable)
+	if err != nil {
+		return nil, fmt.Errorf("discovering copa images: %w", err)
+	}
+	images = filterCopaImagesByName(images, cmd.String("only"))
+
+	return filterDirty(ctx, images, parallel, func(img discovery.DiscoveredImage) ([]nightlyScanTarget, string, error) {
+		targetRef, err := copaTargetRef(img)
+		if err != nil {
+			return nil, "", err
+		}
+		return []nightlyScanTarget{{ref: targetRef, label: targetRef}}, img.Name + " " + targetRef, nil
+	}, force, func(i discovery.DiscoveredImage) discovery.DiscoveredImage { return i })
+}
+
+func nightlyPlanInteger(ctx context.Context, cmd *cli.Command, force bool, parallel int) ([]intdiscovery.DiscoveredImage, error) {
+	cfg, err := intconfig.LoadConfig(cmd.String("integer-config"))
+	if err != nil {
+		return nil, fmt.Errorf("loading integer config: %w", err)
+	}
+	registry := cmd.String("target-registry")
+	if registry == "" {
+		registry = cfg.Target.Registry
+	}
+
+	var pkgs []apkindex.Package
+	if url := cmd.String("apkindex-url"); url != "" {
+		pkgs, err = apkindex.Fetch(url, cmd.String("cache-dir"), apkindex.DefaultCacheMaxAge)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: APKINDEX unavailable (%v) — using versions map only\n", err)
+		}
+	}
+	imagesDir, err := filepath.Abs(cmd.String("images-dir"))
+	if err != nil {
+		return nil, fmt.Errorf("resolving images dir: %w", err)
+	}
+	images, err := intdiscovery.DiscoverFromFiles(intdiscovery.Options{
+		ImagesDir: imagesDir,
+		Registry:  registry,
+		Packages:  pkgs,
+		GenDir:    cmd.String("gen-dir"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discovering integer images: %w", err)
+	}
+	images = filterIntegerImagesByName(images, cmd.String("only"))
+
+	return filterDirty(ctx, images, parallel, func(img intdiscovery.DiscoveredImage) ([]nightlyScanTarget, string, error) {
+		targetRefs, err := integerTargetRefs(img)
+		if err != nil {
+			return nil, "", err
+		}
+		return targetRefs, img.Name + ":" + img.Version + "-" + img.Type, nil
+	}, force, func(i intdiscovery.DiscoveredImage) intdiscovery.DiscoveredImage { return i })
+}
+
+type nightlyScanTarget struct {
+	ref   string
+	label string
+}
+
+func filterDirty[T any](ctx context.Context, items []T, parallel int, target func(T) ([]nightlyScanTarget, string, error), force bool, keep func(T) T) ([]T, error) {
+	if force {
+		fmt.Fprintf(os.Stderr, "Force mode: emitting %d target(s) without scan skip\n", len(items))
+		return items, nil
+	}
+	type result struct {
+		idx   int
+		dirty bool
+		err   error
+	}
+	results := make([]result, len(items))
+	sem := make(chan struct{}, parallel)
+	var wg sync.WaitGroup
+	for i, item := range items {
+		wg.Add(1)
+		go func(idx int, item T) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			targets, label, err := target(item)
+			if err != nil {
+				results[idx] = result{idx: idx, dirty: true, err: err}
+				return
+			}
+			decision := scanPublishedTargets(ctx, targets)
+			if decision.dirty {
+				fmt.Fprintf(os.Stderr, "  BUILD: %s: %s\n", label, decision.reason)
+			} else {
+				fmt.Fprintf(os.Stderr, "  SKIP:  %s: %s\n", label, decision.reason)
+			}
+			results[idx] = result{idx: idx, dirty: decision.dirty}
+		}(i, item)
+	}
+	wg.Wait()
+
+	dirty := make([]T, 0)
+	for _, r := range results {
+		if r.err != nil {
+			fmt.Fprintf(os.Stderr, "  BUILD: target resolution failed: %v\n", r.err)
+		}
+		if r.dirty {
+			dirty = append(dirty, keep(items[r.idx]))
+		}
+	}
+	fmt.Fprintf(os.Stderr, "Nightly plan: %d/%d target(s) need remediation\n", len(dirty), len(items))
+	return dirty, nil
+}
+
+type scanDecision struct {
+	dirty  bool
+	reason string
+}
+
+func scanPublishedTargets(ctx context.Context, targets []nightlyScanTarget) scanDecision {
+	if len(targets) == 0 {
+		return scanDecision{dirty: true, reason: "no target tags to scan"}
+	}
+	seenDigests := map[string]struct{}{}
+	for _, target := range targets {
+		if target.label == "" {
+			target.label = target.ref
+		}
+		digest, err := crane.Digest(target.ref)
+		if err != nil {
+			return scanDecision{dirty: true, reason: target.label + " missing or digest lookup failed: " + err.Error()}
+		}
+		if _, ok := seenDigests[digest]; ok {
+			continue
+		}
+		seenDigests[digest] = struct{}{}
+
+		count, err := nightlyTrivyVulnCount(ctx, target.ref)
+		if err != nil {
+			return scanDecision{dirty: true, reason: target.label + " scan failed: " + err.Error()}
+		}
+		if count > 0 {
+			return scanDecision{dirty: true, reason: fmt.Sprintf("%s has %d vulnerabilities", target.label, count)}
+		}
+	}
+	return scanDecision{dirty: false, reason: fmt.Sprintf("%d published tag(s) are clean", len(targets))}
+}
+
+func nightlyTrivyVulnCount(ctx context.Context, ref string) (int, error) {
+	trivy, err := exec.LookPath("trivy")
+	if err != nil {
+		return 0, fmt.Errorf("trivy not found in PATH: %w", err)
+	}
+	c := exec.CommandContext(ctx, trivy, "image", "--vuln-type", "os,library", "--format", "json", "--quiet", ref)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	var report struct {
+		Results []struct {
+			Vulnerabilities []json.RawMessage `json:"Vulnerabilities"`
+		} `json:"Results"`
+	}
+	if err := json.Unmarshal(out, &report); err != nil {
+		return 0, fmt.Errorf("parsing trivy report: %w", err)
+	}
+	count := 0
+	for _, r := range report.Results {
+		count += len(r.Vulnerabilities)
+	}
+	return count, nil
+}
+
+func copaTargetRef(img discovery.DiscoveredImage) (string, error) {
+	tag := sourceTag(img.Source)
+	if tag == "" {
+		return "", fmt.Errorf("source ref %q is digest-pinned or tagless; cannot derive target tag", img.Source)
+	}
+	if img.TargetRegistry == "" {
+		return "", fmt.Errorf("target registry missing for %q", img.Name)
+	}
+	return strings.TrimRight(img.TargetRegistry, "/") + "/" + img.Name + ":" + tag, nil
+}
+
+func integerTargetRef(img intdiscovery.DiscoveredImage) (string, error) {
+	if len(img.Tags) == 0 {
+		return "", fmt.Errorf("integer image %s:%s-%s has no tags", img.Name, img.Version, img.Type)
+	}
+	if img.Registry == "" {
+		return "", fmt.Errorf("registry missing for integer image %s:%s-%s", img.Name, img.Version, img.Type)
+	}
+	return strings.TrimRight(img.Registry, "/") + "/" + img.Name + ":" + img.Tags[0], nil
+}
+
+func integerTargetRefs(img intdiscovery.DiscoveredImage) ([]nightlyScanTarget, error) {
+	if len(img.Tags) == 0 {
+		return nil, fmt.Errorf("integer image %s:%s-%s has no tags", img.Name, img.Version, img.Type)
+	}
+	if img.Registry == "" {
+		return nil, fmt.Errorf("registry missing for integer image %s:%s-%s", img.Name, img.Version, img.Type)
+	}
+	base := strings.TrimRight(img.Registry, "/") + "/" + img.Name
+	targets := make([]nightlyScanTarget, 0, len(img.Tags))
+	for _, tag := range img.Tags {
+		if tag = strings.TrimSpace(tag); tag != "" {
+			ref := base + ":" + tag
+			targets = append(targets, nightlyScanTarget{ref: ref, label: ref})
+		}
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("integer image %s:%s-%s has no non-empty tags", img.Name, img.Version, img.Type)
+	}
+	return targets, nil
+}
+
+func sourceTag(ref string) string {
+	if strings.Contains(ref, "@") {
+		return ""
+	}
+	lastSlash := strings.LastIndex(ref, "/")
+	lastColon := strings.LastIndex(ref, ":")
+	if lastColon <= lastSlash {
+		return "latest"
+	}
+	return ref[lastColon+1:]
+}
+
+func integerImageNames(imagesDir string) (map[string]struct{}, error) {
+	files, err := intconfig.ImageFilePaths(imagesDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading integer image names: %w", err)
+	}
+	names := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		rel, err := filepath.Rel(imagesDir, f)
+		if err != nil {
+			return nil, fmt.Errorf("relativizing integer image path %s: %w", f, err)
+		}
+		names[strings.TrimSuffix(filepath.ToSlash(rel), yamlExt)] = struct{}{}
+	}
+	return names, nil
+}
+
+func appendGitHubMatrixOutput(path string, count int, data []byte) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening GitHub output %s: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := fmt.Fprintf(f, "count=%d\nimages<<__VERITY_NIGHTLY_JSON__\n%s\n__VERITY_NIGHTLY_JSON__\n", count, data); err != nil {
+		return fmt.Errorf("writing GitHub output %s: %w", path, err)
+	}
+	return nil
+}
+
+func nightlyDispatchInputs(family, inputPath string) ([]map[string]string, error) {
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading dispatch matrix %s: %w", inputPath, err)
+	}
+	switch family {
+	case nightlyFamilyCopa:
+		var items []discovery.DiscoveredImage
+		if err := json.Unmarshal(data, &items); err != nil {
+			return nil, fmt.Errorf("parsing copa matrix: %w", err)
+		}
+		out := make([]map[string]string, 0, len(items))
+		for _, item := range items {
+			in := map[string]string{
+				"image-name":      item.Name,
+				"source-ref":      item.Source,
+				"target-registry": item.TargetRegistry,
+				"platforms":       item.Platforms,
+			}
+			if item.GoVcsURL != "" {
+				in["go-vcs-url"] = item.GoVcsURL
+			}
+			out = append(out, in)
+		}
+		return out, nil
+	case nightlyFamilyInteger:
+		var items []intdiscovery.DiscoveredImage
+		if err := json.Unmarshal(data, &items); err != nil {
+			return nil, fmt.Errorf("parsing integer matrix: %w", err)
+		}
+		out := make([]map[string]string, 0, len(items))
+		for _, item := range items {
+			out = append(out, map[string]string{
+				"image":    item.Name,
+				"version":  item.Version,
+				"type":     item.Type,
+				"tags":     strings.Join(item.Tags, ","),
+				"registry": item.Registry,
+			})
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported --family %q", family)
+	}
+}
+
+func dispatchWorkflow(ctx context.Context, token, repo, workflow, ref string, inputs map[string]string, retries int) error {
+	if retries < 1 {
+		retries = 1
+	}
+	body, err := json.Marshal(map[string]any{
+		"ref":    ref,
+		"inputs": inputs,
+	})
+	if err != nil {
+		return fmt.Errorf("marshalling dispatch body: %w", err)
+	}
+	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/actions/workflows/%s/dispatches", repo, url.PathEscape(workflow))
+	var lastErr error
+	for attempt := 1; attempt <= retries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("creating dispatch request: %w", err)
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil && resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
+		if err == nil && resp.StatusCode == http.StatusNoContent {
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			lastErr = fmt.Errorf("github dispatch returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		}
+		if attempt < retries {
+			time.Sleep(time.Duration(attempt*10) * time.Second)
+		}
+	}
+	return fmt.Errorf("dispatching %s after %d attempt(s): %w", workflow, retries, lastErr)
+}

--- a/cmd/nightly_test.go
+++ b/cmd/nightly_test.go
@@ -1,16 +1,35 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 
 	"github.com/verity-org/verity/internal/discovery"
 	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
+)
+
+var (
+	errTestCloseFailed      = errors.New("close failed")
+	errTestUnexpectedTarget = errors.New("should not be called")
+	errTestBadTarget        = errors.New("bad target")
+	errTestDigestNotFound   = errors.New("not found")
+	errTestNetworkDown      = errors.New("network down")
+	errTestWriteFailed      = errors.New("write failed")
 )
 
 func TestNightlySourceTag(t *testing.T) {
@@ -28,7 +47,7 @@ func TestNightlySourceTag(t *testing.T) {
 }
 
 func TestNightlyTargetRefs(t *testing.T) {
-	copa, err := copaTargetRef(discovery.DiscoveredImage{
+	copa, err := copaTargetRef(&discovery.DiscoveredImage{
 		Name:           "prometheus/prometheus",
 		Source:         "quay.io/prometheus/prometheus:v3.9.1",
 		TargetRegistry: "ghcr.io/verity-org",
@@ -36,7 +55,7 @@ func TestNightlyTargetRefs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ghcr.io/verity-org/prometheus/prometheus:v3.9.1", copa)
 
-	integer, err := integerTargetRef(intdiscovery.DiscoveredImage{
+	integer, err := integerTargetRef(&intdiscovery.DiscoveredImage{
 		Name:     "node",
 		Version:  "24",
 		Type:     "default",
@@ -46,7 +65,7 @@ func TestNightlyTargetRefs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ghcr.io/verity-org/node:24", integer)
 
-	integerRefs, err := integerTargetRefs(intdiscovery.DiscoveredImage{
+	integerRefs, err := integerTargetRefs(&intdiscovery.DiscoveredImage{
 		Name:     "node",
 		Version:  "24",
 		Type:     "dev",
@@ -59,6 +78,37 @@ func TestNightlyTargetRefs(t *testing.T) {
 		{ref: "ghcr.io/verity-org/node:24.18-dev", label: "ghcr.io/verity-org/node:24.18-dev"},
 		{ref: "ghcr.io/verity-org/node:latest-dev", label: "ghcr.io/verity-org/node:latest-dev"},
 	}, integerRefs)
+}
+
+func TestNightlyTargetRefErrors(t *testing.T) {
+	_, err := copaTargetRef(&discovery.DiscoveredImage{
+		Name:           "digest",
+		Source:         "repo/img@sha256:abc",
+		TargetRegistry: "ghcr.io/verity-org",
+	})
+	require.ErrorIs(t, err, errSourceTagUnavailable)
+
+	_, err = copaTargetRef(&discovery.DiscoveredImage{
+		Name:   "missing-registry",
+		Source: "repo/img:tag",
+	})
+	require.ErrorIs(t, err, errMissingTargetRegistry)
+
+	_, err = integerTargetRefs(&intdiscovery.DiscoveredImage{
+		Name:     "node",
+		Version:  "24",
+		Type:     "default",
+		Registry: "ghcr.io/verity-org",
+	})
+	require.ErrorIs(t, err, errMissingIntegerTags)
+
+	_, err = integerTargetRefs(&intdiscovery.DiscoveredImage{
+		Name:    "node",
+		Version: "24",
+		Type:    "default",
+		Tags:    []string{"24"},
+	})
+	require.ErrorIs(t, err, errMissingIntegerRegistry)
 }
 
 func TestNightlyDispatchInputs(t *testing.T) {
@@ -105,4 +155,385 @@ func TestNightlyDispatchInputs(t *testing.T) {
 		"tags":     "24-dev,latest-dev",
 		"registry": "ghcr.io/verity-org",
 	}}, integer)
+}
+
+func TestNightlyPlanPropagatesDiscoveryErrors(t *testing.T) {
+	root := &cli.Command{Commands: []*cli.Command{NightlyCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "nightly", "plan",
+		"--family", nightlyFamilyCopa,
+		"--config", filepath.Join(t.TempDir(), "missing.yaml"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading copa config")
+}
+
+type closeBuffer struct {
+	bytes.Buffer
+	closeErr error
+}
+
+func (b *closeBuffer) Close() error {
+	return b.closeErr
+}
+
+func TestAppendGitHubMatrixOutputToWritesAndCloses(t *testing.T) {
+	w := &closeBuffer{}
+	err := appendGitHubMatrixOutputTo(w, "out", 2, []byte(`[{"name":"x"}]`))
+	require.NoError(t, err)
+	assert.Equal(t, "count=2\nimages<<__VERITY_NIGHTLY_JSON__\n[{\"name\":\"x\"}]\n__VERITY_NIGHTLY_JSON__\n", w.String())
+}
+
+func TestAppendGitHubMatrixOutputToReportsCloseError(t *testing.T) {
+	closeErr := errTestCloseFailed
+	err := appendGitHubMatrixOutputTo(&closeBuffer{closeErr: closeErr}, "out", 1, []byte(`[]`))
+	require.ErrorIs(t, err, closeErr)
+	assert.Contains(t, err.Error(), "closing GitHub output out")
+}
+
+type failingWriteCloser struct{}
+
+func (failingWriteCloser) Write([]byte) (int, error) {
+	return 0, errTestWriteFailed
+}
+
+func (failingWriteCloser) Close() error {
+	return errTestCloseFailed
+}
+
+func TestAppendGitHubMatrixOutputToJoinsWriteAndCloseErrors(t *testing.T) {
+	err := appendGitHubMatrixOutputTo(failingWriteCloser{}, "out", 1, []byte(`[]`))
+	require.ErrorIs(t, err, errTestWriteFailed)
+	require.ErrorIs(t, err, errTestCloseFailed)
+}
+
+func TestAppendGitHubMatrixOutputWritesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "github-output")
+	require.NoError(t, appendGitHubMatrixOutput(path, 0, []byte(`[]`)))
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "count=0\n")
+	assert.Contains(t, string(got), "[]")
+}
+
+func TestAppendGitHubMatrixOutputReportsOpenError(t *testing.T) {
+	err := appendGitHubMatrixOutput(filepath.Join(t.TempDir(), "missing", "out"), 1, []byte(`[]`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening GitHub output")
+}
+
+func TestFilterDirtyForceSkipsTargetResolution(t *testing.T) {
+	want := []string{"a", "b"}
+	got, err := filterDirty(context.Background(), want, 1, func(string) ([]nightlyScanTarget, string, error) {
+		return nil, "", errTestUnexpectedTarget
+	}, true, func(s string) string { return s })
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestFilterDirtyKeepsTargetResolutionErrors(t *testing.T) {
+	targetErr := errTestBadTarget
+	got, err := filterDirty(context.Background(), []string{"a"}, 1, func(string) ([]nightlyScanTarget, string, error) {
+		return nil, "", targetErr
+	}, false, func(s string) string { return s })
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a"}, got)
+}
+
+func TestScanPublishedTargetsDedupesCleanDigests(t *testing.T) {
+	restore := stubScanFunctions(t)
+	digestCalls := 0
+	scanCalls := 0
+	craneDigest = func(string, ...crane.Option) (string, error) {
+		digestCalls++
+		return "sha256:same", nil
+	}
+	trivyVulnCountFor = func(context.Context, string) (int, error) {
+		scanCalls++
+		return 0, nil
+	}
+	t.Cleanup(restore)
+
+	decision := scanPublishedTargets(context.Background(), []nightlyScanTarget{
+		{ref: "repo/img:1"},
+		{ref: "repo/img:latest"},
+	})
+	require.False(t, decision.dirty)
+	assert.Equal(t, 2, digestCalls)
+	assert.Equal(t, 1, scanCalls)
+}
+
+func TestScanPublishedTargetsMarksVulnerableImageDirty(t *testing.T) {
+	restore := stubScanFunctions(t)
+	craneDigest = func(string, ...crane.Option) (string, error) { return "sha256:vuln", nil }
+	trivyVulnCountFor = func(context.Context, string) (int, error) { return 3, nil }
+	t.Cleanup(restore)
+
+	decision := scanPublishedTargets(context.Background(), []nightlyScanTarget{{ref: "repo/img:1"}})
+	require.True(t, decision.dirty)
+	assert.Contains(t, decision.reason, "3 vulnerabilities")
+}
+
+func TestScanPublishedTargetsMarksDigestFailureDirty(t *testing.T) {
+	restore := stubScanFunctions(t)
+	craneDigest = func(string, ...crane.Option) (string, error) { return "", errTestDigestNotFound }
+	t.Cleanup(restore)
+
+	decision := scanPublishedTargets(context.Background(), []nightlyScanTarget{{ref: "repo/img:1"}})
+	require.True(t, decision.dirty)
+	assert.Contains(t, decision.reason, "digest lookup failed")
+}
+
+func TestScanPublishedTargetsMarksScanFailureDirty(t *testing.T) {
+	restore := stubScanFunctions(t)
+	craneDigest = func(string, ...crane.Option) (string, error) { return "sha256:ok", nil }
+	trivyVulnCountFor = func(context.Context, string) (int, error) { return 0, errTestBadTarget }
+	t.Cleanup(restore)
+
+	decision := scanPublishedTargets(context.Background(), []nightlyScanTarget{{ref: "repo/img:1"}})
+	require.True(t, decision.dirty)
+	assert.Contains(t, decision.reason, "scan failed")
+}
+
+func TestScanPublishedTargetsMarksEmptyTargetListDirty(t *testing.T) {
+	decision := scanPublishedTargets(context.Background(), nil)
+	require.True(t, decision.dirty)
+	assert.Contains(t, decision.reason, "no target tags")
+}
+
+func TestDispatchWorkflowUsesGitHubAPI(t *testing.T) {
+	var gotPath, gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		var payload struct {
+			Ref    string            `json:"ref"`
+			Inputs map[string]string `json:"inputs"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		assert.Equal(t, "main", payload.Ref)
+		assert.Equal(t, map[string]string{"image": "node"}, payload.Inputs)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	restore := stubGitHubClient(t, server)
+	t.Cleanup(restore)
+
+	err := dispatchWorkflow(context.Background(), "token", "verity-org/verity", "integer-build-image.yaml", "main", map[string]string{"image": "node"}, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "/repos/verity-org/verity/actions/workflows/integer-build-image.yaml/dispatches", gotPath)
+	assert.Equal(t, "Bearer token", gotAuth)
+}
+
+func TestDispatchWorkflowReportsGitHubStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "secondary rate limit", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+	restore := stubGitHubClient(t, server)
+	t.Cleanup(restore)
+
+	err := dispatchWorkflow(context.Background(), "token", "verity-org/verity", "workflow.yaml", "main", nil, 1)
+	require.ErrorIs(t, err, errGitHubDispatchStatus)
+	assert.Contains(t, err.Error(), "secondary rate limit")
+}
+
+func TestDispatchWorkflowRetriesAfterStatusFailure(t *testing.T) {
+	attempts := 0
+	var slept time.Duration
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			http.Error(w, "try again", http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	restoreClient := stubGitHubClient(t, server)
+	oldSleep := dispatchRetrySleep
+	dispatchRetrySleep = func(d time.Duration) { slept = d }
+	t.Cleanup(func() {
+		restoreClient()
+		dispatchRetrySleep = oldSleep
+	})
+
+	err := dispatchWorkflow(context.Background(), "token", "verity-org/verity", "workflow.yaml", "main", nil, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+	assert.Equal(t, 10*time.Second, slept)
+}
+
+func TestNightlyTrivyVulnCountParsesReport(t *testing.T) {
+	dir := t.TempDir()
+	trivy := filepath.Join(dir, "trivy")
+	script := `#!/usr/bin/env bash
+cat <<'JSON'
+{"Results":[{"Vulnerabilities":[{"VulnerabilityID":"CVE-1"}]},{"Vulnerabilities":[{"VulnerabilityID":"CVE-2"},{"VulnerabilityID":"CVE-3"}]}]}
+JSON
+`
+	require.NoError(t, os.WriteFile(trivy, []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	count, err := nightlyTrivyVulnCount(context.Background(), "repo/img:tag")
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+}
+
+func TestNightlyTrivyVulnCountReportsInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	trivy := filepath.Join(dir, "trivy")
+	require.NoError(t, os.WriteFile(trivy, []byte("#!/usr/bin/env bash\necho nope\n"), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := nightlyTrivyVulnCount(context.Background(), "repo/img:tag")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing trivy report")
+}
+
+func TestNightlyTrivyVulnCountReportsMissingTrivy(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	_, err := nightlyTrivyVulnCount(context.Background(), "repo/img:tag")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trivy not found")
+}
+
+func TestNightlyTrivyVulnCountReportsCommandFailure(t *testing.T) {
+	dir := t.TempDir()
+	trivy := filepath.Join(dir, "trivy")
+	require.NoError(t, os.WriteFile(trivy, []byte("#!/usr/bin/env bash\necho scan failed >&2\nexit 7\n"), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := nightlyTrivyVulnCount(context.Background(), "repo/img:tag")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scan failed")
+}
+
+func stubScanFunctions(t *testing.T) func() {
+	t.Helper()
+	oldDigest := craneDigest
+	oldTrivy := trivyVulnCountFor
+	return func() {
+		craneDigest = oldDigest
+		trivyVulnCountFor = oldTrivy
+	}
+}
+
+func stubGitHubClient(t *testing.T, server *httptest.Server) func() {
+	t.Helper()
+	oldBaseURL := githubAPIBaseURL
+	oldClient := githubHTTPClient
+	githubAPIBaseURL = server.URL
+	githubHTTPClient = server.Client()
+	return func() {
+		githubAPIBaseURL = oldBaseURL
+		githubHTTPClient = oldClient
+	}
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+func (failingReader) Close() error {
+	return nil
+}
+
+func TestDispatchWorkflowReportsResponseReadError(t *testing.T) {
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       failingReader{},
+		}, nil
+	})
+	oldBaseURL := githubAPIBaseURL
+	oldClient := githubHTTPClient
+	githubAPIBaseURL = "https://example.test"
+	githubHTTPClient = &http.Client{Transport: transport}
+	t.Cleanup(func() {
+		githubAPIBaseURL = oldBaseURL
+		githubHTTPClient = oldClient
+	})
+
+	err := dispatchWorkflow(context.Background(), "token", "verity-org/verity", "workflow.yaml", "main", nil, 1)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestDispatchWorkflowReportsNilBodyStatus(t *testing.T) {
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+		}, nil
+	})
+	oldBaseURL := githubAPIBaseURL
+	oldClient := githubHTTPClient
+	githubAPIBaseURL = "https://example.test"
+	githubHTTPClient = &http.Client{Transport: transport}
+	t.Cleanup(func() {
+		githubAPIBaseURL = oldBaseURL
+		githubHTTPClient = oldClient
+	})
+
+	err := dispatchWorkflow(context.Background(), "token", "verity-org/verity", "workflow.yaml", "main", nil, 1)
+	require.ErrorIs(t, err, errGitHubDispatchStatus)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return fn(r)
+}
+
+func TestDispatchWorkflowReportsTransportError(t *testing.T) {
+	transportErr := errTestNetworkDown
+	oldClient := githubHTTPClient
+	githubHTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, transportErr
+	})}
+	t.Cleanup(func() { githubHTTPClient = oldClient })
+
+	err := dispatchWorkflow(context.Background(), "token", "verity-org/verity", "workflow.yaml", "main", nil, 1)
+	require.ErrorIs(t, err, transportErr)
+}
+
+func TestNightlyDispatchInputsRejectsUnsupportedFamily(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "matrix.json")
+	require.NoError(t, os.WriteFile(path, []byte(`[]`), 0o644))
+	_, err := nightlyDispatchInputs("bad", path)
+	require.ErrorIs(t, err, errUnsupportedNightlyFamily)
+	assert.True(t, strings.Contains(err.Error(), "bad"))
+}
+
+func TestNightlyDispatchRejectsMissingToken(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	root := &cli.Command{Commands: []*cli.Command{NightlyCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "nightly", "dispatch",
+		"--family", nightlyFamilyCopa,
+		"--input", filepath.Join(t.TempDir(), "missing.json"),
+		"--repo", "verity-org/verity",
+		"--ref", "main",
+	})
+	require.ErrorIs(t, err, errMissingGitHubToken)
+}
+
+func TestIntegerImageNamesSkipsBaseDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "_base"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "node.yaml"), []byte("name: node"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "nested", "tool.yaml"), []byte("name: tool"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "_base", "skip.yaml"), []byte("skip"), 0o644))
+
+	names, err := integerImageNames(dir)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]struct{}{
+		"node":        {},
+		"nested/tool": {},
+	}, names)
 }

--- a/cmd/nightly_test.go
+++ b/cmd/nightly_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/discovery"
+	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
+)
+
+func TestNightlySourceTag(t *testing.T) {
+	tests := map[string]string{
+		"registry.k8s.io/foo/bar:v1.2.3": "v1.2.3",
+		"docker.io/library/nginx":        "latest",
+		"localhost:5000/ns/img:tag":      "tag",
+		"repo/img@sha256:abc":            "",
+	}
+	for ref, want := range tests {
+		t.Run(ref, func(t *testing.T) {
+			assert.Equal(t, want, sourceTag(ref))
+		})
+	}
+}
+
+func TestNightlyTargetRefs(t *testing.T) {
+	copa, err := copaTargetRef(discovery.DiscoveredImage{
+		Name:           "prometheus/prometheus",
+		Source:         "quay.io/prometheus/prometheus:v3.9.1",
+		TargetRegistry: "ghcr.io/verity-org",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ghcr.io/verity-org/prometheus/prometheus:v3.9.1", copa)
+
+	integer, err := integerTargetRef(intdiscovery.DiscoveredImage{
+		Name:     "node",
+		Version:  "24",
+		Type:     "default",
+		Tags:     []string{"24", "latest"},
+		Registry: "ghcr.io/verity-org",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ghcr.io/verity-org/node:24", integer)
+
+	integerRefs, err := integerTargetRefs(intdiscovery.DiscoveredImage{
+		Name:     "node",
+		Version:  "24",
+		Type:     "dev",
+		Tags:     []string{"24-dev", "24.18-dev", "latest-dev"},
+		Registry: "ghcr.io/verity-org",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []nightlyScanTarget{
+		{ref: "ghcr.io/verity-org/node:24-dev", label: "ghcr.io/verity-org/node:24-dev"},
+		{ref: "ghcr.io/verity-org/node:24.18-dev", label: "ghcr.io/verity-org/node:24.18-dev"},
+		{ref: "ghcr.io/verity-org/node:latest-dev", label: "ghcr.io/verity-org/node:latest-dev"},
+	}, integerRefs)
+}
+
+func TestNightlyDispatchInputs(t *testing.T) {
+	dir := t.TempDir()
+
+	copaPath := filepath.Join(dir, "copa.json")
+	copaData, err := json.Marshal([]discovery.DiscoveredImage{{
+		Name:           "library/nginx",
+		Source:         "mirror.gcr.io/library/nginx:1.29.3",
+		TargetRegistry: "ghcr.io/verity-org",
+		Platforms:      "linux/amd64,linux/arm64",
+		GoVcsURL:       "https://github.com/nginx/nginx@release-1.29.3",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(copaPath, copaData, 0o644))
+
+	copa, err := nightlyDispatchInputs(nightlyFamilyCopa, copaPath)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{{
+		"image-name":      "library/nginx",
+		"source-ref":      "mirror.gcr.io/library/nginx:1.29.3",
+		"target-registry": "ghcr.io/verity-org",
+		"platforms":       "linux/amd64,linux/arm64",
+		"go-vcs-url":      "https://github.com/nginx/nginx@release-1.29.3",
+	}}, copa)
+
+	integerPath := filepath.Join(dir, "integer.json")
+	integerData, err := json.Marshal([]intdiscovery.DiscoveredImage{{
+		Name:     "node",
+		Version:  "24",
+		Type:     "dev",
+		Tags:     []string{"24-dev", "latest-dev"},
+		Registry: "ghcr.io/verity-org",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(integerPath, integerData, 0o644))
+
+	integer, err := nightlyDispatchInputs(nightlyFamilyInteger, integerPath)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{{
+		"image":    "node",
+		"version":  "24",
+		"type":     "dev",
+		"tags":     "24-dev,latest-dev",
+		"registry": "ghcr.io/verity-org",
+	}}, integer)
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 			cmd.DiscoverCommand,
 			cmd.IntegerCommand,
 			cmd.CICommand,
+			cmd.NightlyCommand,
 			cmd.PreflightCommand,
 			cmd.ChartGenCommand,
 			cmd.PatchCommand,


### PR DESCRIPTION
## Summary
- add `verity nightly plan|dispatch` so nightly orchestration lives in Go instead of bash dispatch loops
- make scheduled Copa and Integer runs scan published targets first and dispatch only missing, scan-failing, or vulnerable images
- scan every published Integer tag for a variant, including bespoke/melange-derived aliases, before deciding whether to rebuild
- update workflow guards and docs for the scan-first model

## Validation
- `go test ./...`
- `python3 .github/scripts/validate-nightly-workflows.py && python3 .github/scripts/validate-patch-image-workflow.py && python3 .github/scripts/validate-integer-build-image-workflow.py && python3 .github/scripts/validate-chart-integration-workflow.py && python3 .github/scripts/validate-ci-workflow.py`
- `actionlint .github/workflows/orchestrator.yaml .github/workflows/integer-orchestrator.yaml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scan-first nightly workflow owned by a Go CLI that scans published tags with `trivy` before dispatch. Skips clean images, reduces rebuilds, replaces shell dispatch loops, and adds a stable PR Test gate.

- **New Features**
  - Added `verity nightly plan|dispatch` to plan dirty targets and dispatch via the Actions API (writes matrix to `GITHUB_OUTPUT`, retries with throttle).
  - Copa: scan target-registry tags first; dispatch only missing, scan-failing, or vulnerable images to `patch-image.yaml`.
  - Integer: scan every published tag per variant (includes bespoke/melange aliases); dispatch only dirty images to `integer-build-image.yaml`.
  - Scheduled runs scan-first by default; `--force` enables on-demand or push-triggered rebuilds.

- **Refactors**
  - Replaced shell loops in `orchestrator.yaml` and `integer-orchestrator.yaml` with `nightly plan` + `nightly dispatch`.
  - Validation enforces scan-first orchestration and blocks large Integer dispatch matrices in env; workflows read JSON from files.
  - CI: added a stable PR Test aggregate and validator; PR Test scope now includes `cmd/ci*.go` and `cmd/nightly*.go`; still skips Integer smoke builds for orchestrator-only changes; docs updated in `ARCHITECTURE.md` and `README.md`.

<sup>Written for commit 90920dec5125fbf597aa22623c6496faa1c030cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

