### PR TITLE
[codex] prefer Integer for duplicate images

### DIFF
--- a/copa-config.yaml
+++ b/copa-config.yaml
@@ -843,22 +843,11 @@ images:
 
   # ============================================================================
   #  Copa-first coverage (batch 9) — final fixable CVE tail.
-  #  kubectl: canonical registry.k8s.io image, Go-source patched.
   #  linkerd/proxy moved off Copa: upstream now declares Wolfi and Copa rejects
   #  that osType outright (`unsupported osType wolfi specified`). Keep catalog
   #  coverage on the Integer side instead of burning patch jobs.
   #  eks-pod-identity-agent + crossplane(crank): Go-source patched.
   # ============================================================================
-  - name: "kubectl"
-    image: "registry.k8s.io/kubectl"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v1\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/kubernetes/kubernetes"
-    goVcsTagPrefix: ""
-
   - name: "eks/eks-pod-identity-agent"
     image: "public.ecr.aws/eks/eks-pod-identity-agent"
     platforms: ["linux/amd64", "linux/arm64"]
@@ -888,16 +877,6 @@ images:
   #  fluentd-kubernetes-daemonset, kyverno-readiness-checker, checkov.
   # ============================================================================
   # --- Go tools (goVcsUrl) ---
-  - name: "etcd"
-    image: "registry.k8s.io/etcd"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^v\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/etcd-io/etcd"
-    goVcsTagPrefix: ""
-
   - name: "projectcontour/contour"
     image: "ghcr.io/projectcontour/contour"
     platforms: ["linux/amd64", "linux/arm64"]
@@ -941,16 +920,6 @@ images:
   # earthly moved off Copa: current patch runs explode with repeated apt-layer
   # solver failures on both arches, while the bespoke Integer build already
   # produces a clean receipt for v0.8.16.
-
-  - name: "caddy"
-    image: "docker.io/library/caddy"
-    platforms: ["linux/amd64", "linux/arm64"]
-    tags:
-      strategy: "pattern"
-      pattern: '^\d+\.\d+\.\d+$'
-      maxTags: 3
-    goVcsUrl: "https://github.com/caddyserver/caddy"
-    goVcsTagPrefix: "v"
 
   - name: "prometheus/blackbox-exporter"
     image: "quay.io/prometheus/blackbox-exporter"

--- a/internal/config_ownership_test.go
+++ b/internal/config_ownership_test.go
@@ -1,0 +1,62 @@
+package internal_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type imageName struct {
+	Name string `yaml:"name"`
+}
+
+type copaImageConfig struct {
+	Images []imageName `yaml:"images"`
+}
+
+func TestIntegerImagesDoNotOverlapCopa(t *testing.T) {
+	copaPath := filepath.Join("..", "copa-config.yaml")
+	copaData, err := os.ReadFile(copaPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", copaPath, err)
+	}
+
+	var copa copaImageConfig
+	if err := yaml.Unmarshal(copaData, &copa); err != nil {
+		t.Fatalf("parse %s: %v", copaPath, err)
+	}
+
+	copaNames := make(map[string]struct{}, len(copa.Images))
+	for _, image := range copa.Images {
+		copaNames[image.Name] = struct{}{}
+	}
+
+	integerPaths, err := filepath.Glob(filepath.Join("..", "images", "*.yaml"))
+	if err != nil {
+		t.Fatalf("glob Integer image definitions: %v", err)
+	}
+
+	var overlaps []string
+	for _, imagePath := range integerPaths {
+		imageData, err := os.ReadFile(imagePath)
+		if err != nil {
+			t.Fatalf("read %s: %v", imagePath, err)
+		}
+
+		var image imageName
+		if err := yaml.Unmarshal(imageData, &image); err != nil {
+			t.Fatalf("parse %s: %v", imagePath, err)
+		}
+		if _, exists := copaNames[image.Name]; exists {
+			overlaps = append(overlaps, image.Name)
+		}
+	}
+
+	sort.Strings(overlaps)
+	if len(overlaps) > 0 {
+		t.Fatalf("image names owned by both Copa and Integer: %v", overlaps)
+	}
+}

--- a/test/chart-integration/SKIPS.yaml
+++ b/test/chart-integration/SKIPS.yaml
@@ -58,11 +58,15 @@ skips:
       (c) chart upstream provides a `driver.enabled: false` mode that
           does NOT also strip the container plugin.
     added: 2026-05-16
-    added_by: SCR-2026-05-14-001 (re-added after #378 + #380 follow-up)
+    added_by: "SCR-2026-05-14-001 (re-added after #378 + #380 follow-up)"
 
   - chart: cilium
     reason: kind-cluster-capability
     tracking_issue: https://github.com/verity-org/verity/issues/372
-    exit_criteria: "agent init container hits \"dial tcp 10.96.0.1:443: operation not permitted\" — kind cluster lacks capabilities for cilium's CNI. Revisit when smoke harness gains capability grants OR when cilium chart exposes a CI-friendly probe-disable knob."
+    exit_criteria: >-
+      agent init container hits "dial tcp 10.96.0.1:443: operation not
+      permitted" — kind cluster lacks capabilities for cilium's CNI. Revisit
+      when smoke harness gains capability grants OR when cilium chart exposes
+      a CI-friendly probe-disable knob.
     added: 2026-05-14
     added_by: SCR-2026-05-14-001

--- a/test/chart-integration/values/gitea.yaml
+++ b/test/chart-integration/values/gitea.yaml
@@ -161,7 +161,9 @@ gitea:
 
           host="${args[0]}"
           port="${args[1]}"
-          timeout "${timeout_seconds}" bash -c 'exec 3<>"/dev/tcp/${1}/${2}" && exec 3>&- && exec 3<&-' _ "${host}" "${port}"
+          timeout "${timeout_seconds}" bash -c \
+            'exec 3<>"/dev/tcp/${1}/${2}" && exec 3>&- && exec 3<&-' \
+            _ "${host}" "${port}"
   extraVolumes:
     - name: env-to-ini
       configMap:


### PR DESCRIPTION
## What changed

- Removed `caddy`, `etcd`, and `kubectl` from `copa-config.yaml` so Integer exclusively publishes those repositories.
- Added a repository invariant test rejecting exact image-name ownership overlap between Copa and Integer.
- Cleaned existing YAML lint warnings surfaced by full validation.

## Why

Caddy was published through both pipelines. Copa preserved the upstream image command (`caddy run ...`) without an entrypoint, while Integer published `ENTRYPOINT ["caddy"]`. Whichever pipeline wrote the standard tag last changed whether `docker run IMAGE run` worked. Exact-name duplicate ownership also existed for etcd and kubectl.

Integer now takes precedence for all three image families, preventing tag metadata and contents from being overwritten by Copa.

## Validation

- `make test`
- `make lint`
- `make lint-yaml`
- `make integer-validate`
- Exact Copa/Integer overlap scan returns no names
- Integer discovery returns `caddy`, `etcd`, and `kubectl`

Branch rebased onto current `origin/main` before push.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Integer the sole publisher for `caddy`, `etcd`, and `kubectl` to stop tag/entrypoint drift from duplicate publishing. Adds a guardrail test to block future exact-name overlaps between Copa and Integer.

- **Bug Fixes**
  - Removed `caddy`, `etcd`, and `kubectl` from `copa-config.yaml` so Integer owns these images.
  - Added an invariant test that fails if any image name is owned by both Copa and Integer.
  - Cleaned YAML lint issues in test files (quote fixes, folded blocks, and minor script line wraps) for consistent CI parsing.

<sup>Written for commit b6a63a683c1e7abad5fbfbc1e236ffd03ca1c842. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

