### PR TITLE
fix(ci): restore metrics archive finalization

### DIFF
--- a/.github/scripts/validate-metrics-json.sh
+++ b/.github/scripts/validate-metrics-json.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <run-id> <run-attempt> <metrics-directory>" >&2
+  exit 2
+fi
+
+RUN_ID=$1
+RUN_ATTEMPT=$2
+METRICS_DIR=$3
+
+if [[ ! "$RUN_ID" =~ ^[1-9][0-9]*$ ]] || [[ ! "$RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+  echo "run id and attempt must be positive integers" >&2
+  exit 2
+fi
+
+if [ ! -d "$METRICS_DIR" ]; then
+  echo "metrics directory does not exist: $METRICS_DIR" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+files=("$METRICS_DIR"/metrics-*.json)
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "No metrics artifacts found in $METRICS_DIR" >&2
+  exit 1
+fi
+
+for file in "${files[@]}"; do
+  if ! jq -e \
+    --argjson expected_run_id "$RUN_ID" \
+    --argjson expected_run_attempt "$RUN_ATTEMPT" '
+      def integer: type == "number" and floor == .;
+      def count: integer and . >= 0;
+      def nonempty_string: type == "string" and length > 0;
+      def nullable_string: . == null or nonempty_string;
+      def digest: nonempty_string and test("^sha256:[0-9a-f]{64}$");
+      def nullable_digest: . == null or digest;
+      def severity_counts:
+        type == "object"
+        and (.CRITICAL | count)
+        and (.HIGH | count)
+        and (.MEDIUM | count)
+        and (.LOW | count)
+        and (.UNKNOWN | count);
+      def scan:
+        type == "object"
+        and (.vuln_count | count)
+        and (.by_severity | severity_counts)
+        and .vuln_count == (
+          .by_severity.CRITICAL
+          + .by_severity.HIGH
+          + .by_severity.MEDIUM
+          + .by_severity.LOW
+          + .by_severity.UNKNOWN
+        );
+      def platform($arch):
+        . == null or (
+          type == "object"
+          and .arch == $arch
+          and (.copa_duration_seconds == null or (.copa_duration_seconds | count))
+          and (.copa_exit_code == null or (.copa_exit_code | integer))
+          and (.staging_digest | nullable_digest)
+        );
+
+      .schema_version == "v1"
+      and (.run.id == $expected_run_id)
+      and (.run.attempt == $expected_run_attempt)
+      and (.run.started_at | type == "string")
+      and (.run.ended_at | nonempty_string)
+      and (.run.conclusion | IN("success", "failure", "cancelled", "skipped"))
+      and (.image.name | nonempty_string)
+      and (.image.source_tag | nonempty_string)
+      and (
+        if .run.conclusion == "success" then
+          (.image.target_ref | nonempty_string)
+          and (.image.manifest_digest | digest)
+          and (.scan.before | scan)
+          and (.scan.after | scan)
+        else
+          (.image.target_ref | nullable_string)
+          and (.image.manifest_digest | nullable_digest)
+          and (.scan.before == null or (.scan.before | scan))
+          and (.scan.after == null or (.scan.after | scan))
+        end
+      )
+      and (.platforms.amd64 | platform("amd64"))
+      and (.platforms.arm64 | platform("arm64"))
+      and (.supply_chain.rekor_url | nullable_string)
+      and (.supply_chain.attestation_id | nullable_string)
+      and (.supply_chain.sbom_digest | nullable_digest)
+      and (.supply_chain.attestation_bundle_path | nullable_string)
+    ' "$file" >/dev/null; then
+    echo "Invalid metrics JSON: $file" >&2
+    exit 1
+  fi
+done
+
+echo "Validated ${#files[@]} metrics file(s) for run $RUN_ID attempt $RUN_ATTEMPT"

--- a/.github/scripts/validate-metrics-json.sh
+++ b/.github/scripts/validate-metrics-json.sh
@@ -28,7 +28,7 @@ if [ "${#files[@]}" -eq 0 ]; then
 fi
 
 for file in "${files[@]}"; do
-  if ! jq -e \
+  if ! jq -se \
     --argjson expected_run_id "$RUN_ID" \
     --argjson expected_run_attempt "$RUN_ATTEMPT" '
       def integer: type == "number" and floor == .;
@@ -64,33 +64,42 @@ for file in "${files[@]}"; do
           and (.staging_digest | nullable_digest)
         );
 
-      .schema_version == "v1"
-      and (.run.id == $expected_run_id)
-      and (.run.attempt == $expected_run_attempt)
-      and (.run.started_at | type == "string")
-      and (.run.ended_at | nonempty_string)
-      and (.run.conclusion | IN("success", "failure", "cancelled", "skipped"))
-      and (.image.name | nonempty_string)
-      and (.image.source_tag | nonempty_string)
-      and (
-        if .run.conclusion == "success" then
-          (.image.target_ref | nonempty_string)
-          and (.image.manifest_digest | digest)
-          and (.scan.before | scan)
-          and (.scan.after | scan)
-        else
-          (.image.target_ref | nullable_string)
-          and (.image.manifest_digest | nullable_digest)
-          and (.scan.before == null or (.scan.before | scan))
-          and (.scan.after == null or (.scan.after | scan))
-        end
+      length == 1
+      and (.[0] |
+        type == "object"
+        and (.run | type == "object")
+        and (.image | type == "object")
+        and (.scan | type == "object")
+        and (.platforms | type == "object")
+        and (.supply_chain | type == "object")
+        and .schema_version == "v1"
+        and (.run.id == $expected_run_id)
+        and (.run.attempt == $expected_run_attempt)
+        and (.run.started_at | nonempty_string)
+        and (.run.ended_at | nonempty_string)
+        and (.run.conclusion | IN("success", "failure", "cancelled", "skipped"))
+        and (.image.name | nonempty_string)
+        and (.image.source_tag | nonempty_string)
+        and (
+          if .run.conclusion == "success" then
+            (.image.target_ref | nonempty_string)
+            and (.image.manifest_digest | digest)
+            and (.scan.before | scan)
+            and (.scan.after | scan)
+          else
+            (.image.target_ref | nullable_string)
+            and (.image.manifest_digest | nullable_digest)
+            and (.scan.before == null or (.scan.before | scan))
+            and (.scan.after == null or (.scan.after | scan))
+          end
+        )
+        and (.platforms.amd64 | platform("amd64"))
+        and (.platforms.arm64 | platform("arm64"))
+        and (.supply_chain.rekor_url | nullable_string)
+        and (.supply_chain.attestation_id | nullable_string)
+        and (.supply_chain.sbom_digest | nullable_digest)
+        and (.supply_chain.attestation_bundle_path | nullable_string)
       )
-      and (.platforms.amd64 | platform("amd64"))
-      and (.platforms.arm64 | platform("arm64"))
-      and (.supply_chain.rekor_url | nullable_string)
-      and (.supply_chain.attestation_id | nullable_string)
-      and (.supply_chain.sbom_digest | nullable_digest)
-      and (.supply_chain.attestation_bundle_path | nullable_string)
     ' "$file" >/dev/null; then
     echo "Invalid metrics JSON: $file" >&2
     exit 1

--- a/.github/scripts/validate-metrics-json_test.sh
+++ b/.github/scripts/validate-metrics-json_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression checks for archived metrics validation.
+
+ROOT=$(git rev-parse --show-toplevel)
+VALIDATOR="$ROOT/.github/scripts/validate-metrics-json.sh"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+expect_failure() {
+  local label=$1
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "expected failure: $label" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$TMPDIR/valid"
+cat > "$TMPDIR/valid/metrics-example-1.2.3.json" <<'JSON'
+{
+  "schema_version": "v1",
+  "run": {
+    "id": 42,
+    "attempt": 3,
+    "started_at": "2026-07-14T00:00:00Z",
+    "ended_at": "2026-07-14T00:01:00Z",
+    "conclusion": "success"
+  },
+  "image": {
+    "name": "example",
+    "source_tag": "1.2.3",
+    "target_ref": "ghcr.io/verity-org/example:1.2.3",
+    "manifest_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "scan": {
+    "before": {
+      "vuln_count": 3,
+      "by_severity": {"CRITICAL": 1, "HIGH": 1, "MEDIUM": 1, "LOW": 0, "UNKNOWN": 0}
+    },
+    "after": {
+      "vuln_count": 1,
+      "by_severity": {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
+    }
+  },
+  "platforms": {
+    "amd64": {"arch": "amd64", "copa_duration_seconds": 12, "copa_exit_code": 0, "staging_digest": null},
+    "arm64": null
+  },
+  "supply_chain": {
+    "rekor_url": null,
+    "attestation_id": null,
+    "sbom_digest": null,
+    "attestation_bundle_path": null
+  }
+}
+JSON
+
+bash "$VALIDATOR" 42 3 "$TMPDIR/valid"
+
+mkdir -p "$TMPDIR/failure"
+jq '
+  .run.conclusion = "failure"
+  | .image.target_ref = null
+  | .image.manifest_digest = null
+  | .scan.before = null
+  | .scan.after = null
+' "$TMPDIR/valid/metrics-example-1.2.3.json" \
+  > "$TMPDIR/failure/metrics-example-1.2.3.json"
+bash "$VALIDATOR" 42 3 "$TMPDIR/failure"
+
+mkdir -p "$TMPDIR/null-target"
+jq '.image.target_ref = null' "$TMPDIR/valid/metrics-example-1.2.3.json" \
+  > "$TMPDIR/null-target/metrics-example-1.2.3.json"
+expect_failure "successful record without target" \
+  bash "$VALIDATOR" 42 3 "$TMPDIR/null-target"
+
+mkdir -p "$TMPDIR/wrong-run"
+cp "$TMPDIR/valid/metrics-example-1.2.3.json" \
+  "$TMPDIR/wrong-run/metrics-example-1.2.3.json"
+expect_failure "record from another workflow run" \
+  bash "$VALIDATOR" 43 3 "$TMPDIR/wrong-run"
+
+mkdir -p "$TMPDIR/bad-total"
+jq '.scan.after.vuln_count = 2' "$TMPDIR/valid/metrics-example-1.2.3.json" \
+  > "$TMPDIR/bad-total/metrics-example-1.2.3.json"
+expect_failure "severity total mismatch" \
+  bash "$VALIDATOR" 42 3 "$TMPDIR/bad-total"
+
+mkdir -p "$TMPDIR/empty"
+expect_failure "missing metrics files" bash "$VALIDATOR" 42 3 "$TMPDIR/empty"
+
+echo "metrics JSON validation checks passed"

--- a/.github/scripts/validate-metrics-json_test.sh
+++ b/.github/scripts/validate-metrics-json_test.sh
@@ -88,6 +88,32 @@ jq '.scan.after.vuln_count = 2' "$TMPDIR/valid/metrics-example-1.2.3.json" \
 expect_failure "severity total mismatch" \
   bash "$VALIDATOR" 42 3 "$TMPDIR/bad-total"
 
+mkdir -p "$TMPDIR/multi-document"
+{
+  echo '{}'
+  cat "$TMPDIR/valid/metrics-example-1.2.3.json"
+} > "$TMPDIR/multi-document/metrics-example-1.2.3.json"
+expect_failure "multiple JSON documents" \
+  bash "$VALIDATOR" 42 3 "$TMPDIR/multi-document"
+
+mkdir -p "$TMPDIR/missing-platforms"
+jq 'del(.platforms)' "$TMPDIR/failure/metrics-example-1.2.3.json" \
+  > "$TMPDIR/missing-platforms/metrics-example-1.2.3.json"
+expect_failure "missing platforms container" \
+  bash "$VALIDATOR" 42 3 "$TMPDIR/missing-platforms"
+
+mkdir -p "$TMPDIR/missing-supply-chain"
+jq 'del(.supply_chain)' "$TMPDIR/failure/metrics-example-1.2.3.json" \
+  > "$TMPDIR/missing-supply-chain/metrics-example-1.2.3.json"
+expect_failure "missing supply-chain container" \
+  bash "$VALIDATOR" 42 3 "$TMPDIR/missing-supply-chain"
+
+mkdir -p "$TMPDIR/empty-started-at"
+jq '.run.started_at = ""' "$TMPDIR/valid/metrics-example-1.2.3.json" \
+  > "$TMPDIR/empty-started-at/metrics-example-1.2.3.json"
+expect_failure "empty start timestamp" \
+  bash "$VALIDATOR" 42 3 "$TMPDIR/empty-started-at"
+
 mkdir -p "$TMPDIR/empty"
 expect_failure "missing metrics files" bash "$VALIDATOR" 42 3 "$TMPDIR/empty"
 

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -54,6 +54,20 @@ def self_test() -> None:
         bounded_step is not None and "retention-days: 7" not in bounded_step,
         "step lookup must stop at the next sibling step",
     )
+    unnamed_sibling = named_step_body(
+        """      - name: Upload metrics artifact
+        with:
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+""",
+        "Upload metrics artifact",
+    )
+    require(
+        unnamed_sibling is not None and "retention-days: 1" not in unnamed_sibling,
+        "step lookup must stop at unnamed sibling steps",
+    )
     require(
         named_step_body(
             """      - name: Upload metrics artifact
@@ -84,8 +98,11 @@ def self_test() -> None:
     )
     for top_level in (
         "permissions:\n  actions: write\n",
+        'permissions:\n  "actions": read\n',
+        "permissions:\n  'actions': write\n",
         "permissions: write-all\n",
         "permissions: read-all\n",
+        '"permissions": "write-all"\n',
     ):
         require(
             top_level_grants_actions(top_level),

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -18,8 +18,28 @@ def self_test() -> None:
         "commented workflow commands must not satisfy guards",
     )
     require(
+        "validate-metrics-json_test.sh" not in uncomment_yaml(
+            "run: # bash .github/scripts/validate-metrics-json_test.sh"
+        ),
+        "inline YAML comments must not satisfy guards",
+    )
+    require(
         named_step_body("steps:\n", "Upload metrics artifact") is None,
         "missing workflow steps must return a controlled result",
+    )
+    bounded_step = named_step_body(
+        """      - name: Upload metrics artifact
+        with:
+          retention-days: 1
+      - name: Later step
+        with:
+          retention-days: 7
+""",
+        "Upload metrics artifact",
+    )
+    require(
+        bounded_step is not None and "retention-days: 7" not in bounded_step,
+        "step lookup must stop at the next sibling step",
     )
     archive = """  archive-metrics:
     secrets:
@@ -35,6 +55,15 @@ def self_test() -> None:
         ),
         "additional archive secrets must be rejected",
     )
+    for top_level in (
+        "permissions:\n  actions: write\n",
+        "permissions: write-all\n",
+        "permissions: read-all\n",
+    ):
+        require(
+            top_level_grants_actions(top_level),
+            "top-level Actions permission forms must be detected",
+        )
 
 
 def require(condition: bool, message: str) -> None:
@@ -44,16 +73,53 @@ def require(condition: bool, message: str) -> None:
 
 
 def uncomment_yaml(text: str) -> str:
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
+    lines: list[str] = []
+    for line in text.splitlines():
+        single_quoted = False
+        double_quoted = False
+        comment_at: int | None = None
+        for index, character in enumerate(line):
+            if character == "'" and not double_quoted:
+                single_quoted = not single_quoted
+            elif character == '"' and not single_quoted:
+                double_quoted = not double_quoted
+            elif (
+                character == "#"
+                and not single_quoted
+                and not double_quoted
+                and (index == 0 or line[index - 1].isspace())
+            ):
+                comment_at = index
+                break
+        active = line if comment_at is None else line[:comment_at]
+        if active.strip():
+            lines.append(active.rstrip())
+    return "\n".join(lines)
 
 
 def named_step_body(text: str, step_name: str) -> str | None:
-    parts = text.rsplit(f"- name: {step_name}", 1)
-    if len(parts) != 2:
+    lines = text.splitlines()
+    start = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.lstrip() == f"- name: {step_name}"
+        ),
+        None,
+    )
+    if start is None:
         return None
-    return parts[1]
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if (
+            len(line) - len(line.lstrip()) == indent
+            and line.lstrip().startswith("- name:")
+        ):
+            end = index
+            break
+    return "\n".join(lines[start:end])
 
 
 def has_only_archive_token(job: str) -> bool:
@@ -63,6 +129,17 @@ def has_only_archive_token(job: str) -> bool:
     return secret_lines == [
         "archive-token: ${{ secrets.GITHUB_TOKEN }}"
     ] and "secrets: inherit" not in job
+
+
+def top_level_grants_actions(text: str) -> bool:
+    for line in uncomment_yaml(text).splitlines():
+        stripped = line.strip()
+        if "actions:" in stripped or stripped in {
+            "permissions: read-all",
+            "permissions: write-all",
+        }:
+            return True
+    return False
 
 
 def job_body(text: str, job: str) -> str:
@@ -148,7 +225,7 @@ def main() -> None:
     )
     top_level = uncommented.split("jobs:", 1)[0]
     require(
-        "actions: read" not in top_level
+        not top_level_grants_actions(top_level)
         and "permissions:\n      contents: write\n      actions: read" in archive,
         "artifact read access must be scoped to the archive job",
     )

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -6,6 +6,8 @@ import sys
 
 
 WORKFLOW = Path(".github/workflows/patch-image.yaml")
+METRICS_WORKFLOW = Path(".github/workflows/metrics-finalize.yaml")
+CI_WORKFLOW = Path(".github/workflows/ci.yaml")
 
 
 def require(condition: bool, message: str) -> None:
@@ -33,8 +35,15 @@ def job_body(text: str, job: str) -> str:
 
 def main() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
+    metrics_text = METRICS_WORKFLOW.read_text(encoding="utf-8")
+    ci_text = CI_WORKFLOW.read_text(encoding="utf-8")
     uncommented = "\n".join(
         line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+    metrics_uncommented = "\n".join(
+        line
+        for line in metrics_text.splitlines()
+        if not line.lstrip().startswith("#")
     )
 
     require(
@@ -69,6 +78,57 @@ def main() -> None:
     require(
         '--arg conclusion "${FINALIZE_CONCLUSION}"' in uncommented,
         "metrics JSON must use resolved finalize conclusion",
+    )
+    require(
+        'if [ -z "$TARGET_REF" ] || [ -z "$MANIFEST_DIGEST" ]; then'
+        in uncommented,
+        "successful metrics must require published target and manifest outputs",
+    )
+    require(
+        "- name: Resolve target manifest" in finalize
+        and "id: target" in finalize
+        and 'TARGET_REF: ${{ steps.target.outputs.final-tag }}' in finalize
+        and 'MANIFEST_DIGEST: ${{ steps.target.outputs.digest }}' in finalize,
+        "metrics must resolve the target even when the publish step is a no-op",
+    )
+
+    archive = job_body(uncommented, "archive-metrics")
+    require(
+        "uses: ./.github/workflows/metrics-finalize.yaml" in archive,
+        "patch-image must call the metrics finalizer directly",
+    )
+    require(
+        'archive-token: ${{ secrets.GITHUB_TOKEN }}' in archive
+        and "secrets: inherit" not in archive,
+        "metrics finalization must receive only the repository token",
+    )
+    require(
+        "inputs.is-pr != true" in archive,
+        "PR patch runs must not write to the metrics archive",
+    )
+    require(
+        "workflow_call:" in metrics_uncommented
+        and "workflow_run:" not in metrics_uncommented,
+        "metrics finalization must be reusable instead of relying on workflow_run",
+    )
+    require(
+        "bash .github/scripts/validate-metrics-json.sh" in metrics_uncommented,
+        "metrics artifacts must be schema-validated before commit",
+    )
+    require(
+        "No metrics artifacts found" in metrics_uncommented,
+        "missing metrics artifacts must fail finalization",
+    )
+    failure_metrics = job_body(uncommented, "metrics-on-failure")
+    require(
+        "retention-days: 7" in finalize.rsplit("- name: Upload metrics artifact", 1)[1]
+        and "retention-days: 7"
+        in failure_metrics.rsplit("- name: Upload metrics artifact", 1)[1],
+        "metrics artifacts must remain recoverable for seven days",
+    )
+    require(
+        "bash .github/scripts/validate-metrics-json_test.sh" in ci_text,
+        "CI must run the metrics JSON validator regression checks",
     )
 
 

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -10,10 +10,59 @@ METRICS_WORKFLOW = Path(".github/workflows/metrics-finalize.yaml")
 CI_WORKFLOW = Path(".github/workflows/ci.yaml")
 
 
+def self_test() -> None:
+    require(
+        "validate-metrics-json_test.sh" not in uncomment_yaml(
+            "# bash .github/scripts/validate-metrics-json_test.sh"
+        ),
+        "commented workflow commands must not satisfy guards",
+    )
+    require(
+        named_step_body("steps:\n", "Upload metrics artifact") is None,
+        "missing workflow steps must return a controlled result",
+    )
+    archive = """  archive-metrics:
+    secrets:
+      archive-token: ${{ secrets.GITHUB_TOKEN }}
+"""
+    require(
+        has_only_archive_token(archive),
+        "the archive job's sole token mapping must be accepted",
+    )
+    require(
+        not has_only_archive_token(
+            archive + "      extra-token: ${{ secrets.EXTRA_TOKEN }}\n"
+        ),
+        "additional archive secrets must be rejected",
+    )
+
+
 def require(condition: bool, message: str) -> None:
     if not condition:
         print(f"patch-image workflow check failed: {message}", file=sys.stderr)
         sys.exit(1)
+
+
+def uncomment_yaml(text: str) -> str:
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def named_step_body(text: str, step_name: str) -> str | None:
+    parts = text.rsplit(f"- name: {step_name}", 1)
+    if len(parts) != 2:
+        return None
+    return parts[1]
+
+
+def has_only_archive_token(job: str) -> bool:
+    secret_lines = [
+        line.strip() for line in job.splitlines() if "${{ secrets." in line
+    ]
+    return secret_lines == [
+        "archive-token: ${{ secrets.GITHUB_TOKEN }}"
+    ] and "secrets: inherit" not in job
 
 
 def job_body(text: str, job: str) -> str:
@@ -34,17 +83,13 @@ def job_body(text: str, job: str) -> str:
 
 
 def main() -> None:
+    self_test()
     text = WORKFLOW.read_text(encoding="utf-8")
     metrics_text = METRICS_WORKFLOW.read_text(encoding="utf-8")
     ci_text = CI_WORKFLOW.read_text(encoding="utf-8")
-    uncommented = "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-    metrics_uncommented = "\n".join(
-        line
-        for line in metrics_text.splitlines()
-        if not line.lstrip().startswith("#")
-    )
+    uncommented = uncomment_yaml(text)
+    metrics_uncommented = uncomment_yaml(metrics_text)
+    ci_uncommented = uncomment_yaml(ci_text)
 
     require(
         "docker/login-action" not in uncommented,
@@ -98,9 +143,14 @@ def main() -> None:
         "patch-image must call the metrics finalizer directly",
     )
     require(
-        'archive-token: ${{ secrets.GITHUB_TOKEN }}' in archive
-        and "secrets: inherit" not in archive,
+        has_only_archive_token(archive),
         "metrics finalization must receive only the repository token",
+    )
+    top_level = uncommented.split("jobs:", 1)[0]
+    require(
+        "actions: read" not in top_level
+        and "permissions:\n      contents: write\n      actions: read" in archive,
+        "artifact read access must be scoped to the archive job",
     )
     require(
         "inputs.is-pr != true" in archive,
@@ -120,15 +170,23 @@ def main() -> None:
         "missing metrics artifacts must fail finalization",
     )
     failure_metrics = job_body(uncommented, "metrics-on-failure")
+    finalize_upload = named_step_body(finalize, "Upload metrics artifact")
+    failure_upload = named_step_body(failure_metrics, "Upload metrics artifact")
     require(
-        "retention-days: 7" in finalize.rsplit("- name: Upload metrics artifact", 1)[1]
-        and "retention-days: 7"
-        in failure_metrics.rsplit("- name: Upload metrics artifact", 1)[1],
+        finalize_upload is not None
+        and "retention-days: 7" in finalize_upload
+        and failure_upload is not None
+        and "retention-days: 7" in failure_upload,
         "metrics artifacts must remain recoverable for seven days",
     )
     require(
-        "bash .github/scripts/validate-metrics-json_test.sh" in ci_text,
+        "bash .github/scripts/validate-metrics-json_test.sh" in ci_uncommented,
         "CI must run the metrics JSON validator regression checks",
+    )
+    require(
+        uncommented.count("--jq '.run_started_at'") == 2
+        and "--jq '.run_started_at' 2>/dev/null" not in uncommented,
+        "metrics producers must fail instead of recording an empty start timestamp",
     )
 
 

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -4,6 +4,13 @@
 from pathlib import Path
 import sys
 
+from workflow_validation import (
+    has_only_archive_token,
+    named_step_body,
+    top_level_grants_actions,
+    uncomment_yaml,
+)
+
 
 WORKFLOW = Path(".github/workflows/patch-image.yaml")
 METRICS_WORKFLOW = Path(".github/workflows/metrics-finalize.yaml")
@@ -24,6 +31,12 @@ def self_test() -> None:
         "inline YAML comments must not satisfy guards",
     )
     require(
+        "validate-metrics-json_test.sh" in uncomment_yaml(
+            'run: "printf \\" # literal; bash .github/scripts/validate-metrics-json_test.sh"'
+        ),
+        "hashes inside double-quoted YAML with escaped quotes must remain active",
+    )
+    require(
         named_step_body("steps:\n", "Upload metrics artifact") is None,
         "missing workflow steps must return a controlled result",
     )
@@ -40,6 +53,20 @@ def self_test() -> None:
     require(
         bounded_step is not None and "retention-days: 7" not in bounded_step,
         "step lookup must stop at the next sibling step",
+    )
+    require(
+        named_step_body(
+            """      - name: Upload metrics artifact
+        with:
+          retention-days: 7
+      - name: Upload metrics artifact
+        with:
+          retention-days: 1
+""",
+            "Upload metrics artifact",
+        )
+        is None,
+        "duplicate named workflow steps must be rejected",
     )
     archive = """  archive-metrics:
     secrets:
@@ -70,76 +97,6 @@ def require(condition: bool, message: str) -> None:
     if not condition:
         print(f"patch-image workflow check failed: {message}", file=sys.stderr)
         sys.exit(1)
-
-
-def uncomment_yaml(text: str) -> str:
-    lines: list[str] = []
-    for line in text.splitlines():
-        single_quoted = False
-        double_quoted = False
-        comment_at: int | None = None
-        for index, character in enumerate(line):
-            if character == "'" and not double_quoted:
-                single_quoted = not single_quoted
-            elif character == '"' and not single_quoted:
-                double_quoted = not double_quoted
-            elif (
-                character == "#"
-                and not single_quoted
-                and not double_quoted
-                and (index == 0 or line[index - 1].isspace())
-            ):
-                comment_at = index
-                break
-        active = line if comment_at is None else line[:comment_at]
-        if active.strip():
-            lines.append(active.rstrip())
-    return "\n".join(lines)
-
-
-def named_step_body(text: str, step_name: str) -> str | None:
-    lines = text.splitlines()
-    start = next(
-        (
-            index
-            for index, line in enumerate(lines)
-            if line.lstrip() == f"- name: {step_name}"
-        ),
-        None,
-    )
-    if start is None:
-        return None
-    indent = len(lines[start]) - len(lines[start].lstrip())
-    end = len(lines)
-    for index in range(start + 1, len(lines)):
-        line = lines[index]
-        if (
-            len(line) - len(line.lstrip()) == indent
-            and line.lstrip().startswith("- name:")
-        ):
-            end = index
-            break
-    return "\n".join(lines[start:end])
-
-
-def has_only_archive_token(job: str) -> bool:
-    secret_lines = [
-        line.strip() for line in job.splitlines() if "${{ secrets." in line
-    ]
-    return secret_lines == [
-        "archive-token: ${{ secrets.GITHUB_TOKEN }}"
-    ] and "secrets: inherit" not in job
-
-
-def top_level_grants_actions(text: str) -> bool:
-    for line in uncomment_yaml(text).splitlines():
-        stripped = line.strip()
-        if "actions:" in stripped or stripped in {
-            "permissions: read-all",
-            "permissions: write-all",
-        }:
-            return True
-    return False
 
 
 def job_body(text: str, job: str) -> str:

--- a/.github/scripts/workflow_validation.py
+++ b/.github/scripts/workflow_validation.py
@@ -48,9 +48,10 @@ def named_step_body(text: str, step_name: str) -> str | None:
     end = len(lines)
     for index in range(start + 1, len(lines)):
         line = lines[index]
+        stripped = line.lstrip()
         if (
-            len(line) - len(line.lstrip()) == indent
-            and line.lstrip().startswith("- name:")
+            len(line) - len(stripped) == indent
+            and (stripped == "-" or stripped.startswith("- "))
         ):
             end = index
             break
@@ -69,9 +70,14 @@ def has_only_archive_token(job: str) -> bool:
 def top_level_grants_actions(text: str) -> bool:
     for line in uncomment_yaml(text).splitlines():
         stripped = line.strip()
-        if "actions:" in stripped or stripped in {
-            "permissions: read-all",
-            "permissions: write-all",
-        }:
+        key, separator, value = stripped.partition(":")
+        if not separator:
+            continue
+        normalized_key = key.strip().strip("'\"")
+        normalized_value = value.strip().strip("'\"")
+        if normalized_key == "actions" or (
+            normalized_key == "permissions"
+            and normalized_value in {"read-all", "write-all"}
+        ):
             return True
     return False

--- a/.github/scripts/workflow_validation.py
+++ b/.github/scripts/workflow_validation.py
@@ -1,0 +1,77 @@
+"""Text helpers for workflow policy validators."""
+
+
+def uncomment_yaml(text: str) -> str:
+    lines: list[str] = []
+    for line in text.splitlines():
+        single_quoted = False
+        double_quoted = False
+        comment_at: int | None = None
+        for index, character in enumerate(line):
+            if character == "'" and not double_quoted:
+                single_quoted = not single_quoted
+            elif (
+                character == '"'
+                and not single_quoted
+                and (
+                    len(line[:index]) - len(line[:index].rstrip("\\"))
+                )
+                % 2
+                == 0
+            ):
+                double_quoted = not double_quoted
+            elif (
+                character == "#"
+                and not single_quoted
+                and not double_quoted
+                and (index == 0 or line[index - 1].isspace())
+            ):
+                comment_at = index
+                break
+        active = line if comment_at is None else line[:comment_at]
+        if active.strip():
+            lines.append(active.rstrip())
+    return "\n".join(lines)
+
+
+def named_step_body(text: str, step_name: str) -> str | None:
+    lines = text.splitlines()
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if line.lstrip() == f"- name: {step_name}"
+    ]
+    if len(starts) != 1:
+        return None
+    start = starts[0]
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if (
+            len(line) - len(line.lstrip()) == indent
+            and line.lstrip().startswith("- name:")
+        ):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def has_only_archive_token(job: str) -> bool:
+    secret_lines = [
+        line.strip() for line in job.splitlines() if "${{ secrets." in line
+    ]
+    return secret_lines == [
+        "archive-token: ${{ secrets.GITHUB_TOKEN }}"
+    ] and "secrets: inherit" not in job
+
+
+def top_level_grants_actions(text: str) -> bool:
+    for line in uncomment_yaml(text).splitlines():
+        stripped = line.strip()
+        if "actions:" in stripped or stripped in {
+            "permissions: read-all",
+            "permissions: write-all",
+        }:
+            return True
+    return False

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,6 +170,9 @@ jobs:
       - name: Validate patch-image workflow guards
         run: python3 .github/scripts/validate-patch-image-workflow.py
 
+      - name: Validate metrics JSON guards
+        run: bash .github/scripts/validate-metrics-json_test.sh
+
       - name: Validate integer-build-image workflow guards
         run: python3 .github/scripts/validate-integer-build-image-workflow.py
 

--- a/.github/workflows/metrics-finalize.yaml
+++ b/.github/workflows/metrics-finalize.yaml
@@ -1,16 +1,27 @@
 name: Metrics Finalize
 
 on:
-  workflow_run:
-    workflows: ["Patch Image"]
-    types: [completed]
+  workflow_call:
+    inputs:
+      run-id:
+        description: "Patch Image workflow run containing metrics artifacts"
+        required: true
+        type: string
+      run-attempt:
+        description: "Patch Image workflow run attempt"
+        required: true
+        type: string
+    secrets:
+      archive-token:
+        description: "Token scoped to reading artifacts and writing the archive branch"
+        required: true
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: metrics-finalize-${{ github.event.workflow_run.id }}
+  group: metrics-finalize-${{ inputs.run-id }}
   cancel-in-progress: false
 
 jobs:
@@ -34,39 +45,51 @@ jobs:
       - name: Probe artifact existence
         id: probe
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.archive-token }}
+          RUN_ID: ${{ inputs.run-id }}
         run: |
           set -euo pipefail
-          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" \
+          COUNT=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts" \
             --jq '[.artifacts[] | select(.name | startswith("metrics-"))] | length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::No metrics artifacts found for run ${RUN_ID}"
+            exit 1
+          fi
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 
       - name: Download metrics artifacts
-        if: steps.probe.outputs.count != '0'
         id: download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.run-id }}
+          github-token: ${{ secrets.archive-token }}
           pattern: metrics-*
           merge-multiple: true
           path: ./downloaded-metrics
 
-      - name: Check for metrics
-        id: check
-        if: steps.probe.outputs.count != '0'
+      - name: Validate metrics
+        env:
+          RUN_ID: ${{ inputs.run-id }}
+          RUN_ATTEMPT: ${{ inputs.run-attempt }}
         run: |
-          shopt -s nullglob
-          files=( ./downloaded-metrics/metrics-*.json )
-          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
-          ls -la ./downloaded-metrics/ 2>/dev/null || true
+          bash .github/scripts/validate-metrics-json.sh \
+            "$RUN_ID" "$RUN_ATTEMPT" ./downloaded-metrics
+
+      - name: Resolve workflow creation time
+        id: metadata
+        env:
+          GH_TOKEN: ${{ secrets.archive-token }}
+          RUN_ID: ${{ inputs.run-id }}
+        run: |
+          set -euo pipefail
+          created_at=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.created_at')
+          echo "created-at=${created_at}" >> "$GITHUB_OUTPUT"
 
       - name: Commit metrics to _metrics branch
-        if: steps.check.outputs.count != '0'
         env:
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-          RUN_CREATED_AT: ${{ github.event.workflow_run.created_at }}
+          RUN_ID: ${{ inputs.run-id }}
+          RUN_ATTEMPT: ${{ inputs.run-attempt }}
+          RUN_CREATED_AT: ${{ steps.metadata.outputs.created-at }}
         run: |
           set -euo pipefail
           DATE=$(date -u -d "${RUN_CREATED_AT}" +%Y-%m-%d)

--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -67,7 +67,6 @@ on:
 
 permissions:
   contents: write       # push to reports branch
-  actions: read         # download metrics artifacts in the archive workflow
   packages: write       # push images to GHCR
   id-token: write       # cosign keyless signing + actions/attest
   attestations: write   # actions/attest
@@ -822,7 +821,7 @@ jobs:
         run: |
           set -euo pipefail
           OUT="metrics-${SAFE_NAME}-${SOURCE_TAG}.json"
-          STARTED_AT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq '.run_started_at' 2>/dev/null || true)
+          STARTED_AT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq '.run_started_at')
           FINALIZE_CONCLUSION="success"
           for outcome in \
             "$HARDEN_OUTCOME" \
@@ -964,7 +963,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          STARTED_AT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq '.run_started_at' 2>/dev/null || echo "")
+          STARTED_AT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq '.run_started_at')
           echo "value=${STARTED_AT}" >> "$GITHUB_OUTPUT"
 
       - name: Build minimal failure metrics JSON
@@ -1030,6 +1029,9 @@ jobs:
     name: Archive Metrics
     needs: [scan, patch, finalize, metrics-on-failure]
     if: ${{ always() && !cancelled() && inputs.is-pr != true && needs.scan.outputs.needs-patch == 'true' }}
+    permissions:
+      contents: write
+      actions: read
     uses: ./.github/workflows/metrics-finalize.yaml
     with:
       run-id: ${{ github.run_id }}

--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -67,6 +67,7 @@ on:
 
 permissions:
   contents: write       # push to reports branch
+  actions: read         # download metrics artifacts in the archive workflow
   packages: write       # push images to GHCR
   id-token: write       # cosign keyless signing + actions/attest
   attestations: write   # actions/attest
@@ -577,6 +578,22 @@ jobs:
             echo "FINAL_REPO=${FINAL_REPO}"
           } >> "$GITHUB_ENV"
 
+      - name: Resolve target manifest
+        id: target
+        if: ${{ !cancelled() && inputs.is-pr == false }}
+        env:
+          IMAGE_NAME: ${{ inputs.image-name }}
+          SOURCE_TAG: ${{ needs.scan.outputs.source-tag }}
+          TARGET_REGISTRY: ${{ inputs.target-registry }}
+        run: |
+          set -euo pipefail
+          FINAL_TAG="${TARGET_REGISTRY}/${IMAGE_NAME}:${SOURCE_TAG}"
+          DIGEST=$(crane digest "$FINAL_TAG")
+          {
+            echo "digest=${DIGEST}"
+            echo "final-tag=${FINAL_TAG}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Sign manifest with cosign
         id: cosign-sign
         if: steps.compare.outputs.changed == 'true' && inputs.is-pr == false
@@ -663,7 +680,7 @@ jobs:
             --name "patch-image.finalize" \
             --service verity-ci \
             --kind internal \
-            --attrs "image=${{ inputs.image-name }},source_tag=${{ needs.scan.outputs.source-tag }},manifest_digest=${{ steps.push.outputs.digest }},final_tag=${{ steps.push.outputs.final-tag }},final_repo=${{ steps.push.outputs.final-repo }},post_scan_vuln_count=${{ steps.postscan.outputs.vuln-count }},rekor_url=${{ steps.cosign-sign.outputs.rekor-url }},attestation_id=${{ steps.attest.outputs.attestation-id }},attestation_bundle_path=${{ steps.attest.outputs.bundle-path }},deployment.environment=verity-prod"
+            --attrs "image=${{ inputs.image-name }},source_tag=${{ needs.scan.outputs.source-tag }},manifest_digest=${{ steps.target.outputs.digest }},final_tag=${{ steps.target.outputs.final-tag }},final_repo=${{ steps.push.outputs.final-repo }},post_scan_vuln_count=${{ steps.postscan.outputs.vuln-count }},rekor_url=${{ steps.cosign-sign.outputs.rekor-url }},attestation_id=${{ steps.attest.outputs.attestation-id }},attestation_bundle_path=${{ steps.attest.outputs.bundle-path }},deployment.environment=verity-prod"
 
       - name: Push reports to reports branch
         id: push-reports
@@ -800,6 +817,8 @@ jobs:
           UPLOAD_PR_SCAN_OUTCOME: ${{ steps.upload-pr-scan.outcome }}
           PL_DOWNLOAD_OUTCOME: ${{ steps.pl-download.outcome }}
           PL_MERGE_OUTCOME: ${{ steps.pl-merged.outcome }}
+          TARGET_REF: ${{ steps.target.outputs.final-tag }}
+          MANIFEST_DIGEST: ${{ steps.target.outputs.digest }}
         run: |
           set -euo pipefail
           OUT="metrics-${SAFE_NAME}-${SOURCE_TAG}.json"
@@ -830,6 +849,9 @@ jobs:
               FINALIZE_CONCLUSION="failure"
             fi
           done
+          if [ -z "$TARGET_REF" ] || [ -z "$MANIFEST_DIGEST" ]; then
+            FINALIZE_CONCLUSION="failure"
+          fi
 
           SEVERITIES_BEFORE=$(jq -c '
             {CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0, UNKNOWN: 0} +
@@ -854,8 +876,8 @@ jobs:
             --arg conclusion "${FINALIZE_CONCLUSION}" \
             --arg image_name "${{ inputs.image-name }}" \
             --arg source_tag "${SOURCE_TAG}" \
-            --arg target_ref "${{ steps.push.outputs.final-tag }}" \
-            --arg manifest_digest "${{ steps.push.outputs.digest }}" \
+            --arg target_ref "$TARGET_REF" \
+            --arg manifest_digest "$MANIFEST_DIGEST" \
             --argjson vuln_before "${VULN_BEFORE:-0}" \
             --argjson vuln_after "${VULN_AFTER:-0}" \
             --argjson sev_before "$SEVERITIES_BEFORE" \
@@ -908,7 +930,7 @@ jobs:
         with:
           name: metrics-${{ needs.scan.outputs.safe-name }}-${{ needs.scan.outputs.source-tag }}
           path: ${{ steps.metrics-json.outputs.filename }}
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: error
 
   # ── Job 4: Metrics on Failure ─────────────────────────────────────
@@ -998,5 +1020,19 @@ jobs:
         with:
           name: metrics-${{ needs.scan.outputs.safe-name }}-${{ needs.scan.outputs.source-tag }}
           path: ${{ steps.metrics-json.outputs.filename }}
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: error
+
+  # Call the archive workflow directly. Runs dispatched by GITHUB_TOKEN do not
+  # emit a downstream workflow_run event, but nested reusable workflows remain
+  # part of this run and can consume its completed metrics artifact.
+  archive-metrics:
+    name: Archive Metrics
+    needs: [scan, patch, finalize, metrics-on-failure]
+    if: ${{ always() && !cancelled() && inputs.is-pr != true && needs.scan.outputs.needs-patch == 'true' }}
+    uses: ./.github/workflows/metrics-finalize.yaml
+    with:
+      run-id: ${{ github.run_id }}
+      run-attempt: ${{ github.run_attempt }}
+    secrets:
+      archive-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ lint-workflows:
 	@which actionlint > /dev/null || (echo "actionlint not found. Run: make install-tools" && exit 1)
 	actionlint
 	python3 .github/scripts/validate-patch-image-workflow.py
+	bash .github/scripts/validate-metrics-json_test.sh
 	python3 .github/scripts/validate-integer-build-image-workflow.py
 	python3 .github/scripts/validate-chart-integration-workflow.py
 	python3 .github/scripts/validate-nightly-workflows.py

--- a/_metrics/SCHEMA.md
+++ b/_metrics/SCHEMA.md
@@ -150,5 +150,5 @@ All fields marked nullable may be null when the upstream step was skipped or fai
 
 ## Producer / Consumer
 
-- **Producer**: `.github/workflows/patch-image.yaml` (final consolidate step), via `metrics-finalize.yaml` (workflow_run trigger)
+- **Producer**: `.github/workflows/patch-image.yaml` (final consolidate step), via the reusable `metrics-finalize.yaml` workflow
 - **Consumer**: `verity metrics` subcommand (Phase 4); Honeycomb dataset `verity-ci` (live observability via inline `otel-cli` spans, separate from this archive)

--- a/_metrics/SCHEMA.md
+++ b/_metrics/SCHEMA.md
@@ -93,7 +93,7 @@ _metrics/
 | `schema_version` | string | No | Schema version, currently "v1" |
 | `run.id` | integer | No | GitHub Actions workflow run ID |
 | `run.attempt` | integer | No | Run attempt number (1, 2, ...) |
-| `run.started_at` | string (ISO-8601) | Yes | Workflow start timestamp; empty string when the GitHub API lookup failed |
+| `run.started_at` | string (ISO-8601) | No | Workflow start timestamp; metrics production fails if it cannot be resolved |
 | `run.ended_at` | string (ISO-8601) | No | Workflow end timestamp |
 | `run.conclusion` | string | No | One of: success, failure, cancelled, skipped |
 | `image.name` | string | No | Full image name (e.g., "nginx") |


### PR DESCRIPTION
## Summary

- call metrics finalization directly as a reusable workflow so bot-dispatched patch runs are archived
- resolve the final target digest for both published and no-op patch runs
- reject missing or malformed metrics before committing to the orphan branch
- retain metrics artifacts for seven days and add CI regression coverage

## Root cause

The nightly orchestrator dispatches `patch-image.yaml` with `GITHUB_TOKEN`. GitHub creates the requested `workflow_dispatch` run, but suppresses the downstream `workflow_run` event that previously launched metrics finalization. Separately, successful no-op runs skipped the conditional push step, so their metrics used empty push outputs and recorded null target references.

## Validation

- `make lint-workflows`
- `mise x shellcheck@0.11.0 -- shellcheck .github/scripts/validate-metrics-json.sh .github/scripts/validate-metrics-json_test.sh`
- `yamllint -c .yamllint.yml .github/workflows/patch-image.yaml .github/workflows/metrics-finalize.yaml .github/workflows/ci.yaml`
- validated a real July 14 metrics artifact after resolving its existing target digest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores metrics archiving for Patch Image runs by calling the finalizer as a reusable workflow with explicit run context. Adds strict metrics JSON validation, closes workflow guard bypasses, and keeps artifacts for 7 days.

- Bug Fixes
  - Call `metrics-finalize.yaml` directly from `patch-image.yaml` (`archive-metrics` job) with `run-id` and `run-attempt`; use `archive-token` for artifact reads and commits; concurrency keyed by run ID.
  - Validate metrics with `.github/scripts/validate-metrics-json.sh`; fail when no metrics artifacts exist; add CI regression tests and `make lint-workflows`.
  - Resolve target tag and manifest digest even when publish is a no-op; require both for a “success” record; feed these into metrics and `otel-cli`.
  - Require `run_started_at`; remove the silent fallback; update `_metrics/SCHEMA.md`; archive uses the resolved workflow creation time.
  - Harden policy and text guards: pass only `secrets.GITHUB_TOKEN` as `archive-token` (no `secrets: inherit`), scope `actions: read` to the archive job, block top-level Actions permission grants, skip archiving for PR runs, enforce 7‑day retention on metrics artifacts, and strengthen validator parsing (robust YAML comment/quote handling, bounded step lookup, self-tests via `workflow_validation.py`).

<sup>Written for commit 3da95494b27b51069772b22ed92e79f7a720b115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

