### PR TITLE
feat(site): make machine-readable docs agent-friendly

### DIFF
--- a/site/src/lib/machine-docs.test.ts
+++ b/site/src/lib/machine-docs.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { totalCategories } from "../data/full-catalog.ts";
 import { renderIndexMarkdown } from "../pages/index.md.ts";
 import { renderLlmsText } from "../pages/llms.txt.ts";
+import { renderCategoryRows } from "./machine-docs.ts";
 
 const PREFIX = "https://example.test/";
 const CATEGORY_HEADER_PATTERN = /^categories\[14\]\{category,total,copa,wolfi\}:$/m;
@@ -37,4 +39,18 @@ test("renderIndexMarkdown exposes aggregates and contextual next actions", () =>
   assert.match(output, CATEGORY_HEADER_PATTERN);
   assert.ok(output.includes("## Next Actions"));
   assert.ok(!output.includes("Agent Interface"));
+});
+
+test("machine doc routes share the catalog category rows", () => {
+  // Given
+  const categoryRows = renderCategoryRows();
+
+  // When
+  const llmsText = renderLlmsText(PREFIX);
+  const indexMarkdown = renderIndexMarkdown(PREFIX);
+
+  // Then
+  assert.equal(categoryRows.split("\n").length, totalCategories);
+  assert.ok(llmsText.includes(categoryRows));
+  assert.ok(indexMarkdown.includes(categoryRows));
 });

--- a/site/src/lib/machine-docs.test.ts
+++ b/site/src/lib/machine-docs.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderIndexMarkdown } from "../pages/index.md.ts";
+import { renderLlmsText } from "../pages/llms.txt.ts";
+
+const PREFIX = "https://example.test/";
+const CATEGORY_HEADER_PATTERN = /^categories\[14\]\{category,total,copa,wolfi\}:$/m;
+
+test("renderLlmsText gives a concise live summary with a full-data escape hatch", () => {
+  // Given
+  const prefix = PREFIX;
+
+  // When
+  const output = renderLlmsText(prefix);
+
+  // Then
+  assert.ok(output.includes("scope: summary"));
+  assert.ok(output.includes("total_images: 314"));
+  assert.ok(output.includes("total_categories: 14"));
+  assert.ok(output.includes("full_reference: https://example.test/llms-full.txt"));
+  assert.match(output, CATEGORY_HEADER_PATTERN);
+  assert.ok(output.includes("next[6]{task,url}:"));
+  assert.ok(!output.includes("/axi"));
+});
+
+test("renderIndexMarkdown exposes aggregates and contextual next actions", () => {
+  // Given
+  const prefix = PREFIX;
+
+  // When
+  const output = renderIndexMarkdown(prefix);
+
+  // Then
+  assert.ok(output.includes("scope: overview"));
+  assert.ok(output.includes("total_images: 314"));
+  assert.ok(output.includes("full_reference: https://example.test/llms-full.txt"));
+  assert.match(output, CATEGORY_HEADER_PATTERN);
+  assert.ok(output.includes("## Next Actions"));
+  assert.ok(!output.includes("Agent Interface"));
+});

--- a/site/src/lib/machine-docs.ts
+++ b/site/src/lib/machine-docs.ts
@@ -1,0 +1,11 @@
+import { fullCatalog } from "../data/full-catalog.ts";
+
+export function renderCategoryRows(): string {
+  return fullCatalog
+    .map((category) => {
+      const copaImages = category.images.filter((image) => image.source === "copa").length;
+      const wolfiImages = category.images.length - copaImages;
+      return `  ${category.id},${category.images.length},${copaImages},${wolfiImages}`;
+    })
+    .join("\n");
+}

--- a/site/src/pages/index.md.ts
+++ b/site/src/pages/index.md.ts
@@ -8,32 +8,27 @@ import {
 } from "../data/full-catalog.ts";
 import { getChartsCatalog } from "../lib/charts.ts";
 
-export const GET: APIRoute = ({ site }) => {
-  const base = import.meta.env.BASE_URL;
-  const origin = site?.origin ?? "https://verity.supply";
-  const prefix = `${origin}${base}`;
-
-  const chartsCatalog = getChartsCatalog();
-  const chartCount = chartsCatalog.charts.length;
-
-  const categorySummary = fullCatalog
-    .map((cat) => {
-      const copaImgs = cat.images.filter((i) => i.source === "copa").length;
-      const wolfiImgs = cat.images.filter((i) => i.source === "integer").length;
-      const parts: string[] = [];
-      if (wolfiImgs > 0) {
-        parts.push(`${wolfiImgs} Wolfi`);
-      }
-      if (copaImgs > 0) {
-        parts.push(`${copaImgs} Copa`);
-      }
-      return `- **${cat.label}** — ${cat.images.length} images (${parts.join(", ")})`;
+export function renderIndexMarkdown(prefix: string): string {
+  const chartCount = getChartsCatalog().charts.length;
+  const categoryRows = fullCatalog
+    .map((category) => {
+      const copaImages = category.images.filter((image) => image.source === "copa").length;
+      const wolfiImages = category.images.length - copaImages;
+      return `  ${category.id},${category.images.length},${copaImages},${wolfiImages}`;
     })
     .join("\n");
 
-  const content = `# Verity — Security-Patched Container Images
+  return `# Verity — Security-Patched Container Images
 
 > Self-maintaining registry of security-patched container images. Scans, patches, signs, and publishes drop-in replacements to GitHub Container Registry.
+
+scope: overview
+total_images: ${totalImages}
+total_categories: ${totalCategories}
+copa_images: ${copaCount}
+wolfi_images: ${integerCount}
+helm_charts: ${chartCount}
+full_reference: ${prefix}llms-full.txt
 
 ## What Is Verity?
 
@@ -60,7 +55,8 @@ image: ghcr.io/verity-org/prometheus/prometheus:v3.9.1-patched
 
 ${totalImages} images across ${totalCategories} categories — ${copaCount} Copa-patched upstream images, ${integerCount} Wolfi-based hardened images, ${chartCount} Helm wrapper charts.
 
-${categorySummary}
+categories[${totalCategories}]{category,total,copa,wolfi}:
+${categoryRows}
 
 ## How It Works
 
@@ -74,16 +70,24 @@ ${categorySummary}
 
 Every image carries: cosign signature, SLSA L3 build provenance, CycloneDX SBOM, Trivy vulnerability report, and Rekor transparency log entry.
 
-## More Information
+## Next Actions
 
+- [Browse the live catalog](${prefix}) — Search images and inspect current vulnerability data
 - [Complete LLM Reference](${prefix}llms-full.txt) — Everything in one file
 - [Supply Chain Compliance](${prefix}compliance.md) — Framework mappings (SLSA, FedRAMP, SOC 2, ISO 27001, OWASP)
 - [Helm Charts](${prefix}charts/index.md) — Pre-patched wrapper Helm charts
 - [Experimental APK Repository](${prefix}apk/index.md) — Pending package repository metadata, install flow, trust model, and supported arches
 - [GitHub Repository](https://github.com/verity-org/verity) — Source code and issues
 `;
+}
 
-  return new Response(content.trim() + "\n", {
+export const GET: APIRoute = ({ site }) => {
+  const base = import.meta.env.BASE_URL;
+  const origin = site?.origin ?? "https://verity.supply";
+  const prefix = `${origin}${base}`;
+  const content = renderIndexMarkdown(prefix);
+
+  return new Response(`${content.trim()}\n`, {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600",

--- a/site/src/pages/index.md.ts
+++ b/site/src/pages/index.md.ts
@@ -1,22 +1,11 @@
 import type { APIRoute } from "astro";
-import {
-  copaCount,
-  fullCatalog,
-  integerCount,
-  totalCategories,
-  totalImages,
-} from "../data/full-catalog.ts";
+import { copaCount, integerCount, totalCategories, totalImages } from "../data/full-catalog.ts";
 import { getChartsCatalog } from "../lib/charts.ts";
+import { renderCategoryRows } from "../lib/machine-docs.ts";
 
 export function renderIndexMarkdown(prefix: string): string {
   const chartCount = getChartsCatalog().charts.length;
-  const categoryRows = fullCatalog
-    .map((category) => {
-      const copaImages = category.images.filter((image) => image.source === "copa").length;
-      const wolfiImages = category.images.length - copaImages;
-      return `  ${category.id},${category.images.length},${copaImages},${wolfiImages}`;
-    })
-    .join("\n");
+  const categoryRows = renderCategoryRows();
 
   return `# Verity — Security-Patched Container Images
 

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -1,20 +1,9 @@
 import type { APIRoute } from "astro";
-import {
-  copaCount,
-  fullCatalog,
-  integerCount,
-  totalCategories,
-  totalImages,
-} from "../data/full-catalog.ts";
+import { copaCount, integerCount, totalCategories, totalImages } from "../data/full-catalog.ts";
+import { renderCategoryRows } from "../lib/machine-docs.ts";
 
 export function renderLlmsText(prefix: string): string {
-  const categoryRows = fullCatalog
-    .map((category) => {
-      const copaImages = category.images.filter((image) => image.source === "copa").length;
-      const wolfiImages = category.images.length - copaImages;
-      return `  ${category.id},${category.images.length},${copaImages},${wolfiImages}`;
-    })
-    .join("\n");
+  const categoryRows = renderCategoryRows();
 
   return `# Verity
 

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -1,39 +1,67 @@
 import type { APIRoute } from "astro";
-import { copaCount, integerCount, totalCategories, totalImages } from "../data/full-catalog.ts";
+import {
+  copaCount,
+  fullCatalog,
+  integerCount,
+  totalCategories,
+  totalImages,
+} from "../data/full-catalog.ts";
+
+export function renderLlmsText(prefix: string): string {
+  const categoryRows = fullCatalog
+    .map((category) => {
+      const copaImages = category.images.filter((image) => image.source === "copa").length;
+      const wolfiImages = category.images.length - copaImages;
+      return `  ${category.id},${category.images.length},${copaImages},${wolfiImages}`;
+    })
+    .join("\n");
+
+  return `# Verity
+
+> Self-maintaining registry of security-patched container images. Verity scans, patches, signs, attests, and publishes drop-in replacements at ghcr.io/verity-org.
+
+scope: summary
+total_images: ${totalImages}
+total_categories: ${totalCategories}
+copa_images: ${copaCount}
+wolfi_images: ${integerCount}
+full_reference: ${prefix}llms-full.txt
+
+## Quick Start
+
+\`\`\`
+docker pull ghcr.io/verity-org/prometheus/prometheus:v3.9.1-patched
+\`\`\`
+
+## Catalog by Category
+
+categories[${totalCategories}]{category,total,copa,wolfi}:
+${categoryRows}
+
+## Operational Facts
+
+- Platforms: linux/amd64 and linux/arm64
+- Pipeline: daily at 02:00 UTC and on configuration changes
+- Evidence: cosign signature, SLSA L3 provenance, CycloneDX SBOM, Trivy report, Rekor entry
+- FIPS-capable variants: selected images; see the full reference for the complete list
+
+## Next Actions
+
+next[6]{task,url}:
+  browse_catalog,${prefix}
+  overview,${prefix}index.md
+  full_reference,${prefix}llms-full.txt
+  compliance,${prefix}compliance.md
+  helm_charts,${prefix}charts/index.md
+  apk_repository,${prefix}apk/index.md
+`;
+}
 
 export const GET: APIRoute = ({ site }) => {
   const base = import.meta.env.BASE_URL;
   const origin = site?.origin ?? "https://verity.supply";
   const prefix = `${origin}${base}`;
-
-  const content = `# Verity
-
-> Self-maintaining registry of security-patched container images. Verity continuously scans container images for CVEs, patches them in-place using Copa (no Dockerfile rebuild required), signs with cosign/Sigstore keyless OIDC, attests with SLSA L3 build provenance and CycloneDX SBOMs, and publishes signed drop-in replacements to GitHub Container Registry at ghcr.io/verity-org.
-
-Verity covers ${totalImages} container images across ${totalCategories} categories: languages & build tools, web servers & proxies, databases & caching, messaging & streaming, Kubernetes & orchestration, service mesh & networking, monitoring & observability, logging, CI/CD & GitOps, security & identity, policy & compliance, cert management, data & ML, and base & utilities.
-
-Images are available in two forms: **Copa-patched** (${copaCount} images — in-place OS-level package patching of upstream images) and **Wolfi-based** (${integerCount} images — from-scratch hardened rebuilds using Wolfi packages with minimal attack surface). All images support linux/amd64 and linux/arm64. FIPS variants are available for Go-backed images (golang, caddy, docker-cli, etcd, helm, terraform, cosign, crane, pgweb, vault) and OpenSSL-backed images (node, nginx, php, ruby, erlang, haproxy, httpd, python, postgres, valkey, dotnet).
-
-The patching pipeline runs daily at 02:00 UTC via GitHub Actions. Every published image carries five supply-chain attestations: cosign keyless signature, SLSA Level 3 build provenance, CycloneDX SBOM, Trivy vulnerability report, and a Rekor transparency log entry.
-
-Replace your image reference — that's it:
-\`\`\`
-docker pull ghcr.io/verity-org/prometheus/prometheus:v3.9.1-patched
-\`\`\`
-
-## Documentation
-
-- [Complete LLM Reference](${prefix}llms-full.txt): Full documentation in a single file — project overview, architecture, complete image catalog with all ${totalImages} images, compliance framework mappings, CLI reference, configuration format, and contributing guide
-- [Overview & Quick Start](${prefix}index.md): What Verity is, how to use patched images, catalog summary by category
-- [Supply Chain Compliance](${prefix}compliance.md): SLSA L3, Sigstore/cosign, CycloneDX SBOM, Rekor transparency log, plus framework mappings for FedRAMP/NIST 800-53, SOC 2, ISO 27001, OWASP ASVS, NIST CSF 2.0, and CISA Secure by Design
-- [Helm Charts](${prefix}charts/index.md): Pre-patched wrapper Helm charts that override upstream image references with Verity's patched equivalents
-- [Experimental APK Repository](${prefix}apk/index.md): Pending APK repository entry point with install instructions, key rotation notes, supported arches, and experimental caveats
-
-## Source
-
-- [GitHub Repository](https://github.com/verity-org/verity): Source code, CI/CD pipeline, issue tracker, discussions
-- [Browse Image Catalog](${prefix}): Interactive catalog with vulnerability data, severity breakdowns, and supply chain badges
-`;
+  const content = renderLlmsText(prefix);
 
   return new Response(`${content.trim()}\n`, {
     headers: {


### PR DESCRIPTION
## Summary
- add live aggregate metadata to the existing llms.txt and index.md routes
- replace verbose category prose with compact four-field category tables
- add explicit full-reference links and contextual next actions
- add route-content regression tests

## Verification
- cd site && npm test
- cd site && npm run build
- targeted Biome check
- TypeScript no-excuse audit
- browser verification on the Tailscale preview

## Notes
- the visible HTML interface is unchanged
- no custom AXI namespace, routes, or implementation files are introduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes our machine-readable docs agent-friendly by adding live totals, compact category tables, and explicit next actions to `llms.txt` and `index.md`. Improves parsing for agents and tools without changing the visible UI.

- **New Features**
  - Added aggregates (`scope`, totals, `full_reference`) to both docs; `helm_charts` added to `index.md` only.
  - Replaced category prose with `categories[...]` four-field tables (category,total,copa,wolfi).
  - Added “Next Actions” with task+URL pairs (`next[6]{task,url}`) in `llms.txt`; added a matching Next Actions list in `index.md`.

- **Refactors**
  - Extracted `renderLlmsText`, `renderIndexMarkdown`, and shared `renderCategoryRows`; simplified GET handlers.
  - Added route-content regression tests (`site/src/lib/machine-docs.test.ts`).

<sup>Written for commit b2aa0c9306a22be27467392b7bf4e1fec971a0e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

