### PR TITLE
ci(integer): require dual-architecture PR security gates

### DIFF
--- a/.github/scripts/validate-pr-test-workflow.py
+++ b/.github/scripts/validate-pr-test-workflow.py
@@ -33,6 +33,54 @@ def main() -> None:
         "pr-test-result:" in workflow and "name: PR Test" in workflow,
         "PR Test must expose a stable aggregate gate for branch protection",
     )
+    require(
+        '["amd64", "arm64"][] as $arch' not in workflow,
+        "Integer dual-architecture coverage must not multiply matrices beyond GitHub's 256-job limit",
+    )
+    require(
+        workflow.count("for package_arch in x86_64 aarch64; do") == 2
+        and workflow.count('--arch "$package_arch"') == 2
+        and workflow.count("for arch in amd64 arm64; do") >= 4,
+        "Every Integer build and smoke leg must build its architecture-specific package and image",
+    )
+    require(
+        workflow.count('docker load --input "$tar_path"') == 2
+        and workflow.count('docker image inspect "$loaded_ref"') == 2
+        and workflow.count("docker load did not report an image reference") == 2
+        and workflow.count("runtime architecture mismatch") == 2,
+        "Every Integer build and smoke leg must verify the loaded runtime architecture",
+    )
+    require(
+        workflow.count("name: Set up QEMU for dual-architecture verification") == 2,
+        "Both Integer jobs must register arm64 binfmt before aarch64 package builds",
+    )
+    require(
+        workflow.count('--fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"') == 2,
+        "Every Integer image path must retain strict Trivy exit-code enforcement for every severity",
+    )
+    require(
+        "--exit-code 0" not in workflow
+        and workflow.count("--exit-code 1") >= 3,
+        "Integer Trivy scans must fail closed and never run report-only",
+    )
+    require(
+        "EXPECTED_INTEGER_MATRIX: ${{ needs.detect-changed-images.outputs.expected-matrix }}" in workflow
+        and "EXPECTED_INTEGER_SMOKE_MATRIX: ${{ needs.detect-changed-images.outputs.expected-smoke-matrix }}" in workflow
+        and "for arch in amd64 arm64; do" in workflow
+        and "missing successful Integer ${kind} security leg" in workflow,
+        "The required aggregate must reject any absent, skipped, cancelled, or failed architecture leg",
+    )
+    require(
+        '[ "$image" = linkerd ] && [ "$version" = 25 ] && [ "$type" = default ]' in workflow
+        and "matrix.arch" not in workflow,
+        "The Linkerd dual-architecture pinning canary must run once without standing in for the global arm64 gate",
+    )
+    require(
+        workflow.count("group_by((.key / 16 | floor))") == 2
+        and "expected-matrix" in workflow
+        and "expected-smoke-matrix" in workflow,
+        "Affected Integer entries must be batched below GitHub's 256-job matrix limit without losing aggregate expectations",
+    )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -129,14 +129,13 @@ jobs:
 
   # ── Integer smoke test ────────────────────────────────────────────────
   integer-smoke-test:
-    name: "Integer ${{ matrix.image }}:${{ matrix.version }}-${{ matrix.type }}"
+    name: "Integer smoke batch ${{ matrix.batch_id }}"
     needs: [changes, detect-changed-images]
     if: needs.changes.outputs.integer == 'true' && needs.detect-changed-images.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
     env:
-      INTEGER_IMAGE: ${{ matrix.image }}
-      INTEGER_VERSION: ${{ matrix.version }}
-      INTEGER_TYPE: ${{ matrix.type }}
+      INTEGER_ENTRIES: ${{ toJson(matrix.entries) }}
+      INTEGER_BATCH_ID: ${{ matrix.batch_id }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changed-images.outputs.smoke-matrix) }}
@@ -167,44 +166,81 @@ jobs:
       - name: Build verity CLI
         run: go build -o verity .
 
-      - name: Build bespoke package
+      - name: Set up QEMU for dual-architecture verification
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          image: docker.io/tonistiigi/binfmt:latest@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Build and verify dual-architecture Integer smoke batch
         run: |
-          ./verity integer melange build \
-            --image "$INTEGER_IMAGE" \
-            --version "$INTEGER_VERSION" \
-            --type "$INTEGER_TYPE" \
-            --arch x86_64
+          mkdir -p integer-security
+          while IFS= read -r entry; do
+            image=$(jq -r '.image' <<< "$entry")
+            version=$(jq -r '.version' <<< "$entry")
+            type=$(jq -r '.type' <<< "$entry")
+            safe_image=$(printf '%s' "$image" | tr '/:' '--')
+            report_dir="trivy-reports/${safe_image}-${version}-${type}"
+            mkdir -p "$report_dir"
 
-      - name: Build image (local, no push)
-        run: |
-          ./verity integer build \
-            --image "$INTEGER_IMAGE" \
-            --version "$INTEGER_VERSION" \
-            --type "$INTEGER_TYPE" \
-            --output image.tar \
-            --arch amd64 \
-            --fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+            for package_arch in x86_64 aarch64; do
+              ./verity integer melange build \
+                --image "$image" \
+                --version "$version" \
+                --type "$type" \
+                --arch "$package_arch"
+            done
 
-      - name: Full vulnerability report
-        if: always()
-        run: |
-          trivy image \
-            --exit-code 0 \
-            --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
-            --vuln-type os,library \
-            --format json \
-            --output trivy-report.json \
-            --input image.tar
+            for arch in amd64 arm64; do
+              tar_path="image-${safe_image}-${version}-${type}-${arch}.tar"
+              ./verity integer build \
+                --image "$image" \
+                --version "$version" \
+                --type "$type" \
+                --output "$tar_path" \
+                --arch "$arch" \
+                --fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 
-          TOTAL=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' trivy-report.json)
-          echo "Total vulnerabilities: ${TOTAL}"
+              load_output=$(docker load --input "$tar_path")
+              echo "$load_output"
+              loaded_ref=$(awk -F': ' '/^Loaded image: / {print $2}' <<< "$load_output" | tail -1)
+              if [ -z "$loaded_ref" ]; then
+                echo "::error::docker load did not report an image reference for ${arch}"
+                exit 1
+              fi
+              runtime_arch=$(docker image inspect "$loaded_ref" --format '{{.Architecture}}')
+              if [ "$runtime_arch" != "$arch" ]; then
+                echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
+                exit 1
+              fi
 
-      - name: Upload Trivy report
+              trivy image \
+                --exit-code 1 \
+                --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
+                --vuln-type os,library \
+                --format json \
+                --output "${report_dir}/${arch}.json" \
+                --input "$tar_path"
+              total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "${report_dir}/${arch}.json")
+              echo "${image}:${version}-${type} ${arch}: Total vulnerabilities: ${total}"
+              touch "integer-security/smoke-${safe_image}-${version}-${type}-${arch}.passed"
+              rm -f "$tar_path"
+            done
+          done < <(jq -c '.[]' <<< "$INTEGER_ENTRIES")
+
+      - name: Upload Integer security completion
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "integer-security-smoke-batch-${{ matrix.batch_id }}"
+          path: integer-security/*.passed
+          retention-days: 7
+
+      - name: Upload architecture-qualified Trivy reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "trivy-smoke-${{ matrix.image }}-${{ matrix.version }}-${{ matrix.type }}"
-          path: trivy-report.json
+          name: "trivy-smoke-batch-${{ matrix.batch_id }}-amd64-arm64"
+          path: trivy-reports/**/*.json
           retention-days: 7
 
   # ── Build + scan changed Integer images ──────────────────────────────
@@ -216,6 +252,8 @@ jobs:
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
       smoke-matrix: ${{ steps.detect.outputs.smoke-matrix }}
+      expected-matrix: ${{ steps.detect.outputs.expected-matrix }}
+      expected-smoke-matrix: ${{ steps.detect.outputs.expected-smoke-matrix }}
       has-changes: ${{ steps.detect.outputs.has-changes }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -260,27 +298,31 @@ jobs:
             --gen-dir "$RUNNER_TEMP/integer-gen" \
             > ci-plan.json
 
-          matrix=$(jq -c '.matrix' ci-plan.json)
-          smoke_matrix=$(jq -c '.smokeMatrix' ci-plan.json)
+          expected_matrix=$(jq -c '.matrix' ci-plan.json)
+          expected_smoke_matrix=$(jq -c '.smokeMatrix' ci-plan.json)
+          matrix=$(jq -c '[.matrix.include | to_entries | group_by((.key / 16 | floor))[] | {batch_id: (.[0].key / 16 | floor), entries: map(.value)}] | {include: .}' ci-plan.json)
+          smoke_matrix=$(jq -c '[.smokeMatrix.include | to_entries | group_by((.key / 16 | floor))[] | {batch_id: (.[0].key / 16 | floor), entries: map(.value)}] | {include: .}' ci-plan.json)
           has_changes=$(jq -r '.hasChanges' ci-plan.json)
-          count=$(jq '.include | length' <<< "$matrix")
-          echo "Matrix: ${count} image builds"
+          count=$(jq '.include | length' <<< "$expected_matrix")
+          batch_count=$(jq '.include | length' <<< "$matrix")
+          echo "Matrix: ${count} image builds in ${batch_count} batches"
           echo "$matrix" | jq .
           {
             echo "matrix=${matrix}"
             echo "smoke-matrix=${smoke_matrix}"
+            echo "expected-matrix=${expected_matrix}"
+            echo "expected-smoke-matrix=${expected_smoke_matrix}"
             echo "has-changes=${has_changes}"
           } >> "$GITHUB_OUTPUT"
 
   integer-build-changed:
-    name: "Build ${{ matrix.image }}:${{ matrix.version }}-${{ matrix.type }}"
+    name: "Integer build batch ${{ matrix.batch_id }}"
     needs: [changes, detect-changed-images]
     if: needs.changes.outputs.integer == 'true' && needs.detect-changed-images.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
     env:
-      INTEGER_IMAGE: ${{ matrix.image }}
-      INTEGER_VERSION: ${{ matrix.version }}
-      INTEGER_TYPE: ${{ matrix.type }}
+      INTEGER_ENTRIES: ${{ toJson(matrix.entries) }}
+      INTEGER_BATCH_ID: ${{ matrix.batch_id }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changed-images.outputs.matrix) }}
@@ -311,95 +353,120 @@ jobs:
       - name: Build verity CLI
         run: go build -o verity .
 
-      - name: Build bespoke package
-        run: |
-          ./verity integer melange build \
-            --image "$INTEGER_IMAGE" \
-            --version "$INTEGER_VERSION" \
-            --type "$INTEGER_TYPE" \
-            --arch x86_64
-
-      - name: Set up QEMU for Linkerd pinning canary
-        if: matrix.image == 'linkerd' && matrix.version == '25' && matrix.type == 'default'
+      - name: Set up QEMU for dual-architecture verification
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           image: docker.io/tonistiigi/binfmt:latest@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
           platforms: arm64
 
-      - name: Exercise production package pinning
-        if: matrix.image == 'linkerd' && matrix.version == '25' && matrix.type == 'default'
+      - name: Build and verify dual-architecture Integer batch
         run: |
-          ./verity integer melange build \
-            --image "$INTEGER_IMAGE" \
-            --version "$INTEGER_VERSION" \
-            --type "$INTEGER_TYPE" \
-            --arch aarch64 \
-            --staged
+          mkdir -p integer-security
+          while IFS= read -r entry; do
+            image=$(jq -r '.image' <<< "$entry")
+            version=$(jq -r '.version' <<< "$entry")
+            type=$(jq -r '.type' <<< "$entry")
+            safe_image=$(printf '%s' "$image" | tr '/:' '--')
+            report_dir="trivy-reports/${safe_image}-${version}-${type}"
+            mkdir -p "$report_dir"
 
-          ./verity integer discover \
-            --apkindex-url "" \
-            --gen-dir ./pin-config-gen
-          config="pin-config-gen/${INTEGER_IMAGE}/${INTEGER_VERSION}/${INTEGER_TYPE}.apko.yaml"
-          ./verity integer melange pin-config \
-            --config "$config" \
-            --repository packages/repo \
-            --arch x86_64 \
-            --arch aarch64
-          grep -Eq 'linkerd2-cli=[^ ,]+@local' "$config"
+            for package_arch in x86_64 aarch64; do
+              ./verity integer melange build \
+                --image "$image" \
+                --version "$version" \
+                --type "$type" \
+                --arch "$package_arch"
+            done
 
-          for arch in amd64 arm64; do
-            image="pin-config-${arch}.tar"
-            report="pin-config-${arch}.json"
-            apko build \
-              --arch "$arch" \
-              --repository-append "@local packages/repo" \
-              --keyring-append melange-work/melange.rsa.pub \
-              "$config" \
-              integer:pin-config-canary \
-              "$image"
-            trivy image \
-              --exit-code 1 \
-              --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
-              --vuln-type os,library \
-              --format json \
-              --output "$report" \
-              --input "$image"
-            total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "$report")
-            echo "Pin-config canary ${arch}: Total vulnerabilities: ${total}"
-          done
+            if [ "$image" = linkerd ] && [ "$version" = 25 ] && [ "$type" = default ]; then
+              ./verity integer melange build \
+                --image "$image" \
+                --version "$version" \
+                --type "$type" \
+                --arch aarch64 \
+                --staged
 
-      - name: Build image (local, no push)
-        run: |
-          ./verity integer build \
-            --image "$INTEGER_IMAGE" \
-            --version "$INTEGER_VERSION" \
-            --type "$INTEGER_TYPE" \
-            --output image.tar \
-            --arch amd64 \
-            --fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+              ./verity integer discover --apkindex-url "" --gen-dir ./pin-config-gen
+              config="pin-config-gen/${image}/${version}/${type}.apko.yaml"
+              ./verity integer melange pin-config \
+                --config "$config" \
+                --repository packages/repo \
+                --arch x86_64 \
+                --arch aarch64
+              grep -Eq 'linkerd2-cli=[^ ,]+@local' "$config"
 
-          echo "Built ${INTEGER_IMAGE}:${INTEGER_VERSION}-${INTEGER_TYPE}"
-          ls -lh image.tar
+              for arch in amd64 arm64; do
+                canary_image="pin-config-${arch}.tar"
+                canary_report="pin-config-${arch}.json"
+                apko build \
+                  --arch "$arch" \
+                  --repository-append "@local packages/repo" \
+                  --keyring-append melange-work/melange.rsa.pub \
+                  "$config" \
+                  integer:pin-config-canary \
+                  "$canary_image"
+                trivy image \
+                  --exit-code 1 \
+                  --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
+                  --vuln-type os,library \
+                  --format json \
+                  --output "$canary_report" \
+                  --input "$canary_image"
+                total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "$canary_report")
+                echo "Pin-config canary ${arch}: Total vulnerabilities: ${total}"
+              done
+            fi
 
-      - name: Full vulnerability report
-        if: always()
-        run: |
-          trivy image \
-            --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
-            --vuln-type os,library \
-            --format json \
-            --output trivy-report.json \
-            --input image.tar
+            for arch in amd64 arm64; do
+              tar_path="image-${safe_image}-${version}-${type}-${arch}.tar"
+              ./verity integer build \
+                --image "$image" \
+                --version "$version" \
+                --type "$type" \
+                --output "$tar_path" \
+                --arch "$arch" \
+                --fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 
-          TOTAL=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' trivy-report.json)
-          echo "Total vulnerabilities: ${TOTAL}"
+              load_output=$(docker load --input "$tar_path")
+              echo "$load_output"
+              loaded_ref=$(awk -F': ' '/^Loaded image: / {print $2}' <<< "$load_output" | tail -1)
+              if [ -z "$loaded_ref" ]; then
+                echo "::error::docker load did not report an image reference for ${arch}"
+                exit 1
+              fi
+              runtime_arch=$(docker image inspect "$loaded_ref" --format '{{.Architecture}}')
+              if [ "$runtime_arch" != "$arch" ]; then
+                echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
+                exit 1
+              fi
 
-      - name: Upload Trivy report
+              trivy image \
+                --exit-code 1 \
+                --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
+                --vuln-type os,library \
+                --format json \
+                --output "${report_dir}/${arch}.json" \
+                --input "$tar_path"
+              total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "${report_dir}/${arch}.json")
+              echo "${image}:${version}-${type} ${arch}: Total vulnerabilities: ${total}"
+              touch "integer-security/build-${safe_image}-${version}-${type}-${arch}.passed"
+              rm -f "$tar_path"
+            done
+          done < <(jq -c '.[]' <<< "$INTEGER_ENTRIES")
+
+      - name: Upload Integer security completion
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "integer-security-build-batch-${{ matrix.batch_id }}"
+          path: integer-security/*.passed
+          retention-days: 7
+
+      - name: Upload architecture-qualified Trivy reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "trivy-build-${{ matrix.image }}-${{ matrix.version }}-${{ matrix.type }}"
-          path: trivy-report.json
+          name: "trivy-build-batch-${{ matrix.batch_id }}-amd64-arm64"
+          path: trivy-reports/**/*.json
           retention-days: 7
 
   # ── Detect changed Copa images and test them ─────────────────────────
@@ -721,6 +788,14 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Download Integer security completions
+        if: needs.changes.outputs.integer == 'true' && needs.detect-changed-images.outputs.has-changes == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: integer-security-*
+          path: integer-security-results
+          merge-multiple: true
+
       - name: Aggregate PR test results
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
@@ -732,6 +807,8 @@ jobs:
           INTEGER_HAS_CHANGES: ${{ needs.detect-changed-images.outputs.has-changes }}
           INTEGER_SMOKE_RESULT: ${{ needs.integer-smoke-test.result }}
           INTEGER_BUILD_RESULT: ${{ needs.integer-build-changed.result }}
+          EXPECTED_INTEGER_MATRIX: ${{ needs.detect-changed-images.outputs.expected-matrix }}
+          EXPECTED_INTEGER_SMOKE_MATRIX: ${{ needs.detect-changed-images.outputs.expected-smoke-matrix }}
           DETECT_COPA_RESULT: ${{ needs.detect-copa-changes.result }}
           COPA_CHANGED_RESULT: ${{ needs.copa-patching-changed.result }}
           COPA_REGRESSION_RESULT: ${{ needs.copa-patching-regression.result }}
@@ -770,6 +847,35 @@ jobs:
             esac
           }
 
+          require_integer_markers() {
+            local matrix="$1"
+            local kind="$2"
+            local entries
+            if ! entries=$(jq -ce '
+              if (.include | type) == "array" and (.include | length) > 0 then
+                .include | unique_by(.image, .version, .type)[]
+              else
+                error("expected a non-empty include array")
+              end
+            ' <<< "$matrix"); then
+              echo "::error::invalid expected Integer ${kind} matrix"
+              exit 1
+            fi
+            while IFS= read -r entry; do
+              image=$(jq -r '.image' <<< "$entry")
+              version=$(jq -r '.version' <<< "$entry")
+              type=$(jq -r '.type' <<< "$entry")
+              safe_image=$(printf '%s' "$image" | tr '/:' '--')
+              for arch in amd64 arm64; do
+                marker="integer-security-results/${kind}-${safe_image}-${version}-${type}-${arch}.passed"
+                if [ ! -f "$marker" ]; then
+                  echo "::error::missing successful Integer ${kind} security leg: ${image}:${version}-${type} (${arch})"
+                  exit 1
+                fi
+              done
+            done <<< "$entries"
+          }
+
           require_success "changes" "$CHANGES_RESULT"
 
           if [ "$INTEGER" = "true" ]; then
@@ -778,6 +884,8 @@ jobs:
             if [ "$INTEGER_HAS_CHANGES" = "true" ]; then
               require_success "integer-smoke-test" "$INTEGER_SMOKE_RESULT"
               require_success "integer-build-changed" "$INTEGER_BUILD_RESULT"
+              require_integer_markers "$EXPECTED_INTEGER_SMOKE_MATRIX" smoke
+              require_integer_markers "$EXPECTED_INTEGER_MATRIX" build
             else
               allow_success_or_skipped "integer-smoke-test" "$INTEGER_SMOKE_RESULT"
               allow_success_or_skipped "integer-build-changed" "$INTEGER_BUILD_RESULT"

--- a/internal/integer/melange/build.go
+++ b/internal/integer/melange/build.go
@@ -29,10 +29,34 @@ func Prepare(ctx context.Context, options *BuildOptions) error {
 	if err := Stage(&options.Paths, options.Spec); err != nil {
 		return err
 	}
+	keyPairExists, err := signingKeyPairExists(&options.Paths)
+	if err != nil {
+		return err
+	}
+	if keyPairExists {
+		return restrictStagedPrivateKey(&options.Paths)
+	}
 	if err := runMelange(ctx, options, "keygen", "melange-work/melange.rsa"); err != nil {
 		return err
 	}
 	return restrictStagedPrivateKey(&options.Paths)
+}
+
+func signingKeyPairExists(paths *Paths) (bool, error) {
+	for _, name := range []string{"melange.rsa", "melange.rsa.pub"} {
+		path := filepath.Join(paths.WorkDir, name)
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("inspect signing key %q: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return false, fmt.Errorf("signing key %q %w", path, errNotRegularFile)
+		}
+	}
+	return true, nil
 }
 
 func Build(ctx context.Context, options *BuildOptions) error {

--- a/internal/integer/melange/build_test.go
+++ b/internal/integer/melange/build_test.go
@@ -142,6 +142,32 @@ func TestPrepareRestrictsGeneratedPrivateKeyPermissions(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
+func TestPrepareReusesExistingSigningKeyPair(t *testing.T) {
+	// Given: one workspace used to build packages for multiple architectures.
+	root := t.TempDir()
+	writeTestFile(t, testPath(root, "packages/bespoke/custom.yaml"), "package:\n  name: custom\n")
+	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), `{"packages":{},"pipeline_files":{}}`)
+	runner := &fakeRunner{}
+	options := &BuildOptions{
+		Paths:  testPaths(root),
+		Spec:   Spec{Bespoke: []string{"custom.yaml"}},
+		Runner: runner,
+	}
+
+	// When: preparation runs once per architecture.
+	require.NoError(t, Prepare(context.Background(), options))
+	require.NoError(t, Prepare(context.Background(), options))
+
+	// Then: both architecture indexes will share the same signing key.
+	var keygenCount int
+	for _, command := range runner.commands {
+		if len(command.args) > 0 && command.args[0] == "keygen" {
+			keygenCount++
+		}
+	}
+	assert.Equal(t, 1, keygenCount)
+}
+
 func TestBuildRejectsUnsafeArchitectureBeforeRemovingOutput(t *testing.T) {
 	root := t.TempDir()
 	sentinel := testPath(root, "victim/sentinel")

--- a/scripts/workflow_interpolation_test.go
+++ b/scripts/workflow_interpolation_test.go
@@ -2,6 +2,7 @@ package scripts_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -72,8 +73,8 @@ func TestPRWorkflowUsesDistinctIntegerReportArtifactNames(t *testing.T) {
 			owners[name] = jobName + "/" + step.Name
 		}
 	}
-	require.Contains(t, owners, "trivy-smoke-${{ matrix.image }}-${{ matrix.version }}-${{ matrix.type }}")
-	require.Contains(t, owners, "trivy-build-${{ matrix.image }}-${{ matrix.version }}-${{ matrix.type }}")
+	require.Contains(t, owners, "trivy-smoke-batch-${{ matrix.batch_id }}-amd64-arm64")
+	require.Contains(t, owners, "trivy-build-batch-${{ matrix.batch_id }}-amd64-arm64")
 }
 
 func TestPRWorkflowDiffsBespokeLockForSelectiveImagePlanning(t *testing.T) {
@@ -91,7 +92,9 @@ func TestPRWorkflowKeepsZeroVulnerabilityGateOnBuildAndSmoke(t *testing.T) {
 	workflow := string(data)
 
 	assert.Equal(t, 2, strings.Count(workflow, `--fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"`))
-	assert.Equal(t, 2, strings.Count(workflow, `echo "Total vulnerabilities: ${TOTAL}"`))
+	assert.NotContains(t, workflow, `--exit-code 0`)
+	assert.GreaterOrEqual(t, strings.Count(workflow, `--exit-code 1`), 3)
+	assert.Equal(t, 2, strings.Count(workflow, `echo "${image}:${version}-${type} ${arch}: Total vulnerabilities: ${total}"`))
 }
 
 func TestPRWorkflowExercisesProductionPinningOnLinkerdCanary(t *testing.T) {
@@ -112,44 +115,43 @@ func TestPRWorkflowExercisesProductionPinningOnLinkerdCanary(t *testing.T) {
 	require.NoError(t, yaml.Unmarshal(data, &workflow))
 
 	// When: the changed-image build steps are inspected.
-	var canary struct {
+	var batch struct {
 		Name string            `yaml:"name"`
 		If   string            `yaml:"if"`
 		Run  string            `yaml:"run"`
 		Uses string            `yaml:"uses"`
 		With map[string]string `yaml:"with"`
 	}
-	qemu := canary
-	qemuIndex, canaryIndex := -1, -1
+	qemu := batch
+	qemuIndex, batchIndex := -1, -1
 	for index, step := range workflow.Jobs["integer-build-changed"].Steps {
 		switch step.Name {
-		case "Set up QEMU for Linkerd pinning canary":
+		case "Set up QEMU for dual-architecture verification":
 			qemu = step
 			qemuIndex = index
-		case "Exercise production package pinning":
-			canary = step
-			canaryIndex = index
+		case "Build and verify dual-architecture Integer batch":
+			batch = step
+			batchIndex = index
 		}
 	}
 
-	// Then: only Linkerd runs the real dual-architecture publish pinning path.
-	const canaryCondition = "matrix.image == 'linkerd' && matrix.version == '25' && matrix.type == 'default'"
-	require.Equal(t, "Set up QEMU for Linkerd pinning canary", qemu.Name)
-	assert.Equal(t, canaryCondition, qemu.If)
+	// Then: QEMU is ready before every aarch64 package build, while only
+	// Linkerd runs the production package-pinning canary inside the batch.
+	require.Equal(t, "Set up QEMU for dual-architecture verification", qemu.Name)
 	assert.Equal(t, "docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8", qemu.Uses)
 	assert.Equal(t, "docker.io/tonistiigi/binfmt:latest@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0", qemu.With["image"])
 	assert.Equal(t, "arm64", qemu.With["platforms"])
-	assert.Less(t, qemuIndex, canaryIndex)
-	require.Equal(t, "Exercise production package pinning", canary.Name)
-	assert.Equal(t, canaryCondition, canary.If)
-	assert.Contains(t, canary.Run, `--arch aarch64`)
-	assert.Contains(t, canary.Run, `--staged`)
-	assert.Contains(t, canary.Run, `./verity integer melange pin-config`)
-	assert.Contains(t, canary.Run, `--repository packages/repo`)
-	assert.Contains(t, canary.Run, `--arch x86_64`)
-	assert.Contains(t, canary.Run, `apko build`)
-	assert.Contains(t, canary.Run, `--repository-append "@local packages/repo"`)
-	assert.Contains(t, canary.Run, `trivy image`)
+	assert.Less(t, qemuIndex, batchIndex)
+	require.Equal(t, "Build and verify dual-architecture Integer batch", batch.Name)
+	assert.Contains(t, batch.Run, `[ "$image" = linkerd ] && [ "$version" = 25 ] && [ "$type" = default ]`)
+	assert.Contains(t, batch.Run, `--arch aarch64`)
+	assert.Contains(t, batch.Run, `--staged`)
+	assert.Contains(t, batch.Run, `./verity integer melange pin-config`)
+	assert.Contains(t, batch.Run, `--repository packages/repo`)
+	assert.Contains(t, batch.Run, `--arch x86_64`)
+	assert.Contains(t, batch.Run, `apko build`)
+	assert.Contains(t, batch.Run, `--repository-append "@local packages/repo"`)
+	assert.Contains(t, batch.Run, `trivy image`)
 }
 
 func TestIntegerBuildWorkflowReadsMetadataThroughVerity(t *testing.T) {
@@ -161,4 +163,128 @@ func TestIntegerBuildWorkflowReadsMetadataThroughVerity(t *testing.T) {
 	// Then: metadata resolution uses declared-name lookup in the Go CLI.
 	assert.Contains(t, workflow, `./verity integer metadata`)
 	assert.NotContains(t, workflow, `image_yaml="images/${INPUT_IMAGE}.yaml"`)
+}
+
+func TestPRWorkflowRequiresDualArchitectureIntegerSecurityCompletion(t *testing.T) {
+	// Given: the pull-request workflow for affected Integer images.
+	data, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "pr-test.yaml"))
+	require.NoError(t, err)
+	workflow := string(data)
+
+	// Then: every selected image entry executes both architectures without
+	// multiplying the matrix beyond GitHub's 256-job limit.
+	assert.NotContains(t, workflow, `["amd64", "arm64"][] as $arch`)
+	assert.Equal(t, 2, strings.Count(workflow, `group_by((.key / 16 | floor))`))
+	assert.Contains(t, workflow, `expected-matrix=${expected_matrix}`)
+	assert.Contains(t, workflow, `expected-smoke-matrix=${expected_smoke_matrix}`)
+	assert.Equal(t, 2, strings.Count(workflow, `for package_arch in x86_64 aarch64; do`))
+	assert.Equal(t, 2, strings.Count(workflow, `--arch "$package_arch"`))
+	assert.GreaterOrEqual(t, strings.Count(workflow, `for arch in amd64 arm64; do`), 4)
+	assert.Equal(t, 2, strings.Count(workflow, `docker load --input "$tar_path"`))
+	assert.Equal(t, 2, strings.Count(workflow, `docker image inspect "$loaded_ref"`))
+	assert.Equal(t, 2, strings.Count(workflow, `docker load did not report an image reference`))
+	assert.Equal(t, 2, strings.Count(workflow, `runtime architecture mismatch`))
+	assert.Equal(t, 2, strings.Count(workflow, `name: Set up QEMU for dual-architecture verification`))
+
+	// And: reports and completion evidence cannot collide across architectures.
+	assert.Contains(t, workflow, `trivy-smoke-batch-${{ matrix.batch_id }}-amd64-arm64`)
+	assert.Contains(t, workflow, `trivy-build-batch-${{ matrix.batch_id }}-amd64-arm64`)
+	assert.Contains(t, workflow, `integer-security-smoke-batch-${{ matrix.batch_id }}`)
+	assert.Contains(t, workflow, `integer-security-build-batch-${{ matrix.batch_id }}`)
+
+	// And: the required aggregate verifies every expected marker, so an absent,
+	// skipped, cancelled, or failed arm64 leg cannot be reported as success.
+	assert.Contains(t, workflow, `EXPECTED_INTEGER_MATRIX: ${{ needs.detect-changed-images.outputs.expected-matrix }}`)
+	assert.Contains(t, workflow, `EXPECTED_INTEGER_SMOKE_MATRIX: ${{ needs.detect-changed-images.outputs.expected-smoke-matrix }}`)
+	assert.Contains(t, workflow, `for arch in amd64 arm64; do`)
+	assert.Contains(t, workflow, `::error::missing successful Integer ${kind} security leg: ${image}:${version}-${type} (${arch})`)
+	assert.Contains(t, workflow, `require_integer_markers "$EXPECTED_INTEGER_SMOKE_MATRIX" smoke`)
+	assert.Contains(t, workflow, `require_integer_markers "$EXPECTED_INTEGER_MATRIX" build`)
+}
+
+func TestPRWorkflowAggregateRejectsIncompleteIntegerArchitectureCoverage(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "pr-test.yaml"))
+	require.NoError(t, err)
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `yaml:"name"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &workflow))
+
+	var aggregate string
+	for _, step := range workflow.Jobs["pr-test-result"].Steps {
+		if step.Name == "Aggregate PR test results" {
+			aggregate = step.Run
+		}
+	}
+	require.NotEmpty(t, aggregate)
+
+	matrix := `{"include":[{"image":"demo","version":"1","type":"default"}]}`
+	baseEnv := append(os.Environ(),
+		"CHANGES_RESULT=success", "INTEGER=true", "COPA=false",
+		"DISCOVER_RESULT=success", "VALIDATE_RESULT=success",
+		"DETECT_INTEGER_RESULT=success", "INTEGER_HAS_CHANGES=true",
+		"INTEGER_SMOKE_RESULT=success", "INTEGER_BUILD_RESULT=success",
+		"DETECT_COPA_RESULT=success", "COPA_CHANGED_RESULT=success", "COPA_REGRESSION_RESULT=success",
+		"EXPECTED_INTEGER_MATRIX="+matrix, "EXPECTED_INTEGER_SMOKE_MATRIX="+matrix,
+	)
+
+	runAggregate := func(t *testing.T, env []string, missingMarker string) (string, error) {
+		t.Helper()
+		dir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "integer-security-results"), 0o755))
+		for _, kind := range []string{"smoke", "build"} {
+			for _, arch := range []string{"amd64", "arm64"} {
+				name := kind + "-demo-1-default-" + arch + ".passed"
+				if name == missingMarker {
+					continue
+				}
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "integer-security-results", name), nil, 0o600))
+			}
+		}
+		command := exec.CommandContext(t.Context(), "bash", "-c", aggregate)
+		command.Dir = dir
+		command.Env = env
+		output, runErr := command.CombinedOutput()
+		return string(output), runErr
+	}
+
+	t.Run("complete dual architecture evidence passes", func(t *testing.T) {
+		output, runErr := runAggregate(t, baseEnv, "")
+		require.NoError(t, runErr, output)
+	})
+
+	t.Run("missing arm64 evidence fails", func(t *testing.T) {
+		output, runErr := runAggregate(t, baseEnv, "build-demo-1-default-arm64.passed")
+		require.Error(t, runErr)
+		assert.Contains(t, output, "missing successful Integer build security leg: demo:1-default (arm64)")
+	})
+
+	for _, result := range []string{"skipped", "cancelled", "failure"} {
+		t.Run(result+" matrix job fails", func(t *testing.T) {
+			env := append([]string{}, baseEnv...)
+			env = append(env, "INTEGER_BUILD_RESULT="+result)
+			output, runErr := runAggregate(t, env, "")
+			require.Error(t, runErr)
+			assert.Contains(t, output, "integer-build-changed did not succeed: "+result)
+		})
+	}
+
+	for name, invalidMatrix := range map[string]string{
+		"malformed":       `{`,
+		"null":            `null`,
+		"missing include": `{}`,
+	} {
+		t.Run(name+" expected matrix fails closed", func(t *testing.T) {
+			env := append([]string{}, baseEnv...)
+			env = append(env, "EXPECTED_INTEGER_MATRIX="+invalidMatrix)
+			output, runErr := runAggregate(t, env, "")
+			require.Error(t, runErr)
+			assert.Contains(t, output, "invalid expected Integer build matrix")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- batch affected Integer entries below GitHub’s 256-job matrix limit
- build x86_64 and aarch64 packages plus amd64 and arm64 images for every affected smoke/build entry
- verify loaded runtime architecture, publish architecture-qualified Trivy reports, and emit per-image/per-architecture completion markers
- make the stable `PR Test` aggregate fail closed for absent, skipped, cancelled, failed, or malformed architecture evidence
- reuse one Melange signing key across architecture builds so both APK indexes remain verifiable
- preserve the Linkerd 25/default production pinning canary without treating it as global arm64 coverage

## Security invariant

No vulnerability suppression was added. Both architectures retain `--fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"`; report scans use `--exit-code 1` with all severities. No architecture is excluded or downgraded.

## Regression and verification evidence

- `TestPRWorkflowRequiresDualArchitectureIntegerSecurityCompletion` locks dual-architecture execution, evidence naming, and aggregate enforcement.
- `TestPRWorkflowAggregateRejectsIncompleteIntegerArchitectureCoverage` rejects missing arm64 evidence plus skipped, cancelled, failed, null, malformed, or missing matrices.
- `TestPrepareReusesExistingSigningKeyPair` failed before the CI fix (`keygen` count 2) and passes after it (`keygen` count 1).
- `go test -race -shuffle=on -count=1 ./internal/integer/melange ./scripts` — pass
- `golangci-lint run --timeout=5m` — 0 issues
- `make lint-workflows` — pass
- focused aggregate regression repeated 20 times — pass

## GitHub Actions receipt

Fresh head `2a2f53e021a9a8e0d6c46fc98f4f757eccf49d94`: 21 successful checks, 3 expected skipped checks, 0 failed/cancelled/pending. `Integer build batch 0`, `Integer smoke batch 0`, and the stable `PR Test` aggregate all passed with the strict dual-architecture Trivy gate.