### PR TITLE
fix(integer): rebuild postgres defaults from fixed sources

### DIFF
--- a/images/postgres.yaml
+++ b/images/postgres.yaml
@@ -45,8 +45,14 @@ types:
       - {path: /docker-entrypoint-initdb.d, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
-  "14": {}
-  "15": {}
+  "14":
+    melange:
+      default:
+        bespoke: "postgresql-14.yaml"
+  "15":
+    melange:
+      default:
+        bespoke: "postgresql-15.yaml"
   "16": {}
   "17": {}
   "18": {}

--- a/internal/integer/melange/pin_config_test.go
+++ b/internal/integer/melange/pin_config_test.go
@@ -48,15 +48,17 @@ func TestPinConfigPackagesPinsLocalVersionsAcrossArchitectures(t *testing.T) {
 }
 
 func TestPinConfigPackagesPinsLocalDependencyClosure(t *testing.T) {
-	// Given: the configured package depends on local subpackages in both architecture indexes.
+	// Given: the configured PostgreSQL server and client depend on local subpackages in both architecture indexes.
 	root := t.TempDir()
 	configPath := filepath.Join(root, "config.apko.yaml")
 	repositoryDir := filepath.Join(root, "repo")
-	writeTestFile(t, configPath, "contents:\n  packages: [postgresql-15, bash]\n")
-	index := "P:postgresql-15\nV:15.14-r0\no:postgresql-15\nD:postgresql-15-base=15.14-r0 tzdata\n\n" +
-		"P:postgresql-15-base\nV:15.14-r0\no:postgresql-15\nD:so:libpq.so.5\n\n" +
-		"P:libpq-14\nV:14.20-r2\no:postgresql-14\np:so:libpq.so.5\n\n" +
-		"P:libpq-15\nV:15.14-r0\no:postgresql-15\np:so:libpq.so.5\n\n"
+	writeTestFile(t, configPath, "contents:\n  packages: [postgresql-15, postgresql-15-client, bash]\n")
+	index := "P:postgresql-15\nV:15.18-r0\no:postgresql-15\nD:postgresql-15-base=15.18-r0 libpq-15=15.18-r0 tzdata\n\n" +
+		"P:postgresql-15-client\nV:15.18-r0\no:postgresql-15\nD:postgresql-15-client-base=15.18-r0 libpq-15=15.18-r0\n\n" +
+		"P:postgresql-15-client-base\nV:15.18-r0\no:postgresql-15\n\n" +
+		"P:postgresql-15-base\nV:15.18-r0\no:postgresql-15\nD:so:libpq.so.5\n\n" +
+		"P:libpq-14\nV:14.23-r0\no:postgresql-14\np:so:libpq.so.5\n\n" +
+		"P:libpq-15\nV:15.18-r0\no:postgresql-15\np:so:libpq.so.5\n\n"
 	writeAPKIndexArchive(t, filepath.Join(repositoryDir, "x86_64", "APKINDEX.tar.gz"), index)
 	writeAPKIndexArchive(t, filepath.Join(repositoryDir, "aarch64", "APKINDEX.tar.gz"), index)
 
@@ -71,10 +73,12 @@ func TestPinConfigPackagesPinsLocalDependencyClosure(t *testing.T) {
 	// Then: the root and every local dependency select the tagged repository exactly once.
 	require.NoError(t, err)
 	assert.Equal(t, []string{
-		"postgresql-15=15.14-r0@local",
+		"postgresql-15=15.18-r0@local",
+		"postgresql-15-client=15.18-r0@local",
 		"bash",
-		"postgresql-15-base=15.14-r0@local",
-		"libpq-15=15.14-r0@local",
+		"postgresql-15-base=15.18-r0@local",
+		"libpq-15=15.18-r0@local",
+		"postgresql-15-client-base=15.18-r0@local",
 	}, readConfigPackages(t, configPath))
 }
 

--- a/internal/integer/melange/spec_test.go
+++ b/internal/integer/melange/spec_test.go
@@ -103,6 +103,49 @@ versions:
 	}
 }
 
+func TestResolveSpecUsesBespokePostgreSQLRecipesForDefaultStreams(t *testing.T) {
+	// Given: the repository PostgreSQL image definition.
+	paths := repositoryTestPaths(t)
+	tests := []struct {
+		version string
+		want    Spec
+	}{
+		{version: "14", want: Spec{Bespoke: []string{"postgresql-14.yaml"}}},
+		{version: "15", want: Spec{Bespoke: []string{"postgresql-15.yaml"}}},
+		{version: "16", want: Spec{}},
+		{version: "17", want: Spec{}},
+		{version: "18", want: Spec{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			// When: the default stream's package build is resolved.
+			got, err := ResolveSpec(paths.ImagesDir, "postgres", tt.version, "default")
+
+			// Then: only PostgreSQL 14 and 15 select their matching local recipe.
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveSpecPreservesBespokePostgreSQLFIPSRecipes(t *testing.T) {
+	// Given: the repository PostgreSQL image definition.
+	paths := repositoryTestPaths(t)
+	want := Spec{Bespoke: []string{"openssl-provider-fips.yaml", "postgresql-14.yaml", "postgresql-15.yaml"}}
+
+	for _, version := range []string{"14", "15"} {
+		t.Run(version, func(t *testing.T) {
+			// When: the existing FIPS stream's package build is resolved.
+			got, err := ResolveSpec(paths.ImagesDir, "postgres", version, "fips")
+
+			// Then: its recipe set and ordering remain unchanged.
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
 func TestResolveSpecReturnsEmptyForAutoDiscoveredStandardVersion(t *testing.T) {
 	// Given: a standard image whose APKINDEX-discovered version is newer than
 	// the explicitly curated versions map.

--- a/packages/bespoke/postgresql-14.yaml
+++ b/packages/bespoke/postgresql-14.yaml
@@ -1,10 +1,10 @@
 package:
   name: postgresql-14
-  version: "14.20"
-  epoch: 2
+  version: "14.23"
+  epoch: 0
   description: A sophisticated object-relational DBMS
   copyright:
-    - license: BSD-3-Clause
+    - license: PostgreSQL
   dependencies:
     provides:
       - postgresql=${{package.full-version}}
@@ -41,7 +41,6 @@ environment:
       - tzdata
       - util-linux-dev
       - zlib-dev
-      - zstd-dev
 
 var-transforms:
   - from: ${{package.name}}
@@ -56,7 +55,7 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 9ad034be354da9af1cea76836a9e576c110d1ff3
+      expected-commit: 4e1a23c0ea0be0214c6806baa212886cee8f14a6
       repository: https://github.com/postgres/postgres
       tag: REL_${{vars.mangled-package-version}}
   - runs: |
@@ -96,7 +95,6 @@ pipeline:
         --with-libxslt \
         --with-icu \
         --with-lz4 \
-        --with-zstd \
         --with-gssapi \
         --with-ldap \
         --with-llvm \

--- a/packages/bespoke/postgresql-15.yaml
+++ b/packages/bespoke/postgresql-15.yaml
@@ -1,10 +1,10 @@
 package:
   name: postgresql-15
-  version: "15.14"
+  version: "15.18"
   epoch: 0
   description: A sophisticated object-relational DBMS
   copyright:
-    - license: BSD-3-Clause
+    - license: PostgreSQL
   dependencies:
     provides:
       - postgresql=${{package.full-version}}
@@ -56,7 +56,7 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0ab43b548237b3791261480d6a023f6b95b53942
+      expected-commit: 005c1971a2926fbb9caf5a1ad634cd17a42bfd3c
       repository: https://github.com/postgres/postgres
       tag: REL_${{vars.mangled-package-version}}
   - runs: |


### PR DESCRIPTION
## Summary

- use version-scoped Melange configuration so `postgres:14-default` builds only `postgresql-14.yaml` and `postgres:15-default` builds only `postgresql-15.yaml`
- leave PostgreSQL 16-18 default streams unchanged on their existing upstream package resolution and preserve the existing FIPS recipe/type behavior
- update PostgreSQL 14 to 14.23 (`4e1a23c0ea0be0214c6806baa212886cee8f14a6`) and PostgreSQL 15 to 15.18 (`005c1971a2926fbb9caf5a1ad634cd17a42bfd3c`) under the PostgreSQL license
- pin server, client, base, client-base, and matching libpq subpackages from the local repository without selecting the other major stream

## RED evidence

Before the change, `postgres:14-default` selected remote `14.11-r6`; strict Trivy reported 40 findings: 5 LOW, 20 MEDIUM, and 15 HIGH. The focused regression test also showed both target default streams resolved no Melange spec.

The first CI iteration additionally proved that type-wide Melange incorrectly affected PostgreSQL 16-18; the rebased implementation uses the version-scoped configuration added by #966 and tests 16-18 as empty Melange specs.

## Verification

- focused version-scope, PostgreSQL spec, and package-closure tests pass
- `make integer-validate` passes (334 image definitions)
- full `go test ./...` and `golangci-lint run` pass
- local native x86_64 Melange builds passed for PostgreSQL 14.23 and 15.18 with signed APK indexes
- generated target configs pin the complete matching local server/client/base/client-base/libpq closure
- local amd64 apko assembly emitted SPDX SBOMs for both target default images
- local strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` reports zero vulnerabilities for both target images
- runtime smoke reports `postgres` and `psql` 14.23/15.18
- required CI native amd64 and arm64 package/image/runtime/SPDX gates passed, with strict Trivy UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL reporting zero findings

No vulnerability ignore, VEX substitution, exclusion, architecture skip, severity relaxation, or epoch-only remediation is used.
