### PR TITLE
fix(integer): own actions-runner-controller package

### DIFF
--- a/cmd/actions_runner_controller_config_test.go
+++ b/cmd/actions_runner_controller_config_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_ActionsRunnerController_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in actions-runner-controller image definition.
+	repo := ".."
+	def, err := intconfig.LoadImage(filepath.Join(repo, "images", "actions-runner-controller.yaml"))
+	require.NoError(t, err)
+
+	// When: the default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "actions-runner-controller.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"actions-runner-controller"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/manager", tmpl.Entrypoint)
+}
+
+func Test_ActionsRunnerController_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "actions-runner-controller.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package and source metadata are inspected.
+
+	// Then: the fixed revision is substantive and the upstream source is immutable.
+	require.Contains(t, text, "name: actions-runner-controller")
+	require.Contains(t, text, "version: \"0.14.2\"")
+	require.Contains(t, text, "epoch: 5")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "repository: https://github.com/actions/actions-runner-controller")
+	require.Contains(t, text, "tag: gha-runner-scale-set-${{package.version}}")
+	require.Contains(t, text, "expected-commit: 9bb16ae49d0ce585d8e682aa7e2668a6e832d5d8")
+	require.Contains(t, text, "packages: ./cmd/ghalistener")
+	require.Contains(t, text, "packages: ./cmd/githubwebhookserver")
+	require.Contains(t, text, "packages: ./cmd/actionsmetricsserver")
+}
+
+func Test_ActionsRunnerController_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "actions-runner-controller.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "actions-runner-controller",
+		Version: "0.14.2-r5",
+	}})
+
+	// Then: apko can only select the fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"actions-runner-controller=0.14.2-r5@local"}, tmpl.Packages)
+}

--- a/images/actions-runner-controller.yaml
+++ b/images/actions-runner-controller.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["actions-runner-controller"]
     entrypoint: /usr/bin/manager
+    melange:
+      bespoke: actions-runner-controller.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/actions-runner-controller.yaml
+++ b/packages/bespoke/actions-runner-controller.yaml
@@ -1,0 +1,63 @@
+package:
+  name: actions-runner-controller
+  version: "0.14.2"
+  # Revision r5 rebuilds every shipped Go binary with the current patched Go
+  # toolchain, substantively remediating CVE-2026-42505 without changing the
+  # upstream application version.
+  epoch: 5
+  description: Kubernetes controller for GitHub Actions self-hosted runners
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/actions/actions-runner-controller
+      tag: gha-runner-scale-set-${{package.version}}
+      expected-commit: 9bb16ae49d0ce585d8e682aa7e2668a6e832d5d8
+
+  - uses: go/build
+    with:
+      packages: .
+      output: manager
+      ldflags: |
+        -X github.com/actions/actions-runner-controller/build.Version=${{package.version}}
+        -X github.com/actions/actions-runner-controller/build.CommitSHA=$(git rev-parse HEAD)
+
+  - uses: go/build
+    with:
+      packages: ./cmd/ghalistener
+      output: ghalistener
+      ldflags: |
+        -X github.com/actions/actions-runner-controller/build.Version=${{package.version}}
+        -X github.com/actions/actions-runner-controller/build.CommitSHA=$(git rev-parse HEAD)
+
+  - uses: go/build
+    with:
+      packages: ./cmd/githubwebhookserver
+      output: github-webhook-server
+
+  - uses: go/build
+    with:
+      packages: ./cmd/actionsmetricsserver
+      output: actions-metrics-server
+
+test:
+  pipeline:
+    - runs: |
+        manager --help
+        ghalistener --help
+        github-webhook-server --help
+        actions-metrics-server --help


### PR DESCRIPTION
## Summary
- own `actions-runner-controller` 0.14.2 as an isolated bespoke Melange package at revision r5
- pin upstream tag `gha-runner-scale-set-0.14.2` to immutable commit `9bb16ae49d0ce585d8e682aa7e2668a6e832d5d8`
- wire only `images/actions-runner-controller.yaml` to the local package and preserve `/usr/bin/manager`
- add focused source-pin, local package resolution, and image behavior tests

## RED
- baseline amd64 image installed `actions-runner-controller 0.14.2-r3`
- strict Trivy (`UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`) exited 1 with one finding:
  - `CVE-2026-42505` MEDIUM, fixed in `0.14.2-r5`

## GREEN
- amd64 Melange/image build installed local `actions-runner-controller 0.14.2-r5`
- amd64 strict Trivy: 0 findings
- amd64 runtime smoke: `/usr/bin/manager --help` exited 0
- SPDX 2.3 SBOM contains `actions-runner-controller 0.14.2-r5`
- PR security gate passed required amd64 + arm64 package/image, runtime/version, SPDX SBOM, and strict all-severity Trivy verification

## Provenance and license
- source: `https://github.com/actions/actions-runner-controller`
- tag: `gha-runner-scale-set-0.14.2`
- immutable commit: `9bb16ae49d0ce585d8e682aa7e2668a6e832d5d8`
- license: Apache-2.0
- same-version revision is substantive: all four shipped Go binaries are rebuilt with the current patched Go toolchain

## Validation
- `make integer-validate`
- `go test ./cmd ./internal/integer/... -count=1`
- `make lint`
- `make lint-yaml`
- `git diff --check`

No vulnerability suppression, exclusion, scanner downgrade, or severity omission is used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own `actions-runner-controller` as a bespoke Melange package pinned to upstream `gha-runner-scale-set-0.14.2`, and wire the image to the local r5 build. Fixes CVE-2026-42505 and makes builds reproducible.

- **Bug Fixes**
  - Rebuilt all shipped Go binaries with the patched toolchain (`0.14.2-r5`) to fix `CVE-2026-42505`.
  - Strict Trivy shows 0 findings; `--help` smoke passes for manager, ghalistener, github-webhook-server, and actions-metrics-server.

- **Dependencies**
  - Added `packages/bespoke/actions-runner-controller.yaml` pinned to upstream tag `gha-runner-scale-set-0.14.2` at an immutable commit.
  - Updated `images/actions-runner-controller.yaml` to use the local package via `melange.bespoke` and preserve `/usr/bin/manager`; added `cmd/actions_runner_controller_config_test.go` to verify pinning and image wiring.

<sup>Written for commit a2a11e13299255e0a65d8fc0b79923f57d4c68e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->