### PR TITLE
fix(renovate): support runner scale-set tags

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -42,6 +42,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",
+    "gha-runner-scale-set-${{package.version}}",
     "v${{package.version}}",
     "openssl-${{package.version}}",
     "REL_${{vars.mangled-package-version}}",
@@ -76,6 +77,23 @@ def workflow_image_name(match: re.Match[str]) -> str:
 
 def self_test() -> None:
     errors: list[str] = []
+    require(
+        errors,
+        "gha-runner-scale-set-${{package.version}}" in SUPPORTED_GITHUB_TAGS,
+        "runner scale-set GitHub tag rejected",
+    )
+    for malformed_tag in (
+        "gha-runner-${{package.version}}",
+        "gha-runner-scale-${{package.version}}",
+        "gha-runner-scale-sets-${{package.version}}",
+        "other-gha-runner-scale-set-${{package.version}}",
+    ):
+        require(
+            errors,
+            malformed_tag not in SUPPORTED_GITHUB_TAGS,
+            f"malformed runner scale-set GitHub tag accepted: {malformed_tag}",
+        )
+
     marker = (
         "# renovate: datasource=github-tags depName=example/project "
         "versioning=semver-coerced"


### PR DESCRIPTION
## Summary
- allow the exact upstream GitHub tag shape `gha-runner-scale-set-${{package.version}}`
- keep malformed near-miss prefixes rejected by the exact allowlist
- add validator self-test regression coverage

## Validation
- `python3 .github/scripts/validate-renovate-coverage.py`
- `make lint-workflows`
- `go test ./cmd ./internal/integer/... -count=1`
- `actionlint`
- `git diff --check`

Unblocks #961.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the exact GitHub tag format `gha-runner-scale-set-${{package.version}}` in the Renovate coverage validator so Renovate can track runner scale-set releases. Add a self-test to ensure this tag is accepted and common near-miss prefixes are rejected.

<sup>Written for commit 23bd5becf10a8f664f887d370332a4938f936800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

