### PR TITLE
fix(integer): rebuild alertmanager from fixed source

### DIFF
--- a/images/alertmanager.yaml
+++ b/images/alertmanager.yaml
@@ -11,6 +11,8 @@ types:
     paths:
       - {path: /etc/alertmanager, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /alertmanager, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+    melange:
+      upstream: "prometheus-alertmanager"
 
   fips:
     base: wolfi-base

--- a/internal/integer/config/alertmanager_image_test.go
+++ b/internal/integer/config/alertmanager_image_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAlertmanagerDefaultUsesApprovedBespokePackage(t *testing.T) {
+	// Given: the Alertmanager image definition and its locked package recipe.
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "locating test file")
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	def, err := LoadImage(filepath.Join(repoRoot, "images", "alertmanager.yaml"))
+	require.NoError(t, err)
+	recipeData, err := os.ReadFile(filepath.Join(repoRoot, "packages", "bespoke", "locked", "prometheus-alertmanager.yaml"))
+	require.NoError(t, err)
+
+	var recipe struct {
+		Package struct {
+			Version   string `yaml:"version"`
+			Epoch     int    `yaml:"epoch"`
+			Copyright []struct {
+				License string `yaml:"license"`
+			} `yaml:"copyright"`
+		} `yaml:"package"`
+		Pipeline []struct {
+			Uses string `yaml:"uses"`
+			Name string `yaml:"name"`
+			With struct {
+				ExpectedCommit string `yaml:"expected-commit"`
+				Deps           string `yaml:"deps"`
+			} `yaml:"with"`
+			Runs string `yaml:"runs"`
+		} `yaml:"pipeline"`
+	}
+	require.NoError(t, yaml.Unmarshal(recipeData, &recipe))
+
+	// When: the default image and recipe are checked against the approved matrix row.
+	defaultType := def.Types["default"]
+	require.NotNil(t, defaultType.Melange)
+
+	// Then: the image builds the fixed, source-pinned Apache-2.0 package.
+	require.Equal(t, "prometheus-alertmanager", defaultType.Melange.Upstream)
+	require.Equal(t, "0.33.1", recipe.Package.Version)
+	require.Equal(t, 2, recipe.Package.Epoch)
+	require.Equal(t, "Apache-2.0", recipe.Package.Copyright[0].License)
+
+	var checkoutCommit, bumpedDependencies, recoveredAssets string
+	for _, step := range recipe.Pipeline {
+		switch {
+		case step.Uses == "git-checkout":
+			checkoutCommit = step.With.ExpectedCommit
+		case step.Uses == "go/bump":
+			bumpedDependencies = step.With.Deps
+		case step.Name == "Recover prebuilt UI dist from upstream binary":
+			recoveredAssets = step.Runs
+		}
+	}
+	require.Equal(t, "2c8da51e03f3dbbed24f9711ca2d76aab4eef9c5", checkoutCommit)
+	require.Contains(t, bumpedDependencies, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, bumpedDependencies, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.True(t, strings.Contains(recoveredAssets, "93d802cba6a8d27239d747ce117df7648d326ab67394e32247540b030e9842ba") &&
+		strings.Contains(recoveredAssets, "50b32a346c3c29da411643dfa84990440e8fd03800380d7e664f22a863b7a0cf"))
+}

--- a/packages/bespoke/locked/prometheus-alertmanager.yaml
+++ b/packages/bespoke/locked/prometheus-alertmanager.yaml
@@ -1,13 +1,16 @@
 package:
   name: prometheus-alertmanager
-  version: "0.31.1"
-  epoch: 1 # GHSA-9h8m-3fm2-qjrq
+  version: "0.33.1"
+  epoch: 2 # CVE-2026-41178, CVE-2026-42505
   description: Prometheus Alertmanager
   copyright:
     - license: Apache-2.0
   resources:
-    cpu: "3"
+    cpu: "2"
     memory: 9Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
 
 environment:
   contents:
@@ -17,31 +20,105 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl
-      - go
-      - nodejs<21
-      - npm
-
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+).*
-    replace: $1
-    to: major-version
+      - go-1.26
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/prometheus/alertmanager
       tag: v${{package.version}}
-      expected-commit: 7a639ba087d6e877038cabfdaa645230f79001b8
+      expected-commit: 2c8da51e03f3dbbed24f9711ca2d76aab4eef9c5
 
   - uses: go/bump
     with:
       deps: |-
-        go.opentelemetry.io/otel/sdk@v1.40.0
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+        go.opentelemetry.io/otel/sdk@v1.44.0
 
   - runs: |
       sed -i '/_ "net\/http\/pprof"/d' ui/web.go
       git diff
+
+  # Alertmanager 0.32.0 introduced a Vite/Elm UI build that can hang in
+  # melange's isolated builder while Elm contacts package.elm-lang.org.
+  # Recover only the architecture-independent compiled UI assets from the
+  # checksummed upstream release; the shipped binaries are still built from
+  # the immutable source commit above.
+  - name: Recover prebuilt UI dist from upstream binary
+    runs: |
+      set -eu
+      case "$(uname -m)" in
+        x86_64)  ARCH=amd64; SHA=93d802cba6a8d27239d747ce117df7648d326ab67394e32247540b030e9842ba ;;
+        aarch64) ARCH=arm64; SHA=50b32a346c3c29da411643dfa84990440e8fd03800380d7e664f22a863b7a0cf ;;
+        *) echo "unsupported arch: $(uname -m)"; exit 1 ;;
+      esac
+      cd /tmp
+      TGZ="alertmanager-${{package.version}}.linux-${ARCH}.tar.gz"
+      curl -fsSL -o "${TGZ}" "https://github.com/prometheus/alertmanager/releases/download/v${{package.version}}/${TGZ}"
+      echo "${SHA}  ${TGZ}" | sha256sum -c -
+      tar -xzf "${TGZ}"
+      AM="/tmp/alertmanager-${{package.version}}.linux-${ARCH}/alertmanager"
+
+      cat > /tmp/am.yml <<'YAML'
+      route: { receiver: devnull }
+      receivers: [{ name: devnull }]
+      YAML
+      mkdir -p /tmp/am-data
+      "${AM}" --config.file=/tmp/am.yml --storage.path=/tmp/am-data \
+              --web.listen-address=127.0.0.1:9094 --cluster.listen-address="" \
+              > /tmp/am.log 2>&1 &
+      AMPID=$!
+      trap 'kill "${AMPID}" 2>/dev/null || true; wait "${AMPID}" 2>/dev/null || true' EXIT INT TERM
+      for _ in $(seq 1 30); do
+        curl -sf http://127.0.0.1:9094/-/ready >/dev/null 2>&1 && break
+        sleep 1
+      done
+
+      cd /home/build
+      DIST=ui/app/dist
+      mkdir -p "${DIST}/assets"
+
+      curl -sf http://127.0.0.1:9094/ -o /tmp/index.plain
+      URLS="/ /favicon.ico"
+      for u in $(grep -oE '/?assets/[A-Za-z0-9._-]+' /tmp/index.plain | sed 's,^/\?,/,' | sort -u); do
+        URLS="${URLS} ${u}"
+      done
+      for u in ${URLS}; do
+        case "${u}" in
+          *.css)
+            curl -sf "http://127.0.0.1:9094${u}" -o /tmp/style.css
+            for f in $(grep -oE 'url\(\./[A-Za-z0-9._-]+\.(woff2?|ttf|eot|svg)' /tmp/style.css | sed -E 's,url\(\./,,' | sort -u); do
+              URLS="${URLS} /assets/${f}"
+            done
+            ;;
+        esac
+      done
+
+      # ui/web.go serves woff/woff2 plain and the other embedded assets from
+      # their precompressed .gz/.br files.
+      for u in $(echo "${URLS}" | tr ' ' '\n' | sort -u); do
+        [ -n "${u}" ] || continue
+        if [ "${u}" = "/" ]; then out="${DIST}/index.html"; else out="${DIST}${u}"; fi
+        mkdir -p "$(dirname "${out}")"
+        case "${out##*.}" in
+          woff|woff2)
+            curl -sf -H 'Accept-Encoding: identity' "http://127.0.0.1:9094${u}" -o "${out}"
+            ;;
+          *)
+            curl -sf -H 'Accept-Encoding: gzip' "http://127.0.0.1:9094${u}" -o "${out}.gz"
+            curl -sf -H 'Accept-Encoding: br' "http://127.0.0.1:9094${u}" -o "${out}.br"
+            ;;
+        esac
+      done
+
+      test -s "${DIST}/index.html.gz" || { echo "FATAL: ${DIST}/index.html.gz empty/missing"; exit 1; }
+      test -s "${DIST}/favicon.ico.gz" || { echo "FATAL: ${DIST}/favicon.ico.gz empty/missing"; exit 1; }
+      js_count=$(find "${DIST}/assets" -name '*.js.gz' -type f | wc -l)
+      [ "${js_count}" -ge 1 ] || { echo "FATAL: no .js.gz assets recovered under ${DIST}/assets"; exit 1; }
+
+      sed -i 's/^build: ui-elm common-build/build: common-build/' Makefile
 
   - runs: |
       make build
@@ -50,8 +127,6 @@ pipeline:
       install -Dm755 amtool "${{targets.destdir}}"/usr/bin/amtool
       install -Dm755 alertmanager "${{targets.destdir}}"/usr/bin/alertmanager
       install -Dm644 examples/ha/alertmanager.yml "${{targets.destdir}}"/etc/alertmanager/alertmanager.yml
-
-  - uses: strip
 
 update:
   enabled: true
@@ -64,6 +139,7 @@ test:
     contents:
       packages:
         - curl
+        - wait-for-it
   pipeline:
     - runs: |
         alertmanager --version
@@ -72,15 +148,16 @@ test:
         amtool --help
     - name: Functional tests
       runs: |
+        set -euo pipefail
         # Start alertmanager with test config
         alertmanager \
-          --config.file=test-alertmanager-config.yaml \
+          --config.file=/etc/alertmanager/alertmanager.yml \
           --storage.path=alertmanager \
           --web.listen-address=127.0.0.1:9093 \
           --cluster.listen-address="" \
           --log.level=debug > /dev/null 2>&1 &
         AM_PID=$!
-        sleep 5
+        wait-for-it 127.0.0.1:9093 -t 30
 
         # Test health endpoints
         curl -s http://127.0.0.1:9093/-/ready || exit 1
@@ -92,7 +169,7 @@ test:
           http://127.0.0.1:9093/api/v2/alerts
 
         # Verify alert exists
-        curl -s http://127.0.0.1:9093/api/v2/alerts | grep -q "TestAlertFromMelangeTest"
+        curl -s http://127.0.0.1:9093/api/v2/alerts | grep -F "TestAlertFromMelangeTest"
 
         # Create a silence for our test alert
         SILENCE_ID=$(curl -s -XPOST -H "Content-Type: application/json" \
@@ -100,4 +177,4 @@ test:
           http://127.0.0.1:9093/api/v2/silences | grep -o '"silenceID":"[^"]*"' | cut -d'"' -f4)
 
         # Verify silence exists
-        curl -s http://127.0.0.1:9093/api/v2/silences | grep -q "$SILENCE_ID"
+        curl -s http://127.0.0.1:9093/api/v2/silences | grep -F "$SILENCE_ID"

--- a/packages/upstream.lock.json
+++ b/packages/upstream.lock.json
@@ -15,13 +15,15 @@
     },
     "prometheus-alertmanager": {
       "file": "prometheus-alertmanager.yaml",
-      "sha256": "db7e0e2e620831413b83bcc8efa3cff423a96949a98a73a861f1720e45c24b39",
+      "sha256": "cc8e06bfbf75d34997f381fb33757dc2202499cfd0fcf5f23e492a60237ae3f0",
       "assets": {
         "prometheus-alertmanager/test-alertmanager-config.yaml": "bd6a4b1e896e9ad556ce07567fcb16f2644dc3bca2ca885d1e96ad5b5391f22f"
       },
-      "version": "0.31.1",
-      "source": "public-recipe-baseline@3bc1a15922962c2ffbc0844b7f98672b79c5fd71",
-      "cve_tracking": "removed an unconsumed compatibility subpackage that executed mutable external build tooling; publication remains contingent on the strict zero-vulnerability gate"
+      "version": "0.33.1",
+      "source": "wolfi-dev/os@86766d6e33db6f815a823947fea05e03ef76e147",
+      "upstream": "prometheus/alertmanager@v0.33.1#2c8da51e03f3dbbed24f9711ca2d76aab4eef9c5",
+      "bespoke_status": "direct-bump",
+      "cve_tracking": "bumped from the installed 0.32.1-r3 to 0.33.1-r2; forces OpenTelemetry-Go core modules to v1.44.0 for CVE-2026-41178 and builds with fixed go-1.26 for CVE-2026-42505; upstream release UI assets are architecture-specific SHA-256 pinned"
     },
     "argocd": {
       "file": "argo-cd-3.3.yaml",


### PR DESCRIPTION
## Summary

- rebuild alertmanager:0-default from the locked prometheus-alertmanager recipe
- bump the failing installed 0.32.1-r3 package to approved fixed candidate 0.33.1-r2
- pin Alertmanager source commit 2c8da51e03f3dbbed24f9711ca2d76aab4eef9c5 and amd64/arm64 release-asset SHA-256 values
- force OpenTelemetry-Go core modules to v1.44.0 and build with Go 1.26.5
- preserve the entrypoint, nonroot user, filesystem paths, and functional Alertmanager tests

## Evidence

- RED baseline: strict Trivy found CVE-2026-41178 and CVE-2026-42505 in 0.32.1-r3
- focused regression: TestAlertmanagerDefaultUsesApprovedBespokePackage
- local: targeted race test, full Go suite, Integer validation, lock inventory
- local amd64: package/image build, Alertmanager 0.33.1 runtime smoke, SPDX-2.3 with Apache-2.0, strict all-severity Trivy with 0 findings
- PR Test run 29398134381: amd64 and arm64 package/image builds, runtime architecture checks, and strict UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL Trivy with 0 findings on both
- native proof run 29398608329:
  - x86_64 melange build succeeded
  - aarch64 melange build succeeded on ubuntu-24.04-arm
  - native aarch64 APK is 0.33.1-r2 with SPDX-2.3 and declared Apache-2.0
  - amd64 and arm64 strict prepublish Trivy gates each reported 0 findings
  - published OCI index contains linux/amd64 and linux/arm64; both report Alertmanager 0.33.1, source revision 2c8da51e, Go 1.26.5

## Review

- one epoch-priority thread was answered and resolved: pin-config uses exact version@local selectors, so repository ordering cannot substitute another package
- all required checks are green
