### PR TITLE
feat(integer): support version-scoped melange config

### DIFF
--- a/cmd/integer_build.go
+++ b/cmd/integer_build.go
@@ -135,7 +135,7 @@ var integerBuildCmd = &cli.Command{
 		// — see ResolveStreamRenderVersion's doc for the design.
 		renderVersion := discovery.ResolveStreamRenderVersion(def, pkgs, version)
 		arch := cmd.String("arch")
-		melangeArtifacts, err := integerPrepareMelangeBuild(ctx, tmpl.Melange, renderVersion, arch)
+		melangeArtifacts, err := integerPrepareMelangeBuild(ctx, def.MelangeFor(version, typeName), renderVersion, arch)
 		if err != nil {
 			return fmt.Errorf("preparing melange build: %w", err)
 		}

--- a/cmd/integer_validate.go
+++ b/cmd/integer_validate.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
-	"strings"
 
 	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"
@@ -176,9 +174,9 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 	for typeName := range def.Types {
 		tmpl := def.Types[typeName]
 		for _, selected := range melangeSpecsForType(def, typeName) {
-			matchesPackage := selected.packageMatcher(def, typeName, tmpl.Packages)
+			matchesPackage := selected.packageMatcher(tmpl.Packages)
 			for _, bespokeFile := range selected.spec.Bespoke {
-				resolvedFiles, rerr := selected.resolveBespokeFiles(def, typeName, bespokeFile)
+				resolvedFiles, rerr := selected.resolveBespokeFiles(bespokeFile)
 				if rerr != nil {
 					fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
 						defPath, typeName, bespokeFile, rerr)
@@ -194,7 +192,7 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 						continue
 					}
 
-					if err := validateBespokePackage(filepath.Join(bespokeDir, resolvedFile), matchesPackage); err != nil {
+					if err := validateBespokePackage(filepath.Join(bespokeDir, resolvedFile), tmpl.Packages, matchesPackage); err != nil {
 						fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
 							defPath, typeName, resolvedFile, err)
 						failures++
@@ -213,26 +211,6 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 	}
 
 	return failures
-}
-
-func tmplPackageMatchesBespoke(def *intconfig.ImageDef, typeName string, packages []string, pkgName string) bool {
-	for _, pkg := range packages {
-		if apkPackageName(pkg) == pkgName {
-			return true
-		}
-		if !strings.Contains(pkg, "{{version}}") {
-			continue
-		}
-		for version, meta := range def.Versions {
-			if slices.Contains(meta.SkipTypes, typeName) {
-				continue
-			}
-			if apkPackageName(strings.ReplaceAll(pkg, "{{version}}", version)) == pkgName {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func apkPackageName(pkg string) string {

--- a/cmd/integer_validate.go
+++ b/cmd/integer_validate.go
@@ -175,47 +175,31 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 	bespokeRefs := 0
 	for typeName := range def.Types {
 		tmpl := def.Types[typeName]
-		if tmpl.Melange == nil || len(tmpl.Melange.Bespoke) == 0 {
-			continue
-		}
-		for _, bespokeFile := range tmpl.Melange.Bespoke {
-			resolvedFiles, rerr := resolveBespokeFiles(def, typeName, bespokeFile)
-			if rerr != nil {
-				fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
-					defPath, typeName, bespokeFile, rerr)
-				failures++
-				continue
-			}
-
-			for _, resolvedFile := range resolvedFiles {
-				referenced[resolvedFile] = defPath
-				bespokeRefs++
-
-				if !dirExists {
-					continue
-				}
-
-				bespokePath := filepath.Join(bespokeDir, resolvedFile)
-				pkgName, berr := readBespokePackageName(bespokePath)
-				if berr != nil {
+		for _, selected := range melangeSpecsForType(def, typeName) {
+			matchesPackage := selected.packageMatcher(def, typeName, tmpl.Packages)
+			for _, bespokeFile := range selected.spec.Bespoke {
+				resolvedFiles, rerr := selected.resolveBespokeFiles(def, typeName, bespokeFile)
+				if rerr != nil {
 					fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
-						defPath, typeName, resolvedFile, berr)
+						defPath, typeName, bespokeFile, rerr)
 					failures++
 					continue
 				}
-				if pkgName == "" {
-					fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: missing package.name\n",
-						defPath, typeName, resolvedFile)
-					failures++
-					continue
-				}
-				if !tmplPackageMatchesBespoke(def, typeName, tmpl.Packages, pkgName) {
-					fmt.Fprintf(os.Stderr,
-						"FAIL %s type %q: bespoke package.name %q not satisfiable by apko packages %v "+
-							"for any declared version of this type (apko will fail with 'not in indexes' at publish time)\n",
-						defPath, typeName, pkgName, tmpl.Packages)
-					failures++
-					continue
+
+				for _, resolvedFile := range resolvedFiles {
+					referenced[resolvedFile] = defPath
+					bespokeRefs++
+
+					if !dirExists {
+						continue
+					}
+
+					if err := validateBespokePackage(filepath.Join(bespokeDir, resolvedFile), matchesPackage); err != nil {
+						fmt.Fprintf(os.Stderr, "FAIL %s type %q: bespoke %s: %v\n",
+							defPath, typeName, resolvedFile, err)
+						failures++
+						continue
+					}
 				}
 			}
 		}
@@ -229,36 +213,6 @@ func validateBespokeRefs(def *intconfig.ImageDef, defPath, bespokeDir string, re
 	}
 
 	return failures
-}
-
-func resolveBespokeFiles(def *intconfig.ImageDef, typeName, bespokeFile string) ([]string, error) {
-	if !strings.Contains(bespokeFile, "{{version}}") {
-		return []string{bespokeFile}, nil
-	}
-
-	versions := make([]string, 0, len(def.Versions))
-	for version, meta := range def.Versions {
-		if slices.Contains(meta.SkipTypes, typeName) {
-			continue
-		}
-		versions = append(versions, version)
-	}
-	if len(versions) == 0 {
-		return nil, fmt.Errorf("%w: %q", errMissingDeclaredVersionType, typeName)
-	}
-
-	apkindex.SortVersions(versions)
-	resolved := make([]string, 0, len(versions))
-	seen := make(map[string]struct{}, len(versions))
-	for _, version := range versions {
-		name := strings.ReplaceAll(bespokeFile, "{{version}}", version)
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		seen[name] = struct{}{}
-		resolved = append(resolved, name)
-	}
-	return resolved, nil
 }
 
 func tmplPackageMatchesBespoke(def *intconfig.ImageDef, typeName string, packages []string, pkgName string) bool {

--- a/cmd/integer_validate_melange.go
+++ b/cmd/integer_validate_melange.go
@@ -16,18 +16,35 @@ var (
 )
 
 type versionedMelangeSpec struct {
-	version string
-	spec    *intconfig.MelangeSpec
+	version  string
+	versions []string
+	spec     *intconfig.MelangeSpec
 }
 
-func (s versionedMelangeSpec) resolveBespokeFiles(def *intconfig.ImageDef, typeName, bespokeFile string) ([]string, error) {
+func (s versionedMelangeSpec) resolveBespokeFiles(bespokeFile string) ([]string, error) {
 	if s.version != "" {
 		return []string{strings.ReplaceAll(bespokeFile, "{{version}}", s.version)}, nil
 	}
-	return resolveBespokeFiles(def, typeName, bespokeFile)
+	if !strings.Contains(bespokeFile, "{{version}}") {
+		return []string{bespokeFile}, nil
+	}
+	if len(s.versions) == 0 {
+		return nil, errMissingDeclaredVersionType
+	}
+	resolved := make([]string, 0, len(s.versions))
+	seen := make(map[string]struct{}, len(s.versions))
+	for _, version := range s.versions {
+		name := strings.ReplaceAll(bespokeFile, "{{version}}", version)
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		resolved = append(resolved, name)
+	}
+	return resolved, nil
 }
 
-func (s versionedMelangeSpec) packageMatcher(def *intconfig.ImageDef, typeName string, packages []string) func(string) bool {
+func (s versionedMelangeSpec) packageMatcher(packages []string) func(string) bool {
 	if s.version != "" {
 		return func(pkgName string) bool {
 			for _, pkg := range packages {
@@ -39,15 +56,25 @@ func (s versionedMelangeSpec) packageMatcher(def *intconfig.ImageDef, typeName s
 		}
 	}
 	return func(pkgName string) bool {
-		return tmplPackageMatchesBespoke(def, typeName, packages, pkgName)
+		for _, pkg := range packages {
+			if apkPackageName(pkg) == pkgName {
+				return true
+			}
+			if !strings.Contains(pkg, "{{version}}") {
+				continue
+			}
+			for _, version := range s.versions {
+				if apkPackageName(strings.ReplaceAll(pkg, "{{version}}", version)) == pkgName {
+					return true
+				}
+			}
+		}
+		return false
 	}
 }
 
 func melangeSpecsForType(def *intconfig.ImageDef, typeName string) []versionedMelangeSpec {
 	selected := []versionedMelangeSpec{}
-	if tmpl, ok := def.Types[typeName]; ok && tmpl.Melange != nil {
-		selected = append(selected, versionedMelangeSpec{spec: tmpl.Melange})
-	}
 	versions := make([]string, 0, len(def.Versions))
 	for version, meta := range def.Versions {
 		if !slices.Contains(meta.SkipTypes, typeName) {
@@ -55,6 +82,17 @@ func melangeSpecsForType(def *intconfig.ImageDef, typeName string) []versionedMe
 		}
 	}
 	apkindex.SortVersions(versions)
+	if tmpl, ok := def.Types[typeName]; ok && tmpl.Melange != nil {
+		sharedVersions := make([]string, 0, len(versions))
+		for _, version := range versions {
+			if def.MelangeFor(version, typeName) == tmpl.Melange {
+				sharedVersions = append(sharedVersions, version)
+			}
+		}
+		if len(def.Versions) == 0 || len(sharedVersions) > 0 {
+			selected = append(selected, versionedMelangeSpec{versions: sharedVersions, spec: tmpl.Melange})
+		}
+	}
 	for _, version := range versions {
 		if spec, configured := def.Versions[version].Melange[typeName]; configured && spec != nil {
 			selected = append(selected, versionedMelangeSpec{version: version, spec: spec})
@@ -63,37 +101,7 @@ func melangeSpecsForType(def *intconfig.ImageDef, typeName string) []versionedMe
 	return selected
 }
 
-func resolveBespokeFiles(def *intconfig.ImageDef, typeName, bespokeFile string) ([]string, error) {
-	if !strings.Contains(bespokeFile, "{{version}}") {
-		return []string{bespokeFile}, nil
-	}
-
-	versions := make([]string, 0, len(def.Versions))
-	for version, meta := range def.Versions {
-		if slices.Contains(meta.SkipTypes, typeName) {
-			continue
-		}
-		versions = append(versions, version)
-	}
-	if len(versions) == 0 {
-		return nil, fmt.Errorf("%w: %q", errMissingDeclaredVersionType, typeName)
-	}
-
-	apkindex.SortVersions(versions)
-	resolved := make([]string, 0, len(versions))
-	seen := make(map[string]struct{}, len(versions))
-	for _, version := range versions {
-		name := strings.ReplaceAll(bespokeFile, "{{version}}", version)
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		seen[name] = struct{}{}
-		resolved = append(resolved, name)
-	}
-	return resolved, nil
-}
-
-func validateBespokePackage(path string, matches func(string) bool) error {
+func validateBespokePackage(path string, packages []string, matches func(string) bool) error {
 	pkgName, err := readBespokePackageName(path)
 	if err != nil {
 		return err
@@ -102,7 +110,7 @@ func validateBespokePackage(path string, matches func(string) bool) error {
 		return errMissingBespokePackageName
 	}
 	if !matches(pkgName) {
-		return fmt.Errorf("%w: %q", errBespokePackageMismatch, pkgName)
+		return fmt.Errorf("%w %q; apko packages %v (apko will fail with 'not in indexes' at publish time)", errBespokePackageMismatch, pkgName, packages)
 	}
 	return nil
 }

--- a/cmd/integer_validate_melange.go
+++ b/cmd/integer_validate_melange.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+var (
+	errMissingBespokePackageName = errors.New("missing package.name")
+	errBespokePackageMismatch    = errors.New("package.name is not satisfiable by the image packages")
+)
+
+type versionedMelangeSpec struct {
+	version string
+	spec    *intconfig.MelangeSpec
+}
+
+func (s versionedMelangeSpec) resolveBespokeFiles(def *intconfig.ImageDef, typeName, bespokeFile string) ([]string, error) {
+	if s.version != "" {
+		return []string{strings.ReplaceAll(bespokeFile, "{{version}}", s.version)}, nil
+	}
+	return resolveBespokeFiles(def, typeName, bespokeFile)
+}
+
+func (s versionedMelangeSpec) packageMatcher(def *intconfig.ImageDef, typeName string, packages []string) func(string) bool {
+	if s.version != "" {
+		return func(pkgName string) bool {
+			for _, pkg := range packages {
+				if apkPackageName(strings.ReplaceAll(pkg, "{{version}}", s.version)) == pkgName {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return func(pkgName string) bool {
+		return tmplPackageMatchesBespoke(def, typeName, packages, pkgName)
+	}
+}
+
+func melangeSpecsForType(def *intconfig.ImageDef, typeName string) []versionedMelangeSpec {
+	selected := []versionedMelangeSpec{}
+	if tmpl, ok := def.Types[typeName]; ok && tmpl.Melange != nil {
+		selected = append(selected, versionedMelangeSpec{spec: tmpl.Melange})
+	}
+	versions := make([]string, 0, len(def.Versions))
+	for version, meta := range def.Versions {
+		if !slices.Contains(meta.SkipTypes, typeName) {
+			versions = append(versions, version)
+		}
+	}
+	apkindex.SortVersions(versions)
+	for _, version := range versions {
+		if spec, configured := def.Versions[version].Melange[typeName]; configured && spec != nil {
+			selected = append(selected, versionedMelangeSpec{version: version, spec: spec})
+		}
+	}
+	return selected
+}
+
+func resolveBespokeFiles(def *intconfig.ImageDef, typeName, bespokeFile string) ([]string, error) {
+	if !strings.Contains(bespokeFile, "{{version}}") {
+		return []string{bespokeFile}, nil
+	}
+
+	versions := make([]string, 0, len(def.Versions))
+	for version, meta := range def.Versions {
+		if slices.Contains(meta.SkipTypes, typeName) {
+			continue
+		}
+		versions = append(versions, version)
+	}
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("%w: %q", errMissingDeclaredVersionType, typeName)
+	}
+
+	apkindex.SortVersions(versions)
+	resolved := make([]string, 0, len(versions))
+	seen := make(map[string]struct{}, len(versions))
+	for _, version := range versions {
+		name := strings.ReplaceAll(bespokeFile, "{{version}}", version)
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		resolved = append(resolved, name)
+	}
+	return resolved, nil
+}
+
+func validateBespokePackage(path string, matches func(string) bool) error {
+	pkgName, err := readBespokePackageName(path)
+	if err != nil {
+		return err
+	}
+	if pkgName == "" {
+		return errMissingBespokePackageName
+	}
+	if !matches(pkgName) {
+		return fmt.Errorf("%w: %q", errBespokePackageMismatch, pkgName)
+	}
+	return nil
+}

--- a/cmd/integer_validate_melange_test.go
+++ b/cmd/integer_validate_melange_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v3"
+)
+
+func TestIntegerValidateCommand_SharedBespokePreservesDeclaredVersionMatching(t *testing.T) {
+	// Given: an existing shared recipe list whose files each match one declared stream.
+	imagesDir, cfgPath := intSetupCmdImages(t)
+	intWriteFile(t, filepath.Join(imagesDir, "postgres.yaml"), `
+name: postgres
+description: postgres
+upstream:
+  package: postgresql-{{version}}
+types:
+  default:
+    base: wolfi-base
+    packages: ["postgresql-{{version}}"]
+    melange:
+      bespoke: [postgresql-14.yaml, postgresql-15.yaml]
+versions:
+  "14": {}
+  "15": {}
+  "16": {}
+`)
+	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
+	intWriteFile(t, filepath.Join(bespokeDir, "postgresql-14.yaml"), "package:\n  name: postgresql-14\n  version: 14.23\n")
+	intWriteFile(t, filepath.Join(bespokeDir, "postgresql-15.yaml"), "package:\n  name: postgresql-15\n  version: 15.18\n")
+
+	// When: the existing unscoped configuration is validated.
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "validate",
+		"--config", cfgPath,
+		"--images-dir", imagesDir,
+		"--bespoke-dir", bespokeDir,
+	})
+
+	// Then: each recipe may match any declared version, preserving prior validation semantics.
+	assert.NoError(t, err)
+}
+
+func TestIntegerValidateCommand_VersionScopedBespokeOK(t *testing.T) {
+	// Given: a bespoke recipe referenced only by version 14 of the default type.
+	imagesDir, cfgPath := intSetupCmdImages(t)
+	intWriteFile(t, filepath.Join(imagesDir, "postgres.yaml"), `
+name: postgres
+description: postgres
+upstream:
+  package: postgresql-{{version}}
+types:
+  default:
+    base: wolfi-base
+    packages: ["postgresql-{{version}}"]
+versions:
+  "14":
+    melange:
+      default:
+        bespoke: postgresql-14.yaml
+  "16": {}
+`)
+	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
+	intWriteFile(t, filepath.Join(bespokeDir, "postgresql-14.yaml"), `
+package:
+  name: postgresql-14
+  version: "14.23"
+  epoch: 0
+`)
+
+	// When: the complete Integer configuration is validated.
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "validate",
+		"--config", cfgPath,
+		"--images-dir", imagesDir,
+		"--bespoke-dir", bespokeDir,
+	})
+
+	// Then: the scoped recipe is recognized as a valid, non-orphan reference.
+	assert.NoError(t, err)
+}

--- a/cmd/integer_validate_melange_test.go
+++ b/cmd/integer_validate_melange_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,4 +84,57 @@ package:
 
 	// Then: the scoped recipe is recognized as a valid, non-orphan reference.
 	assert.NoError(t, err)
+}
+
+func TestIntegerValidateCommand_ExactOverrideSuppressesSharedRecipeForVersion(t *testing.T) {
+	// Given: version 14 overrides a shared templated recipe while version 15 keeps the shared fallback.
+	imagesDir, cfgPath := intSetupCmdImages(t)
+	intWriteFile(t, filepath.Join(imagesDir, "postgres.yaml"), `
+name: postgres
+description: postgres
+upstream:
+  package: postgresql-{{version}}
+types:
+  default:
+    base: wolfi-base
+    packages: ["postgresql-{{version}}"]
+    melange:
+      bespoke: postgresql-{{version}}.yaml
+versions:
+  "14":
+    melange:
+      default:
+        bespoke: scoped-postgresql-14.yaml
+  "15": {}
+`)
+	bespokeDir := filepath.Join(filepath.Dir(imagesDir), "packages", "bespoke")
+	intWriteFile(t, filepath.Join(bespokeDir, "scoped-postgresql-14.yaml"), "package:\n  name: postgresql-14\n  version: 14.23\n")
+	intWriteFile(t, filepath.Join(bespokeDir, "postgresql-15.yaml"), "package:\n  name: postgresql-15\n  version: 15.18\n")
+
+	// When: the complete Integer configuration is validated.
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "validate",
+		"--config", cfgPath,
+		"--images-dir", imagesDir,
+		"--bespoke-dir", bespokeDir,
+	})
+
+	// Then: validation does not require the shadowed shared PostgreSQL 14 recipe.
+	assert.NoError(t, err)
+}
+
+func TestValidateBespokePackageMismatchIncludesPackagesAndApkoHint(t *testing.T) {
+	// Given: a bespoke recipe whose package cannot satisfy the image package list.
+	path := filepath.Join(t.TempDir(), "recipe.yaml")
+	intWriteFile(t, path, "package:\n  name: other-package\n  version: 1.0.0\n")
+	packages := []string{"postgresql-14", "postgresql-14-client"}
+
+	// When: the recipe package is checked against the image packages.
+	err := validateBespokePackage(path, packages, func(string) bool { return false })
+
+	// Then: the diagnostic retains the available packages and downstream apko failure hint.
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), strings.Join(packages, " "))
+	assert.Contains(t, err.Error(), "not in indexes")
 }

--- a/internal/ci/integer_impact.go
+++ b/internal/ci/integer_impact.go
@@ -110,7 +110,7 @@ func integerImpactVariants(imagesDir string, imgs []intdiscovery.DiscoveredImage
 			}
 			definitions[definitionFile] = def
 		}
-		configSpec := def.Types[img.Type].Melange
+		configSpec := def.MelangeFor(img.Version, img.Type)
 		if configSpec == nil {
 			continue
 		}
@@ -163,7 +163,7 @@ func integerConstrainedMelangeVariants(imagesDir string, imgs []intdiscovery.Dis
 			definitions[definitionFile] = def
 		}
 		template := def.Types[img.Type]
-		if template.Melange == nil {
+		if def.MelangeFor(img.Version, img.Type) == nil {
 			continue
 		}
 		for _, packageSpec := range template.Packages {

--- a/internal/ci/integer_impact_test.go
+++ b/internal/ci/integer_impact_test.go
@@ -119,6 +119,38 @@ versions:
 	assert.Equal(t, plan.Matrix.Include, plan.SmokeMatrix.Include)
 }
 
+func TestPlanIntegerPRRecipeImpactSelectsOnlyVersionScopedConsumers(t *testing.T) {
+	// Given: one bespoke recipe is scoped to only version 14 of the default type.
+	root := setupIntegerPlanRepo(t)
+	writeTestFile(t, filepath.Join(root, "images", "scoped-postgres.yaml"), `
+name: scoped-postgres
+description: scoped postgres
+upstream:
+  package: scoped-postgres-{{version}}
+types:
+  default:
+    base: wolfi-base
+    packages: ["scoped-postgres-{{version}}"]
+versions:
+  "14":
+    melange:
+      default:
+        bespoke: scoped-postgres-14.yaml
+  "16": {}
+`)
+	writeTestFile(t, filepath.Join(root, "packages", "bespoke", "scoped-postgres-14.yaml"), "pipeline: []\n")
+
+	// When: the scoped recipe changes.
+	plan, err := PlanIntegerPR(integerPlanOptions(root, "packages/bespoke/scoped-postgres-14.yaml"))
+
+	// Then: only the configured version is rebuilt and smoke-tested.
+	require.NoError(t, err)
+	require.True(t, plan.HasChanges)
+	want := []map[string]string{{"image": "scoped-postgres", "version": "14", "type": "default"}}
+	assert.Equal(t, want, plan.Matrix.Include)
+	assert.Equal(t, want, plan.SmokeMatrix.Include)
+}
+
 func TestPlanIntegerPRChangedDefinitionUsesDiscoveredName(t *testing.T) {
 	// Given: a nested definition whose file path and declared name differ.
 	root := setupIntegerPlanRepo(t)

--- a/internal/integer/config/loader.go
+++ b/internal/integer/config/loader.go
@@ -49,6 +49,9 @@ var (
 
 	// ErrMelangePathTraversal is returned when a filename field contains a path separator or traversal sequence.
 	ErrMelangePathTraversal = errors.New("melange: filename fields must not contain path separators or traversal sequences")
+
+	// ErrMelangeTypeNotFound is returned when a version scopes Melange configuration to an undefined image type.
+	ErrMelangeTypeNotFound = errors.New("melange: version-scoped type is not defined")
 )
 
 // LoadConfig loads the global integer.yaml configuration file.
@@ -102,6 +105,21 @@ func Validate(def *ImageDef) error {
 		}
 		if err := validateFIPSProfile(def.Name, typeName, &tmpl); err != nil {
 			return err
+		}
+	}
+	for version, meta := range def.Versions {
+		for typeName, melangeSpec := range meta.Melange {
+			tmpl, ok := def.Types[typeName]
+			if !ok {
+				return fmt.Errorf("image %q version %q type %q: %w", def.Name, version, typeName, ErrMelangeTypeNotFound)
+			}
+			if err := validateMelange(def.Name, typeName, melangeSpec); err != nil {
+				return fmt.Errorf("image %q version %q: %w", def.Name, version, err)
+			}
+			tmpl.Melange = melangeSpec
+			if err := validateFIPSProfile(def.Name, typeName, &tmpl); err != nil {
+				return fmt.Errorf("image %q version %q: %w", def.Name, version, err)
+			}
 		}
 	}
 	return nil

--- a/internal/integer/config/loader.go
+++ b/internal/integer/config/loader.go
@@ -52,6 +52,9 @@ var (
 
 	// ErrMelangeTypeNotFound is returned when a version scopes Melange configuration to an undefined image type.
 	ErrMelangeTypeNotFound = errors.New("melange: version-scoped type is not defined")
+
+	// ErrInvalidMelangeVersion is returned when a version-scoped Melange key is unsafe for placeholder substitution.
+	ErrInvalidMelangeVersion = errors.New("melange: invalid version scope")
 )
 
 // LoadConfig loads the global integer.yaml configuration file.
@@ -108,6 +111,9 @@ func Validate(def *ImageDef) error {
 		}
 	}
 	for version, meta := range def.Versions {
+		if len(meta.Melange) > 0 && !ValidMelangeVersion(version) {
+			return fmt.Errorf("image %q version %q: %w", def.Name, version, ErrInvalidMelangeVersion)
+		}
 		for typeName, melangeSpec := range meta.Melange {
 			tmpl, ok := def.Types[typeName]
 			if !ok {

--- a/internal/integer/config/melange.go
+++ b/internal/integer/config/melange.go
@@ -1,5 +1,14 @@
 package config
 
+import "regexp"
+
+var melangeVersionPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
+
+// ValidMelangeVersion reports whether a version is safe for Melange placeholder substitution.
+func ValidMelangeVersion(version string) bool {
+	return melangeVersionPattern.MatchString(version)
+}
+
 // MelangeFor returns the Melange configuration for one image version and type.
 // An exact version-scoped entry takes precedence over the shared type template.
 func (d *ImageDef) MelangeFor(version, typeName string) *MelangeSpec {

--- a/internal/integer/config/melange.go
+++ b/internal/integer/config/melange.go
@@ -1,0 +1,19 @@
+package config
+
+// MelangeFor returns the Melange configuration for one image version and type.
+// An exact version-scoped entry takes precedence over the shared type template.
+func (d *ImageDef) MelangeFor(version, typeName string) *MelangeSpec {
+	if d == nil {
+		return nil
+	}
+	if meta, ok := d.Versions[version]; ok {
+		if spec, configured := meta.Melange[typeName]; configured {
+			return spec
+		}
+	}
+	tmpl, ok := d.Types[typeName]
+	if !ok {
+		return nil
+	}
+	return tmpl.Melange
+}

--- a/internal/integer/config/melange_test.go
+++ b/internal/integer/config/melange_test.go
@@ -1,0 +1,81 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/config"
+)
+
+func TestImageDefMelangeForPrefersExactVersionAndPreservesSharedFallback(t *testing.T) {
+	// Given: an existing shared config plus one exact override and one explicit disable.
+	shared := &config.MelangeSpec{Bespoke: config.StringList{"shared.yaml"}}
+	scoped := &config.MelangeSpec{Bespoke: config.StringList{"scoped.yaml"}}
+	def := &config.ImageDef{
+		Types: map[string]config.TypeTemplate{
+			"default": {Melange: shared},
+		},
+		Versions: map[string]config.VersionMeta{
+			"14": {Melange: map[string]*config.MelangeSpec{"default": scoped}},
+			"16": {},
+			"17": {Melange: map[string]*config.MelangeSpec{"default": nil}},
+		},
+	}
+
+	// When: each configuration scope is resolved.
+	// Then: exact entries win, absent entries fall back, and explicit nil disables the shared config.
+	assert.Same(t, scoped, def.MelangeFor("14", "default"))
+	assert.Same(t, shared, def.MelangeFor("16", "default"))
+	assert.Nil(t, def.MelangeFor("17", "default"))
+	assert.Same(t, shared, def.MelangeFor("18", "default"))
+}
+
+func TestValidateAcceptsVersionScopedMelange(t *testing.T) {
+	// Given: a declared version with a Melange override for an existing type.
+	def := &config.ImageDef{
+		Name:     "postgres",
+		Upstream: config.Upstream{Package: "postgresql-{{version}}"},
+		Types: map[string]config.TypeTemplate{
+			"default": {Base: "wolfi-base"},
+		},
+		Versions: map[string]config.VersionMeta{
+			"14": {
+				Melange: map[string]*config.MelangeSpec{
+					"default": {Bespoke: config.StringList{"postgresql-14.yaml"}},
+				},
+			},
+		},
+	}
+
+	// When: the image definition is validated.
+	err := config.Validate(def)
+
+	// Then: the scoped configuration is accepted.
+	require.NoError(t, err)
+}
+
+func TestValidateRejectsVersionScopedMelangeForUndefinedType(t *testing.T) {
+	// Given: a version-scoped Melange key that does not name a declared type.
+	def := &config.ImageDef{
+		Name:     "postgres",
+		Upstream: config.Upstream{Package: "postgresql-{{version}}"},
+		Types: map[string]config.TypeTemplate{
+			"default": {Base: "wolfi-base"},
+		},
+		Versions: map[string]config.VersionMeta{
+			"14": {
+				Melange: map[string]*config.MelangeSpec{
+					"typo": {Bespoke: config.StringList{"postgresql-14.yaml"}},
+				},
+			},
+		},
+	}
+
+	// When: the image definition is validated.
+	err := config.Validate(def)
+
+	// Then: the invalid type reference is rejected with a typed error.
+	require.ErrorIs(t, err, config.ErrMelangeTypeNotFound)
+}

--- a/internal/integer/config/melange_test.go
+++ b/internal/integer/config/melange_test.go
@@ -79,3 +79,27 @@ func TestValidateRejectsVersionScopedMelangeForUndefinedType(t *testing.T) {
 	// Then: the invalid type reference is rejected with a typed error.
 	require.ErrorIs(t, err, config.ErrMelangeTypeNotFound)
 }
+
+func TestValidateRejectsUnsafeVersionScopedMelangeKey(t *testing.T) {
+	// Given: a scoped version key that would escape a directory after placeholder substitution.
+	def := &config.ImageDef{
+		Name:     "postgres",
+		Upstream: config.Upstream{Package: "postgresql-{{version}}"},
+		Types: map[string]config.TypeTemplate{
+			"default": {Base: "wolfi-base"},
+		},
+		Versions: map[string]config.VersionMeta{
+			"../14": {
+				Melange: map[string]*config.MelangeSpec{
+					"default": {Bespoke: config.StringList{"postgresql-{{version}}.yaml"}},
+				},
+			},
+		},
+	}
+
+	// When: the image definition is validated.
+	err := config.Validate(def)
+
+	// Then: the unsafe key is rejected before any path substitution.
+	require.ErrorIs(t, err, config.ErrInvalidMelangeVersion)
+}

--- a/internal/integer/config/types.go
+++ b/internal/integer/config/types.go
@@ -270,7 +270,8 @@ type PathDef struct {
 // Fields are optional — versions without an entry in the map are still
 // built with auto-generated tags.
 type VersionMeta struct {
-	EOL       string   `yaml:"eol,omitempty"`        // "2027-04-30"
-	Latest    bool     `yaml:"latest,omitempty"`     // carries the "latest" tag
-	SkipTypes []string `yaml:"skip-types,omitempty"` // types to exclude for this version (e.g. ["fips"])
+	EOL       string                  `yaml:"eol,omitempty"`        // "2027-04-30"
+	Latest    bool                    `yaml:"latest,omitempty"`     // carries the "latest" tag
+	SkipTypes []string                `yaml:"skip-types,omitempty"` // types to exclude for this version (e.g. ["fips"])
+	Melange   map[string]*MelangeSpec `yaml:"melange,omitempty"`    // per-type overrides for this version
 }

--- a/internal/integer/discovery/discover.go
+++ b/internal/integer/discovery/discover.go
@@ -164,6 +164,7 @@ func expandImage(def *config.ImageDef, imagesDir, registry string, pkgs []apkind
 				continue
 			}
 			tmpl := def.Types[typeName]
+			tmpl.Melange = def.MelangeFor(v, typeName)
 
 			// Resolve full version from APKINDEX for semver tag expansion. Use
 			// the aliased stem so semver cascade tags ("1.17", "1.17.5") still
@@ -251,7 +252,7 @@ func ShouldSkipType(def *config.ImageDef, version, typeName string) bool {
 	meta, ok := def.Versions[version]
 	if !ok {
 		// Auto-discovered version: skip types that require a melange build.
-		return exists && tmpl.Melange != nil
+		return exists && def.MelangeFor(version, typeName) != nil
 	}
 	return slices.Contains(meta.SkipTypes, typeName)
 }

--- a/internal/integer/discovery/discover_melange_test.go
+++ b/internal/integer/discovery/discover_melange_test.go
@@ -1,0 +1,60 @@
+package discovery_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	"github.com/verity-org/verity/internal/integer/discovery"
+)
+
+func TestDiscoverFromFiles_VersionScopedBespokeOverridesOnlyMatchingTags(t *testing.T) {
+	// Given: only stream 1.26 uses a bespoke recipe with a newer full version.
+	const imageYAML = `
+name: scoped-istio
+description: scoped istio
+upstream:
+  package: "scoped-istio-{{version}}"
+types:
+  default:
+    base: wolfi-base
+    packages: ["scoped-istio-{{version}}"]
+versions:
+  "1.26":
+    melange:
+      default:
+        bespoke: scoped-istio-1.26.yaml
+  "1.30":
+    latest: true
+`
+	const bespoke = `
+package:
+  name: scoped-istio-1.26
+  version: "1.26.8"
+  epoch: 0
+`
+	imagesDir := setupImages(t, map[string]string{"scoped-istio.yaml": imageYAML})
+	writeFile(t, filepath.Dir(imagesDir), filepath.Join("packages", "bespoke", "scoped-istio-1.26.yaml"), bespoke)
+	genDir := t.TempDir()
+	pkgs := []apkindex.Package{
+		{Name: "scoped-istio-1.26", Version: "1.26.4-r1"},
+		{Name: "scoped-istio-1.30", Version: "1.30.1-r0"},
+	}
+
+	// When: image variants and semantic tags are discovered.
+	imgs, err := discovery.DiscoverFromFiles(opts(imagesDir, genDir, pkgs))
+
+	// Then: the bespoke version affects 1.26 while 1.30 keeps APKINDEX resolution.
+	require.NoError(t, err)
+	got := map[string][]string{}
+	for _, img := range imgs {
+		if img.Type == typeDefault {
+			got[img.Version] = img.Tags
+		}
+	}
+	assert.Equal(t, []string{"1.26", "1.26.8"}, got["1.26"])
+	assert.Equal(t, []string{"1.30", "1.30.1", "latest"}, got["1.30"])
+}

--- a/internal/integer/melange/inventory_test.go
+++ b/internal/integer/melange/inventory_test.go
@@ -48,18 +48,20 @@ func TestEveryMelangeUpstreamConsumerHasLockedRecipe(t *testing.T) {
 			return loadErr
 		}
 		for typeName, imageType := range def.Types {
-			if imageType.Melange == nil || imageType.Melange.Upstream == "" {
-				continue
-			}
 			if len(def.Versions) == 0 {
-				requireLockedConsumer(t, lock, def.Name, typeName, "latest", imageType.Melange)
+				if imageType.Melange != nil && imageType.Melange.Upstream != "" {
+					requireLockedConsumer(t, lock, def.Name, typeName, "latest", imageType.Melange)
+				}
 				continue
 			}
 			for version, metadata := range def.Versions {
 				if slices.Contains(metadata.SkipTypes, typeName) {
 					continue
 				}
-				requireLockedConsumer(t, lock, def.Name, typeName, version, imageType.Melange)
+				configSpec := def.MelangeFor(version, typeName)
+				if configSpec != nil && configSpec.Upstream != "" {
+					requireLockedConsumer(t, lock, def.Name, typeName, version, configSpec)
+				}
 			}
 		}
 		return nil

--- a/internal/integer/melange/spec.go
+++ b/internal/integer/melange/spec.go
@@ -13,7 +13,6 @@ import (
 var (
 	imagePattern      = regexp.MustCompile(`^[a-z][a-z0-9-]*(/[a-z][a-z0-9-]*)*$`)
 	typePattern       = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
-	versionPattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
 	identifierPattern = regexp.MustCompile(`^[A-Za-z0-9._+-]+$`)
 )
 
@@ -24,7 +23,7 @@ func ResolveSpec(imagesDir, image, version, imageType string) (Spec, error) {
 	if !typePattern.MatchString(imageType) {
 		return Spec{}, fmt.Errorf("%w %q", errInvalidImageType, imageType)
 	}
-	if !versionPattern.MatchString(version) {
+	if !intconfig.ValidMelangeVersion(version) {
 		return Spec{}, fmt.Errorf("%w %q", errInvalidVersion, version)
 	}
 

--- a/internal/integer/melange/spec.go
+++ b/internal/integer/melange/spec.go
@@ -32,11 +32,12 @@ func ResolveSpec(imagesDir, image, version, imageType string) (Spec, error) {
 	if err != nil {
 		return Spec{}, fmt.Errorf("load image %q: %w", image, err)
 	}
-	tmpl, ok := def.Types[imageType]
+	_, ok := def.Types[imageType]
 	if !ok {
 		return Spec{}, fmt.Errorf("%w: image %q type %q", errImageTypeNotFound, image, imageType)
 	}
-	if tmpl.Melange == nil {
+	configSpec := def.MelangeFor(version, imageType)
+	if configSpec == nil {
 		return Spec{}, nil
 	}
 	if meta, ok := def.Versions[version]; len(def.Versions) > 0 && !ok {
@@ -44,7 +45,7 @@ func ResolveSpec(imagesDir, image, version, imageType string) (Spec, error) {
 	} else if ok && slices.Contains(meta.SkipTypes, imageType) {
 		return Spec{}, fmt.Errorf("%w: image %q version %q type %q", errImageTypeSkipped, image, version, imageType)
 	}
-	return ResolveConfigSpec(tmpl.Melange, version)
+	return ResolveConfigSpec(configSpec, version)
 }
 
 func ResolveConfigSpec(input *intconfig.MelangeSpec, version string) (Spec, error) {

--- a/internal/integer/melange/spec_test.go
+++ b/internal/integer/melange/spec_test.go
@@ -59,6 +59,50 @@ versions:
 	assert.False(t, spec.Needed())
 }
 
+func TestResolveSpecScopesMelangeByVersion(t *testing.T) {
+	// Given: only PostgreSQL 14 and 15 declare bespoke recipes for the default type.
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "images", "postgres.yaml"), `
+name: postgres
+description: postgres
+upstream:
+  package: postgresql-{{version}}
+types:
+  default:
+    base: wolfi-base
+    packages: ["postgresql-{{version}}"]
+versions:
+  "14":
+    melange:
+      default:
+        bespoke: postgresql-14.yaml
+  "15":
+    melange:
+      default:
+        bespoke: postgresql-15.yaml
+  "16": {}
+`)
+
+	tests := []struct {
+		version string
+		want    Spec
+	}{
+		{version: "14", want: Spec{Bespoke: []string{"postgresql-14.yaml"}}},
+		{version: "15", want: Spec{Bespoke: []string{"postgresql-15.yaml"}}},
+		{version: "16", want: Spec{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			// When: the default type's Melange input is resolved for one stream.
+			got, err := ResolveSpec(filepath.Join(root, "images"), "postgres", tt.version, "default")
+
+			// Then: only that stream's scoped recipe is selected.
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestResolveSpecReturnsEmptyForAutoDiscoveredStandardVersion(t *testing.T) {
 	// Given: a standard image whose APKINDEX-discovered version is newer than
 	// the explicitly curated versions map.


### PR DESCRIPTION
## Summary

- add typed `versions.<version>.melange.<type>` overrides with exact-version precedence and shared type-level fallback
- route build preparation, discovery tags, CI impact planning, config validation, and recipe inventory through the version-aware resolver
- preserve existing unscoped Melange configs and validation behavior; no PostgreSQL product changes are included

This is the shared tooling prerequisite for #960 so PostgreSQL 14/15 can select bespoke default recipes without changing 16-18 resolution.

## TDD evidence

- RED: `TestResolveSpecScopesMelangeByVersion` resolved empty specs for scoped 14/15 entries before implementation
- GREEN: focused config, resolver, discovery, CI planning, and validation regressions pass

## Validation

- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m`
- `make integer-validate` (334 images)
- `make lint-workflows lint-yaml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds version-scoped Melange config so images can override recipes per stream, with exact-version precedence and shared type fallback. Validation and discovery now use the same resolver and reject unsafe version keys; unscoped configs keep working.

- **New Features**
  - Support `versions.<version>.melange.<type>` overrides with fallback to `types.<type>.melange`.
  - New resolver `ImageDef.MelangeFor(version, type)` used by build, discovery, and CI impact.
  - Discovery and tags honor scoped bespoke versions; only matching streams get bespoke tags.
  - CI impact planning rebuilds only the version/type that references a changed scoped recipe.
  - Validation rejects unknown types and unsafe version keys in scoped config, and checks bespoke package names against image packages with an apko “not in indexes” hint.

- **Migration**
  - No changes required for existing configs.
  - To scope a recipe, add it under `versions.<version>.melange.<type>`; set the scoped value to `null` to disable the shared config for that stream.

<sup>Written for commit a67e1e8a10d75858d8650fdda54b68f1b5965892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

