### PR TITLE
fix(integer): update kyverno 1.18 source

### DIFF
--- a/packages/bespoke/kyverno-1.18.yaml
+++ b/packages/bespoke/kyverno-1.18.yaml
@@ -1,6 +1,6 @@
 package:
   name: kyverno-1.18
-  version: "1.18.1"
+  version: "1.18.2"
   epoch: 99
   description: "Kyverno policy engine rebuilt from source for zero-CVE Integer images"
   copyright:
@@ -26,6 +26,7 @@ pipeline:
     with:
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
+      expected-commit: 945ac9ce8546ea6cd51370f24b615148c577da5e
 
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/bin"

--- a/packages/bespoke/kyverno-background-controller-1.18.yaml
+++ b/packages/bespoke/kyverno-background-controller-1.18.yaml
@@ -1,6 +1,6 @@
 package:
   name: kyverno-background-controller-1.18
-  version: "1.18.1"
+  version: "1.18.2"
   epoch: 99
   description: "Kyverno background controller rebuilt from source"
   copyright:
@@ -26,6 +26,7 @@ pipeline:
     with:
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
+      expected-commit: 945ac9ce8546ea6cd51370f24b615148c577da5e
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/bin"
       go build -trimpath -ldflags='-s -w' -o "${{targets.contextdir}}/usr/bin/background-controller" ./cmd/background-controller

--- a/packages/bespoke/kyverno-cleanup-controller-1.18.yaml
+++ b/packages/bespoke/kyverno-cleanup-controller-1.18.yaml
@@ -1,6 +1,6 @@
 package:
   name: kyverno-cleanup-controller-1.18
-  version: "1.18.1"
+  version: "1.18.2"
   epoch: 99
   description: "Kyverno cleanup controller rebuilt from source"
   copyright:
@@ -26,6 +26,7 @@ pipeline:
     with:
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
+      expected-commit: 945ac9ce8546ea6cd51370f24b615148c577da5e
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/bin"
       go build -trimpath -ldflags='-s -w' -o "${{targets.contextdir}}/usr/bin/cleanup-controller" ./cmd/cleanup-controller

--- a/packages/bespoke/kyverno-cli-1.18.yaml
+++ b/packages/bespoke/kyverno-cli-1.18.yaml
@@ -1,6 +1,6 @@
 package:
   name: kyverno-cli-1.18
-  version: "1.18.1"
+  version: "1.18.2"
   epoch: 99
   description: "Kyverno CLI rebuilt from source"
   copyright:
@@ -26,6 +26,7 @@ pipeline:
     with:
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
+      expected-commit: 945ac9ce8546ea6cd51370f24b615148c577da5e
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/bin"
       go build -trimpath -ldflags='-s -w' -o "${{targets.contextdir}}/usr/bin/kubectl-kyverno" ./cmd/cli/kubectl-kyverno

--- a/packages/bespoke/kyverno-kyvernopre-1.18.yaml
+++ b/packages/bespoke/kyverno-kyvernopre-1.18.yaml
@@ -1,6 +1,6 @@
 package:
   name: kyverno-init-container-1.18
-  version: "1.18.1"
+  version: "1.18.2"
   epoch: 99
   description: "Kyverno init container rebuilt from source"
   copyright:
@@ -26,6 +26,7 @@ pipeline:
     with:
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
+      expected-commit: 945ac9ce8546ea6cd51370f24b615148c577da5e
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/bin"
       go build -trimpath -ldflags='-s -w' -o "${{targets.contextdir}}/usr/bin/kyvernopre" ./cmd/kyverno-init

--- a/packages/bespoke/kyverno-reports-controller-1.18.yaml
+++ b/packages/bespoke/kyverno-reports-controller-1.18.yaml
@@ -1,6 +1,6 @@
 package:
   name: kyverno-reports-controller-1.18
-  version: "1.18.1"
+  version: "1.18.2"
   epoch: 99
   description: "Kyverno reports controller rebuilt from source"
   copyright:
@@ -26,6 +26,7 @@ pipeline:
     with:
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
+      expected-commit: 945ac9ce8546ea6cd51370f24b615148c577da5e
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/bin"
       go build -trimpath -ldflags='-s -w' -o "${{targets.contextdir}}/usr/bin/reports-controller" ./cmd/reports-controller


### PR DESCRIPTION
## Summary
- upgrade the local Kyverno 1.18 bespoke family from v1.18.1 to fixed upstream v1.18.2
- pin public tag v1.18.2 to commit 945ac9ce8546ea6cd51370f24b615148c577da5e
- retain Apache-2.0 metadata and epoch 99 only to guarantee local APK precedence

## RED
Current main image `ghcr.io/verity-org/kyverno:1.18.1` reproduced 11 Trivy findings:
- HIGH: 5
- MEDIUM: 5
- LOW: 1

The source-pin regression also failed: recipe version was 1.18.1 and no expected commit was present.

## GREEN
- amd64 and arm64 Melange builds: six signed `1.18.2-r99` APKs per architecture
- generic `1-default` and pinned `1.18-default` both resolve to `kyverno-1.18=1.18.2-r99@local`
- four image assemblies completed for both aliases and architectures
- runtime architecture matched; runtime version trace reported `v1.18.2+dirty` at pinned commit
- SPDX 2.3 generated for all four images
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings on all four images
- `make integer-validate`
- `go test ./...`
- `go test ./internal/integer/... ./cmd/... ./scripts/...`
- `yamllint images/kyverno.yaml packages/bespoke/kyverno-1.18.yaml`
- `git diff --check`

## Security
No ignore, VEX substitution, exclusion, architecture skip, severity relaxation, or suppression is used. The fix is the upstream v1.18.2 source release, not epoch-only metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the Kyverno 1.18 family to v1.18.2 and pin the upstream tag to commit 945ac9ce8546ea6cd51370f24b615148c577da5e across all packages (`kyverno-1.18`, `kyverno-background-controller-1.18`, `kyverno-cleanup-controller-1.18`, `kyverno-cli-1.18`, `kyverno-init-container-1.18`, `kyverno-reports-controller-1.18`). Fixes the source-pin regression by adding `expected-commit`, aligns all components, keeps epoch 99 for local APK precedence, and yields zero Trivy findings.

<sup>Written for commit d88cf95d554c8ef37859456395f2be5a1c0d9a6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

