### PR TITLE
fix(integer): own apisix-ingress-controller package

### DIFF
--- a/cmd/apisix_ingress_controller_config_test.go
+++ b/cmd/apisix_ingress_controller_config_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_APISIXIngressController_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in APISIX Ingress Controller image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "apisix-ingress-controller.yaml"))
+	require.NoError(t, err)
+
+	// When: the default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "apisix-ingress-controller.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"apisix-ingress-controller"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/apisix-ingress-controller", tmpl.Entrypoint)
+}
+
+func Test_APISIXIngressController_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "apisix-ingress-controller.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, and dependency metadata are inspected.
+
+	// Then: revision r5 is substantive and the upstream source is immutable.
+	require.Contains(t, text, "name: apisix-ingress-controller")
+	require.Contains(t, text, "version: \"2.1.0\"")
+	require.Contains(t, text, "epoch: 5")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "repository: https://github.com/apache/apisix-ingress-controller")
+	require.Contains(t, text, "tag: ${{package.version}}")
+	require.Contains(t, text, "expected-commit: f4a8dd1223573a5b72e1c7b65b37c13b49d98042")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+}
+
+func Test_APISIXIngressController_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "apisix-ingress-controller.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "apisix-ingress-controller",
+		Version: "2.1.0-r5",
+	}})
+
+	// Then: apko can only select the fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"apisix-ingress-controller=2.1.0-r5@local"}, tmpl.Packages)
+}

--- a/images/apisix-ingress-controller.yaml
+++ b/images/apisix-ingress-controller.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["apisix-ingress-controller"]
     entrypoint: /usr/bin/apisix-ingress-controller
+    melange:
+      bespoke: apisix-ingress-controller.yaml
 
 versions:
   "1": {}

--- a/packages/bespoke/apisix-ingress-controller.yaml
+++ b/packages/bespoke/apisix-ingress-controller.yaml
@@ -1,0 +1,51 @@
+package:
+  name: apisix-ingress-controller
+  version: "2.1.0"
+  # Revision r5 rebuilds the pinned upstream release with OpenTelemetry Go
+  # v1.44.0, substantively remediating CVE-2026-41178.
+  epoch: 5
+  description: APISIX Ingress Controller for Kubernetes
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "4"
+    memory: 5Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/apisix-ingress-controller
+      tag: ${{package.version}}
+      expected-commit: f4a8dd1223573a5b72e1c7b65b37c13b49d98042
+
+  - uses: go/bump
+    with:
+      deps: |-
+        google.golang.org/grpc@v1.79.3
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        golang.org/x/net@v0.55.0
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      packages: cmd/main.go
+      output: apisix-ingress-controller
+      ldflags: |
+        -X=github.com/apache/apisix-ingress-controller/internal/version._buildVersion=${{package.version}}
+        -X=github.com/apache/apisix-ingress-controller/internal/version._buildGitRevision=$(git rev-parse --short HEAD)
+        -X=github.com/apache/apisix-ingress-controller/internal/version._buildOS=$(uname -s)/$(uname -m)
+        -X=github.com/apache/apisix-ingress-controller/internal/manager._minK8sVersion=1.26.0
+
+test:
+  pipeline:
+    - runs: |
+        apisix-ingress-controller --help
+        apisix-ingress-controller --version


### PR DESCRIPTION
## Summary
- own `apisix-ingress-controller` 2.1.0 as an isolated bespoke Melange package at revision r5
- pin upstream tag `2.1.0` to immutable commit `f4a8dd1223573a5b72e1c7b65b37c13b49d98042`
- rebuild with OpenTelemetry Go v1.44.0 to remediate CVE-2026-41178
- wire only `images/apisix-ingress-controller.yaml` to the local package and preserve `/usr/bin/apisix-ingress-controller`
- add focused source-pin, local package resolution, and image behavior tests

## RED
- main run 29309589812 installed `apisix-ingress-controller 2.1.0-r1`
- strict Trivy (`UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`) exited 1 with one finding:
  - `CVE-2026-41178` MEDIUM, fixed in `2.1.0-r5`

## GREEN
- native package workflow 29401348757 passed:
  - x86_64 package: `apisix-ingress-controller-2.1.0-r5.apk`
  - native aarch64 package on `ubuntu-24.04-arm`: `apisix-ingress-controller-2.1.0-r5.apk`
  - amd64 and arm64 image publish gates passed before cache promotion
- required PR workflow 29400298375 passed both dual-architecture smoke and build batches
- published cache evidence digest: `sha256:7600305f0af6cf35d52db341196b5524cbcba3be65417b21afc13947f1829477`
- amd64 runtime/version: `apisix-ingress-controller version 2.1.0-f4a8dd1-go1.26.5`
- arm64 runtime/version: `apisix-ingress-controller version 2.1.0-f4a8dd1-go1.26.5`
- amd64 SPDX 2.3: 97 packages; `apisix-ingress-controller 2.1.0-r5`, declared `Apache-2.0`
- arm64 SPDX 2.3: 97 packages; `apisix-ingress-controller 2.1.0-r5`, declared `Apache-2.0`
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings on amd64 and 0 findings on arm64

## Provenance and license
- Wolfi open-source recipe provenance: `wolfi-dev/os` historical `apisix-ingress-controller.yaml`
- source: `https://github.com/apache/apisix-ingress-controller`
- tag: `2.1.0`
- immutable commit: `f4a8dd1223573a5b72e1c7b65b37c13b49d98042`
- license: Apache-2.0
- same-version revision is substantive: OpenTelemetry modules are rebuilt at v1.44.0

## Validation
- `make integer-validate`
- `go test -race -shuffle=on -count=1 ./cmd -run APISIXIngressController`
- `go test ./... -count=1`
- `make lint`
- `make lint-yaml`
- `git diff --check`

No vulnerability suppression, ignore, exclusion, downgrade, architecture skip, scanner relaxation, or severity omission is used.
