### PR TITLE
fix(ci): preserve version-scoped integer targets

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -292,10 +292,21 @@ jobs:
         run: |
           git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
           git show "${BASE_SHA}":packages/upstream.lock.json > "$RUNNER_TEMP/base-upstream.lock.json" 2>/dev/null || printf '{"packages":{},"pipeline_files":{}}\n' > "$RUNNER_TEMP/base-upstream.lock.json"
+          mkdir -p "$RUNNER_TEMP/base-images"
+          while IFS= read -r file; do
+            case "$file" in
+              images/*.yaml)
+                relative="${file#images/}"
+                mkdir -p "$RUNNER_TEMP/base-images/$(dirname "$relative")"
+                git show "${BASE_SHA}:${file}" > "$RUNNER_TEMP/base-images/$relative" 2>/dev/null || rm -f "$RUNNER_TEMP/base-images/$relative"
+                ;;
+            esac
+          done < changed-files.txt
           ./verity ci plan \
             --kind integer-pr \
             --changed-files changed-files.txt \
             --base-upstream-lock "$RUNNER_TEMP/base-upstream.lock.json" \
+            --base-images-dir "$RUNNER_TEMP/base-images" \
             --gen-dir "$RUNNER_TEMP/integer-gen" \
             > ci-plan.json
 

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -35,6 +35,7 @@ var ciPlanCommand = &cli.Command{
 		&cli.StringFlag{Name: "images-dir", Usage: "Path to images/", Value: "images"},
 		&cli.StringFlag{Name: "repo-root", Usage: "Repository root for bespoke package inputs", Value: "."},
 		&cli.StringFlag{Name: "base-upstream-lock", Usage: "Base bespoke lock for selective PR impact diffing"},
+		&cli.StringFlag{Name: "base-images-dir", Usage: "Base images directory for semantic definition impact"},
 		&cli.StringFlag{Name: "apkindex-url", Usage: "Wolfi APKINDEX URL; empty disables online discovery", Value: apkindex.DefaultAPKINDEXURL},
 		&cli.StringFlag{Name: "cache-dir", Usage: "APKINDEX cache dir"},
 		&cli.StringFlag{Name: "gen-dir", Usage: "Generated apko config directory"},
@@ -59,14 +60,15 @@ func runCIPlan(_ context.Context, cmd *cli.Command) error {
 	switch cmd.String("kind") {
 	case "integer-pr":
 		plan, err = ci.PlanIntegerPR(&ci.IntegerPROptions{
-			ChangedFiles: changed,
-			RepoRoot:     cmd.String("repo-root"),
-			BaseLockPath: cmd.String("base-upstream-lock"),
-			ConfigPath:   cmd.String("integer-config"),
-			ImagesDir:    cmd.String("images-dir"),
-			APKIndexURL:  cmd.String("apkindex-url"),
-			CacheDir:     cmd.String("cache-dir"),
-			GenDir:       cmd.String("gen-dir"),
+			ChangedFiles:  changed,
+			RepoRoot:      cmd.String("repo-root"),
+			BaseLockPath:  cmd.String("base-upstream-lock"),
+			BaseImagesDir: cmd.String("base-images-dir"),
+			ConfigPath:    cmd.String("integer-config"),
+			ImagesDir:     cmd.String("images-dir"),
+			APKIndexURL:   cmd.String("apkindex-url"),
+			CacheDir:      cmd.String("cache-dir"),
+			GenDir:        cmd.String("gen-dir"),
 		})
 	case "copa-pr":
 		plan, err = ci.PlanCopaPR(&ci.CopaPROptions{

--- a/internal/ci/integer_definition_changes.go
+++ b/internal/ci/integer_definition_changes.go
@@ -2,14 +2,19 @@ package ci
 
 import (
 	"fmt"
+	"maps"
+	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
+	intconfig "github.com/verity-org/verity/internal/integer/config"
 	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
 )
 
-func changedIntegerDefinitions(files []string) (definitions map[string]struct{}, all bool) {
+func changedIntegerDefinitions(files []string, imagesDir, baseImagesDir string) (definitions map[string]struct{}, variants integerVariantImpacts, all bool, err error) {
 	definitions = map[string]struct{}{}
+	variants = integerVariantImpacts{}
 	for _, file := range files {
 		file = filepath.ToSlash(strings.TrimSpace(file))
 		switch {
@@ -21,7 +26,61 @@ func changedIntegerDefinitions(files []string) (definitions map[string]struct{},
 			}
 		}
 	}
-	return definitions, all
+	if all || strings.TrimSpace(baseImagesDir) == "" {
+		return definitions, variants, all, nil
+	}
+
+	for relative := range definitions {
+		headPath := filepath.Join(imagesDir, filepath.FromSlash(relative))
+		basePath := filepath.Join(baseImagesDir, filepath.FromSlash(relative))
+		if !fileExists(headPath) || !fileExists(basePath) {
+			continue
+		}
+		head, loadErr := intconfig.LoadImage(headPath)
+		if loadErr != nil {
+			return nil, nil, false, fmt.Errorf("load head definition %s: %w", headPath, loadErr)
+		}
+		base, loadErr := intconfig.LoadImage(basePath)
+		if loadErr != nil {
+			return nil, nil, false, fmt.Errorf("load base definition %s: %w", basePath, loadErr)
+		}
+		if !reflect.DeepEqual(withoutScopedMelange(base), withoutScopedMelange(head)) {
+			continue
+		}
+
+		delete(definitions, relative)
+		maps.Copy(variants, changedScopedMelangeVariants(base, head))
+	}
+	return definitions, variants, false, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func withoutScopedMelange(def *intconfig.ImageDef) intconfig.ImageDef {
+	normalized := *def
+	normalized.Versions = make(map[string]intconfig.VersionMeta, len(def.Versions))
+	for version, meta := range def.Versions {
+		meta.Melange = nil
+		normalized.Versions[version] = meta
+	}
+	return normalized
+}
+
+func changedScopedMelangeVariants(base, head *intconfig.ImageDef) integerVariantImpacts {
+	variants := integerVariantImpacts{}
+	for version := range unionKeys(base.Versions, head.Versions) {
+		baseMeta := base.Versions[version]
+		headMeta := head.Versions[version]
+		for imageType := range unionKeys(baseMeta.Melange, headMeta.Melange) {
+			if !reflect.DeepEqual(baseMeta.Melange[imageType], headMeta.Melange[imageType]) {
+				variants[integerVariant{image: head.Name, version: version, imageType: imageType}] = integerImpactVersion
+			}
+		}
+	}
+	return variants
 }
 
 func changedIntegerImageNames(imagesDir string, imgs []intdiscovery.DiscoveredImage, definitions map[string]struct{}) (map[string]struct{}, error) {

--- a/internal/ci/integer_impact.go
+++ b/internal/ci/integer_impact.go
@@ -26,6 +26,15 @@ type integerVariant struct {
 	imageType string
 }
 
+type integerImpactScope uint8
+
+const (
+	integerImpactShared integerImpactScope = iota
+	integerImpactVersion
+)
+
+type integerVariantImpacts map[integerVariant]integerImpactScope
+
 type integerBuildLock struct {
 	Packages      map[string]integerBuildLockPackage `json:"packages"`
 	PipelineFiles map[string]string                  `json:"pipeline_files"`
@@ -93,9 +102,9 @@ func addLockedPathImpact(keys map[string]struct{}, changed string, lock integerB
 	return matched
 }
 
-func integerImpactVariants(imagesDir string, imgs []intdiscovery.DiscoveredImage, impact integerInputImpact) (map[integerVariant]struct{}, error) {
+func integerImpactVariants(imagesDir string, imgs []intdiscovery.DiscoveredImage, impact integerInputImpact) (integerVariantImpacts, error) {
 	definitions := map[string]*intconfig.ImageDef{}
-	variants := map[integerVariant]struct{}{}
+	variants := integerVariantImpacts{}
 	for _, img := range imgs {
 		definitionFile := img.DefinitionFile
 		if definitionFile == "" {
@@ -119,10 +128,19 @@ func integerImpactVariants(imagesDir string, imgs []intdiscovery.DiscoveredImage
 			return nil, fmt.Errorf("resolve %s:%s-%s: %w", img.Name, img.Version, img.Type, err)
 		}
 		if specConsumesImpact(spec, impact) {
-			variants[variantForImage(&img)] = struct{}{}
+			variants[variantForImage(&img)] = melangeImpactScope(def, img.Version, img.Type)
 		}
 	}
 	return variants, nil
+}
+
+func melangeImpactScope(def *intconfig.ImageDef, version, imageType string) integerImpactScope {
+	if meta, ok := def.Versions[version]; ok {
+		if _, configured := meta.Melange[imageType]; configured {
+			return integerImpactVersion
+		}
+	}
+	return integerImpactShared
 }
 
 func integerPinningToolingChanged(files []string) bool {
@@ -145,9 +163,9 @@ func integerPinningToolingChanged(files []string) bool {
 	return false
 }
 
-func integerConstrainedMelangeVariants(imagesDir string, imgs []intdiscovery.DiscoveredImage) (map[integerVariant]struct{}, error) {
+func integerConstrainedMelangeVariants(imagesDir string, imgs []intdiscovery.DiscoveredImage) (integerVariantImpacts, error) {
 	definitions := map[string]*intconfig.ImageDef{}
-	variants := map[integerVariant]struct{}{}
+	variants := integerVariantImpacts{}
 	for _, img := range imgs {
 		definitionFile := img.DefinitionFile
 		if definitionFile == "" {
@@ -168,7 +186,7 @@ func integerConstrainedMelangeVariants(imagesDir string, imgs []intdiscovery.Dis
 		}
 		for _, packageSpec := range template.Packages {
 			if apkindex.PackageName(packageSpec) != packageSpec {
-				variants[variantForImage(&img)] = struct{}{}
+				variants[variantForImage(&img)] = integerImpactShared
 				break
 			}
 		}

--- a/internal/ci/integer_pr_plan.go
+++ b/internal/ci/integer_pr_plan.go
@@ -2,6 +2,7 @@ package ci
 
 import (
 	"fmt"
+	"maps"
 	"os"
 
 	"github.com/verity-org/verity/internal/integer/apkindex"
@@ -10,10 +11,11 @@ import (
 )
 
 type integerPRChanges struct {
-	definitions    map[string]struct{}
-	impact         integerInputImpact
-	allImages      bool
-	pinningTooling bool
+	definitions        map[string]struct{}
+	definitionVariants integerVariantImpacts
+	impact             integerInputImpact
+	allImages          bool
+	pinningTooling     bool
 }
 
 type integerPRSelection struct {
@@ -54,12 +56,20 @@ func PlanIntegerPR(opts *IntegerPROptions) (Plan, error) {
 }
 
 func loadIntegerPRChanges(opts *IntegerPROptions) (integerPRChanges, error) {
-	definitions, allImages := changedIntegerDefinitions(opts.ChangedFiles)
+	definitions, definitionVariants, allImages, err := changedIntegerDefinitions(
+		opts.ChangedFiles,
+		defaultString(opts.ImagesDir, "images"),
+		opts.BaseImagesDir,
+	)
+	if err != nil {
+		return integerPRChanges{}, fmt.Errorf("classify changed image definitions: %w", err)
+	}
 	changes := integerPRChanges{
-		definitions:    definitions,
-		impact:         newIntegerInputImpact(),
-		allImages:      allImages,
-		pinningTooling: integerPinningToolingChanged(opts.ChangedFiles),
+		definitions:        definitions,
+		definitionVariants: definitionVariants,
+		impact:             newIntegerInputImpact(),
+		allImages:          allImages,
+		pinningTooling:     integerPinningToolingChanged(opts.ChangedFiles),
 	}
 	if allImages {
 		return changes, nil
@@ -78,7 +88,7 @@ func loadIntegerPRChanges(opts *IntegerPROptions) (integerPRChanges, error) {
 }
 
 func (c integerPRChanges) empty() bool {
-	return !c.allImages && len(c.definitions) == 0 && c.impact.empty() && !c.pinningTooling
+	return !c.allImages && len(c.definitions) == 0 && len(c.definitionVariants) == 0 && c.impact.empty() && !c.pinningTooling
 }
 
 func discoverIntegerPRImages(opts *IntegerPROptions) ([]intdiscovery.DiscoveredImage, error) {
@@ -126,6 +136,7 @@ func resolveIntegerPRSelection(opts *IntegerPROptions, images []intdiscovery.Dis
 			return integerPRSelection{}, fmt.Errorf("resolve affected bespoke variants: %w", err)
 		}
 	}
+	maps.Copy(selection.variants, changes.definitionVariants)
 	if changes.pinningTooling {
 		canaries, err := integerConstrainedMelangeVariants(imagesDir, images)
 		if err != nil {

--- a/internal/ci/integer_pr_plan.go
+++ b/internal/ci/integer_pr_plan.go
@@ -18,7 +18,7 @@ type integerPRChanges struct {
 
 type integerPRSelection struct {
 	imageNames map[string]struct{}
-	variants   map[integerVariant]struct{}
+	variants   integerVariantImpacts
 }
 
 var apkindexFetch = apkindex.Fetch
@@ -115,7 +115,7 @@ func resolveIntegerPRSelection(opts *IntegerPROptions, images []intdiscovery.Dis
 	}
 	selection := integerPRSelection{
 		imageNames: imageNames,
-		variants:   map[integerVariant]struct{}{},
+		variants:   integerVariantImpacts{},
 	}
 	if changes.allImages {
 		return selection, nil
@@ -132,7 +132,7 @@ func resolveIntegerPRSelection(opts *IntegerPROptions, images []intdiscovery.Dis
 			return integerPRSelection{}, fmt.Errorf("resolve package-pinning canaries: %w", err)
 		}
 		for variant := range canaries {
-			selection.variants[variant] = struct{}{}
+			selection.variants[variant] = integerImpactShared
 		}
 	}
 	return selection, nil

--- a/internal/ci/integer_selection.go
+++ b/internal/ci/integer_selection.go
@@ -16,23 +16,17 @@ func selectIntegerPRImages(imgs []intdiscovery.DiscoveredImage, changedImages ma
 	buildSet := map[integerVariant]intdiscovery.DiscoveredImage{}
 	smokeSet := map[integerVariant]intdiscovery.DiscoveredImage{}
 	latest := map[integerImageType]intdiscovery.DiscoveredImage{}
-	impactedImageTypes := map[integerImageType]struct{}{}
-	for variant := range impactedVariants {
-		impactedImageTypes[integerImageType{image: variant.image, imageType: variant.imageType}] = struct{}{}
-	}
 	for _, img := range imgs {
 		variant := variantForImage(&img)
 		imageType := integerImageType{image: img.Name, imageType: img.Type}
 		_, imageChanged := changedImages[img.Name]
 		impactScope, variantImpacted := impactedVariants[variant]
-		_, imageTypeImpacted := impactedImageTypes[imageType]
-		familyChanged := imageChanged && !imageTypeImpacted
-		if !all && !familyChanged && !variantImpacted {
+		if !all && !imageChanged && !variantImpacted {
 			continue
 		}
 
 		smokeSet[variant] = img
-		if !all && !familyChanged && impactScope == integerImpactVersion {
+		if !all && !imageChanged && impactScope == integerImpactVersion {
 			buildSet[variant] = img
 			continue
 		}

--- a/internal/ci/integer_selection.go
+++ b/internal/ci/integer_selection.go
@@ -7,21 +7,38 @@ import (
 	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
 )
 
-func selectIntegerPRImages(imgs []intdiscovery.DiscoveredImage, changedImages map[string]struct{}, impactedVariants map[integerVariant]struct{}, all bool) (builds, smokes []intdiscovery.DiscoveredImage) {
+type integerImageType struct {
+	image     string
+	imageType string
+}
+
+func selectIntegerPRImages(imgs []intdiscovery.DiscoveredImage, changedImages map[string]struct{}, impactedVariants integerVariantImpacts, all bool) (builds, smokes []intdiscovery.DiscoveredImage) {
 	buildSet := map[integerVariant]intdiscovery.DiscoveredImage{}
 	smokeSet := map[integerVariant]intdiscovery.DiscoveredImage{}
-	latest := map[string]intdiscovery.DiscoveredImage{}
+	latest := map[integerImageType]intdiscovery.DiscoveredImage{}
+	impactedImageTypes := map[integerImageType]struct{}{}
+	for variant := range impactedVariants {
+		impactedImageTypes[integerImageType{image: variant.image, imageType: variant.imageType}] = struct{}{}
+	}
 	for _, img := range imgs {
 		variant := variantForImage(&img)
+		imageType := integerImageType{image: img.Name, imageType: img.Type}
 		_, imageChanged := changedImages[img.Name]
-		_, variantImpacted := impactedVariants[variant]
-		if all || imageChanged || variantImpacted {
-			smokeSet[variant] = img
-			key := img.Name + "\x00" + img.Type
-			previous, ok := latest[key]
-			if !ok || apkindex.VersionLess(previous.Version, img.Version) {
-				latest[key] = img
-			}
+		impactScope, variantImpacted := impactedVariants[variant]
+		_, imageTypeImpacted := impactedImageTypes[imageType]
+		familyChanged := imageChanged && !imageTypeImpacted
+		if !all && !familyChanged && !variantImpacted {
+			continue
+		}
+
+		smokeSet[variant] = img
+		if !all && !familyChanged && impactScope == integerImpactVersion {
+			buildSet[variant] = img
+			continue
+		}
+		previous, ok := latest[imageType]
+		if !ok || apkindex.VersionLess(previous.Version, img.Version) {
+			latest[imageType] = img
 		}
 	}
 	for _, img := range latest {

--- a/internal/ci/integer_version_impact_test.go
+++ b/internal/ci/integer_version_impact_test.go
@@ -1,0 +1,99 @@
+package ci
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+)
+
+func TestPlanIntegerPRVersionScopedChangesSelectExactPackageBuildAndSmokeConsumers(t *testing.T) {
+	// Given: versions 14 and 15 gain scoped recipes while discovery also finds stale 12/13 and latest 18.
+	opts := versionScopedPostgresPlanOptions(t)
+
+	// When: the definition and both scoped recipes change together.
+	plan, err := PlanIntegerPR(opts)
+
+	// Then: package, image build, and smoke gates receive exactly the changed consumers.
+	require.NoError(t, err)
+	require.True(t, plan.HasChanges)
+	want := []map[string]string{
+		{"image": "scoped-postgres", "version": "14", "type": "default"},
+		{"image": "scoped-postgres", "version": "15", "type": "default"},
+	}
+	assert.Equal(t, want, plan.Matrix.Include)
+	assert.Equal(t, want, plan.SmokeMatrix.Include)
+}
+
+func TestPlanIntegerPRVersionScopedChangesDoNotSubstituteUnrelatedVersions(t *testing.T) {
+	// Given: discovery returns unsupported historical streams and a newer unmodified stream.
+	opts := versionScopedPostgresPlanOptions(t)
+
+	// When: planning the scoped 14/15 change.
+	plan, err := PlanIntegerPR(opts)
+
+	// Then: 12/13 are not added to smoke and 18 does not replace the required builds.
+	require.NoError(t, err)
+	for _, version := range []string{"12", "13", "18"} {
+		unexpected := map[string]string{"image": "scoped-postgres", "version": version, "type": "default"}
+		assert.NotContains(t, plan.Matrix.Include, unexpected)
+		assert.NotContains(t, plan.SmokeMatrix.Include, unexpected)
+	}
+}
+
+func versionScopedPostgresPlanOptions(t *testing.T) *IntegerPROptions {
+	t.Helper()
+	root := setupIntegerPlanRepo(t)
+	writeTestFile(t, filepath.Join(root, "images", "scoped-postgres.yaml"), `
+name: scoped-postgres
+description: scoped postgres
+upstream:
+  package: scoped-postgres-{{version}}
+types:
+  default:
+    base: wolfi-base
+    packages: ["scoped-postgres-{{version}}"]
+versions:
+  "14":
+    melange:
+      default:
+        bespoke: scoped-postgres-14.yaml
+  "15":
+    melange:
+      default:
+        bespoke: scoped-postgres-15.yaml
+  "16": {}
+  "17": {}
+  "18": {}
+`)
+	for _, version := range []string{"14", "15"} {
+		writeTestFile(t, filepath.Join(root, "packages", "bespoke", "scoped-postgres-"+version+".yaml"), "pipeline: []\n")
+	}
+
+	originalFetch := apkindexFetch
+	apkindexFetch = func(string, string, time.Duration) ([]apkindex.Package, error) {
+		return []apkindex.Package{
+			{Name: "scoped-postgres-12"},
+			{Name: "scoped-postgres-13"},
+			{Name: "scoped-postgres-14"},
+			{Name: "scoped-postgres-15"},
+			{Name: "scoped-postgres-16"},
+			{Name: "scoped-postgres-17"},
+			{Name: "scoped-postgres-18"},
+		}, nil
+	}
+	t.Cleanup(func() { apkindexFetch = originalFetch })
+
+	opts := integerPlanOptions(
+		root,
+		"images/scoped-postgres.yaml",
+		"packages/bespoke/scoped-postgres-14.yaml",
+		"packages/bespoke/scoped-postgres-15.yaml",
+	)
+	opts.APKIndexURL = "test://apkindex"
+	return opts
+}

--- a/internal/ci/integer_version_impact_test.go
+++ b/internal/ci/integer_version_impact_test.go
@@ -1,7 +1,9 @@
 package ci
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,7 +11,45 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/verity-org/verity/internal/integer/apkindex"
+	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
 )
+
+func TestSelectIntegerPRImagesSharedDefinitionChangeRemainsFamilyWideWithScopedImpact(t *testing.T) {
+	// Given: a shared definition field and two version-scoped recipes change together.
+	images := make([]intdiscovery.DiscoveredImage, 0, 7)
+	for _, version := range []string{"12", "13", "14", "15", "16", "17", "18"} {
+		images = append(images, intdiscovery.DiscoveredImage{Name: "postgres", Version: version, Type: "default"})
+	}
+	changedImages := map[string]struct{}{"postgres": {}}
+	impacts := integerVariantImpacts{
+		{image: "postgres", version: "14", imageType: "default"}: integerImpactVersion,
+		{image: "postgres", version: "15", imageType: "default"}: integerImpactVersion,
+	}
+
+	// When: selecting required builds and smokes.
+	builds, smokes := selectIntegerPRImages(images, changedImages, impacts, false)
+
+	// Then: the shared definition change still fans out, regardless of the narrower recipe impact.
+	require.Equal(t, []string{"18"}, imageVersions(builds))
+	require.Equal(t, []string{"12", "13", "14", "15", "16", "17", "18"}, imageVersions(smokes))
+}
+
+func TestPlanIntegerPRSharedDefinitionChangeRemainsFamilyWideWithScopedRecipes(t *testing.T) {
+	// Given: the scoped 14/15 recipe change also edits a shared image description.
+	opts := versionScopedPostgresPlanOptions(t)
+	definitionPath := filepath.Join(opts.ImagesDir, "scoped-postgres.yaml")
+	definition, err := os.ReadFile(definitionPath)
+	require.NoError(t, err)
+	writeTestFile(t, definitionPath, strings.Replace(string(definition), "description: scoped postgres", "description: changed shared postgres", 1))
+
+	// When: planning through semantic base-versus-head definition impact.
+	plan, err := PlanIntegerPR(opts)
+
+	// Then: the shared definition edit keeps family-wide smoke and latest-build behavior.
+	require.NoError(t, err)
+	require.Equal(t, []string{"18"}, matrixVersions(plan.Matrix))
+	require.Equal(t, []string{"12", "13", "14", "15", "16", "17", "18"}, matrixVersions(*plan.SmokeMatrix))
+}
 
 func TestPlanIntegerPRVersionScopedChangesSelectExactPackageBuildAndSmokeConsumers(t *testing.T) {
 	// Given: versions 14 and 15 gain scoped recipes while discovery also finds stale 12/13 and latest 18.
@@ -48,6 +88,23 @@ func TestPlanIntegerPRVersionScopedChangesDoNotSubstituteUnrelatedVersions(t *te
 func versionScopedPostgresPlanOptions(t *testing.T) *IntegerPROptions {
 	t.Helper()
 	root := setupIntegerPlanRepo(t)
+	baseImagesDir := filepath.Join(root, "base-images")
+	writeTestFile(t, filepath.Join(baseImagesDir, "scoped-postgres.yaml"), `
+name: scoped-postgres
+description: scoped postgres
+upstream:
+  package: scoped-postgres-{{version}}
+types:
+  default:
+    base: wolfi-base
+    packages: ["scoped-postgres-{{version}}"]
+versions:
+  "14": {}
+  "15": {}
+  "16": {}
+  "17": {}
+  "18": {}
+`)
 	writeTestFile(t, filepath.Join(root, "images", "scoped-postgres.yaml"), `
 name: scoped-postgres
 description: scoped postgres
@@ -95,5 +152,22 @@ versions:
 		"packages/bespoke/scoped-postgres-15.yaml",
 	)
 	opts.APKIndexURL = "test://apkindex"
+	opts.BaseImagesDir = baseImagesDir
 	return opts
+}
+
+func imageVersions(images []intdiscovery.DiscoveredImage) []string {
+	versions := make([]string, 0, len(images))
+	for _, image := range images {
+		versions = append(versions, image.Version)
+	}
+	return versions
+}
+
+func matrixVersions(matrix Matrix) []string {
+	versions := make([]string, 0, len(matrix.Include))
+	for _, entry := range matrix.Include {
+		versions = append(versions, entry["version"])
+	}
+	return versions
 }

--- a/internal/ci/plan.go
+++ b/internal/ci/plan.go
@@ -30,14 +30,15 @@ type Plan struct {
 }
 
 type IntegerPROptions struct {
-	ChangedFiles []string
-	RepoRoot     string
-	BaseLockPath string
-	ConfigPath   string
-	ImagesDir    string
-	APKIndexURL  string
-	CacheDir     string
-	GenDir       string
+	ChangedFiles  []string
+	RepoRoot      string
+	BaseLockPath  string
+	BaseImagesDir string
+	ConfigPath    string
+	ImagesDir     string
+	APKIndexURL   string
+	CacheDir      string
+	GenDir        string
 }
 
 type CopaPROptions struct {

--- a/scripts/integer_plan_workflow_test.go
+++ b/scripts/integer_plan_workflow_test.go
@@ -1,0 +1,21 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPRWorkflowProvidesBaseDefinitionsToIntegerPlanner(t *testing.T) {
+	// Given: the pull-request workflow that invokes semantic Integer planning.
+	data, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "pr-test.yaml"))
+	require.NoError(t, err)
+	workflow := string(data)
+
+	// Then: changed base definitions are materialized and passed to the planner.
+	assert.Contains(t, workflow, `git show "${BASE_SHA}:${file}" > "$RUNNER_TEMP/base-images/$relative"`)
+	assert.Contains(t, workflow, `--base-images-dir "$RUNNER_TEMP/base-images"`)
+}


### PR DESCRIPTION
## Summary

- carry shared versus version-scoped Melange impact through Integer PR planning
- let exact scoped consumers override path-only family fanout without replacing them with the latest stream
- preserve existing latest-build and all-impacted-smoke behavior for truly shared changes

This is the minimal shared CI planner prerequisite for #960. It does not change PostgreSQL recipes, image manifests, or vulnerability policy.

## TDD evidence

- RED: the PR #960 shape selected default build 18 and default smoke streams 12 through 18
- GREEN: the same input selects default package/build/smoke consumers 14 and 15 exactly
- shared FIPS consumers retain their existing latest-build and family smoke behavior

## Verification

- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m`
- `make integer-validate` (334 images)
- `make lint-workflows lint-yaml`
- `actionlint`
- `git diff --check`

## Manual planner QA

Running the real `verity ci plan --kind integer-pr` against PR #960 and the live Wolfi APKINDEX changed PostgreSQL default output from build 18 / smoke 12-18 to builds 14,15 / smokes 14,15. Existing shared FIPS selection remained build 18 / smokes 14-18.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the integer PR planner to preserve version-scoped targets while keeping shared definition fanout. Version-scoped Melange changes now select exact builds/smokes; shared definition edits still fan out to the latest build and family-wide smokes.

- **Bug Fixes**
  - Detect semantic definition vs version-scoped Melange changes by diffing base vs head `images/` via `--base-images-dir`; the PR workflow now collects base definitions and passes this flag.
  - For version-scoped changes, build and smoke only the exact impacted variants (no latest-stream substitution).
  - For any shared definition change, keep latest-build and family-wide smokes, even when scoped recipes also changed.
  - Keep package-pinning canaries treated as shared; add tests for exact 14/15 selection, no 12/13/18 substitution, shared fanout, and workflow wiring.

<sup>Written for commit 88f96550d89fcc68c713f2f2f9d1ac19bb085489. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

