### PR TITLE
fix(integer): own authservice package

### DIFF
--- a/cmd/authservice_config_test.go
+++ b/cmd/authservice_config_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Authservice_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Authservice image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "authservice.yaml"))
+	require.NoError(t, err)
+
+	// When: the default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "authservice.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"authservice"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/authservice", tmpl.Entrypoint)
+}
+
+func Test_Authservice_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "authservice.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package and source metadata are inspected.
+
+	// Then: revision r2 is the approved fixed release from immutable Apache-2.0 source.
+	require.Contains(t, text, "name: authservice")
+	require.Contains(t, text, "version: \"1.1.7\"")
+	require.Contains(t, text, "epoch: 2")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "repository: https://github.com/istio-ecosystem/authservice")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 9d868a5a9b93b49eeba72f4852164798fc794a1d")
+	require.Contains(t, text, "packages: ./cmd")
+	require.Contains(t, text, "github.com/tetratelabs/run/pkg/version.build")
+}
+
+func Test_Authservice_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "authservice.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "authservice",
+		Version: "1.1.7-r2",
+	}})
+
+	// Then: apko can only select the fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"authservice=1.1.7-r2@local"}, tmpl.Packages)
+}

--- a/images/authservice.yaml
+++ b/images/authservice.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["authservice"]
     entrypoint: /usr/bin/authservice
+    melange:
+      bespoke: authservice.yaml
 
 versions:
   "1": {}

--- a/packages/bespoke/authservice.yaml
+++ b/packages/bespoke/authservice.yaml
@@ -1,0 +1,42 @@
+package:
+  name: authservice
+  version: "1.1.7"
+  # Revision r2 is the approved fixed release for CVE-2026-42505.
+  epoch: 2
+  description: Move OIDC token acquisition out of application code and into the Istio mesh
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 6Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio-ecosystem/authservice
+      tag: v${{package.version}}
+      expected-commit: 9d868a5a9b93b49eeba72f4852164798fc794a1d
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      packages: ./cmd
+      output: authservice
+      ldflags: |
+        -X github.com/tetratelabs/run/pkg/version.build=v${{package.version}}-0-g$(git rev-parse --short HEAD)-main
+
+test:
+  pipeline:
+    - runs: |
+        authservice --help
+        [ "$(authservice --version)" = "authservice v${{package.version}}" ]


### PR DESCRIPTION
## Summary

- own the `authservice` package with a minimal bespoke Melange recipe
- bump the approved `authservice:1-default` row from `1.1.5-r10` to fixed `1.1.7-r2`
- pin upstream `v1.1.7` to immutable commit `9d868a5a9b93b49eeba72f4852164798fc794a1d`
- preserve the Apache-2.0 license and embed a truthful `authservice v1.1.7` runtime version
- exact-pin the locally built package during image assembly

## RED evidence

Strict Trivy 0.72.0 scans of the previous `ghcr.io/verity-org/authservice:1` image failed on both `linux/amd64` and `linux/arm64`:

- CVE-2026-42505, MEDIUM
- installed: `authservice 1.1.5-r10`
- fixed: `1.1.7-r2`
- status: fixed (no `NO_FIX` findings)

The focused regression test failed before implementation because the image had no Melange package selection and `packages/bespoke/authservice.yaml` did not exist.

## Verification

- focused regression: `go test ./cmd -run Authservice -count=1`
- full suite: `go test -race -shuffle=on -count=1 ./...`
- `mise exec -- golangci-lint run ./...` (0 issues)
- `go run . integer validate` (334 images valid)
- Integer build and PR workflow validators
- PR CI run `29403647689`: both build and smoke batches produced exact x86_64/aarch64 `authservice-1.1.7-r2.apk`; amd64 and arm64 strict Trivy totals were 0
- native workflow run `29405476284`:
  - x86_64 package build succeeded on `ubuntu-latest`
  - aarch64 package build succeeded on `ubuntu-24.04-arm`
  - Melange license detection reported Apache-2.0 on both architectures
  - final multi-arch image publish, strict Trivy gate, and cosign signing succeeded
- published `ghcr.io/verity-org/authservice:1` digest: `sha256:b1c675cb6c404547da274d9ab1221aaefa841b8abaac6840e405a503783de7aa`
- published manifest includes `linux/amd64` and `linux/arm64`
- remote-only immutable-digest Trivy scans with `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: exit 0 and 0 findings on both architectures
- runtime smoke on both architectures: `/usr/bin/authservice --help` and `authservice v1.1.7`
- SPDX 2.3 on both architectures: `authservice 1.1.7-r2`, `licenseDeclared: Apache-2.0`
