### PR TITLE
fix(integer): own aws-load-balancer-controller package

### DIFF
--- a/cmd/aws_load_balancer_controller_config_test.go
+++ b/cmd/aws_load_balancer_controller_config_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_AWSLoadBalancerController_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in AWS Load Balancer Controller image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "aws-load-balancer-controller.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "aws-load-balancer-controller.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"aws-load-balancer-controller"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/controller", tmpl.Entrypoint)
+}
+
+func Test_AWSLoadBalancerController_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "aws-load-balancer-controller.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package and source metadata are inspected.
+
+	// Then: revision r1 is the approved fixed release from immutable Apache-2.0 source.
+	require.Contains(t, text, "name: aws-load-balancer-controller")
+	require.Contains(t, text, "version: \"3.4.1\"")
+	require.Contains(t, text, "epoch: 1")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "repository: https://github.com/kubernetes-sigs/aws-load-balancer-controller")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: bc8331031ce97cc33d0bc0f85ab696c73942570a")
+	require.Contains(t, text, "sigs.k8s.io/aws-load-balancer-controller/pkg/version")
+}
+
+func Test_AWSLoadBalancerController_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "aws-load-balancer-controller.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "2", []apkindex.Package{{
+		Name:    "aws-load-balancer-controller",
+		Version: "3.4.1-r1",
+	}})
+
+	// Then: apko can only select the fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"aws-load-balancer-controller=3.4.1-r1@local"}, tmpl.Packages)
+}

--- a/images/aws-load-balancer-controller.yaml
+++ b/images/aws-load-balancer-controller.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["aws-load-balancer-controller"]
     entrypoint: /usr/bin/controller
+    melange:
+      bespoke: aws-load-balancer-controller.yaml
 
 versions:
   "2": {}

--- a/packages/bespoke/aws-load-balancer-controller.yaml
+++ b/packages/bespoke/aws-load-balancer-controller.yaml
@@ -1,0 +1,43 @@
+package:
+  name: aws-load-balancer-controller
+  version: "3.4.1"
+  # Revision r1 is the approved fixed release for the default v2 image stream.
+  epoch: 1
+  description: A Kubernetes controller for Elastic Load Balancers
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 8Gi
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+
+pipeline:
+  # Adapted from wolfi-dev/os@05cef2f5b5b59f8a0352fb018248c65bcc3fc2e2.
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/aws-load-balancer-controller
+      tag: v${{package.version}}
+      expected-commit: bc8331031ce97cc33d0bc0f85ab696c73942570a
+
+  - runs: |
+      VERSION_PKG=sigs.k8s.io/aws-load-balancer-controller/pkg/version
+      GIT_VERSION=$(git describe --tags --dirty --always) && \
+      GIT_COMMIT=$(git rev-parse HEAD) && \
+      BUILD_DATE=$(date -d@"${SOURCE_DATE_EPOCH}" +%Y-%m-%dT%H:%M:%S%z) && \
+      GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) GO111MODULE=on \
+      CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2" \
+      CGO_LDFLAGS="-Wl,-z,relro,-z,now" \
+      go build -buildmode=pie -tags 'osusergo,netgo,static_build' \
+        -ldflags="-linkmode=external -extldflags '-static-pie' -X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
+        -mod=readonly -a -o /home/build/out/controller main.go
+
+  - runs: |
+      install -Dm755 /home/build/out/controller "${{targets.destdir}}"/usr/bin/controller


### PR DESCRIPTION
## Summary

- rebuild `aws-load-balancer-controller:2-default` as bespoke package `3.4.1-r1`
- pin upstream `v3.4.1` to immutable commit `bc8331031ce97cc33d0bc0f85ab696c73942570a` with Apache-2.0 metadata
- bind the image to the local package and lock the approved matrix row with focused regression tests

## Proof

- RED: focused regression failed before the bespoke binding and recipe existed
- GREEN: focused regression and full `go test -race -shuffle=on -count=1 ./...` pass
- config validation: all 334 image configs valid
- native package builds: x86_64 and aarch64 produced `aws-load-balancer-controller-3.4.1-r1.apk`
- architecture image builds: amd64 and arm64 load with the expected architecture and `/usr/bin/controller` entrypoint
- runtime/version smoke: amd64 and arm64 report `v3.4.1` at commit `bc8331031ce97cc33d0bc0f85ab696c73942570a`
- SPDX 2.3: package version `3.4.1-r1`, declared license `Apache-2.0`
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings on amd64 and arm64
- CI: 18 passing checks, 0 failures, 0 pending
- review: 0 unresolved threads and 0 issue comments; automated review found no issues

Native proof workflow: https://github.com/verity-org/verity/actions/runs/29407270536
PR security workflow: https://github.com/verity-org/verity/actions/runs/29407235107