### PR TITLE
fix(integer): own aws-node-termination-handler package

### DIFF
--- a/cmd/aws_node_termination_handler_config_test.go
+++ b/cmd/aws_node_termination_handler_config_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_AWSNodeTerminationHandler_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in AWS Node Termination Handler image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "aws-node-termination-handler.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "aws-node-termination-handler.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"aws-node-termination-handler"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/node-termination-handler", tmpl.Entrypoint)
+}
+
+func Test_AWSNodeTerminationHandler_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "aws-node-termination-handler.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, and dependency metadata are inspected.
+
+	// Then: revision r13 is rebuilt from immutable Apache-2.0 source with both approved fixes.
+	require.Contains(t, text, "name: aws-node-termination-handler")
+	require.Contains(t, text, "version: \"1.25.6\"")
+	require.Contains(t, text, "epoch: 13")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "repository: https://github.com/aws/aws-node-termination-handler")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 77ca841d1329504e981542775f78403feb114048")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "node-termination-handler --help")
+}
+
+func Test_AWSNodeTerminationHandler_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "aws-node-termination-handler.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "aws-node-termination-handler",
+		Version: "1.25.6-r13",
+	}})
+
+	// Then: apko can only select the fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"aws-node-termination-handler=1.25.6-r13@local"}, tmpl.Packages)
+}

--- a/images/aws-node-termination-handler.yaml
+++ b/images/aws-node-termination-handler.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["aws-node-termination-handler"]
     entrypoint: /usr/bin/node-termination-handler
+    melange:
+      bespoke: aws-node-termination-handler.yaml
 
 versions:
   "1": {}

--- a/packages/bespoke/aws-node-termination-handler.yaml
+++ b/packages/bespoke/aws-node-termination-handler.yaml
@@ -1,0 +1,47 @@
+package:
+  name: aws-node-termination-handler
+  version: "1.25.6"
+  # Revision r13 includes the r12 OpenTelemetry remediation and rebuilds with
+  # the fixed Go toolchain for CVE-2026-42505.
+  epoch: 13
+  description: Gracefully handle EC2 instance shutdown within Kubernetes
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 6Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+
+pipeline:
+  # Adapted from wolfi-dev/os@5ee6c1d7bc3635d9e061dc08f1f7641512554b49.
+  - uses: git-checkout
+    with:
+      repository: https://github.com/aws/aws-node-termination-handler
+      tag: v${{package.version}}
+      expected-commit: 77ca841d1329504e981542775f78403feb114048
+
+  - uses: go/bump
+    with:
+      deps: |-
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        github.com/moby/spdystream@v0.5.1
+        golang.org/x/net@v0.55.0
+        golang.org/x/sys@v0.45.0
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      output: node-termination-handler
+      packages: ./cmd/node-termination-handler.go
+      tags: nthlinux
+
+test:
+  pipeline:
+    - runs: node-termination-handler --help


### PR DESCRIPTION
## Summary

- own `aws-node-termination-handler:1-default` as bespoke package `1.25.6-r13`
- rebuild immutable upstream `v1.25.6` commit `77ca841d1329504e981542775f78403feb114048` with Apache-2.0 metadata
- bump OpenTelemetry core modules to `v1.44.0` and build with fixed Go 1.26 toolchain
- pin apko to the local `1.25.6-r13@local` package and preserve the existing entrypoint

## Security evidence

Baseline `1.25.6-r10` strict scans failed on both amd64 and arm64 with:
- CVE-2026-41178 (MEDIUM), fixed in `1.25.6-r12`
- CVE-2026-42505 (MEDIUM), fixed in `1.25.6-r13`

No `NO_FIX` findings were present.

Local native amd64 verification:
- Melange package build and runtime help smoke passed
- binary reports Go `1.26.5` and OpenTelemetry core/metric/trace/sdk `v1.44.0`
- SPDX 2.3 declares `Apache-2.0` for `aws-node-termination-handler 1.25.6-r13`
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings

Native amd64+arm64 package/image builds and strict scans are required from PR CI before merge.

## Tests

- `go test -race -shuffle=on -count=1 ./cmd -run AWSNodeTerminationHandler`
- `go test -race -shuffle=on -count=1 ./...`
- `mise exec -- golangci-lint run ./...`
- `mise exec -- yamllint images/aws-node-termination-handler.yaml packages/bespoke/aws-node-termination-handler.yaml`
- `./verity integer validate`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own and pin `aws-node-termination-handler` as a bespoke package (`1.25.6-r13`) and update the image to use it. Fixes recent CVEs and ensures reproducible builds with Go 1.26 and OpenTelemetry `v1.44.0`.

- **Bug Fixes**
  - Rebuild as `1.25.6-r13` to address upstream medium CVEs.
  - Pin `apko` to `1.25.6-r13@local` and preserve `/usr/bin/node-termination-handler`.
  - Add tests to verify image selection, recipe metadata, and local pinning.

- **Dependencies**
  - Bump `go.opentelemetry.io/otel`, `go.opentelemetry.io/otel/trace`, `go.opentelemetry.io/otel/metric`, `go.opentelemetry.io/otel/sdk` to `v1.44.0`.
  - Build with `go-1.26`.

<sup>Written for commit a6d654bc90e1bd214a5a4348188e1ebd6dbf9917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

