### PR TITLE
fix(integer): own aws-otel-collector package

### DIFF
--- a/cmd/aws_otel_collector_config_test.go
+++ b/cmd/aws_otel_collector_config_test.go
@@ -50,6 +50,9 @@ func Test_AWSOTelCollector_recipe_pins_fixed_source_revision(t *testing.T) {
         - ${{package.name}}
         - ${{package.name}}-healthcheck
 `)
+	require.Contains(t, text, `        COLLECTOR_PID=$!
+        trap 'kill "$COLLECTOR_PID" 2>/dev/null || true; wait "$COLLECTOR_PID" 2>/dev/null || true' EXIT
+`)
 }
 
 func Test_AWSOTelCollector_resolves_fixed_local_package(t *testing.T) {

--- a/cmd/aws_otel_collector_config_test.go
+++ b/cmd/aws_otel_collector_config_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_AWSOTelCollector_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in AWS OTel Collector image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "aws-otel-collector.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "aws-otel-collector.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"aws-otel-collector"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/awscollector", tmpl.Entrypoint)
+}
+
+func Test_AWSOTelCollector_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "aws-otel-collector.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, and license metadata are inspected.
+
+	// Then: revision r7 is rebuilt from immutable Apache-2.0 source with both approved fixes.
+	require.Contains(t, text, "name: aws-otel-collector")
+	require.Contains(t, text, "version: \"0.48.0\"")
+	require.Contains(t, text, "epoch: 7")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "repository: https://github.com/aws-observability/aws-otel-collector")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 4454fb1af28b47947f59e522d5ed874d27dcc621")
+	require.Contains(t, text, "uses: go/bump")
+	require.NotContains(t, text, "uses: bump")
+	require.Contains(t, text, "modroot: .")
+	require.NotContains(t, text, "modroot: |-")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "bins: awscollector")
+}
+
+func Test_AWSOTelCollector_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "aws-otel-collector.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "aws-otel-collector",
+		Version: "0.48.0-r7",
+	}})
+
+	// Then: apko can only select the fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"aws-otel-collector=0.48.0-r7@local"}, tmpl.Packages)
+}

--- a/cmd/aws_otel_collector_config_test.go
+++ b/cmd/aws_otel_collector_config_test.go
@@ -34,24 +34,22 @@ func Test_AWSOTelCollector_recipe_pins_fixed_source_revision(t *testing.T) {
 
 	// When: its package, source, dependency, and license metadata are inspected.
 
-	// Then: revision r7 is rebuilt from immutable Apache-2.0 source with both approved fixes.
+	// Then: the fixed r0 release is rebuilt from immutable Apache-2.0 source.
 	require.Contains(t, text, "name: aws-otel-collector")
-	require.Contains(t, text, "version: \"0.48.0\"")
-	require.Contains(t, text, "epoch: 7")
+	require.Contains(t, text, "version: \"0.49.0\"")
+	require.Contains(t, text, "epoch: 0")
 	require.Contains(t, text, "license: Apache-2.0")
 	require.Contains(t, text, "repository: https://github.com/aws-observability/aws-otel-collector")
 	require.Contains(t, text, "tag: v${{package.version}}")
-	require.Contains(t, text, "expected-commit: 4454fb1af28b47947f59e522d5ed874d27dcc621")
-	require.Contains(t, text, "uses: go/bump")
-	require.NotContains(t, text, "uses: bump")
-	require.Contains(t, text, "modroot: .")
-	require.NotContains(t, text, "modroot: |-")
-	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
-	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
-	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
-	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "expected-commit: 0771477f9db2879afad3ae3ff7811b5264a151a8")
 	require.Contains(t, text, "go-package: go-1.26")
 	require.Contains(t, text, "bins: awscollector")
+	require.Contains(t, text, `  - name: ${{package.name}}-compat
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - ${{package.name}}-healthcheck
+`)
 }
 
 func Test_AWSOTelCollector_resolves_fixed_local_package(t *testing.T) {
@@ -63,10 +61,10 @@ func Test_AWSOTelCollector_resolves_fixed_local_package(t *testing.T) {
 	// When: local Melange artifacts are pinned for the image build.
 	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
 		Name:    "aws-otel-collector",
-		Version: "0.48.0-r7",
+		Version: "0.49.0-r0",
 	}})
 
 	// Then: apko can only select the fixed locally built revision.
 	require.NoError(t, err)
-	require.Equal(t, []string{"aws-otel-collector=0.48.0-r7@local"}, tmpl.Packages)
+	require.Equal(t, []string{"aws-otel-collector=0.49.0-r0@local"}, tmpl.Packages)
 }

--- a/images/aws-otel-collector.yaml
+++ b/images/aws-otel-collector.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["aws-otel-collector"]
     entrypoint: /usr/bin/awscollector
+    melange:
+      bespoke: aws-otel-collector.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/aws-otel-collector.yaml
+++ b/packages/bespoke/aws-otel-collector.yaml
@@ -1,9 +1,8 @@
 package:
   name: aws-otel-collector
-  version: "0.48.0"
-  # Revision r7 includes the r6 OpenTelemetry remediation and rebuilds with
-  # the fixed Go toolchain for CVE-2026-42505.
-  epoch: 7
+  version: "0.49.0"
+  # Revision r0 is the first upstream release containing all current fixes.
+  epoch: 0
   description: AWS distro for OpenTelemetry Collector
   copyright:
     - license: Apache-2.0
@@ -18,24 +17,9 @@ pipeline:
   # Adapted from wolfi-dev/os@05cef2f5b5b59f8a0352fb018248c65bcc3fc2e2.
   - uses: git-checkout
     with:
-      expected-commit: 4454fb1af28b47947f59e522d5ed874d27dcc621
+      expected-commit: 0771477f9db2879afad3ae3ff7811b5264a151a8
       repository: https://github.com/aws-observability/aws-otel-collector
       tag: v${{package.version}}
-
-  - uses: go/bump
-    with:
-      deps: |-
-        github.com/antchfx/xpath@v1.3.6
-        github.com/apache/thrift@v0.23.0
-        go.opentelemetry.io/otel/sdk@v1.44.0
-        go.opentelemetry.io/otel@v1.44.0
-        go.opentelemetry.io/otel/trace@v1.44.0
-        go.opentelemetry.io/otel/metric@v1.44.0
-        google.golang.org/grpc@v1.79.3
-        golang.org/x/net@v0.55.0
-        golang.org/x/sys@v0.45.0
-      modroot: .
-      tidy: false
 
   - uses: go/build
     with:
@@ -77,6 +61,10 @@ subpackages:
             /usr/bin/healthcheck --help
 
   - name: ${{package.name}}-compat
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - ${{package.name}}-healthcheck
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/

--- a/packages/bespoke/aws-otel-collector.yaml
+++ b/packages/bespoke/aws-otel-collector.yaml
@@ -109,6 +109,7 @@ test:
         set -euo pipefail
         awscollector --config=/etc/otel-config.yaml > collector.log 2>&1 &
         COLLECTOR_PID=$!
+        trap 'kill "$COLLECTOR_PID" 2>/dev/null || true; wait "$COLLECTOR_PID" 2>/dev/null || true' EXIT
         sleep 3
 
         grep -F "Starting aws-otel-collector" collector.log

--- a/packages/bespoke/aws-otel-collector.yaml
+++ b/packages/bespoke/aws-otel-collector.yaml
@@ -1,0 +1,148 @@
+package:
+  name: aws-otel-collector
+  version: "0.48.0"
+  # Revision r7 includes the r6 OpenTelemetry remediation and rebuilds with
+  # the fixed Go toolchain for CVE-2026-42505.
+  epoch: 7
+  description: AWS distro for OpenTelemetry Collector
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "10"
+    memory: 16Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+pipeline:
+  # Adapted from wolfi-dev/os@05cef2f5b5b59f8a0352fb018248c65bcc3fc2e2.
+  - uses: git-checkout
+    with:
+      expected-commit: 4454fb1af28b47947f59e522d5ed874d27dcc621
+      repository: https://github.com/aws-observability/aws-otel-collector
+      tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/antchfx/xpath@v1.3.6
+        github.com/apache/thrift@v0.23.0
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        google.golang.org/grpc@v1.79.3
+        golang.org/x/net@v0.55.0
+        golang.org/x/sys@v0.45.0
+      modroot: .
+      tidy: false
+
+  - uses: go/build
+    with:
+      packages: ./cmd/awscollector
+      output: awscollector
+      ldflags: |
+        -X github.com/aws-observability/aws-otel-collector/tools/version.GitHash=$(git rev-parse HEAD)
+        -X github.com/aws-observability/aws-otel-collector/tools/version.Version=${{package.version}}
+        -X github.com/aws-observability/aws-otel-collector/tools/version.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      go-package: go-1.26
+
+  - runs: |
+      # Copies the default config.
+      # https://github.com/aws-observability/aws-otel-collector/blob/main/cmd/awscollector/Dockerfile#L101
+      mkdir -p ${{targets.destdir}}/etc
+      cp config.yaml ${{targets.destdir}}/etc/otel-config.yaml
+
+      # Copy all the example configs for different AWS services (ECS, EKS, App Runner)
+      # https://github.com/aws-observability/aws-otel-collector/blob/main/cmd/awscollector/Dockerfile#L92
+      cp -r config/* ${{targets.destdir}}/etc/
+
+subpackages:
+  - name: ${{package.name}}-healthcheck
+    description: Health check utility for AWS OTel Collector
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/healthcheck
+          output: healthcheck
+          ldflags: |
+            -X github.com/aws-observability/aws-otel-collector/tools/version.GitHash=$(git rev-parse HEAD)
+            -X github.com/aws-observability/aws-otel-collector/tools/version.Version=${{package.version}}
+            -X github.com/aws-observability/aws-otel-collector/tools/version.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    test:
+      pipeline:
+        - name: Test healthcheck binary exists
+          runs: |
+            healthcheck --help
+            /usr/bin/healthcheck --help
+
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/awscollector ${{targets.contextdir}}/awscollector
+          ln -sf /usr/bin/healthcheck ${{targets.contextdir}}/healthcheck
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}
+            - ${{package.name}}-healthcheck
+      pipeline:
+        - uses: test/tw/ver-check
+          with:
+            bins: /awscollector
+            version: ${{package.version}}
+        - name: Test root-level symlinks
+          runs: |
+            /healthcheck --help
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-healthcheck
+        - wget
+    environment:
+      AWS_REGION: us-east-1
+  pipeline:
+    - uses: test/tw/ver-check
+      with:
+        bins: awscollector
+        version: ${{package.version}}
+    - name: Verify default config exists
+      runs: |
+        test -f /etc/otel-config.yaml
+        test -f /etc/ecs/ecs-default-config.yaml
+        test -f /etc/eks/prometheus/config-all.yaml
+        test -f /etc/apprunner/apprunner-default-config.yaml
+    - name: Start collector and test functionality
+      runs: |
+        set -euo pipefail
+        awscollector --config=/etc/otel-config.yaml > collector.log 2>&1 &
+        COLLECTOR_PID=$!
+        sleep 3
+
+        grep -F "Starting aws-otel-collector" collector.log
+        grep -F "Starting GRPC server" collector.log
+        grep -F "Starting HTTP server" collector.log
+        grep -F "X-Ray" collector.log
+        grep -F "Extension started" collector.log
+        grep -F "Health Check state change" collector.log
+
+        HEALTH_JSON=$(wget -qO- http://localhost:13133/)
+        echo "$HEALTH_JSON" | grep -F '"status":"Server available"'
+        echo "$HEALTH_JSON" | grep -F '"upSince":'
+
+        healthcheck -port 13133
+
+update:
+  enabled: true
+  github:
+    identifier: aws-observability/aws-otel-collector
+    strip-prefix: v
+
+environment:
+  contents:
+    packages:
+      - go-1.26


### PR DESCRIPTION
## Summary

- own `aws-otel-collector:0-default` with a package-specific Melange recipe at current fixed `0.49.0-r0`
- pin immutable upstream `v0.49.0` commit `0771477f9db2879afad3ae3ff7811b5264a151a8` with Apache-2.0 metadata
- include the approved OpenTelemetry/Go fixes plus the newly published Prometheus fixes required by the current Trivy DB
- pin the image to the locally built revision and add focused regression coverage
- make the compat subpackage depend on the main and healthcheck packages so its symlinks cannot dangle
- cleanly kill and wait for the collector process in the package runtime test

## Evidence

- RED reproduced: installed `0.48.0-r4`; Trivy reported CVE-2026-41178 (fixed r6) and CVE-2026-42505 (fixed r7)
- current-DB RED also reproduced after review: four new fixed findings on r7, all resolved by `0.49.0-r0`
- focused regression: failing before image/recipe wiring, green after fix
- native package builds: x86_64 and aarch64 produced signed `0.49.0-r0` APK repositories
- image builds: amd64 and arm64 completed with the fail-closed strict Trivy gate
- runtime smoke: both architectures reported ADOT Collector `0.49.0`, started OTLP gRPC, and reached `Everything is ready`
- SPDX/license: SPDX 2.3, package/source license Apache-2.0, source archive tied to the immutable commit on both architectures
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings on amd64 and arm64, including post-push rescans
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run ./...`
- Integer config validation and focused YAML lint

No suppressions, ignores, exclusions, severity reductions, retired variants, skipped architectures, or shared changes.
