### PR TITLE
fix(ci): run Integer architecture checks natively

### DIFF
--- a/.github/scripts/validate-pr-test-workflow.py
+++ b/.github/scripts/validate-pr-test-workflow.py
@@ -34,14 +34,16 @@ def main() -> None:
         "PR Test must expose a stable aggregate gate for branch protection",
     )
     require(
-        '["amd64", "arm64"][] as $arch' not in workflow,
-        "Integer dual-architecture coverage must not multiply matrices beyond GitHub's 256-job limit",
+        workflow.count('["amd64", "arm64"][] as $arch') == 2
+        and workflow.count("runs-on: ${{ matrix.runner }}") == 2
+        and workflow.count("ubuntu-24.04-arm") >= 2,
+        "Integer build and smoke matrices must place each architecture on its native runner",
     )
     require(
-        workflow.count("for package_arch in x86_64 aarch64; do") == 2
-        and workflow.count('--arch "$package_arch"') == 2
-        and workflow.count("for arch in amd64 arm64; do") >= 4,
-        "Every Integer build and smoke leg must build its architecture-specific package and image",
+        "for package_arch in x86_64 aarch64; do" not in workflow
+        and workflow.count('--arch "$INTEGER_PACKAGE_ARCH"') >= 3
+        and workflow.count("for arch in amd64 arm64; do") == 1,
+        "Every Integer matrix leg must build only its native package and image architecture",
     )
     require(
         workflow.count('docker load --input "$tar_path"') == 2
@@ -51,8 +53,8 @@ def main() -> None:
         "Every Integer build and smoke leg must verify the loaded runtime architecture",
     )
     require(
-        workflow.count("name: Set up QEMU for dual-architecture verification") == 2,
-        "Both Integer jobs must register arm64 binfmt before aarch64 package builds",
+        "docker/setup-qemu-action" not in workflow,
+        "Integer PR jobs must not compile aarch64 packages through QEMU",
     )
     require(
         workflow.count('--fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"') == 2,
@@ -72,14 +74,16 @@ def main() -> None:
     )
     require(
         '[ "$image" = linkerd ] && [ "$version" = 25 ] && [ "$type" = default ]' in workflow
-        and "matrix.arch" not in workflow,
-        "The Linkerd dual-architecture pinning canary must run once without standing in for the global arm64 gate",
+        and "--staged" in workflow
+        and '--arch "$INTEGER_PACKAGE_ARCH"' in workflow,
+        "The Linkerd pinning canary must retain staged package coverage on each native architecture",
     )
     require(
         workflow.count("group_by((.key / 16 | floor))") == 2
+        and workflow.count('["amd64", "arm64"][] as $arch') == 2
         and "expected-matrix" in workflow
         and "expected-smoke-matrix" in workflow,
-        "Affected Integer entries must be batched below GitHub's 256-job matrix limit without losing aggregate expectations",
+        "Affected Integer entries must remain bounded to 32 native architecture batches without losing aggregate expectations",
     )
 
 

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -129,13 +129,15 @@ jobs:
 
   # ── Integer smoke test ────────────────────────────────────────────────
   integer-smoke-test:
-    name: "Integer smoke batch ${{ matrix.batch_id }}"
+    name: "Integer smoke batch ${{ matrix.batch_id }} (${{ matrix.arch }})"
     needs: [changes, detect-changed-images]
     if: needs.changes.outputs.integer == 'true' && needs.detect-changed-images.outputs.has-changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     env:
       INTEGER_ENTRIES: ${{ toJson(matrix.entries) }}
       INTEGER_BATCH_ID: ${{ matrix.batch_id }}
+      INTEGER_ARCH: ${{ matrix.arch }}
+      INTEGER_PACKAGE_ARCH: ${{ matrix.package_arch }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changed-images.outputs.smoke-matrix) }}
@@ -166,14 +168,7 @@ jobs:
       - name: Build verity CLI
         run: go build -o verity .
 
-      - name: Set up QEMU for dual-architecture verification
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          # renovate: datasource=docker depName=tonistiigi/binfmt
-          image: docker.io/tonistiigi/binfmt:latest@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
-          platforms: arm64
-
-      - name: Build and verify dual-architecture Integer smoke batch
+      - name: Build and verify native-architecture Integer smoke batch
         run: |
           mkdir -p integer-security
           while IFS= read -r entry; do
@@ -184,55 +179,62 @@ jobs:
             report_dir="trivy-reports/${safe_image}-${version}-${type}"
             mkdir -p "$report_dir"
 
-            for package_arch in x86_64 aarch64; do
+            echo "::group::Melange ${image}:${version}-${type} (${INTEGER_PACKAGE_ARCH})"
+            started=$SECONDS
+            if timeout --signal=TERM --kill-after=1m 30m \
               ./verity integer melange build \
                 --image "$image" \
                 --version "$version" \
                 --type "$type" \
-                --arch "$package_arch"
-            done
+                --arch "$INTEGER_PACKAGE_ARCH"; then
+              echo "Melange ${image}:${version}-${type} (${INTEGER_PACKAGE_ARCH}) completed in $((SECONDS - started))s"
+            else
+              rc=$?
+              echo "::error::Melange ${image}:${version}-${type} (${INTEGER_PACKAGE_ARCH}) failed after $((SECONDS - started))s with exit ${rc}"
+              exit "$rc"
+            fi
+            echo "::endgroup::"
 
-            for arch in amd64 arm64; do
-              tar_path="image-${safe_image}-${version}-${type}-${arch}.tar"
-              ./verity integer build \
-                --image "$image" \
-                --version "$version" \
-                --type "$type" \
-                --output "$tar_path" \
-                --arch "$arch" \
-                --fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+            arch="$INTEGER_ARCH"
+            tar_path="image-${safe_image}-${version}-${type}-${arch}.tar"
+            ./verity integer build \
+              --image "$image" \
+              --version "$version" \
+              --type "$type" \
+              --output "$tar_path" \
+              --arch "$arch" \
+              --fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 
-              load_output=$(docker load --input "$tar_path")
-              echo "$load_output"
-              loaded_ref=$(awk -F': ' '/^Loaded image: / {print $2}' <<< "$load_output" | tail -1)
-              if [ -z "$loaded_ref" ]; then
-                echo "::error::docker load did not report an image reference for ${arch}"
-                exit 1
-              fi
-              runtime_arch=$(docker image inspect "$loaded_ref" --format '{{.Architecture}}')
-              if [ "$runtime_arch" != "$arch" ]; then
-                echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
-                exit 1
-              fi
+            load_output=$(docker load --input "$tar_path")
+            echo "$load_output"
+            loaded_ref=$(awk -F': ' '/^Loaded image: / {print $2}' <<< "$load_output" | tail -1)
+            if [ -z "$loaded_ref" ]; then
+              echo "::error::docker load did not report an image reference for ${arch}"
+              exit 1
+            fi
+            runtime_arch=$(docker image inspect "$loaded_ref" --format '{{.Architecture}}')
+            if [ "$runtime_arch" != "$arch" ]; then
+              echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
+              exit 1
+            fi
 
-              trivy image \
-                --exit-code 1 \
-                --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
-                --vuln-type os,library \
-                --format json \
-                --output "${report_dir}/${arch}.json" \
-                --input "$tar_path"
-              total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "${report_dir}/${arch}.json")
-              echo "${image}:${version}-${type} ${arch}: Total vulnerabilities: ${total}"
-              touch "integer-security/smoke-${safe_image}-${version}-${type}-${arch}.passed"
-              rm -f "$tar_path"
-            done
+            trivy image \
+              --exit-code 1 \
+              --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
+              --vuln-type os,library \
+              --format json \
+              --output "${report_dir}/${arch}.json" \
+              --input "$tar_path"
+            total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "${report_dir}/${arch}.json")
+            echo "${image}:${version}-${type} ${arch}: Total vulnerabilities: ${total}"
+            touch "integer-security/smoke-${safe_image}-${version}-${type}-${arch}.passed"
+            rm -f "$tar_path"
           done < <(jq -c '.[]' <<< "$INTEGER_ENTRIES")
 
       - name: Upload Integer security completion
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "integer-security-smoke-batch-${{ matrix.batch_id }}"
+          name: "integer-security-smoke-batch-${{ matrix.batch_id }}-${{ matrix.arch }}"
           path: integer-security/*.passed
           retention-days: 7
 
@@ -240,7 +242,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "trivy-smoke-batch-${{ matrix.batch_id }}-amd64-arm64"
+          name: "trivy-smoke-batch-${{ matrix.batch_id }}-${{ matrix.arch }}"
           path: trivy-reports/**/*.json
           retention-days: 7
 
@@ -312,8 +314,8 @@ jobs:
 
           expected_matrix=$(jq -c '.matrix' ci-plan.json)
           expected_smoke_matrix=$(jq -c '.smokeMatrix' ci-plan.json)
-          matrix=$(jq -c '[.matrix.include | to_entries | group_by((.key / 16 | floor))[] | {batch_id: (.[0].key / 16 | floor), entries: map(.value)}] | {include: .}' ci-plan.json)
-          smoke_matrix=$(jq -c '[.smokeMatrix.include | to_entries | group_by((.key / 16 | floor))[] | {batch_id: (.[0].key / 16 | floor), entries: map(.value)}] | {include: .}' ci-plan.json)
+          matrix=$(jq -c '[.matrix.include | to_entries | group_by((.key / 16 | floor))[] | {batch_id: (.[0].key / 16 | floor), entries: map(.value)} as $batch | ["amd64", "arm64"][] as $arch | $batch + {arch: $arch, package_arch: (if $arch == "amd64" then "x86_64" else "aarch64" end), runner: (if $arch == "amd64" then "ubuntu-latest" else "ubuntu-24.04-arm" end)}] | {include: .}' ci-plan.json)
+          smoke_matrix=$(jq -c '[.smokeMatrix.include | to_entries | group_by((.key / 16 | floor))[] | {batch_id: (.[0].key / 16 | floor), entries: map(.value)} as $batch | ["amd64", "arm64"][] as $arch | $batch + {arch: $arch, package_arch: (if $arch == "amd64" then "x86_64" else "aarch64" end), runner: (if $arch == "amd64" then "ubuntu-latest" else "ubuntu-24.04-arm" end)}] | {include: .}' ci-plan.json)
           has_changes=$(jq -r '.hasChanges' ci-plan.json)
           count=$(jq '.include | length' <<< "$expected_matrix")
           batch_count=$(jq '.include | length' <<< "$matrix")
@@ -328,13 +330,15 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   integer-build-changed:
-    name: "Integer build batch ${{ matrix.batch_id }}"
+    name: "Integer build batch ${{ matrix.batch_id }} (${{ matrix.arch }})"
     needs: [changes, detect-changed-images]
     if: needs.changes.outputs.integer == 'true' && needs.detect-changed-images.outputs.has-changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     env:
       INTEGER_ENTRIES: ${{ toJson(matrix.entries) }}
       INTEGER_BATCH_ID: ${{ matrix.batch_id }}
+      INTEGER_ARCH: ${{ matrix.arch }}
+      INTEGER_PACKAGE_ARCH: ${{ matrix.package_arch }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changed-images.outputs.matrix) }}
@@ -365,14 +369,7 @@ jobs:
       - name: Build verity CLI
         run: go build -o verity .
 
-      - name: Set up QEMU for dual-architecture verification
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          # renovate: datasource=docker depName=tonistiigi/binfmt
-          image: docker.io/tonistiigi/binfmt:latest@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
-          platforms: arm64
-
-      - name: Build and verify dual-architecture Integer batch
+      - name: Build and verify native-architecture Integer batch
         run: |
           mkdir -p integer-security
           while IFS= read -r entry; do
@@ -383,94 +380,105 @@ jobs:
             report_dir="trivy-reports/${safe_image}-${version}-${type}"
             mkdir -p "$report_dir"
 
-            for package_arch in x86_64 aarch64; do
+            echo "::group::Melange ${image}:${version}-${type} (${INTEGER_PACKAGE_ARCH})"
+            started=$SECONDS
+            if timeout --signal=TERM --kill-after=1m 30m \
               ./verity integer melange build \
                 --image "$image" \
                 --version "$version" \
                 --type "$type" \
-                --arch "$package_arch"
-            done
+                --arch "$INTEGER_PACKAGE_ARCH"; then
+              echo "Melange ${image}:${version}-${type} (${INTEGER_PACKAGE_ARCH}) completed in $((SECONDS - started))s"
+            else
+              rc=$?
+              echo "::error::Melange ${image}:${version}-${type} (${INTEGER_PACKAGE_ARCH}) failed after $((SECONDS - started))s with exit ${rc}"
+              exit "$rc"
+            fi
+            echo "::endgroup::"
 
             if [ "$image" = linkerd ] && [ "$version" = 25 ] && [ "$type" = default ]; then
-              ./verity integer melange build \
-                --image "$image" \
-                --version "$version" \
-                --type "$type" \
-                --arch aarch64 \
-                --staged
+              if timeout --signal=TERM --kill-after=1m 30m \
+                ./verity integer melange build \
+                  --image "$image" \
+                  --version "$version" \
+                  --type "$type" \
+                  --arch "$INTEGER_PACKAGE_ARCH" \
+                  --staged; then
+                echo "Staged Melange canary completed for ${INTEGER_PACKAGE_ARCH}"
+              else
+                rc=$?
+                echo "::error::staged Melange canary failed for ${INTEGER_PACKAGE_ARCH} with exit ${rc}"
+                exit "$rc"
+              fi
 
               ./verity integer discover --apkindex-url "" --gen-dir ./pin-config-gen
               config="pin-config-gen/${image}/${version}/${type}.apko.yaml"
               ./verity integer melange pin-config \
                 --config "$config" \
                 --repository packages/repo \
-                --arch x86_64 \
-                --arch aarch64
+                --arch "$INTEGER_PACKAGE_ARCH"
               grep -Eq 'linkerd2-cli=[^ ,]+@local' "$config"
 
-              for arch in amd64 arm64; do
-                canary_image="pin-config-${arch}.tar"
-                canary_report="pin-config-${arch}.json"
-                apko build \
-                  --arch "$arch" \
-                  --repository-append "@local packages/repo" \
-                  --keyring-append melange-work/melange.rsa.pub \
-                  "$config" \
-                  integer:pin-config-canary \
-                  "$canary_image"
-                trivy image \
-                  --exit-code 1 \
-                  --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
-                  --vuln-type os,library \
-                  --format json \
-                  --output "$canary_report" \
-                  --input "$canary_image"
-                total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "$canary_report")
-                echo "Pin-config canary ${arch}: Total vulnerabilities: ${total}"
-              done
-            fi
-
-            for arch in amd64 arm64; do
-              tar_path="image-${safe_image}-${version}-${type}-${arch}.tar"
-              ./verity integer build \
-                --image "$image" \
-                --version "$version" \
-                --type "$type" \
-                --output "$tar_path" \
-                --arch "$arch" \
-                --fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
-
-              load_output=$(docker load --input "$tar_path")
-              echo "$load_output"
-              loaded_ref=$(awk -F': ' '/^Loaded image: / {print $2}' <<< "$load_output" | tail -1)
-              if [ -z "$loaded_ref" ]; then
-                echo "::error::docker load did not report an image reference for ${arch}"
-                exit 1
-              fi
-              runtime_arch=$(docker image inspect "$loaded_ref" --format '{{.Architecture}}')
-              if [ "$runtime_arch" != "$arch" ]; then
-                echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
-                exit 1
-              fi
-
+              canary_image="pin-config-${INTEGER_ARCH}.tar"
+              canary_report="pin-config-${INTEGER_ARCH}.json"
+              apko build \
+                --arch "$INTEGER_ARCH" \
+                --repository-append "@local packages/repo" \
+                --keyring-append melange-work/melange.rsa.pub \
+                "$config" \
+                integer:pin-config-canary \
+                "$canary_image"
               trivy image \
                 --exit-code 1 \
                 --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
                 --vuln-type os,library \
                 --format json \
-                --output "${report_dir}/${arch}.json" \
-                --input "$tar_path"
-              total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "${report_dir}/${arch}.json")
-              echo "${image}:${version}-${type} ${arch}: Total vulnerabilities: ${total}"
-              touch "integer-security/build-${safe_image}-${version}-${type}-${arch}.passed"
-              rm -f "$tar_path"
-            done
+                --output "$canary_report" \
+                --input "$canary_image"
+              total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "$canary_report")
+              echo "Pin-config canary ${INTEGER_ARCH}: Total vulnerabilities: ${total}"
+            fi
+
+            arch="$INTEGER_ARCH"
+            tar_path="image-${safe_image}-${version}-${type}-${arch}.tar"
+            ./verity integer build \
+              --image "$image" \
+              --version "$version" \
+              --type "$type" \
+              --output "$tar_path" \
+              --arch "$arch" \
+              --fail-on-severity "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+
+            load_output=$(docker load --input "$tar_path")
+            echo "$load_output"
+            loaded_ref=$(awk -F': ' '/^Loaded image: / {print $2}' <<< "$load_output" | tail -1)
+            if [ -z "$loaded_ref" ]; then
+              echo "::error::docker load did not report an image reference for ${arch}"
+              exit 1
+            fi
+            runtime_arch=$(docker image inspect "$loaded_ref" --format '{{.Architecture}}')
+            if [ "$runtime_arch" != "$arch" ]; then
+              echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
+              exit 1
+            fi
+
+            trivy image \
+              --exit-code 1 \
+              --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
+              --vuln-type os,library \
+              --format json \
+              --output "${report_dir}/${arch}.json" \
+              --input "$tar_path"
+            total=$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "${report_dir}/${arch}.json")
+            echo "${image}:${version}-${type} ${arch}: Total vulnerabilities: ${total}"
+            touch "integer-security/build-${safe_image}-${version}-${type}-${arch}.passed"
+            rm -f "$tar_path"
           done < <(jq -c '.[]' <<< "$INTEGER_ENTRIES")
 
       - name: Upload Integer security completion
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "integer-security-build-batch-${{ matrix.batch_id }}"
+          name: "integer-security-build-batch-${{ matrix.batch_id }}-${{ matrix.arch }}"
           path: integer-security/*.passed
           retention-days: 7
 
@@ -478,7 +486,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "trivy-build-batch-${{ matrix.batch_id }}-amd64-arm64"
+          name: "trivy-build-batch-${{ matrix.batch_id }}-${{ matrix.arch }}"
           path: trivy-reports/**/*.json
           retention-days: 7
 

--- a/scripts/workflow_interpolation_test.go
+++ b/scripts/workflow_interpolation_test.go
@@ -73,8 +73,8 @@ func TestPRWorkflowUsesDistinctIntegerReportArtifactNames(t *testing.T) {
 			owners[name] = jobName + "/" + step.Name
 		}
 	}
-	require.Contains(t, owners, "trivy-smoke-batch-${{ matrix.batch_id }}-amd64-arm64")
-	require.Contains(t, owners, "trivy-build-batch-${{ matrix.batch_id }}-amd64-arm64")
+	require.Contains(t, owners, "trivy-smoke-batch-${{ matrix.batch_id }}-${{ matrix.arch }}")
+	require.Contains(t, owners, "trivy-build-batch-${{ matrix.batch_id }}-${{ matrix.arch }}")
 }
 
 func TestPRWorkflowDiffsBespokeLockForSelectiveImagePlanning(t *testing.T) {
@@ -122,33 +122,28 @@ func TestPRWorkflowExercisesProductionPinningOnLinkerdCanary(t *testing.T) {
 		Uses string            `yaml:"uses"`
 		With map[string]string `yaml:"with"`
 	}
-	qemu := batch
-	qemuIndex, batchIndex := -1, -1
+	batchIndex := -1
 	for index, step := range workflow.Jobs["integer-build-changed"].Steps {
-		switch step.Name {
-		case "Set up QEMU for dual-architecture verification":
-			qemu = step
-			qemuIndex = index
-		case "Build and verify dual-architecture Integer batch":
+		if step.Name == "Build and verify native-architecture Integer batch" {
 			batch = step
 			batchIndex = index
 		}
 	}
 
-	// Then: QEMU is ready before every aarch64 package build, while only
-	// Linkerd runs the production package-pinning canary inside the batch.
-	require.Equal(t, "Set up QEMU for dual-architecture verification", qemu.Name)
-	assert.Equal(t, "docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8", qemu.Uses)
-	assert.Equal(t, "docker.io/tonistiigi/binfmt:latest@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0", qemu.With["image"])
-	assert.Equal(t, "arm64", qemu.With["platforms"])
-	assert.Less(t, qemuIndex, batchIndex)
-	require.Equal(t, "Build and verify dual-architecture Integer batch", batch.Name)
+	// Then: each architecture uses its native runner and only Linkerd runs
+	// the production package-pinning canary inside the batch.
+	assert.NotContains(t, string(data), "docker/setup-qemu-action")
+	assert.Contains(t, string(data), "ubuntu-24.04-arm")
+	assert.NotEqual(t, -1, batchIndex)
+	require.Equal(t, "Build and verify native-architecture Integer batch", batch.Name)
+	assert.NotContains(t, batch.Run, `for package_arch in x86_64 aarch64; do`)
+	assert.Contains(t, batch.Run, `timeout --signal=TERM --kill-after=1m 30m`)
+	assert.Contains(t, batch.Run, `--arch "$INTEGER_PACKAGE_ARCH"`)
 	assert.Contains(t, batch.Run, `[ "$image" = linkerd ] && [ "$version" = 25 ] && [ "$type" = default ]`)
-	assert.Contains(t, batch.Run, `--arch aarch64`)
 	assert.Contains(t, batch.Run, `--staged`)
 	assert.Contains(t, batch.Run, `./verity integer melange pin-config`)
 	assert.Contains(t, batch.Run, `--repository packages/repo`)
-	assert.Contains(t, batch.Run, `--arch x86_64`)
+	assert.Contains(t, batch.Run, `--arch "$INTEGER_PACKAGE_ARCH"`)
 	assert.Contains(t, batch.Run, `apko build`)
 	assert.Contains(t, batch.Run, `--repository-append "@local packages/repo"`)
 	assert.Contains(t, batch.Run, `trivy image`)
@@ -173,24 +168,25 @@ func TestPRWorkflowRequiresDualArchitectureIntegerSecurityCompletion(t *testing.
 
 	// Then: every selected image entry executes both architectures without
 	// multiplying the matrix beyond GitHub's 256-job limit.
-	assert.NotContains(t, workflow, `["amd64", "arm64"][] as $arch`)
+	assert.Equal(t, 2, strings.Count(workflow, `["amd64", "arm64"][] as $arch`))
 	assert.Equal(t, 2, strings.Count(workflow, `group_by((.key / 16 | floor))`))
 	assert.Contains(t, workflow, `expected-matrix=${expected_matrix}`)
 	assert.Contains(t, workflow, `expected-smoke-matrix=${expected_smoke_matrix}`)
-	assert.Equal(t, 2, strings.Count(workflow, `for package_arch in x86_64 aarch64; do`))
-	assert.Equal(t, 2, strings.Count(workflow, `--arch "$package_arch"`))
-	assert.GreaterOrEqual(t, strings.Count(workflow, `for arch in amd64 arm64; do`), 4)
+	assert.NotContains(t, workflow, `for package_arch in x86_64 aarch64; do`)
+	assert.Equal(t, 2, strings.Count(workflow, `runs-on: ${{ matrix.runner }}`))
+	assert.GreaterOrEqual(t, strings.Count(workflow, `ubuntu-24.04-arm`), 2)
+	assert.Equal(t, 1, strings.Count(workflow, `for arch in amd64 arm64; do`))
 	assert.Equal(t, 2, strings.Count(workflow, `docker load --input "$tar_path"`))
 	assert.Equal(t, 2, strings.Count(workflow, `docker image inspect "$loaded_ref"`))
 	assert.Equal(t, 2, strings.Count(workflow, `docker load did not report an image reference`))
 	assert.Equal(t, 2, strings.Count(workflow, `runtime architecture mismatch`))
-	assert.Equal(t, 2, strings.Count(workflow, `name: Set up QEMU for dual-architecture verification`))
+	assert.NotContains(t, workflow, `name: Set up QEMU for dual-architecture verification`)
 
 	// And: reports and completion evidence cannot collide across architectures.
-	assert.Contains(t, workflow, `trivy-smoke-batch-${{ matrix.batch_id }}-amd64-arm64`)
-	assert.Contains(t, workflow, `trivy-build-batch-${{ matrix.batch_id }}-amd64-arm64`)
-	assert.Contains(t, workflow, `integer-security-smoke-batch-${{ matrix.batch_id }}`)
-	assert.Contains(t, workflow, `integer-security-build-batch-${{ matrix.batch_id }}`)
+	assert.Contains(t, workflow, `trivy-smoke-batch-${{ matrix.batch_id }}-${{ matrix.arch }}`)
+	assert.Contains(t, workflow, `trivy-build-batch-${{ matrix.batch_id }}-${{ matrix.arch }}`)
+	assert.Contains(t, workflow, `integer-security-smoke-batch-${{ matrix.batch_id }}-${{ matrix.arch }}`)
+	assert.Contains(t, workflow, `integer-security-build-batch-${{ matrix.batch_id }}-${{ matrix.arch }}`)
 
 	// And: the required aggregate verifies every expected marker, so an absent,
 	// skipped, cancelled, or failed arm64 leg cannot be reported as success.


### PR DESCRIPTION
## Summary
- split each Integer PR batch into native amd64/x86_64 and arm64/aarch64 legs
- remove QEMU from package/image/security verification while preserving exact selected entries
- hard-fail any Melange package command that exceeds 30 minutes
- keep per-architecture image load/inspect, SPDX generation, and strict Trivy UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL gates

## Root cause
PR #960 run 29404423917 compiled PostgreSQL arm64 under x86-hosted QEMU in both smoke and build jobs. All six cancelled jobs were still emitting compiler progress, not deadlocked. Native arm controls for PostgreSQL 14 and 15 completed in under nine minutes.

## Verification
- failing-first workflow regression assertions
- go test ./scripts -count=1
- make test
- make lint
- make lint-workflows
- make lint-yaml
- actionlint

No PostgreSQL recipes or vulnerability suppressions changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Integer smoke and build checks natively on `amd64` and `arm64` to remove QEMU overhead and stop CI stalls, especially on `PostgreSQL`. Enforces a 30-minute `melange` timeout and keeps strict per-arch `trivy` gates.

- **Bug Fixes**
  - Split the matrix into native `amd64`/`arm64` legs on `runs-on: ${{ matrix.runner }}` (`ubuntu-latest` vs `ubuntu-24.04-arm`); removed `docker/setup-qemu-action` and `tonistiigi/binfmt`.
  - Each leg builds only its native package/image arch (`INTEGER_PACKAGE_ARCH`/`INTEGER_ARCH`) and verifies runtime architecture after load.
  - Preserve selection and batching; bound to 32 native-arch batches with aggregate expectations intact.
  - Make artifact names arch-qualified to avoid collisions (e.g., `integer-security-...-${{ matrix.arch }}`, `trivy-...-${{ matrix.arch }}`).
  - Run the Linkerd pinning canary per native arch with staged `melange`, `apko`, and `trivy`.
  - Update the matrix validator and tests to enforce native runner placement, staged Linkerd canary coverage, and arch-qualified artifacts.
  - No recipe or vulnerability suppression changes.

<sup>Written for commit f0b80dc2f1bb1367d7954ab5beac80157ee5a546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

