### PR TITLE
fix(integer): own aws-s3-controller package

### DIFF
--- a/cmd/aws_s3_controller_config_test.go
+++ b/cmd/aws_s3_controller_config_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_AWSS3Controller_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in AWS S3 Controller image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "aws-s3-controller.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "aws-s3-controller.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"aws-s3-controller"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/controller", tmpl.Entrypoint)
+}
+
+func Test_AWSS3Controller_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "aws-s3-controller.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, version, and license metadata are inspected.
+
+	// Then: the fixed r0 release is rebuilt from immutable Apache-2.0 source.
+	require.Contains(t, text, "name: aws-s3-controller")
+	require.Contains(t, text, "version: \"1.8.1\"")
+	require.Contains(t, text, "epoch: 0")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "uri: https://github.com/aws-controllers-k8s/s3-controller/archive/refs/tags/v${{package.version}}.tar.gz")
+	require.Contains(t, text, "expected-sha256: 28ceade153f536c77c9b80dcd24a9a54fae879d60c6b4108565726ce7f0bab8c")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "github.com/aws-controllers-k8s/s3-controller/pkg/version.GitVersion")
+	require.Contains(t, text, "github.com/aws-controllers-k8s/s3-controller/pkg/version.GitCommit")
+	require.Contains(t, text, "github.com/aws-controllers-k8s/s3-controller/pkg/version.BuildDate")
+	require.Contains(t, text, "cba55a118f7ee122c2da08f3d4148d79ac953972")
+}
+
+func Test_AWSS3Controller_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "aws-s3-controller.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "aws-s3-controller",
+		Version: "1.8.1-r0",
+	}})
+
+	// Then: apko can only select the fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"aws-s3-controller=1.8.1-r0@local"}, tmpl.Packages)
+}

--- a/cmd/aws_s3_controller_config_test.go
+++ b/cmd/aws_s3_controller_config_test.go
@@ -39,13 +39,17 @@ func Test_AWSS3Controller_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "version: \"1.8.1\"")
 	require.Contains(t, text, "epoch: 0")
 	require.Contains(t, text, "license: Apache-2.0")
-	require.Contains(t, text, "uri: https://github.com/aws-controllers-k8s/s3-controller/archive/refs/tags/v${{package.version}}.tar.gz")
-	require.Contains(t, text, "expected-sha256: 28ceade153f536c77c9b80dcd24a9a54fae879d60c6b4108565726ce7f0bab8c")
+	require.Contains(t, text, "repository: https://github.com/aws-controllers-k8s/s3-controller.git")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: cba55a118f7ee122c2da08f3d4148d79ac953972")
 	require.Contains(t, text, "go-package: go-1.26")
 	require.Contains(t, text, "github.com/aws-controllers-k8s/s3-controller/pkg/version.GitVersion")
 	require.Contains(t, text, "github.com/aws-controllers-k8s/s3-controller/pkg/version.GitCommit")
 	require.Contains(t, text, "github.com/aws-controllers-k8s/s3-controller/pkg/version.BuildDate")
 	require.Contains(t, text, "cba55a118f7ee122c2da08f3d4148d79ac953972")
+	require.Contains(t, text, "identifier: aws-controllers-k8s/s3-controller")
+	require.Contains(t, text, "strip-prefix: v")
+	require.Contains(t, text, "use-tag: true")
 }
 
 func Test_AWSS3Controller_resolves_fixed_local_package(t *testing.T) {

--- a/images/aws-s3-controller.yaml
+++ b/images/aws-s3-controller.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["aws-s3-controller"]
     entrypoint: /usr/bin/controller
+    melange:
+      bespoke: aws-s3-controller.yaml
 
 versions:
   "1": {}

--- a/packages/bespoke/aws-s3-controller.yaml
+++ b/packages/bespoke/aws-s3-controller.yaml
@@ -1,0 +1,55 @@
+package:
+  name: aws-s3-controller
+  version: "1.8.1"
+  # Revision r0 is the approved fixed release for the default v1 image stream.
+  epoch: 0
+  description: ACK service controller for Amazon Simple Storage Service (S3)
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 6Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+
+pipeline:
+  # Adapted from wolfi-dev/os@05cef2f5b5b59f8a0352fb018248c65bcc3fc2e2.
+  - uses: fetch
+    with:
+      uri: https://github.com/aws-controllers-k8s/s3-controller/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-sha256: 28ceade153f536c77c9b80dcd24a9a54fae879d60c6b4108565726ce7f0bab8c
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      ldflags: |
+        -X github.com/aws-controllers-k8s/s3-controller/pkg/version.GitVersion=v${{package.version}}
+        -X github.com/aws-controllers-k8s/s3-controller/pkg/version.GitCommit=cba55a118f7ee122c2da08f3d4148d79ac953972
+        -X github.com/aws-controllers-k8s/s3-controller/pkg/version.BuildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +'%Y-%m-%dT%H:%M:%SZ')
+      packages: ./cmd/controller
+      output: controller
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}
+      cp LICENSE ${{targets.contextdir}}/
+      cp ATTRIBUTION.md ${{targets.contextdir}}/
+
+test:
+  environment:
+    contents:
+      packages:
+        - binutils
+  pipeline:
+    - uses: test/tw/help-check
+      with:
+        bins: controller
+    - name: Verify embedded release metadata
+      runs: |
+        strings /usr/bin/controller | grep -Fx "v${{package.version}}"
+        strings /usr/bin/controller | grep -Fx "cba55a118f7ee122c2da08f3d4148d79ac953972"

--- a/packages/bespoke/aws-s3-controller.yaml
+++ b/packages/bespoke/aws-s3-controller.yaml
@@ -20,10 +20,11 @@ environment:
 
 pipeline:
   # Adapted from wolfi-dev/os@05cef2f5b5b59f8a0352fb018248c65bcc3fc2e2.
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/aws-controllers-k8s/s3-controller/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 28ceade153f536c77c9b80dcd24a9a54fae879d60c6b4108565726ce7f0bab8c
+      repository: https://github.com/aws-controllers-k8s/s3-controller.git
+      tag: v${{package.version}}
+      expected-commit: cba55a118f7ee122c2da08f3d4148d79ac953972
 
   - uses: go/build
     with:
@@ -39,6 +40,13 @@ pipeline:
       mkdir -p ${{targets.contextdir}}
       cp LICENSE ${{targets.contextdir}}/
       cp ATTRIBUTION.md ${{targets.contextdir}}/
+
+update:
+  enabled: true
+  github:
+    identifier: aws-controllers-k8s/s3-controller
+    strip-prefix: v
+    use-tag: true
 
 test:
   environment:


### PR DESCRIPTION
## Summary

- own `aws-s3-controller` as a bespoke `1.8.1-r0` package for the `1-default` image
- build from upstream tag `v1.8.1` pinned to immutable release commit `cba55a118f7ee122c2da08f3d4148d79ac953972`
- preserve the `/usr/bin/controller` runtime contract and add focused package/source/pinning regressions

## Security evidence

- RED: the previous image installed `aws-s3-controller 1.6.0-r2`; strict Trivy found `CVE-2026-42505` (MEDIUM), fixed by `1.8.1-r0`
- amd64 image: `aws-s3-controller 1.8.1-r0`, Trivy UNKNOWN/LOW/MEDIUM/HIGH/CRITICAL = 0
- arm64 image: `aws-s3-controller 1.8.1-r0`, Trivy UNKNOWN/LOW/MEDIUM/HIGH/CRITICAL = 0
- scans used `/dev/null` as the ignore file; no suppressions, exclusions, or severity reductions

## Verification

- focused regression RED then green
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run ./cmd`
- Integer config validation and YAML lint
- x86_64 and aarch64 APK builds and signed indexes
- amd64 and arm64 apko image builds pinned to `aws-s3-controller=1.8.1-r0@local`
- runtime `controller --help` smoke on both platforms
- exact embedded `v1.8.1` and release commit on both binaries
- SPDX 2.3 SBOMs declare `Apache-2.0`; LICENSE and ATTRIBUTION payloads match across architectures

The PR workflow provides the required native x86_64 and aarch64 package/image security gates.
