### PR TITLE
fix(integer): own azure-workload-identity-webhook package

### DIFF
--- a/cmd/azure_workload_identity_webhook_config_test.go
+++ b/cmd/azure_workload_identity_webhook_config_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_AzureWorkloadIdentityWebhook_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Azure Workload Identity Webhook image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "azure-workload-identity-webhook.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "azure-workload-identity-webhook.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"azure-workload-identity-webhook"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/manager", tmpl.Entrypoint)
+}
+
+func Test_AzureWorkloadIdentityWebhook_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "azure-workload-identity-webhook.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, version, and license metadata are inspected.
+
+	// Then: revision r4 is rebuilt from immutable MIT-licensed v1.6.0 source.
+	require.Contains(t, text, "name: azure-workload-identity-webhook")
+	require.Contains(t, text, "version: \"1.6.0\"")
+	require.Contains(t, text, "epoch: 4")
+	require.Contains(t, text, "license: MIT")
+	require.Contains(t, text, "repository: https://github.com/Azure/azure-workload-identity")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 04d01a2fc7f5024290a38f6ccaf69561cf70455d")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/webhook")
+	require.Contains(t, text, "github.com/Azure/azure-workload-identity/pkg/version.BuildVersion")
+	require.Contains(t, text, "github.com/Azure/azure-workload-identity/pkg/version.Vcs")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_AzureWorkloadIdentityWebhook_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "azure-workload-identity-webhook.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "azure-workload-identity-webhook",
+		Version: "1.6.0-r4",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"azure-workload-identity-webhook=1.6.0-r4@local"}, tmpl.Packages)
+}

--- a/images/azure-workload-identity-webhook.yaml
+++ b/images/azure-workload-identity-webhook.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["azure-workload-identity-webhook"]
     entrypoint: /usr/bin/manager
+    melange:
+      bespoke: azure-workload-identity-webhook.yaml
 
 versions:
   "1": {}

--- a/packages/bespoke/azure-workload-identity-webhook.yaml
+++ b/packages/bespoke/azure-workload-identity-webhook.yaml
@@ -1,0 +1,65 @@
+package:
+  name: azure-workload-identity-webhook
+  version: "1.6.0"
+  # Revision r4 is the approved fixed release for CVE-2026-41178 and CVE-2026-42505.
+  epoch: 4
+  description: Mutating webhook for Azure Workload Identity
+  copyright:
+    - license: MIT
+  resources:
+    cpu: "3"
+    memory: 6Gi
+  test-resources:
+    cpu: "1"
+    memory: 2Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@d4ac7483f8a1b1977429dd9f8ad51c2f83be0599.
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Azure/azure-workload-identity
+      tag: v${{package.version}}
+      expected-commit: 04d01a2fc7f5024290a38f6ccaf69561cf70455d
+
+  - uses: go/build
+    with:
+      packages: ./cmd/webhook
+      output: manager
+      go-package: go-1.26
+      ldflags: |-
+        -X github.com/Azure/azure-workload-identity/pkg/version.BuildVersion=v${{package.version}}
+        -X github.com/Azure/azure-workload-identity/pkg/version.BuildTime=$(date -u -d "@$SOURCE_DATE_EPOCH" +%Y-%m-%d-%H:%M)
+        -X github.com/Azure/azure-workload-identity/pkg/version.Vcs=04d01a2fc7f5024290a38f6ccaf69561cf70455d
+        -X github.com/Azure/azure-workload-identity/pkg/webhook.ProxyImageVersion=v${{package.version}}
+        -X github.com/Azure/azure-workload-identity/pkg/webhook.ProxyImageRegistry=mcr.microsoft.com/oss/azure/workload-identity
+
+  - runs: |
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: Azure/azure-workload-identity
+    strip-prefix: v
+    use-tag: true
+
+test:
+  pipeline:
+    - uses: test/tw/help-check
+      with:
+        bins: manager
+    - name: Verify embedded release metadata
+      runs: |
+        manager --version | grep -F '"buildVersion":"v${{package.version}}"'
+        manager --version | grep -F '"gitCommit":"04d01a2fc7f5024290a38f6ccaf69561cf70455d"'
+    - name: Verify packaged license
+      runs: |
+        test -s "/usr/share/licenses/${{package.name}}/LICENSE"
+        grep -F "MIT License" "/usr/share/licenses/${{package.name}}/LICENSE"


### PR DESCRIPTION
## Summary
- rebuild azure-workload-identity-webhook 1.6.0-r4 from immutable upstream tag v1.6.0 at commit `04d01a2fc7f5024290a38f6ccaf69561cf70455d`
- declare the authoritative MIT license, package the upstream license text, and preserve `/usr/bin/manager` plus nonroot UID 65532
- select the local bespoke package for the existing `1-default` image stream and lock the behavior with focused regression tests
- adapt the last open-source Wolfi recipe provenance from `wolfi-dev/os@d4ac7483f8a1b1977429dd9f8ad51c2f83be0599`

## Reproduced RED
Trivy 0.72.0 against the current published amd64 and arm64 manifests (`1.5.1-r21`) exits 1 on both:
- CVE-2026-41178 MEDIUM, fixed in 1.6.0-r2
- CVE-2026-42505 MEDIUM, fixed in 1.6.0-r4

No NO_FIX findings.

## Verification
- failing-first focused regression, then `go test ./cmd -run AzureWorkloadIdentityWebhook -race -shuffle=on -count=1`
- `make test`
- `make lint`
- `make lint-yaml`
- `go run . integer validate`
- native amd64 Melange package build: `azure-workload-identity-webhook-1.6.0-r4.apk`
- native amd64 image build and runtime smoke: v1.6.0, pinned commit, linux/amd64, UID 65532
- SPDX JSON: package 1.6.0-r4 with declared license MIT; packaged license text verified
- strict Trivy UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL: zero findings

The PR CI from #975 provides the required native amd64 and arm64 package/image builds, runtime architecture checks, SPDX generation, and strict per-architecture Trivy gates. No suppressions, ignores, exclusions, severity reductions, or skipped architectures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own the `azure-workload-identity-webhook` package and point the default image to a locally rebuilt v1.6.0-r4 from a pinned upstream tag. This remediates current CVEs and locks the image to a known-good build.

- **Bug Fixes**
  - Fixes Trivy findings (CVE-2026-41178, CVE-2026-42505) by upgrading to 1.6.0-r4.

- **Dependencies**
  - Add bespoke Melange recipe for `azure-workload-identity-webhook` v1.6.0 (epoch 4) from `Azure/azure-workload-identity` tag v1.6.0.
  - Update the image to use the local package via `melange.bespoke`, preserving `/usr/bin/manager`.
  - Package and declare MIT license; add focused tests to pin version/source and enforce package selection.

<sup>Written for commit b7d98459f8cdfde46c019e0f14251b31dfe98499. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

