### PR TITLE
fix(integer): own descheduler package

### DIFF
--- a/cmd/descheduler_config_test.go
+++ b/cmd/descheduler_config_test.go
@@ -47,6 +47,8 @@ func Test_Descheduler_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "golang.org/x/net@v0.55.0")
 	require.Contains(t, text, "go-package: go-1.26")
 	require.Contains(t, text, "packages: ./cmd/descheduler")
+	require.Contains(t, text, "\"${{targets.destdir}}/usr/bin/descheduler\" version")
+	require.Contains(t, text, "\"${{targets.destdir}}/usr/bin/descheduler\" --help")
 	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
 }
 

--- a/cmd/descheduler_config_test.go
+++ b/cmd/descheduler_config_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Descheduler_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Descheduler image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "descheduler.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "descheduler.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"descheduler"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/descheduler", tmpl.Entrypoint)
+}
+
+func Test_Descheduler_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "descheduler.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, and license metadata are inspected.
+
+	// Then: approved revision r6 is rebuilt from immutable Apache-2.0 v0.36.0 source.
+	require.Contains(t, text, "name: descheduler")
+	require.Contains(t, text, "version: \"0.36.0\"")
+	require.Contains(t, text, "epoch: 6")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@90987ee0b29e578acc95eeb1f7efdae35d30d569")
+	require.Contains(t, text, "repository: https://github.com/kubernetes-sigs/descheduler")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 8005cdf78391e2c071cfa653c462dfefc2de8856")
+	require.Contains(t, text, "uses: go/bump")
+	require.Contains(t, text, "golang.org/x/net@v0.55.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/descheduler")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_Descheduler_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "descheduler.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "descheduler",
+		Version: "0.36.0-r6",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"descheduler=0.36.0-r6@local"}, tmpl.Packages)
+}

--- a/images/descheduler.yaml
+++ b/images/descheduler.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["descheduler"]
     entrypoint: /usr/bin/descheduler
+    melange:
+      bespoke: descheduler.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/descheduler.yaml
+++ b/packages/bespoke/descheduler.yaml
@@ -45,6 +45,8 @@ pipeline:
         -X sigs.k8s.io/descheduler/pkg/version.gitbranch=$(git rev-parse --abbrev-ref HEAD)
 
   - runs: |
+      "${{targets.destdir}}/usr/bin/descheduler" version | grep -F "GitVersion:${{package.version}}"
+      "${{targets.destdir}}/usr/bin/descheduler" --help >/dev/null
       install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
 
 test:

--- a/packages/bespoke/descheduler.yaml
+++ b/packages/bespoke/descheduler.yaml
@@ -1,0 +1,67 @@
+package:
+  name: descheduler
+  version: "0.36.0"
+  # Direct revision r6 includes fixes published in r5 and r6.
+  epoch: 6
+  description: Descheduler for Kubernetes
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 6Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@90987ee0b29e578acc95eeb1f7efdae35d30d569.
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/descheduler
+      tag: v${{package.version}}
+      expected-commit: 8005cdf78391e2c071cfa653c462dfefc2de8856
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.55.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/descheduler
+      output: descheduler
+      go-package: go-1.26
+      ldflags: |
+        -X sigs.k8s.io/descheduler/pkg/version.version=${{package.version}}
+        -X sigs.k8s.io/descheduler/pkg/version.gitsha1=$(git rev-parse HEAD)
+        -X sigs.k8s.io/descheduler/pkg/version.buildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
+        -X sigs.k8s.io/descheduler/pkg/version.gitbranch=$(git rev-parse --abbrev-ref HEAD)
+
+  - runs: |
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  pipeline:
+    - uses: test/tw/ver-check
+      with:
+        bins: descheduler
+        version: ${{package.version}}
+        version-flag: version
+    - uses: test/tw/help-check
+      with:
+        bins: descheduler
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/descheduler
+    strip-prefix: v
+  ignore-regex-patterns:
+    - descheduler-helm-chart-.*


### PR DESCRIPTION
## Summary
- own Descheduler 0.36.0-r6 as a bespoke Melange package
- pin immutable upstream v0.36.0 source commit 8005cdf78391e2c071cfa653c462dfefc2de8856
- preserve the Apache-2.0 license and package SPDX metadata
- select the exact locally signed package via descheduler=0.36.0-r6@local
- execute native version/help smoke during each architecture package build
- add focused ownership, provenance, runtime-smoke, and exact-revision regressions

## Security evidence
- baseline RED: 0.36.0-r3 had CVE-2026-41178 (fixed r5) and CVE-2026-42505 (fixed r6)
- no NO_FIX findings
- native amd64 and arm64 package/image builds passed
- native runtime output reported GitVersion 0.36.0 on linux/amd64 and linux/arm64
- Apache-2.0 license detection passed on both architectures; Melange generated package SPDX metadata
- strict Trivy UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL: 0 findings on amd64 and arm64
- no suppressions, ignores, exclusions, severity reductions, or architecture skips

## Validation
- focused RED then GREEN regression
- go test -race -shuffle=on -count=1 ./...
- make lint-yaml
- golangci-lint run ./...
- go run . integer validate
- python3 .github/scripts/validate-renovate-coverage.py
- PR Test native dual-architecture matrix and aggregate gate
