### PR TITLE
fix(integer): own dex package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -63,6 +63,18 @@
     },
     {
       "customType": "regex",
+      "description": "Dex package releases",
+      "managerFilePatterns": ["/^packages/bespoke/dex\\.yaml$/"],
+      "matchStrings": [
+        "package:\\n\\s+name:\\s*dex\\n\\s+version:\\s*[\\\"']?(?<currentValue>[\\w.+-]+)[\\\"']?"
+      ],
+      "depNameTemplate": "dexidp/dex",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver-coerced",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
       "description": "PostgreSQL package releases",
       "managerFilePatterns": ["/^packages/bespoke/postgresql-(?:14|15)\\.yaml$/"],
       "matchStrings": [

--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -19,6 +19,7 @@ REQUIRED_CUSTOM_MANAGERS: Final = {
     "Annotated dependencies",
     "Bespoke GitHub package releases",
     "Bespoke prefixed GitHub package releases",
+    "Dex package releases",
     "PostgreSQL package releases",
     "Airflow package release",
     "HAProxy package releases",
@@ -34,6 +35,7 @@ LOCAL_RECIPE_VERSIONS: Final = {
 }
 SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/airflow-3.yaml",
+    "packages/bespoke/dex.yaml",
     "packages/bespoke/haproxy-3.0.yaml",
     "packages/bespoke/haproxy-3.1.yaml",
     "packages/bespoke/haproxy-3.2.yaml",

--- a/cmd/dex_config_test.go
+++ b/cmd/dex_config_test.go
@@ -47,7 +47,8 @@ func Test_Dex_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "go-package: go-1.26")
 	require.Contains(t, text, "packages: ./cmd/dex")
 	require.Contains(t, text, "output: dex")
-	require.Contains(t, text, "usr/bin/docker-entrypoint")
+	require.NotContains(t, text, "./cmd/docker-entrypoint")
+	require.NotContains(t, text, "usr/bin/docker-entrypoint")
 	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
 	require.NotContains(t, text, "\"${{targets.destdir}}/var/dex\"")
 }

--- a/cmd/dex_config_test.go
+++ b/cmd/dex_config_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Dex_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Dex image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "dex.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package without changing the chart-driven argv contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "dex.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"dex"}, tmpl.Packages)
+	require.Empty(t, tmpl.Entrypoint)
+}
+
+func Test_Dex_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "dex.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, build, and license metadata are inspected.
+
+	// Then: approved revision r15 is rebuilt from immutable Apache-2.0 v2.45.1 source.
+	require.Contains(t, text, "name: dex")
+	require.Contains(t, text, "version: \"2.45.1\"")
+	require.Contains(t, text, "epoch: 15")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@e3f029ef29e67d4d8d9f041b1ae994719d96161f")
+	require.Contains(t, text, "11d2eeb52b42e1980e14cb91e69dd9e3faab2076.tar.gz")
+	require.Contains(t, text, "expected-sha256: 18bf92e8ccbf53e86814c2beb39b7d59f28fb07c84639e9f47a9bb5ea764e0b9")
+	require.Contains(t, text, "golang.org/x/net@v0.55.0")
+	require.Contains(t, text, "golang.org/x/crypto@v0.52.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/dex")
+	require.Contains(t, text, "output: dex")
+	require.Contains(t, text, "usr/bin/docker-entrypoint")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.NotContains(t, text, "\"${{targets.destdir}}/var/dex\"")
+}
+
+func Test_Dex_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "dex.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "2", []apkindex.Package{{
+		Name:    "dex",
+		Version: "2.45.1-r15",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"dex=2.45.1-r15@local"}, tmpl.Packages)
+}

--- a/images/dex.yaml
+++ b/images/dex.yaml
@@ -7,6 +7,8 @@ types:
   default:
     base: wolfi-base
     packages: ["dex"]
+    melange:
+      bespoke: dex.yaml
     # Intentionally NO `entrypoint:` — dex's binary (cmd/dex/main.go) does
     # NOT do argv[0]-basename dispatch (verified via upstream raw source —
     # see evidences/.../logs/subtask-4b-argv0-verification.md). Its cobra

--- a/packages/bespoke/dex.yaml
+++ b/packages/bespoke/dex.yaml
@@ -73,16 +73,6 @@ pipeline:
         -X main.version=v${{package.version}}
         -extldflags "-static"
 
-  - uses: go/build
-    with:
-      packages: ./cmd/docker-entrypoint
-      output: docker-entrypoint
-      go-package: go-1.26
-      ldflags: |
-        -w
-        -X main.version=v${{package.version}}
-        -extldflags "-static"
-
   - runs: |
       install -d \
         "${{targets.destdir}}/etc/dex" \
@@ -132,7 +122,6 @@ test:
       with:
         bins: dex
     - runs: |
-        test -x /usr/bin/docker-entrypoint
         test -f /etc/dex/config.docker.yaml
         test -d /srv/dex/web
         test -f /usr/share/licenses/${{package.name}}/LICENSE

--- a/packages/bespoke/dex.yaml
+++ b/packages/bespoke/dex.yaml
@@ -1,0 +1,145 @@
+package:
+  name: dex
+  version: "2.45.1"
+  # Direct revision r15 includes the approved fixed dependency revisions.
+  epoch: 15
+  description: OpenID Connect identity and OAuth 2.0 provider with pluggable connectors
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+  resources:
+    cpu: "4"
+    memory: 8Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@e3f029ef29e67d4d8d9f041b1ae994719d96161f.
+  - uses: fetch
+    with:
+      uri: https://github.com/dexidp/dex/archive/11d2eeb52b42e1980e14cb91e69dd9e3faab2076.tar.gz
+      expected-sha256: 18bf92e8ccbf53e86814c2beb39b7d59f28fb07c84639e9f47a9bb5ea764e0b9
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.55.0
+        google.golang.org/grpc@v1.79.3
+        github.com/russellhaering/goxmldsig@v1.6.0
+        github.com/go-jose/go-jose/v4@v4.1.4
+        github.com/Azure/go-ntlmssp@v0.1.1
+        go.opentelemetry.io/otel@v1.41.0
+        golang.org/x/crypto@v0.52.0
+      tidy: false
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.55.0
+        google.golang.org/grpc@v1.79.3
+        github.com/go-jose/go-jose/v4@v4.1.4
+        golang.org/x/crypto@v0.52.0
+      modroot: examples
+      tidy: false
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.55.0
+        google.golang.org/grpc@v1.79.3
+        golang.org/x/crypto@v0.52.0
+      modroot: api/v2
+      tidy: false
+
+  - uses: go/build
+    with:
+      packages: ./cmd/dex
+      output: dex
+      go-package: go-1.26
+      ldflags: |
+        -w
+        -X main.version=v${{package.version}}
+        -extldflags "-static"
+
+  - uses: go/build
+    with:
+      packages: ./cmd/docker-entrypoint
+      output: docker-entrypoint
+      go-package: go-1.26
+      ldflags: |
+        -w
+        -X main.version=v${{package.version}}
+        -extldflags "-static"
+
+  - runs: |
+      install -d \
+        "${{targets.destdir}}/etc/dex" \
+        "${{targets.destdir}}/srv/dex"
+      cp -R web "${{targets.destdir}}/srv/dex/"
+      install -Dm644 config.docker.yaml "${{targets.destdir}}/etc/dex/config.docker.yaml"
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+      "${{targets.destdir}}/usr/bin/dex" version | grep -F "v${{package.version}}"
+      "${{targets.destdir}}/usr/bin/dex" --help >/dev/null
+
+      cat > smoke.yaml <<'EOF'
+      issuer: http://127.0.0.1:15556/dex
+      storage:
+        type: memory
+      web:
+        http: 127.0.0.1:15556
+      connectors:
+        - type: mockCallback
+          id: mock
+          name: Example
+      EOF
+      "${{targets.destdir}}/usr/bin/dex" serve smoke.yaml >dex-smoke.log 2>&1 &
+      pid=$!
+      trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+      for attempt in $(seq 1 30); do
+        if wget -qO- http://127.0.0.1:15556/dex/healthz | grep -Fq "Health check passed"; then
+          exit 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+          cat dex-smoke.log
+          exit 1
+        fi
+        sleep 1
+      done
+      cat dex-smoke.log
+      exit 1
+
+test:
+  pipeline:
+    - uses: test/tw/ver-check
+      with:
+        bins: dex
+        version: v${{package.version}}
+        version-flag: version
+    - uses: test/tw/help-check
+      with:
+        bins: dex
+    - runs: |
+        test -x /usr/bin/docker-entrypoint
+        test -f /etc/dex/config.docker.yaml
+        test -d /srv/dex/web
+        test -f /usr/share/licenses/${{package.name}}/LICENSE
+
+update:
+  enabled: true
+  github:
+    identifier: dexidp/dex
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
## Summary
- own Dex `2.45.1-r15` as the bespoke package for approved `dex:2-default` direct-revision remediation
- build from immutable upstream commit archive `11d2eeb52b42e1980e14cb91e69dd9e3faab2076` with SHA-256 `18bf92e8ccbf53e86814c2beb39b7d59f28fb07c84639e9f47a9bb5ea764e0b9`
- preserve the chart-driven null entrypoint contract and omit the unreachable upstream `docker-entrypoint` binary
- classify the fetch-based Dex source for Renovate coverage

## Evidence
- RED: ownership regression failed with nil Melange/absent recipe before the implementation
- review regression: failed while `docker-entrypoint` remained, green after removing it
- focused regression: `go test ./cmd -run 'Test_Dex_' -count=1`
- full suite: `go test ./...`
- static/config: Renovate coverage, JSON, YAML, actionlint, CI workflow validator all green
- native amd64 package/image build and smoke: `dex-2.45.1-r15`, Dex `v2.45.1`, 0 vulnerabilities
- native arm64 package/image build and smoke: `dex-2.45.1-r15`, Dex `v2.45.1`, 0 vulnerabilities
- Trivy on both architectures: `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`, OS + library, exit-code enforced, zero findings
- SPDX 2.3/image metadata: `dex 2.45.1-r15`, declared `Apache-2.0`; LICENSE installed

## Scope
Dex only, plus the repository-required Dex Renovate manager/classification. No suppressions, ignores, exclusions, severity reductions, retirement, or architecture skips.
