### PR TITLE
fix(integer): own distribution package

### DIFF
--- a/cmd/distribution_config_test.go
+++ b/cmd/distribution_config_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Distribution_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in CNCF Distribution image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "distribution.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "distribution.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"distribution"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/registry serve /etc/docker/registry/config.yml", tmpl.Entrypoint)
+}
+
+func Test_Distribution_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "distribution.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, and license metadata are inspected.
+
+	// Then: approved revision r7 is rebuilt from immutable Apache-2.0 v3.1.1 source.
+	require.Contains(t, text, "name: distribution")
+	require.Contains(t, text, "version: \"3.1.1\"")
+	require.Contains(t, text, "epoch: 7")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@572ee9ed3e434cc0991a8b6967873896381e76b8")
+	require.Contains(t, text, "repository: https://github.com/distribution/distribution")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 9a8d98b679740cd514aa7e7d84d23d442a5ef54c")
+	require.Contains(t, text, "uses: go/bump")
+	require.Contains(t, text, "golang.org/x/net@v0.55.0")
+	require.Contains(t, text, "golang.org/x/crypto@v0.51.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/registry")
+	require.Contains(t, text, "/version.version=v${{package.version}}")
+	require.Contains(t, text, "/version.revision=$(git rev-parse --short HEAD)")
+	require.NotContains(t, text, "/version.Version=")
+	require.Contains(t, text, "registry --version")
+	require.Contains(t, text, "! registry --version | grep -F \"+unknown\"")
+	require.Contains(t, text, "registry --help")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "var/lib/db/sbom")
+	require.Contains(t, text, "chmod 0777")
+	require.Contains(t, text, "\"tag\":")
+	require.NotContains(t, text, "test/tw/ldd-check")
+}
+
+func Test_Distribution_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "distribution.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "distribution",
+		Version: "3.1.1-r7",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"distribution=3.1.1-r7@local"}, tmpl.Packages)
+}

--- a/cmd/distribution_config_test.go
+++ b/cmd/distribution_config_test.go
@@ -24,6 +24,12 @@ func Test_Distribution_uses_pinned_bespoke_package(t *testing.T) {
 	require.Equal(t, "distribution.yaml", tmpl.Melange.Bespoke.First())
 	require.Equal(t, []string{"distribution"}, tmpl.Packages)
 	require.Equal(t, "/usr/bin/registry serve /etc/docker/registry/config.yml", tmpl.Entrypoint)
+	require.Len(t, tmpl.Paths, 1)
+	require.Equal(t, "/var/lib/registry", tmpl.Paths[0].Path)
+	require.Equal(t, "directory", tmpl.Paths[0].Type)
+	require.Equal(t, 65532, tmpl.Paths[0].UID)
+	require.Equal(t, 65532, tmpl.Paths[0].GID)
+	require.Equal(t, "0o755", tmpl.Paths[0].Permissions)
 }
 
 func Test_Distribution_recipe_pins_fixed_source_revision(t *testing.T) {

--- a/images/distribution.yaml
+++ b/images/distribution.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["distribution"]
     entrypoint: /usr/bin/registry serve /etc/docker/registry/config.yml
+    melange:
+      bespoke: distribution.yaml
 
 versions:
   "3": {}

--- a/images/distribution.yaml
+++ b/images/distribution.yaml
@@ -10,6 +10,8 @@ types:
     entrypoint: /usr/bin/registry serve /etc/docker/registry/config.yml
     melange:
       bespoke: distribution.yaml
+    paths:
+      - {path: /var/lib/registry, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:
   "3": {}

--- a/packages/bespoke/distribution.yaml
+++ b/packages/bespoke/distribution.yaml
@@ -1,0 +1,119 @@
+package:
+  name: distribution
+  version: "3.1.1"
+  # Direct revision r7 supersedes the vulnerable public r4 package.
+  epoch: 7
+  description: The toolkit to pack, ship, store, and deliver container content
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - ${{package.name}}-compat=${{package.full-version}}
+    runtime:
+      - merged-bin
+      - wolfi-baselayout
+  resources:
+    cpu: "3"
+    memory: 6Gi
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@572ee9ed3e434cc0991a8b6967873896381e76b8.
+  - uses: git-checkout
+    with:
+      repository: https://github.com/distribution/distribution
+      tag: v${{package.version}}
+      expected-commit: 9a8d98b679740cd514aa7e7d84d23d442a5ef54c
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/net@v0.55.0
+        golang.org/x/crypto@v0.51.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/registry
+      output: registry
+      go-package: go-1.26
+      vendor: true
+      ldflags: |
+        -X github.com/distribution/distribution/v3/version.version=v${{package.version}}
+        -X github.com/distribution/distribution/v3/version.revision=$(git rev-parse --short HEAD)
+        -X github.com/distribution/distribution/v3/version.mainpkg=github.com/distribution/distribution/v3
+
+  - runs: |
+      install -d \
+        "${{targets.contextdir}}/etc/docker/registry" \
+        "${{targets.contextdir}}/etc/distribution" \
+        "${{targets.contextdir}}/var/lib/db/sbom" \
+        "${{targets.contextdir}}/var/lib/registry"
+      chmod 0755 \
+        "${{targets.contextdir}}/var" \
+        "${{targets.contextdir}}/var/lib" \
+        "${{targets.contextdir}}/var/lib/db" \
+        "${{targets.contextdir}}/var/lib/registry"
+      chmod 0777 "${{targets.contextdir}}/var/lib/db/sbom"
+      cat > "${{targets.contextdir}}/etc/docker/registry/config.yml" <<'EOF'
+      version: 0.1
+
+      log:
+        level: debug
+        fields:
+          service: registry
+          environment: development
+
+      storage:
+        delete:
+          enabled: true
+        cache:
+          blobdescriptor: inmemory
+        filesystem:
+          rootdirectory: /var/lib/registry
+        "tag":
+          concurrencylimit: 5
+
+      http:
+        addr: :5000
+        debug:
+          addr: :5001
+          prometheus:
+            enabled: true
+            path: /metrics
+
+      health:
+        storagedriver:
+          enabled: true
+          interval: 10s
+          threshold: 3
+      EOF
+      cp \
+        "${{targets.contextdir}}/etc/docker/registry/config.yml" \
+        "${{targets.contextdir}}/etc/distribution/config.yml"
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  pipeline:
+    - runs: |
+        registry --version | grep -F "v${{package.version}}"
+        ! registry --version | grep -F "+unknown"
+        registry --help >/dev/null
+        test -s /etc/docker/registry/config.yml
+        test -s /etc/distribution/config.yml
+        test -d /var/lib/registry
+        grep -F "Apache License" "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: distribution/distribution
+    strip-prefix: v


### PR DESCRIPTION
## Summary

- own CNCF Distribution `3.1.1-r7` as a source-maintained bespoke package
- pin immutable upstream `v3.1.1` commit `9a8d98b679740cd514aa7e7d84d23d442a5ef54c`
- preserve the Distribution runtime/config contract and Apache-2.0 license
- route only `distribution:3-default` through the local package
- provision `/var/lib/registry` for the image runtime UID/GID 65532

## Security evidence

- RED: published amd64 image installs `distribution-3.1.1-r4`; strict Trivy exits 1 on `CVE-2026-41178` (MEDIUM), fixed in `3.1.1-r7`
- GREEN: local amd64 package and image build installs `distribution-3.1.1-r7`
- GREEN: strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` reports 0 findings after the review fix
- no ignores, suppressions, exclusions, severity reduction, or skipped architecture logic

## Verification

- `go test -race -shuffle=on -count=1 ./...`
- `make lint`
- `yamllint -c .yamllint.yml packages/bespoke/distribution.yaml images/distribution.yaml`
- `python3 .github/scripts/validate-renovate-coverage.py`
- `verity integer validate` (334 images)
- native amd64 Melange/APK and apko image build
- runtime: UID 65532, exact `v3.1.1`, `--help` passes
- real registry push/upload succeeds and returns a digest while running as UID 65532
- SPDX-2.3 package SBOM declares `distribution 3.1.1-r7` as Apache-2.0; packaged LICENSE verified
- CI passed native amd64 and arm64 package/image builds, runtime smoke, and strict Trivy gates

