### PR TITLE
fix(integer): rebuild etcd 3.6 from fixed source

### DIFF
--- a/images/etcd.yaml
+++ b/images/etcd.yaml
@@ -46,4 +46,7 @@ types:
 versions:
   "3.5":
     skip-types: [default, fips]
-  "3.6": {}
+  "3.6":
+    melange:
+      default:
+        upstream: "etcd"

--- a/internal/integer/config/etcd_image_test.go
+++ b/internal/integer/config/etcd_image_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestEtcd36DefaultUsesApprovedBespokePackage(t *testing.T) {
+	// Given: the etcd image definition, locked recipe, and provenance lock.
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "locating test file")
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	def, err := LoadImage(filepath.Join(repoRoot, "images", "etcd.yaml"))
+	require.NoError(t, err)
+	recipeData, err := os.ReadFile(filepath.Join(repoRoot, "packages", "bespoke", "locked", "etcd-3.6.yaml"))
+	require.NoError(t, err)
+	lockData, err := os.ReadFile(filepath.Join(repoRoot, "packages", "upstream.lock.json"))
+	require.NoError(t, err)
+
+	var recipe struct {
+		Package struct {
+			Name      string `yaml:"name"`
+			Version   string `yaml:"version"`
+			Epoch     int    `yaml:"epoch"`
+			Copyright []struct {
+				License string `yaml:"license"`
+			} `yaml:"copyright"`
+		} `yaml:"package"`
+		Pipeline []struct {
+			Uses string `yaml:"uses"`
+			With struct {
+				ExpectedCommit string `yaml:"expected-commit"`
+				Deps           string `yaml:"deps"`
+				ModRoot        string `yaml:"modroot"`
+			} `yaml:"with"`
+		} `yaml:"pipeline"`
+	}
+	require.NoError(t, yaml.Unmarshal(recipeData, &recipe))
+
+	var lock struct {
+		Packages map[string]struct {
+			File        string `json:"file"`
+			Version     string `json:"version"`
+			SHA256      string `json:"sha256"`
+			Source      string `json:"source"`
+			CVETracking string `json:"cve_tracking"`
+		} `json:"packages"`
+	}
+	require.NoError(t, json.Unmarshal(lockData, &lock))
+
+	// When: the approved etcd 3.6 default matrix row is resolved.
+	version36 := def.Versions["3.6"]
+	defaultOverride := version36.Melange["default"]
+	require.NotNil(t, defaultOverride)
+
+	// Then: only that row selects the fixed, source-pinned Apache-2.0 package.
+	require.Len(t, version36.Melange, 1)
+	require.Equal(t, []string{"default", "fips"}, def.Versions["3.5"].SkipTypes)
+	require.Equal(t, "etcd", defaultOverride.Upstream)
+	require.Equal(t, "etcd-3.6", recipe.Package.Name)
+	require.Equal(t, "3.6.13", recipe.Package.Version)
+	require.Equal(t, 1, recipe.Package.Epoch)
+	require.Len(t, recipe.Package.Copyright, 1)
+	require.Equal(t, "Apache-2.0", recipe.Package.Copyright[0].License)
+
+	var checkoutCommit string
+	bumpedModules := make(map[string]string)
+	for _, step := range recipe.Pipeline {
+		switch step.Uses {
+		case "git-checkout":
+			checkoutCommit = step.With.ExpectedCommit
+		case "go/bump":
+			bumpedModules[step.With.ModRoot] = step.With.Deps
+		}
+	}
+	require.Equal(t, "b0f9ef190952e6e66a778513097a02ee41220727", checkoutCommit)
+	require.Len(t, bumpedModules, 4)
+	for _, modRoot := range []string{"", "tests", "server", "etcdutl"} {
+		require.Contains(t, bumpedModules[modRoot], "go.opentelemetry.io/otel/sdk@v1.44.0")
+	}
+
+	locked := lock.Packages["etcd"]
+	require.Equal(t, "etcd-3.6.yaml", locked.File)
+	require.Equal(t, "3.6.13", locked.Version)
+	require.Equal(t, fmt.Sprintf("%x", sha256.Sum256(recipeData)), locked.SHA256)
+	require.Equal(t, "public-recipe-baseline@3bc1a15922962c2ffbc0844b7f98672b79c5fd71", locked.Source)
+	require.Contains(t, locked.CVETracking, "CVE-2026-41178")
+	require.Contains(t, locked.CVETracking, "3.6.13-r1")
+}

--- a/internal/integer/config/etcd_image_test.go
+++ b/internal/integer/config/etcd_image_test.go
@@ -35,7 +35,9 @@ func TestEtcd36DefaultUsesApprovedBespokePackage(t *testing.T) {
 			} `yaml:"copyright"`
 		} `yaml:"package"`
 		Pipeline []struct {
+			Name string `yaml:"name"`
 			Uses string `yaml:"uses"`
+			Runs string `yaml:"runs"`
 			With struct {
 				ExpectedCommit string `yaml:"expected-commit"`
 				Deps           string `yaml:"deps"`
@@ -71,7 +73,7 @@ func TestEtcd36DefaultUsesApprovedBespokePackage(t *testing.T) {
 	require.Len(t, recipe.Package.Copyright, 1)
 	require.Equal(t, "Apache-2.0", recipe.Package.Copyright[0].License)
 
-	var checkoutCommit string
+	var checkoutCommit, runtimeSmoke string
 	bumpedModules := make(map[string]string)
 	for _, step := range recipe.Pipeline {
 		switch step.Uses {
@@ -80,12 +82,20 @@ func TestEtcd36DefaultUsesApprovedBespokePackage(t *testing.T) {
 		case "go/bump":
 			bumpedModules[step.With.ModRoot] = step.With.Deps
 		}
+		if step.Name == "Smoke built etcd runtime" {
+			runtimeSmoke = step.Runs
+		}
 	}
 	require.Equal(t, "b0f9ef190952e6e66a778513097a02ee41220727", checkoutCommit)
 	require.Len(t, bumpedModules, 4)
 	for _, modRoot := range []string{"", "tests", "server", "etcdutl"} {
 		require.Contains(t, bumpedModules[modRoot], "go.opentelemetry.io/otel/sdk@v1.44.0")
 	}
+	require.Contains(t, runtimeSmoke, `ETCD_BIN="${{targets.destdir}}/usr/bin/etcd"`)
+	require.Contains(t, runtimeSmoke, `"$ETCD_BIN" --version`)
+	require.Contains(t, runtimeSmoke, `endpoint health`)
+	require.Contains(t, runtimeSmoke, `put verity-smoke "Hello, etcd"`)
+	require.Contains(t, runtimeSmoke, `get verity-smoke --print-value-only`)
 
 	locked := lock.Packages["etcd"]
 	require.Equal(t, "etcd-3.6.yaml", locked.File)

--- a/packages/bespoke/locked/etcd-3.6.yaml
+++ b/packages/bespoke/locked/etcd-3.6.yaml
@@ -80,6 +80,42 @@ pipeline:
       ldflags: "-X go.etcd.io/etcd/api/v3/version.GitSHA=$(git rev-parse HEAD) -X go.etcd.io/etcd/server/v3/version.Version=${{package.version}}"
       extra-args: "-buildvcs=false"
 
+  - name: Smoke built etcd runtime
+    runs: |
+      set -euo pipefail
+      ETCD_BIN="${{targets.destdir}}/usr/bin/etcd"
+      ETCDCTL_BIN="${{targets.destdir}}/usr/bin/etcdctl"
+      ENDPOINT="http://127.0.0.1:12379"
+      PEER_ENDPOINT="http://127.0.0.1:12380"
+      DATA_DIR=$(mktemp -d)
+
+      "$ETCD_BIN" --version | grep -F "etcd Version: ${{package.version}}"
+      "$ETCD_BIN" \
+        --name default \
+        --data-dir "$DATA_DIR" \
+        --listen-client-urls "$ENDPOINT" \
+        --advertise-client-urls "$ENDPOINT" \
+        --listen-peer-urls "$PEER_ENDPOINT" \
+        --initial-advertise-peer-urls "$PEER_ENDPOINT" \
+        --initial-cluster "default=$PEER_ENDPOINT" \
+        > etcd-smoke.log 2>&1 &
+      ETCD_PID=$!
+      trap 'kill "$ETCD_PID" 2>/dev/null || true; wait "$ETCD_PID" 2>/dev/null || true; rm -rf "$DATA_DIR"' EXIT
+
+      for attempt in $(seq 1 30); do
+        if "$ETCDCTL_BIN" --endpoints="$ENDPOINT" endpoint health; then
+          break
+        fi
+        if ! kill -0 "$ETCD_PID" 2>/dev/null || [ "$attempt" -eq 30 ]; then
+          cat etcd-smoke.log
+          exit 1
+        fi
+        sleep 1
+      done
+
+      "$ETCDCTL_BIN" --endpoints="$ENDPOINT" put verity-smoke "Hello, etcd"
+      test "$("$ETCDCTL_BIN" --endpoints="$ENDPOINT" get verity-smoke --print-value-only)" = "Hello, etcd"
+
   - runs: |
       mkdir -p "${{targets.contextdir}}"/var/lib/${{package.name}} \
                "${{targets.contextdir}}"/var/lib/db/sbom

--- a/packages/upstream.lock.json
+++ b/packages/upstream.lock.json
@@ -137,7 +137,7 @@
     "etcd": {
       "file": "etcd-3.6.yaml",
       "version": "3.6.13",
-      "sha256": "b45648bb12e310d11da445cab5fe23f8d302b5e42ab4e2a49bc135ae74656f90",
+      "sha256": "aae0634d9f939cb9c0761e2b93ec0b7ccd6470931a705866792cb7c62c547484",
       "source": "public-recipe-baseline@3bc1a15922962c2ffbc0844b7f98672b79c5fd71",
       "cve_tracking": "bumped to 3.6.13-r1 for CVE-2026-41178 and forced go.opentelemetry.io/otel/sdk v1.44.0 in every module; retained public-build compatibility and writable SBOM output fixes; publication remains contingent on the strict zero-vulnerability gate",
       "assets": {}


### PR DESCRIPTION
## Summary

- route only `etcd:3.6-default` through the locked bespoke `etcd` recipe
- install approved `etcd-3.6 3.6.13-r1` from immutable `v3.6.13` commit `b0f9ef190952e6e66a778513097a02ee41220727`
- run bounded native build-time version, endpoint-health, and put/get smoke checks
- add a focused regression for matrix scope, recipe checksum/provenance, Apache-2.0 license, CVE remediation inputs, and runtime smoke

## Evidence

- RED: Wolfi `3.6.12-r1` produced `CVE-2026-41178` (MEDIUM), fixed in `3.6.13-r1`
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run ./...`
- native amd64 and arm64 Melange package builds: `etcd-3.6-3.6.13-r1`
- native amd64 and arm64 runtime: etcd 3.6.13, endpoint healthy, put/get successful
- native amd64 and arm64 image builds with strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings
- SPDX 2.3: `etcd-3.6 3.6.13-r1`, declared license `Apache-2.0`
- all CI and chart-integration checks green; zero unresolved review threads/comments
