### PR TITLE
fix(integer): own external-secrets-operator package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -36,6 +36,7 @@ LOCAL_RECIPE_VERSIONS: Final = {
 SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/airflow-3.yaml",
     "packages/bespoke/dex.yaml",
+    "packages/bespoke/external-secrets-operator.yaml",
     "packages/bespoke/haproxy-3.0.yaml",
     "packages/bespoke/haproxy-3.1.yaml",
     "packages/bespoke/haproxy-3.2.yaml",

--- a/cmd/external_secrets_config_test.go
+++ b/cmd/external_secrets_config_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_ExternalSecrets_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in External Secrets Operator image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "external-secrets.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "external-secrets-operator.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"external-secrets-operator"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/external-secrets", tmpl.Entrypoint)
+}
+
+func Test_ExternalSecrets_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "external-secrets-operator.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, build, and license metadata are inspected.
+
+	// Then: approved revision r5 rebuilds immutable Apache-2.0 v2.6.0 source with every required fix.
+	require.Contains(t, text, "name: external-secrets-operator")
+	require.Contains(t, text, "version: \"2.6.0\"")
+	require.Contains(t, text, "epoch: 5")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@253fef5452f6d4c7636f72b697e87eed95dafd94")
+	require.Contains(t, text, "cc1ae7fe2927fbe61df9aa87bf2e5075972c79f9.tar.gz")
+	require.Contains(t, text, "expected-sha256: c45b054f10c90acf2d5814296205438631c83c17a9bb32d0888703b631d266fb")
+	require.Contains(t, text, "go.mongodb.org/mongo-driver@v1.17.7")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: .")
+	require.Contains(t, text, "output: external-secrets")
+	require.Contains(t, text, "\"${{targets.destdir}}/usr/bin/external-secrets\" --help")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/external-secrets")
+	require.Contains(t, text, "${{package.name}}-${{package.full-version}}")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_ExternalSecrets_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "external-secrets.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "external-secrets-operator",
+		Version: "2.6.0-r5",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"external-secrets-operator=2.6.0-r5@local"}, tmpl.Packages)
+}

--- a/images/external-secrets.yaml
+++ b/images/external-secrets.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["external-secrets-operator"]
     entrypoint: /usr/bin/external-secrets
+    melange:
+      bespoke: external-secrets-operator.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/external-secrets-operator.yaml
+++ b/packages/bespoke/external-secrets-operator.yaml
@@ -1,0 +1,61 @@
+package:
+  name: external-secrets-operator
+  # renovate: datasource=github-tags depName=external-secrets/external-secrets versioning=semver-coerced
+  version: "2.6.0"
+  # Direct revision r5 includes the fixes first published in r2, r3, and r5.
+  epoch: 5
+  description: Integrate external secret management systems with Kubernetes
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "4"
+    memory: 8Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@253fef5452f6d4c7636f72b697e87eed95dafd94.
+  - uses: fetch
+    with:
+      uri: https://github.com/external-secrets/external-secrets/archive/cc1ae7fe2927fbe61df9aa87bf2e5075972c79f9.tar.gz
+      expected-sha256: c45b054f10c90acf2d5814296205438631c83c17a9bb32d0888703b631d266fb
+
+  - uses: go/bump
+    with:
+      deps: |-
+        go.mongodb.org/mongo-driver@v1.17.7
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      packages: .
+      output: external-secrets
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/external-secrets" --help >/dev/null
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  pipeline:
+    - uses: test/tw/help-check
+      with:
+        bins: external-secrets
+    - runs: |
+        apk info --who-owns /usr/bin/external-secrets \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        test -f /usr/share/licenses/${{package.name}}/LICENSE
+
+update:
+  enabled: true
+  github:
+    identifier: external-secrets/external-secrets
+    strip-prefix: v


### PR DESCRIPTION
## Summary

- own External Secrets Operator `2.6.0-r5` as a bespoke package for `external-secrets:0-default`
- fetch immutable upstream commit `cc1ae7fe2927fbe61df9aa87bf2e5075972c79f9` with SHA-256 `c45b054f10c90acf2d5814296205438631c83c17a9bb32d0888703b631d266fb`
- remediate `CVE-2026-2303`, `CVE-2026-41178`, and `CVE-2026-42505` via fixed MongoDB driver, OpenTelemetry, and Go toolchain revisions
- preserve `/usr/bin/external-secrets` runtime behavior, Apache-2.0 license material, and Renovate source tracking

## Security evidence

Current image RED reproduced on amd64:

- `CVE-2026-2303`: installed `2.6.0-r0`, fixed `2.6.0-r2`
- `CVE-2026-41178`: installed `2.6.0-r0`, fixed `2.6.0-r3`
- `CVE-2026-42505`: installed `2.6.0-r0`, fixed `2.6.0-r5`
- no `NO_FIX` findings

Owned-package evidence:

- local amd64 Melange package and apko image builds: pass
- local runtime smoke: `/usr/bin/external-secrets --help` pass
- SPDX package version/license: `2.6.0-r5`, `Apache-2.0`
- packaged license: `/usr/share/licenses/external-secrets-operator/LICENSE`
- Syft module proof: MongoDB driver `v1.17.7`, OpenTelemetry `v1.44.0`, stdlib `go1.26.5`
- local strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings
- post-push local strict Trivy rescan: 0 findings
- native amd64 package/image build and strict smoke scan: pass
- native arm64 package/image build and strict smoke scan: pass

## Validation

- focused regression RED then green
- `go test -race -shuffle=on -count=1 ./...`
- `make lint`
- `make lint-workflows`
- `make lint-yaml`
- `verity integer validate`
- Renovate coverage validation
- all PR checks green
- final paginated review scan: 0 unresolved threads
