### PR TITLE
fix(integer): own hydra package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -41,6 +41,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.1.yaml",
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
+    "packages/bespoke/hydra.yaml",
     "packages/bespoke/linkerd2-cli-25.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {

--- a/cmd/hydra_config_test.go
+++ b/cmd/hydra_config_test.go
@@ -52,6 +52,8 @@ func Test_Hydra_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "/usr/bin/hydra version")
 	require.Contains(t, text, "apk info --who-owns /usr/bin/hydra")
 	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "curl --fail-with-body --silent --show-error http://localhost:4444/health/alive")
+	require.NotContains(t, text, "curl -s http://localhost:4444/health/alive")
 }
 
 func Test_Hydra_resolves_fixed_local_package(t *testing.T) {

--- a/cmd/hydra_config_test.go
+++ b/cmd/hydra_config_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Hydra_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Ory Hydra image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "hydra.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "hydra.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"hydra"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/hydra", tmpl.Entrypoint)
+}
+
+func Test_Hydra_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "hydra.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, build, and license metadata are inspected.
+
+	// Then: approved revision r16 rebuilds immutable Apache-2.0 v26.2.0 source with both required fixes.
+	require.Contains(t, text, "name: hydra")
+	require.Contains(t, text, "version: \"26.2.0\"")
+	require.Contains(t, text, "epoch: 16")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@0c73a9cad82af43a57378c3a0da356f9a8c4a740")
+	require.Contains(t, text, "0b84568fffccf151dc5e6c7955fdfb738555bf4b.tar.gz")
+	require.Contains(t, text, "expected-sha256: 7ceaae3299780959e8390925732629931f63f20300464d2822d49628eeb3332e")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: .")
+	require.Contains(t, text, "output: hydra")
+	require.Contains(t, text, "tags: sqlite,json1,hsm")
+	require.Contains(t, text, "/usr/bin/hydra version")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/hydra")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_Hydra_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "hydra.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "2", []apkindex.Package{{
+		Name:    "hydra",
+		Version: "26.2.0-r16",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"hydra=26.2.0-r16@local"}, tmpl.Packages)
+}

--- a/images/hydra.yaml
+++ b/images/hydra.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["hydra"]
     entrypoint: /usr/bin/hydra
+    melange:
+      bespoke: hydra.yaml
 
 versions:
   "2": {}

--- a/packages/bespoke/hydra.yaml
+++ b/packages/bespoke/hydra.yaml
@@ -95,7 +95,7 @@ test:
           client applied successfully
           Thank you for using Ory Hydra
         post: |
-          curl -s http://localhost:4444/health/alive
+          curl --fail-with-body --silent --show-error http://localhost:4444/health/alive
 
 update:
   enabled: true

--- a/packages/bespoke/hydra.yaml
+++ b/packages/bespoke/hydra.yaml
@@ -1,0 +1,107 @@
+package:
+  name: hydra
+  # renovate: datasource=github-tags depName=ory/hydra versioning=semver-coerced
+  version: "26.2.0"
+  # Direct revision r16 includes the fixes first published in r12 and r16.
+  epoch: 16
+  description: OpenID Certified OAuth 2.0 Server and OpenID Connect Provider
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "5"
+    memory: 8Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+
+pipeline:
+  # Adapted from wolfi-dev/os@0c73a9cad82af43a57378c3a0da356f9a8c4a740.
+  - uses: fetch
+    with:
+      uri: https://github.com/ory/hydra/archive/0b84568fffccf151dc5e6c7955fdfb738555bf4b.tar.gz
+      expected-sha256: 7ceaae3299780959e8390925732629931f63f20300464d2822d49628eeb3332e
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/go-jose/go-jose/v3@v3.0.5
+        github.com/jackc/pgx/v5@v5.9.2
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+        golang.org/x/crypto@v0.51.0
+        golang.org/x/net@v0.55.0
+        golang.org/x/text@v0.37.0
+      modroot: .
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/go-jose/go-jose/v3@v3.0.5
+        github.com/jackc/pgx/v5@v5.9.2
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+        golang.org/x/crypto@v0.51.0
+        golang.org/x/net@v0.55.0
+        golang.org/x/text@v0.37.0
+      modroot: oryx
+
+  - uses: go/build
+    with:
+      packages: .
+      output: hydra
+      ldflags: |
+        -X 'github.com/ory/hydra/v2/driver/config.Version=v${{package.version}}'
+        -X 'github.com/ory/hydra/v2/driver/config.Date=$(TZ=UTC date -u -d "@$SOURCE_DATE_EPOCH" "+%Y-%m-%dT%H:%M:%SZ")'
+        -X 'github.com/ory/hydra/v2/driver/config.Commit=0b84568fffccf151dc5e6c7955fdfb738555bf4b'
+      tags: sqlite,json1,hsm
+      go-package: go-1.26
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/hydra" version | grep -F "${{package.version}}"
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    environment:
+      DSN: memory
+    contents:
+      packages:
+        - curl
+  pipeline:
+    - runs: |
+        /usr/bin/hydra version | grep -F "${{package.version}}"
+        /usr/bin/hydra help >/dev/null
+        /usr/bin/hydra migrate sql up -e --yes
+        apk info --who-owns /usr/bin/hydra \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        grep -F "Apache License" "/usr/share/licenses/${{package.name}}/LICENSE"
+    - name: Start server and test
+      uses: test/daemon-check-output
+      with:
+        start: /usr/bin/hydra serve all --dev
+        timeout: "30"
+        expected_output: |
+          DSN is memory
+          running migration
+          networks applied successfully
+          client applied successfully
+          Thank you for using Ory Hydra
+        post: |
+          curl -s http://localhost:4444/health/alive
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - rc*
+    - pre*
+  github:
+    identifier: ory/hydra
+    strip-prefix: v


### PR DESCRIPTION
## Summary
- replace the public `hydra` package with a bespoke direct-revision `26.2.0-r16` build
- pin immutable Ory Hydra source commit `0b84568fffccf151dc5e6c7955fdfb738555bf4b` and SHA-256 checksum
- carry the r12 OpenTelemetry 1.44.0 remediation and r16 Go 1.26.5 toolchain remediation
- preserve the Hydra runtime contract, Apache-2.0 license, and Renovate source coverage

## Verification
- reproduced RED: public `hydra 26.2.0-r9` failed strict Trivy with CVE-2026-41178 (fixed r12) and CVE-2026-42505 (fixed r16); no NO_FIX findings
- focused Hydra regression tests: pass
- full `go test -race -shuffle=on -count=1 ./...`: pass
- `golangci-lint run ./...`: pass
- Integer config and Renovate coverage validation: pass
- native amd64 Melange package and image builds: pass
- runtime: `v26.2.0`, commit `0b84568fffccf151dc5e6c7955fdfb738555bf4b`, architecture `amd64`
- installed APK: `hydra-26.2.0-r16`; Apache-2.0 license file present
- SPDX 2.3 SBOM declares `hydra 26.2.0-r16` / `Apache-2.0`
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings
- native amd64/arm64 package and image proof is required from the parallel PR CI matrix before merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the public `hydra` APK with a pinned bespoke build `26.2.0-r16` and updated the Hydra image to use it. Fixes known CVEs and hardens the health check to fail on HTTP errors while keeping the runtime contract the same.

- **Dependencies**
  - Added `packages/bespoke/hydra.yaml` pinned to an immutable source with a verified SHA-256.
  - Carries `go.opentelemetry.io/otel@v1.44.0` and `go-1.26` toolchain updates; preserves build tags and Apache-2.0 license.
  - Pointed `images/hydra.yaml` to use the bespoke recipe via `melange.bespoke: hydra.yaml`.

- **Bug Fixes**
  - Remediates CVE-2026-41178 and CVE-2026-42505; strict Trivy scan is clean.
  - Health check now fails on HTTP errors (`curl --fail-with-body --silent --show-error`) to avoid false positives.
  - Added tests to ensure the image selects `hydra=26.2.0-r16@local` and validates the pinned source.
  - Updated Renovate coverage script to include the new `packages/bespoke/hydra.yaml`.

<sup>Written for commit 25e780fdc2b5c505514e0dd3c705885055b9d7b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

