### PR TITLE
fix(integer): own filebrowser package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -37,6 +37,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/airflow-3.yaml",
     "packages/bespoke/dex.yaml",
     "packages/bespoke/external-secrets-operator.yaml",
+    "packages/bespoke/filebrowser.yaml",
     "packages/bespoke/haproxy-3.0.yaml",
     "packages/bespoke/haproxy-3.1.yaml",
     "packages/bespoke/haproxy-3.2.yaml",

--- a/cmd/filebrowser_config_test.go
+++ b/cmd/filebrowser_config_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_FileBrowser_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in File Browser image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "filebrowser.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "filebrowser.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"filebrowser"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/filebrowser", tmpl.Entrypoint)
+	require.Len(t, tmpl.Paths, 2)
+}
+
+func Test_FileBrowser_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "filebrowser.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, build, test, and license metadata are inspected.
+
+	// Then: approved revision r1 rebuilds immutable Apache-2.0 v2.63.18 source.
+	require.Contains(t, text, "name: filebrowser")
+	require.Contains(t, text, "version: \"2.63.18\"")
+	require.Contains(t, text, "epoch: 1")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@6993e8258528d998f90581d5f9f97cbfdbe17c3f")
+	require.Contains(t, text, "https://github.com/filebrowser/filebrowser/archive/refs/tags/v${{package.version}}.tar.gz")
+	require.Contains(t, text, "expected-sha256: b665942fa4adb882498e89f09ef90f4690de4f22de043453c28e201c812060c5")
+	require.Contains(t, text, "node-version: 24")
+	require.Contains(t, text, "pnpm install --frozen-lockfile")
+	require.Contains(t, text, "packages: .")
+	require.Contains(t, text, "output: ${{package.name}}")
+	require.Contains(t, text, "Version=${{package.version}}")
+	require.NotContains(t, text, "Version=v${{package.version}}")
+	require.Contains(t, text, "CommitSHA=fe7efb2e6afe66774cd86a5b0a03033bd514d0c0")
+	require.Contains(t, text, "filebrowser version")
+	require.Contains(t, text, "curl -sf http://localhost:8080/health")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_FileBrowser_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "filebrowser.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "filebrowser",
+		Version: "2.63.18-r1",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"filebrowser=2.63.18-r1@local"}, tmpl.Packages)
+}

--- a/images/filebrowser.yaml
+++ b/images/filebrowser.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["filebrowser"]
     entrypoint: /usr/bin/filebrowser
+    melange:
+      bespoke: filebrowser.yaml
     paths:
       - {path: /database, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /srv, type: directory, uid: 65532, gid: 65532, permissions: 0o755}

--- a/packages/bespoke/filebrowser.yaml
+++ b/packages/bespoke/filebrowser.yaml
@@ -1,0 +1,84 @@
+package:
+  name: filebrowser
+  # renovate: datasource=github-tags depName=filebrowser/filebrowser versioning=semver-coerced
+  version: "2.63.18"
+  # Direct revision r1 supersedes the vulnerable public 2.63.14-r0 package.
+  epoch: 1
+  description: Web File Browser
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "1"
+    memory: 8Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - go-1.26
+      - nodejs-${{vars.node-version}}
+      - pnpm
+  environment:
+    CGO_ENABLED: "0"
+
+vars:
+  node-version: 24
+
+pipeline:
+  # Adapted from wolfi-dev/os@6993e8258528d998f90581d5f9f97cbfdbe17c3f.
+  - uses: fetch
+    with:
+      uri: https://github.com/filebrowser/filebrowser/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-sha256: b665942fa4adb882498e89f09ef90f4690de4f22de043453c28e201c812060c5
+
+  - name: install frontend dependencies
+    working-directory: frontend
+    pipeline:
+      - runs: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      modroot: .
+      packages: .
+      ldflags: |
+        -X github.com/filebrowser/filebrowser/v2/version.Version=${{package.version}}
+        -X github.com/filebrowser/filebrowser/v2/version.CommitSHA=fe7efb2e6afe66774cd86a5b0a03033bd514d0c0
+      output: ${{package.name}}
+
+  - runs: |
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+  pipeline:
+    - runs: |
+        filebrowser version \
+          | grep -F "File Browser v${{package.version}}/fe7efb2e6afe66774cd86a5b0a03033bd514d0c0"
+        filebrowser --help >/dev/null
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+    - uses: test/daemon-check-output
+      with:
+        setup: mkdir -p /tmp/filebrowser-root
+        start: filebrowser --noauth --address 127.0.0.1 --port 8080 --root /tmp/filebrowser-root --database /tmp/filebrowser.db
+        timeout: 60
+        expected_output: Listening on
+        post: |
+          wait-for-it -t 10 --strict localhost:8080 -- echo "Server is up"
+          curl -sf http://localhost:8080/health | grep -F "OK"
+
+update:
+  enabled: true
+  github:
+    identifier: filebrowser/filebrowser
+    strip-prefix: v


### PR DESCRIPTION
## Summary

- replace the public `filebrowser 2.63.14-r0` dependency with a repository-owned `2.63.18-r1` Melange build
- pin immutable upstream `v2.63.18` source by SHA-256 and record the resolved upstream commit
- preserve the existing File Browser image contract while adding package version, license, health, and local-pinning regressions
- classify the checksum-pinned fetch recipe for Renovate coverage

## Vulnerability proof

Strict pre-fix Trivy scans on both amd64 and arm64 found exactly:

- `CVE-2026-42505` (MEDIUM), fixed in `2.63.18-r1`
- `CVE-2026-46602` (UNKNOWN), fixed in `2.63.16-r1`

Both findings were fixed-status; neither was `NO_FIX`.

## Verification

- focused regression: RED before the package/image change, GREEN after
- Integer config validation: all 334 image definitions valid
- race tests: `./cmd` and `./internal/integer/...`
- exact runtime: `File Browser v2.63.18/fe7efb2e...`
- basic health: HTTP 200 with `{"status":"OK"}`
- SPDX 2.3 SBOM with `filebrowser 2.63.18-r1` declaring `Apache-2.0`; license file installed
- native CI run `29448250270`: amd64 and arm64 Melange package builds, image builds, and smoke builds passed
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`, OS and library: zero findings on amd64 and arm64

No vulnerability suppressions, ignores, exclusions, severity reductions, retirements, or architecture skips are used.
