### PR TITLE
fix(integer): own karpenter 1.11 package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -42,7 +42,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.1.yaml",
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
-    "packages/bespoke/hydra.yaml",
+    "packages/bespoke/hydra.yaml", "packages/bespoke/karpenter-1.11.yaml",
     "packages/bespoke/linkerd2-cli-25.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {

--- a/cmd/karpenter_config_test.go
+++ b/cmd/karpenter_config_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Karpenter_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Karpenter 1.11 image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "karpenter.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "karpenter-1.11.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"karpenter-1.11"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/controller", tmpl.Entrypoint)
+}
+
+func Test_Karpenter_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "karpenter-1.11.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, build, test, and license metadata are inspected.
+
+	// Then: approved revision r7 rebuilds immutable Apache-2.0 v1.11.1 source with fixed Go.
+	require.Contains(t, text, "name: karpenter-1.11")
+	require.Contains(t, text, "version: \"1.11.1\"")
+	require.Contains(t, text, "epoch: 7")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@2c0385b38bd6869a0e928363916e7a7148a1acaf")
+	require.Contains(t, text, "77c161351fbad4f23fae329412de22f1045ccb42.tar.gz")
+	require.Contains(t, text, "expected-sha256: 73ee8d8865e0bddbe963923172c894212c4775063c5bebdfea7535ec2e6812c7")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/controller")
+	require.Contains(t, text, "output: controller")
+	require.Contains(t, text, "Version=${{package.version}}")
+	require.Contains(t, text, "/usr/bin/controller --help")
+	require.Contains(t, text, "go version -m /usr/bin/controller")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/controller")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_Karpenter_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "karpenter.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1.11", []apkindex.Package{{
+		Name:    "karpenter-1.11",
+		Version: "1.11.1-r7",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"karpenter-1.11=1.11.1-r7@local"}, tmpl.Packages)
+}

--- a/images/karpenter.yaml
+++ b/images/karpenter.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["karpenter-1.11"]
     entrypoint: /usr/bin/controller
+    melange:
+      bespoke: karpenter-1.11.yaml
 
 versions:
   "1.11": {}

--- a/packages/bespoke/karpenter-1.11.yaml
+++ b/packages/bespoke/karpenter-1.11.yaml
@@ -1,0 +1,66 @@
+package:
+  name: karpenter-1.11
+  # renovate: datasource=github-tags depName=aws/karpenter-provider-aws versioning=semver-coerced
+  version: "1.11.1"
+  # Direct revision r7 supersedes the vulnerable public 1.11.1-r0 package.
+  epoch: 7
+  description: Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - karpenter=${{package.full-version}}
+      - karpenter-provider-aws=${{package.full-version}}
+  resources:
+    cpu: "8"
+    memory: 16Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+
+pipeline:
+  # Adapted from wolfi-dev/os@2c0385b38bd6869a0e928363916e7a7148a1acaf.
+  - uses: fetch
+    with:
+      uri: https://github.com/aws/karpenter-provider-aws/archive/77c161351fbad4f23fae329412de22f1045ccb42.tar.gz
+      expected-sha256: 73ee8d8865e0bddbe963923172c894212c4775063c5bebdfea7535ec2e6812c7
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      packages: ./cmd/controller
+      output: controller
+      ldflags: -X=sigs.k8s.io/karpenter/pkg/operator.Version=${{package.version}}
+
+  - runs: |
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - go-1.26
+    environment:
+      SYSTEM_NAMESPACE: default
+      KUBERNETES_SERVICE_HOST: "127.0.0.1"
+      KUBERNETES_SERVICE_PORT: "32764"
+  pipeline:
+    - runs: |
+        /usr/bin/controller --help >/dev/null
+        go version -m /usr/bin/controller \
+          | grep -F "github.com/aws/karpenter-provider-aws"
+        strings /usr/bin/controller | grep -F -m1 "${{package.version}}"
+        apk info --who-owns /usr/bin/controller \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: aws/karpenter-provider-aws
+    tag-filter-prefix: v1.11.
+    strip-prefix: v


### PR DESCRIPTION
## Summary

- own `karpenter-1.11` at approved direct revision `1.11.1-r7`
- rebuild immutable upstream commit `77c161351fbad4f23fae329412de22f1045ccb42` with pinned SHA-256 and Apache-2.0 license payload
- wire `karpenter:1.11-default` to the bespoke package and lock exact local revision selection with focused regressions

## Evidence

- RED: public `1.11.1-r0` reproduced six fixed Trivy findings; highest fixed revision `1.11.1-r7`
- focused regression red then green
- local native amd64 Melange build, runtime/version smoke, SPDX/license checks, and strict Trivy passed
- PR Test run 29451718994 passed native amd64 and arm64 package/image build and smoke jobs
- both native build and smoke jobs install `karpenter-1.11=1.11.1-r7` and report `Total vulnerabilities: 0`
- strict Trivy severities: `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` with no ignores or suppressions
- `go test -race -shuffle=on -count=1 ./...`
- CI, CodeQL, Integer/PR/CI/Renovate validators, golangci-lint, actionlint, and yamllint passed
