### PR TITLE
fix(integer): own jaeger package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -42,7 +42,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.1.yaml",
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
-    "packages/bespoke/hydra.yaml", "packages/bespoke/karpenter-1.11.yaml",
+    "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml",
     "packages/bespoke/linkerd2-cli-25.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {

--- a/cmd/jaeger_config_test.go
+++ b/cmd/jaeger_config_test.go
@@ -58,6 +58,7 @@ func Test_Jaeger_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "npm install --prefix jaeger-ui/ --ignore-scripts --no-audit --no-fund")
 	require.Contains(t, text, "npm run --workspace @jaegertracing/plexus prepublishOnly")
 	require.NotContains(t, text, "npm install --prefix jaeger-ui/\n")
+	require.NotContains(t, text, "resolutions.react-icons")
 	require.Contains(t, text, "start: env JAEGER_LISTEN_HOST=127.0.0.1 all-in-one")
 	require.Contains(t, text, "all-in-one version")
 	require.Contains(t, text, "http://127.0.0.1:13133/status")

--- a/cmd/jaeger_config_test.go
+++ b/cmd/jaeger_config_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Jaeger_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Jaeger image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "jaeger.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the fixed local all-in-one package and preserves its entrypoint.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "jaeger-2-all-in-one.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"jaeger-2-all-in-one"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/all-in-one", tmpl.Entrypoint)
+}
+
+func Test_Jaeger_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "jaeger-2-all-in-one.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, build, test, and license metadata are inspected.
+
+	// Then: approved revision r8 rebuilds immutable Apache-2.0 v2.17.0 source with every required fix.
+	require.Contains(t, text, "name: jaeger-2-all-in-one")
+	require.Contains(t, text, "version: \"2.17.0\"")
+	require.Contains(t, text, "epoch: 8")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@63a28690a65cf1d91d381afd8769218aab2c59cf")
+	require.Contains(t, text, "b5be18b10053a087a9bb272a1d9a0c71bcaac2c7.tar.gz")
+	require.Contains(t, text, "expected-sha256: 63d2d9c495dd0151dcd15475e200e08e4bccffb1b3e454a7333bd950c2b5b542")
+	require.Contains(t, text, "be495f74ce4fbb68c722dbb8e1cbb6461b052aec.tar.gz")
+	require.Contains(t, text, "expected-sha256: 1617359592a041a34844e08acf7e06140c41a1b1236e2cc5952805ae415b6f35")
+	require.Contains(t, text, "4e887dcec50fb9f7b675fb4619ea8e3fb4c0447f.tar.gz")
+	require.Contains(t, text, "expected-sha256: 1bba3a51884f3f94ab8b79fbbcc719f9aa77bd3baead4fd9c9c919bfa034098e")
+	require.Contains(t, text, "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp@v0.19.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.43.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.43.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.43.0")
+	require.Contains(t, text, "github.com/prometheus/prometheus@v0.311.3")
+	require.Contains(t, text, "github.com/apache/thrift@v0.23.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/jaeger")
+	require.Contains(t, text, "output: all-in-one")
+	require.Contains(t, text, "npm install --prefix jaeger-ui/ --ignore-scripts --no-audit --no-fund")
+	require.Contains(t, text, "npm run --workspace @jaegertracing/plexus prepublishOnly")
+	require.NotContains(t, text, "npm install --prefix jaeger-ui/\n")
+	require.Contains(t, text, "start: env JAEGER_LISTEN_HOST=127.0.0.1 all-in-one")
+	require.Contains(t, text, "all-in-one version")
+	require.Contains(t, text, "http://127.0.0.1:13133/status")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_Jaeger_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "jaeger.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "jaeger-2-all-in-one",
+		Version: "2.17.0-r8",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"jaeger-2-all-in-one=2.17.0-r8@local"}, tmpl.Packages)
+}

--- a/images/jaeger.yaml
+++ b/images/jaeger.yaml
@@ -6,8 +6,10 @@ upstream:
 types:
   default:
     base: wolfi-base
-    packages: ["jaeger-all-in-one"]
+    packages: ["jaeger-2-all-in-one"]
     entrypoint: /usr/bin/all-in-one
+    melange:
+      bespoke: jaeger-2-all-in-one.yaml
 
 versions:
   "1": {}

--- a/packages/bespoke/jaeger-2-all-in-one.yaml
+++ b/packages/bespoke/jaeger-2-all-in-one.yaml
@@ -58,9 +58,6 @@ pipeline:
         github.com/prometheus/prometheus@v0.311.3
         github.com/apache/thrift@v0.23.0
 
-  - working-directory: jaeger-ui
-    runs: npm pkg set resolutions.react-icons=5.0.1
-
   - runs: |
       rm -rf cmd/jaeger/internal/extension/jaegerquery/internal/ui/actual/*
       npm install --prefix jaeger-ui/ --ignore-scripts --no-audit --no-fund

--- a/packages/bespoke/jaeger-2-all-in-one.yaml
+++ b/packages/bespoke/jaeger-2-all-in-one.yaml
@@ -1,0 +1,124 @@
+package:
+  name: jaeger-2-all-in-one
+  # renovate: datasource=github-tags depName=jaegertracing/jaeger versioning=semver-coerced
+  version: "2.17.0"
+  # Direct revision r8 carries every approved fix through GHSA-wf45-q9ch-q8gh.
+  epoch: 8
+  description: Jaeger distributed tracing all-in-one service
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+  resources:
+    cpu: "6"
+    memory: 16Gi
+  test-resources:
+    cpu: "2"
+    memory: 4Gi
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+      - node-gyp
+      - nodejs-24
+      - npm
+
+pipeline:
+  # Adapted from wolfi-dev/os@63a28690a65cf1d91d381afd8769218aab2c59cf.
+  - uses: fetch
+    with:
+      uri: https://github.com/jaegertracing/jaeger/archive/b5be18b10053a087a9bb272a1d9a0c71bcaac2c7.tar.gz
+      expected-sha256: 63d2d9c495dd0151dcd15475e200e08e4bccffb1b3e454a7333bd950c2b5b542
+
+  - runs: mkdir -p idl jaeger-ui
+
+  - uses: fetch
+    working-directory: idl
+    with:
+      uri: https://github.com/jaegertracing/jaeger-idl/archive/be495f74ce4fbb68c722dbb8e1cbb6461b052aec.tar.gz
+      expected-sha256: 1617359592a041a34844e08acf7e06140c41a1b1236e2cc5952805ae415b6f35
+
+  - uses: fetch
+    working-directory: jaeger-ui
+    with:
+      uri: https://github.com/jaegertracing/jaeger-ui/archive/4e887dcec50fb9f7b675fb4619ea8e3fb4c0447f.tar.gz
+      expected-sha256: 1bba3a51884f3f94ab8b79fbbcc719f9aa77bd3baead4fd9c9c919bfa034098e
+
+  - uses: go/bump
+    with:
+      deps: |-
+        go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp@v0.19.0
+        go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.43.0
+        go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.43.0
+        go.opentelemetry.io/otel/sdk@v1.43.0
+        github.com/prometheus/prometheus@v0.311.3
+        github.com/apache/thrift@v0.23.0
+
+  - working-directory: jaeger-ui
+    runs: npm pkg set resolutions.react-icons=5.0.1
+
+  - runs: |
+      rm -rf cmd/jaeger/internal/extension/jaegerquery/internal/ui/actual/*
+      npm install --prefix jaeger-ui/ --ignore-scripts --no-audit --no-fund
+      cd jaeger-ui
+      npm run --workspace @jaegertracing/plexus prepublishOnly
+      cd packages/jaeger-ui
+      npm run build
+
+  - runs: |
+      cp -r jaeger-ui/packages/jaeger-ui/build/* \
+        cmd/jaeger/internal/extension/jaegerquery/internal/ui/actual
+      find cmd/jaeger/internal/extension/jaegerquery/internal/ui/actual \
+        -type f | grep -v .gitignore | xargs gzip --no-name
+      touch -t "$(date -r jaeger-ui/packages/jaeger-ui/build/index.html '+%Y%m%d%H%M.%S')" \
+        cmd/jaeger/internal/extension/jaegerquery/internal/ui/actual/index.html.gz
+
+  - uses: go/build
+    with:
+      packages: ./cmd/jaeger
+      output: all-in-one
+      go-package: go-1.26
+      ldflags: |
+        -X github.com/jaegertracing/jaeger/internal/version.latestVersion=v${{package.version}}
+        -X github.com/jaegertracing/jaeger/internal/version.commitSHA=b5be18b10053a087a9bb272a1d9a0c71bcaac2c7
+        -X github.com/jaegertracing/jaeger/internal/version.date=2026-03-30T15:11:26Z
+
+  - runs: |
+      install -Dm644 cmd/jaeger/sampling-strategies.json \
+        "${{targets.destdir}}/etc/jaeger/sampling_strategies.json"
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - wget
+  pipeline:
+    - uses: test/tw/help-check
+      with:
+        bins: all-in-one
+    - runs: |
+        all-in-one version | grep -F "v${{package.version}}"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+        test -f /etc/jaeger/sampling_strategies.json
+    - uses: test/daemon-check-output
+      with:
+        start: env JAEGER_LISTEN_HOST=127.0.0.1 all-in-one
+        timeout: 60
+        expected_output: Everything is ready
+        post: |
+          wget -qO- http://127.0.0.1:13133/status \
+            | grep -Eq '"healthy"[[:space:]]*:[[:space:]]*true'
+
+update:
+  enabled: true
+  github:
+    identifier: jaegertracing/jaeger
+    strip-prefix: v
+    tag-filter: v2


### PR DESCRIPTION
## Summary

- replace the Jaeger image's Wolfi `jaeger-all-in-one` dependency with a bespoke `jaeger-2-all-in-one` `2.17.0-r8` package
- build from immutable Jaeger, Jaeger IDL, and Jaeger UI commits with pinned SHA-256 checksums and Apache-2.0 licensing
- carry the approved fixed Go dependency revisions and exercise package selection, source pins, runtime version, readiness, health, and license behavior
- remove an inherited Yarn-only `resolutions` field that npm ignored, with a regression assertion preventing its return

## Security disposition

- matrix: `jaeger:1-default`
- previous package: `jaeger-2-all-in-one 2.17.0-r4`
- required package: `jaeger-2-all-in-one 2.17.0-r8`
- disposition: direct revision
- baseline published amd64 and arm64 images: 4 findings each (`CVE-2026-41602`, `CVE-2026-42154`, `CVE-2026-40179`, `CVE-2026-44903`)
- no `NO_FIX` findings and no suppressions, ignores, exclusions, severity reduction, retirement, or architecture skips

## Evidence

- focused Jaeger regressions pass, including the review-caught npm-resolution defect
- full `go test -race -shuffle=on -count=1 ./...` passes
- `golangci-lint run --timeout=5m` reports zero issues
- Renovate coverage, YAML lint, and all 334 Integer configs validate
- native amd64 and arm64 Melange package builds produce `jaeger-2-all-in-one-2.17.0-r8.apk`
- native amd64 and arm64 image build and smoke jobs pass
- exact local runtime version/commit, readiness log, and `/status` health JSON pass
- SPDX 2.3 metadata and bundled Apache-2.0 license verified; CI independently validates Apache-2.0 across Jaeger, IDL, and UI sources
- strict Trivy scan across `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` reports `Total vulnerabilities: 0` on both amd64 and arm64
