### PR TITLE
fix(integer): own kube-bench package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -43,7 +43,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml",
-    "packages/bespoke/linkerd2-cli-25.yaml",
+    "packages/bespoke/kube-bench.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/cmd/kube_bench_config_test.go
+++ b/cmd/kube_bench_config_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_KubeBench_uses_pinned_bespoke_packages(t *testing.T) {
+	// Given: the checked-in kube-bench image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "kube-bench.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "kube-bench.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"kube-bench", "kube-bench-configs"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/kube-bench", tmpl.Entrypoint)
+}
+
+func Test_KubeBench_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "kube-bench.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, build, test, and license metadata are inspected.
+
+	// Then: approved revision r15 rebuilds immutable Apache-2.0 v0.15.0 source with fixed Go.
+	require.Contains(t, text, "name: kube-bench")
+	require.Contains(t, text, "version: \"0.15.0\"")
+	require.Contains(t, text, "epoch: 15")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@f27a9a5190075207acb9d5244fa982b58423e812")
+	require.Contains(t, text, "8a7204d42f0bea44db453c545db052c29f58a9cc.tar.gz")
+	require.Contains(t, text, "expected-sha256: 47dd0f0c95134c103bbd1dae7ccf4295fc343f0ebb6ba9aac1184a2c781a5e58")
+	require.Contains(t, text, "github.com/jackc/pgx/v5@v5.9.2")
+	require.Contains(t, text, "golang.org/x/net@v0.55.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: .")
+	require.Contains(t, text, "output: kube-bench")
+	require.Contains(t, text, "KubeBenchVersion=v${{package.version}}")
+	require.Contains(t, text, "name: \"kube-bench-configs\"")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "kube-bench version")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/kube-bench")
+}
+
+func Test_KubeBench_resolves_fixed_local_packages(t *testing.T) {
+	// Given: the checked-in image template and packages produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "kube-bench.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{
+		{Name: "kube-bench", Version: "0.15.0-r15"},
+		{Name: "kube-bench-configs", Version: "0.15.0-r15"},
+	})
+
+	// Then: apko can only select the approved fixed locally built revisions.
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"kube-bench=0.15.0-r15@local",
+		"kube-bench-configs=0.15.0-r15@local",
+	}, tmpl.Packages)
+}

--- a/images/kube-bench.yaml
+++ b/images/kube-bench.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["kube-bench", "kube-bench-configs"]
     entrypoint: /usr/bin/kube-bench
+    melange:
+      bespoke: kube-bench.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/kube-bench.yaml
+++ b/packages/bespoke/kube-bench.yaml
@@ -1,0 +1,94 @@
+package:
+  name: kube-bench
+  # renovate: datasource=github-tags depName=aquasecurity/kube-bench versioning=semver-coerced
+  version: "0.15.0"
+  # Direct revision r15 rebuilds r12 with the fixed Go toolchain.
+  epoch: 15
+  description: Checks whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash
+      - busybox
+      - coreutils
+      - findutils
+      - jq
+      - kubectl
+      - procps
+      - systemd
+  resources:
+    cpu: "2"
+    memory: 6Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@f27a9a5190075207acb9d5244fa982b58423e812.
+  - uses: fetch
+    with:
+      uri: https://github.com/aquasecurity/kube-bench/archive/8a7204d42f0bea44db453c545db052c29f58a9cc.tar.gz
+      expected-sha256: 47dd0f0c95134c103bbd1dae7ccf4295fc343f0ebb6ba9aac1184a2c781a5e58
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/jackc/pgx/v5@v5.9.2
+        golang.org/x/net@v0.55.0
+
+  - uses: go/build
+    with:
+      packages: .
+      output: kube-bench
+      go-package: go-1.26
+      ldflags: |
+        -X github.com/aquasecurity/kube-bench/cmd.cfgDir=/etc/kube-bench/cfg
+        -X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=v${{package.version}}
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/kube-bench" version | grep -F "${{package.version}}"
+      "${{targets.destdir}}/usr/bin/kube-bench" --help >/dev/null
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+subpackages:
+  - name: "kube-bench-configs"
+    description: Configuration files for kube-bench
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/kube-bench/cfg"
+          cp -rv ./cfg/* "${{targets.subpkgdir}}/etc/kube-bench/cfg"
+    test:
+      pipeline:
+        - runs: |
+            stat /etc/kube-bench/cfg
+            stat /etc/kube-bench/cfg/eks-1.1.0
+
+test:
+  environment:
+    contents:
+      packages:
+        - kube-bench-configs
+  pipeline:
+    - runs: |
+        kube-bench version | grep -F "${{package.version}}"
+        kube-bench --help >/dev/null
+        kube-bench run --help | grep -F "target"
+        stat /etc/kube-bench/cfg/eks-1.1.0
+        apk info --who-owns /usr/bin/kube-bench \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        grep -F "Apache License" "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: aquasecurity/kube-bench
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
## Summary

- own kube-bench `0.15.0-r15` with a minimal bespoke Melange recipe adapted from the last open-source Wolfi recipe
- pin immutable upstream commit archive `8a7204d42f0bea44db453c545db052c29f58a9cc` with SHA-256 `47dd0f0c95134c103bbd1dae7ccf4295fc343f0ebb6ba9aac1184a2c781a5e58`
- preserve the kube-bench/config subpackage runtime contract and declare/install Apache-2.0 licensing
- add focused regression coverage for recipe selection and exact local `r15` package pins

## Evidence

- RED: strict Trivy found CVE-2026-42505 in `kube-bench` and `kube-bench-configs` `0.15.0-r12`, fixed by `0.15.0-r15`; no NO_FIX findings
- focused regression: `go test -race -shuffle=on -count=1 ./cmd -run Test_KubeBench`
- full tests: `go test -race -shuffle=on -count=1 ./...`
- validation: Integer config validation, YAML lint, Go vet, and Renovate coverage
- package builds: x86_64 and aarch64 `kube-bench` plus `kube-bench-configs` at `0.15.0-r15`
- image builds/runtime: amd64 and arm64 images report `v0.15.0` and correct architecture
- SPDX/license: both image SBOMs declare Apache-2.0 for both `0.15.0-r15` packages and contain the upstream LICENSE
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings on amd64 and arm64

Native architecture CI is required before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own `kube-bench` with a bespoke recipe and pin to 0.15.0-r15 to remove CVE-2026-42505. The image now builds from our local packages while keeping the same entrypoint and configs.

- **Bug Fixes**
  - Upgrade `kube-bench` and `kube-bench-configs` to 0.15.0-r15; Trivy shows 0 findings on amd64/arm64.
  - Preserve `kube-bench` entrypoint and config subpackage; declare Apache-2.0.

- **Dependencies**
  - Add `packages/bespoke/kube-bench.yaml`, pinned to `8a7204d4` (sha256 `47dd0f0...e58`), with `go-1.26` and bumps for `github.com/jackc/pgx/v5@v5.9.2` and `golang.org/x/net@v0.55.0`.
  - Update `images/kube-bench.yaml` to use `melange.bespoke: kube-bench.yaml`.
  - Add focused tests to enforce recipe selection and exact `r15` pins; include package in Renovate coverage.

<sup>Written for commit da3dc3cb8571a127f92e99f23f016db2df629470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

