### PR TITLE
fix(integer): own kor package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -42,7 +42,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.1.yaml",
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
-    "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml",
+    "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/linkerd2-cli-25.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {

--- a/cmd/kor_config_test.go
+++ b/cmd/kor_config_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_KOR_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in KOR image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "kor.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the locally rebuilt package and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "kor.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"kor"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/kor", tmpl.Entrypoint)
+}
+
+func Test_KOR_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "kor.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, build, and license metadata are inspected.
+
+	// Then: approved revision r8 rebuilds immutable MIT-licensed v0.6.8 source with the fixed toolchain.
+	require.Contains(t, text, "name: kor")
+	require.Contains(t, text, "version: \"0.6.8\"")
+	require.Contains(t, text, "epoch: 8")
+	require.Contains(t, text, "license: MIT")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@86f2c8a880f339829deb63a993f563382356221e")
+	require.Contains(t, text, "d6986c937ce72d331fef965c1b103fab69b4ea93.tar.gz")
+	require.Contains(t, text, "expected-sha256: dce84e8a1d5de7311a5ddf3bd31c443f177f3ea96d182757fd4190e5b484bdfa")
+	require.Contains(t, text, "golang.org/x/net@v0.55.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: .")
+	require.Contains(t, text, "output: kor")
+	require.Contains(t, text, "github.com/yonahd/kor/pkg/utils.Version=${{package.version}}")
+	require.Contains(t, text, "\"${{targets.destdir}}/usr/bin/kor\" version")
+	require.Contains(t, text, "\"${{targets.destdir}}/usr/bin/kor\" --help")
+	require.Contains(t, text, "/usr/bin/kor version")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/kor")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_KOR_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "kor.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "kor",
+		Version: "0.6.8-r8",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"kor=0.6.8-r8@local"}, tmpl.Packages)
+}

--- a/cmd/kor_config_test.go
+++ b/cmd/kor_config_test.go
@@ -39,6 +39,7 @@ func Test_KOR_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "version: \"0.6.8\"")
 	require.Contains(t, text, "epoch: 8")
 	require.Contains(t, text, "license: MIT")
+	require.NotContains(t, text, "renovate: datasource=github-tags depName=yonahd/kor")
 	require.Contains(t, text, "Adapted from wolfi-dev/os@86f2c8a880f339829deb63a993f563382356221e")
 	require.Contains(t, text, "d6986c937ce72d331fef965c1b103fab69b4ea93.tar.gz")
 	require.Contains(t, text, "expected-sha256: dce84e8a1d5de7311a5ddf3bd31c443f177f3ea96d182757fd4190e5b484bdfa")

--- a/images/kor.yaml
+++ b/images/kor.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["kor"]
     entrypoint: /usr/bin/kor
+    melange:
+      bespoke: kor.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/kor.yaml
+++ b/packages/bespoke/kor.yaml
@@ -1,0 +1,62 @@
+package:
+  name: kor
+  # renovate: datasource=github-tags depName=yonahd/kor versioning=semver-coerced
+  version: "0.6.8"
+  # Direct revision r8 rebuilds the fixed source with the remediated Go toolchain.
+  epoch: 8
+  description: A Golang tool to discover unused Kubernetes resources
+  copyright:
+    - license: MIT
+  resources:
+    cpu: "2"
+    memory: 5Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+
+pipeline:
+  # Adapted from wolfi-dev/os@86f2c8a880f339829deb63a993f563382356221e.
+  - uses: fetch
+    with:
+      uri: https://github.com/yonahd/kor/archive/d6986c937ce72d331fef965c1b103fab69b4ea93.tar.gz
+      expected-sha256: dce84e8a1d5de7311a5ddf3bd31c443f177f3ea96d182757fd4190e5b484bdfa
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.55.0
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: .
+      output: kor
+      go-package: go-1.26
+      ldflags: |
+        -X github.com/yonahd/kor/pkg/utils.Version=${{package.version}}
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/kor" version \
+        | grep -F "kor version: v${{package.version}}"
+      "${{targets.destdir}}/usr/bin/kor" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  pipeline:
+    - runs: |
+        /usr/bin/kor version | grep -F "kor version: v${{package.version}}"
+        /usr/bin/kor --help >/dev/null
+        apk info --who-owns /usr/bin/kor \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        grep -F "MIT License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: yonahd/kor
+    strip-prefix: v
+  ignore-regex-patterns:
+    - ^kor-.*

--- a/packages/bespoke/kor.yaml
+++ b/packages/bespoke/kor.yaml
@@ -1,6 +1,5 @@
 package:
   name: kor
-  # renovate: datasource=github-tags depName=yonahd/kor versioning=semver-coerced
   version: "0.6.8"
   # Direct revision r8 rebuilds the fixed source with the remediated Go toolchain.
   epoch: 8


### PR DESCRIPTION
## Summary
- own `kor` as a bespoke `0.6.8-r8` package for `kor:0-default`
- pin immutable upstream commit `d6986c937ce72d331fef965c1b103fab69b4ea93` with SHA-256 `dce84e8a1d5de7311a5ddf3bd31c443f177f3ea96d182757fd4190e5b484bdfa`
- rebuild with fixed Go 1.26 tooling and `golang.org/x/net@v0.55.0`, preserve MIT license, and pin image assembly to the local APK
- add regressions for provenance, exact `0.6.8-r8@local` resolution, runtime contract, and synchronized immutable source metadata

## Evidence
- RED: `kor 0.6.8-r5` failed strict Trivy on `CVE-2026-42505` MEDIUM; fixed revision is `0.6.8-r8`
- local amd64 package/image build, version/help smoke, SPDX MIT declaration, and strict `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` Trivy: 0 findings
- native PR CI amd64 and arm64 package/image build/security legs: pass
- native PR CI amd64 and arm64 runtime smoke/security legs: pass
- full race-enabled Go tests, focused regressions, golangci-lint, YAML/Integer/Renovate validation, CodeQL, and aggregate PR Test: pass
- paginated review scan: 0 unresolved; review-caught immutable-source drift bug fixed with regression
