### PR TITLE
fix(integer): own kube-rbac-proxy package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -43,7 +43,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml",
-    "packages/bespoke/kube-bench.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
+    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/cmd/kube_rbac_proxy_config_test.go
+++ b/cmd/kube_rbac_proxy_config_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_KubeRBACProxy_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in kube-rbac-proxy image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "kube-rbac-proxy.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "kube-rbac-proxy.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"kube-rbac-proxy"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/kube-rbac-proxy", tmpl.Entrypoint)
+}
+
+func Test_KubeRBACProxy_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "kube-rbac-proxy.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, build, test, and license metadata are inspected.
+
+	// Then: approved revision r1 rebuilds immutable Apache-2.0 v0.22.1 source.
+	require.Contains(t, text, "name: kube-rbac-proxy")
+	require.Contains(t, text, "version: \"0.22.1\"")
+	require.Contains(t, text, "epoch: 1")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@832715bf59583579564b2fe393aba0a6b466fb85")
+	require.Contains(t, text, "v0.22.1 resolves to a67fc47c9e13db72e64b3cf0a369de4350e1c59b")
+	require.Contains(t, text, "https://github.com/kube-rbac-proxy/kube-rbac-proxy/archive/refs/tags/v${{package.version}}.tar.gz")
+	require.Contains(t, text, "expected-sha256: f8c6d4bc140ae04f20d6d0fedb077e8c233b72bab681500d32cc07c65208c41a")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/kube-rbac-proxy")
+	require.Contains(t, text, "output: kube-rbac-proxy")
+	require.Contains(t, text, "gitVersion=v${{package.version}}")
+	require.Contains(t, text, "kube-rbac-proxy --version")
+	require.Contains(t, text, "apk info --license kube-rbac-proxy")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_KubeRBACProxy_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "kube-rbac-proxy.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "kube-rbac-proxy",
+		Version: "0.22.1-r1",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"kube-rbac-proxy=0.22.1-r1@local"}, tmpl.Packages)
+}

--- a/images/kube-rbac-proxy.yaml
+++ b/images/kube-rbac-proxy.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["kube-rbac-proxy"]
     entrypoint: /usr/bin/kube-rbac-proxy
+    melange:
+      bespoke: kube-rbac-proxy.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/kube-rbac-proxy.yaml
+++ b/packages/bespoke/kube-rbac-proxy.yaml
@@ -1,0 +1,62 @@
+package:
+  name: kube-rbac-proxy
+  # renovate: datasource=github-tags depName=kube-rbac-proxy/kube-rbac-proxy versioning=semver-coerced
+  version: "0.22.1"
+  # Direct revision r1 rebuilds the fixed v0.22.1 source.
+  epoch: 1
+  description: Kubernetes RBAC authorizing HTTP proxy for a single upstream
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 6Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@832715bf59583579564b2fe393aba0a6b466fb85.
+  # v0.22.1 resolves to a67fc47c9e13db72e64b3cf0a369de4350e1c59b.
+  - uses: fetch
+    with:
+      uri: https://github.com/kube-rbac-proxy/kube-rbac-proxy/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-sha256: f8c6d4bc140ae04f20d6d0fedb077e8c233b72bab681500d32cc07c65208c41a
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      packages: ./cmd/kube-rbac-proxy
+      output: kube-rbac-proxy
+      ldflags: -X k8s.io/component-base/version.gitVersion=v${{package.version}}
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/kube-rbac-proxy" --version \
+        | grep -F "v${{package.version}}"
+      "${{targets.destdir}}/usr/bin/kube-rbac-proxy" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  pipeline:
+    - runs: |
+        kube-rbac-proxy --version | grep -F "v${{package.version}}"
+        kube-rbac-proxy --help >/dev/null
+        apk info --who-owns /usr/bin/kube-rbac-proxy \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license kube-rbac-proxy | grep -F "Apache-2.0"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: kube-rbac-proxy/kube-rbac-proxy
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
## Summary

- own only the `kube-rbac-proxy:0-default` package/image path
- rebuild `kube-rbac-proxy 0.22.1-r1` from checksum-pinned upstream v0.22.1 source
- preserve the existing image entrypoint and pin the local Melange artifact
- record Apache-2.0 package metadata and ship the upstream LICENSE
- add focused configuration, provenance, and local-package resolution regressions

## Current RED

Strict Trivy 0.72.0 on the published `ghcr.io/verity-org/kube-rbac-proxy:0` image fails on both amd64 and arm64:

- CVE-2026-41178: installed `0.22.0-r5`, fixed `0.22.1-r1`
- CVE-2026-42505: installed `0.22.0-r5`, fixed `0.22.1-r0`

Both findings are MEDIUM with fixed upstream revisions; there are no NO_FIX findings.

## Local verification

- focused regression: RED before recipe/image ownership, GREEN after
- `go test -race -shuffle=on -count=1 ./...`
- Integer config validation: 334 images valid
- Renovate source coverage validation
- native x86_64 Melange package build and tests
- amd64 image build and runtime: `Kubernetes v0.22.1`
- embedded SPDX: `kube-rbac-proxy 0.22.1-r1`, declared `Apache-2.0`
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings

## CI proof required

The existing PR workflow runs package/image builds natively and in parallel on:

- amd64 / x86_64: `ubuntu-latest`
- arm64 / aarch64: `ubuntu-24.04-arm`

Both build and smoke matrices enforce runtime architecture and strict zero-finding Trivy gates with no suppressions, ignores, exclusions, severity reduction, or architecture skips.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own the `kube-rbac-proxy` package and rebuild `0.22.1-r1`, pinning the image to the local artifact to fix Trivy findings and keep the existing entrypoint. Adds a bespoke Melange recipe and tests; updates coverage validation.

- **Dependencies**
  - Added `packages/bespoke/kube-rbac-proxy.yaml` pinned to `v0.22.1` (sha256) with epoch 1; builds with Go 1.26 and installs LICENSE.
  - Updated `images/kube-rbac-proxy.yaml` to use the bespoke package and preserve `/usr/bin/kube-rbac-proxy`; added the package to `.github/scripts/validate-renovate-coverage.py`.

- **Bug Fixes**
  - Upgraded to `kube-rbac-proxy=0.22.1-r1` to fix CVE-2026-41178 and CVE-2026-42505; strict Trivy passes with 0 findings on amd64 and arm64.
  - Added tests enforcing pinned bespoke package selection, immutable source revision and license, and local package resolution.

<sup>Written for commit 4f65b0267d566f9e13a24c6f78df0d9c091b252a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

