### PR TITLE
fix(integer): own kube-state-metrics package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -43,7 +43,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
-    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
+    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/cmd/kube_state_metrics_config_test.go
+++ b/cmd/kube_state_metrics_config_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_KubeStateMetrics_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in kube-state-metrics image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "kube-state-metrics.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its version and runtime contracts.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "kube-state-metrics.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"kube-state-metrics"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/kube-state-metrics", tmpl.Entrypoint)
+	require.Contains(t, def.Versions, "2.18")
+}
+
+func Test_KubeStateMetrics_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "kube-state-metrics.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, build, test, and license metadata are inspected.
+
+	// Then: approved revision r2 rebuilds immutable Apache-2.0 v2.19.1 source with the fixed toolchain.
+	require.Contains(t, text, "name: kube-state-metrics")
+	require.Contains(t, text, "version: \"2.19.1\"")
+	require.Contains(t, text, "epoch: 2")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@3c2a196ecb89848f52929d91659461a5edd8764c")
+	require.Contains(t, text, "45e1513e95beaaa2f2df92af9958cd9837bb66ab.tar.gz")
+	require.Contains(t, text, "expected-sha256: cbe6345fe3b927d0c8f7732eca5d14af300f928511d09548181d437210f99ca7")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: .")
+	require.Contains(t, text, "output: kube-state-metrics")
+	require.Contains(t, text, "github.com/prometheus/common/version.Version=${{package.version}}")
+	require.Contains(t, text, "github.com/prometheus/common/version.BuildDate=2026-06-11T18:22:59Z")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "test:\n  environment:\n    contents:\n      packages:\n        - apk-tools\n        - busybox")
+	require.Contains(t, text, "kube-state-metrics version")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/kube-state-metrics")
+}
+
+func Test_KubeStateMetrics_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "kube-state-metrics.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "2.18", []apkindex.Package{{
+		Name:    "kube-state-metrics",
+		Version: "2.19.1-r2",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"kube-state-metrics=2.19.1-r2@local"}, tmpl.Packages)
+}

--- a/cmd/kube_state_metrics_config_test.go
+++ b/cmd/kube_state_metrics_config_test.go
@@ -37,6 +37,7 @@ func Test_KubeStateMetrics_recipe_pins_fixed_source_revision(t *testing.T) {
 
 	// Then: approved revision r2 rebuilds immutable Apache-2.0 v2.19.1 source with the fixed toolchain.
 	require.Contains(t, text, "name: kube-state-metrics")
+	require.Contains(t, text, "# renovate: datasource=github-tags depName=kubernetes/kube-state-metrics versioning=semver-coerced")
 	require.Contains(t, text, "version: \"2.19.1\"")
 	require.Contains(t, text, "epoch: 2")
 	require.Contains(t, text, "license: Apache-2.0")

--- a/images/kube-state-metrics.yaml
+++ b/images/kube-state-metrics.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["kube-state-metrics"]
     entrypoint: /usr/bin/kube-state-metrics
+    melange:
+      bespoke: kube-state-metrics.yaml
     paths:
       - {path: /tmp, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 

--- a/packages/bespoke/kube-state-metrics.yaml
+++ b/packages/bespoke/kube-state-metrics.yaml
@@ -1,5 +1,6 @@
 package:
   name: kube-state-metrics
+  # renovate: datasource=github-tags depName=kubernetes/kube-state-metrics versioning=semver-coerced
   version: "2.19.1"
   # Direct revision r2 replaces vulnerable 2.19.0-r4 with the approved fixed release.
   epoch: 2

--- a/packages/bespoke/kube-state-metrics.yaml
+++ b/packages/bespoke/kube-state-metrics.yaml
@@ -1,0 +1,74 @@
+package:
+  name: kube-state-metrics
+  version: "2.19.1"
+  # Direct revision r2 replaces vulnerable 2.19.0-r4 with the approved fixed release.
+  epoch: 2
+  description: Add-on agent to generate and expose cluster-level metrics
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - merged-usrsbin
+      - tzdata
+      - wolfi-baselayout
+  resources:
+    cpu: "2"
+    memory: 5Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@3c2a196ecb89848f52929d91659461a5edd8764c.
+  - uses: fetch
+    with:
+      uri: https://github.com/kubernetes/kube-state-metrics/archive/45e1513e95beaaa2f2df92af9958cd9837bb66ab.tar.gz
+      expected-sha256: cbe6345fe3b927d0c8f7732eca5d14af300f928511d09548181d437210f99ca7
+
+  - uses: go/build
+    with:
+      packages: .
+      output: kube-state-metrics
+      go-package: go-1.26
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=45e1513e95beaaa2f2df92af9958cd9837bb66ab
+        -X github.com/prometheus/common/version.Branch=v${{package.version}}
+        -X github.com/prometheus/common/version.BuildUser=verity
+        -X github.com/prometheus/common/version.BuildDate=2026-06-11T18:22:59Z
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/kube-state-metrics" version \
+        | grep -F "${{package.version}}"
+      "${{targets.destdir}}/usr/bin/kube-state-metrics" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+  pipeline:
+    - runs: |
+        kube-state-metrics version | grep -F "${{package.version}}"
+        kube-state-metrics --help >/dev/null
+        apk info --who-owns /usr/bin/kube-state-metrics \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/kube-state-metrics
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
## Summary

- rebuild `kube-state-metrics` as the approved `2.19.1-r2` bespoke package from immutable upstream commit `45e1513e95beaaa2f2df92af9958cd9837bb66ab` and SHA-256 `cbe6345fe3b927d0c8f7732eca5d14af300f928511d09548181d437210f99ca7`
- preserve the `kube-state-metrics:2.18-default` image, `2.18`/`latest` aliases, entrypoint, and runtime paths while pinning the local package
- declare and verify Apache-2.0, embed the upstream license and SPDX 2.3 package SBOM, and add focused regression coverage
- classify the immutable-fetch recipe for Renovate coverage; this is the only shared integration change

## Security evidence

- RED reproduced on current base: installed `2.19.0-r4` failed strict Trivy with `CVE-2026-41178` MEDIUM; fixed version reported as `2.19.1-r2`
- native amd64/x86_64 and arm64/aarch64 Melange builds produced `kube-state-metrics-2.19.1-r2.apk`
- native amd64 and arm64 apko images installed `2.19.1-r2`, loaded with their matching runtime architectures, and passed the image gate
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings on amd64 and 0 findings on arm64
- runtime reported version `2.19.1` and pinned upstream revision; SPDX 2.3 declares `Apache-2.0`
- no suppressions, ignores, exclusions, severity reduction, retirement, or architecture skips

## Tests

- `go test -race -shuffle=on -count=1 ./cmd`
- `go test -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m ./cmd/...`
- `python3 .github/scripts/validate-renovate-coverage.py`
- `yamllint -c .yamllint.yml images/kube-state-metrics.yaml packages/bespoke/kube-state-metrics.yaml`
- `go run . integer validate`
- local native amd64 Melange package build/test, apko image build, runtime/version smoke, SPDX/license inspection, and strict Trivy scan
- PR run `29459080752`: native parallel amd64/arm64 package builds, image builds, runtime architecture checks, and strict zero-finding scans all passed
