### PR TITLE
fix(integer): own kube-vip package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -43,7 +43,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
-    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
+    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/images/kube-vip.yaml
+++ b/images/kube-vip.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["kube-vip"]
     entrypoint: /usr/bin/kube-vip
+    melange:
+      bespoke: kube-vip.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/kube-vip.yaml
+++ b/packages/bespoke/kube-vip.yaml
@@ -1,0 +1,73 @@
+package:
+  name: kube-vip
+  # renovate: datasource=github-tags depName=kube-vip/kube-vip versioning=semver-coerced
+  version: "1.2.1"
+  # Direct revision r2 includes the fixes published through r2.
+  epoch: 2
+  description: Kubernetes Control Plane Virtual IP and Load-Balancer
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 6Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@05cef2f5b5b59f8a0352fb018248c65bcc3fc2e2.
+  # v1.2.1 resolves to 4708b07343dd9209f9b56cfa52dc53a85d8d3166.
+  - uses: fetch
+    with:
+      uri: https://github.com/kube-vip/kube-vip/archive/4708b07343dd9209f9b56cfa52dc53a85d8d3166.tar.gz
+      expected-sha256: ee1a91145d44b831b8f0248d67a92eac2b49cc75b5836bcdb8403a3842fe6466
+
+  - uses: go/build
+    with:
+      packages: .
+      output: kube-vip
+      go-package: go-1.26
+      ldflags: |-
+        -X=main.Version=${{package.version}}
+        -X=main.Build=4708b07343dd9209f9b56cfa52dc53a85d8d3166
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/kube-vip" version \
+        | grep -F "Version:  ${{package.version}}"
+      "${{targets.destdir}}/usr/bin/kube-vip" version \
+        | grep -F "Build:    4708b07343dd9209f9b56cfa52dc53a85d8d3166"
+      "${{targets.destdir}}/usr/bin/kube-vip" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  pipeline:
+    - runs: |
+        kube-vip version | grep -F "Version:  ${{package.version}}"
+        kube-vip version \
+          | grep -F "Build:    4708b07343dd9209f9b56cfa52dc53a85d8d3166"
+        kube-vip --help >/dev/null
+        kube-vip manifest pod \
+          --interface eth0 \
+          --vip 192.0.2.1 \
+          --arp \
+          | grep -F "kube-vip"
+        apk info --who-owns /usr/bin/kube-vip \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license kube-vip | grep -F "Apache-2.0"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: kube-vip/kube-vip
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
## Summary

- own `kube-vip:0-default` at the required fixed package version `1.2.1-r2`
- build immutable upstream commit `4708b07343dd9209f9b56cfa52dc53a85d8d3166` with SHA-256 `ee1a91145d44b831b8f0248d67a92eac2b49cc75b5836bcdb8403a3842fe6466`
- classify the new checksum-pinned recipe in the existing Renovate coverage data table
- leave shared build/security behavior unchanged

## Security matrix

- image: `kube-vip:0-default`
- installed RED: `kube-vip-1.2.0-r1`
- required fixed: `kube-vip-1.2.1-r2`
- disposition: direct-bump
- NO_FIX findings: none

## Reproduced RED

Both published architectures reported the same three fixable findings:

- `CVE-2026-30405` HIGH, fixed in `1.2.1-r0`
- `CVE-2026-42505` MEDIUM, fixed in `1.2.1-r1`
- `CVE-2026-49838` MEDIUM, fixed in `1.2.1-r2`

## Proof

Local:

- `go test ./...`
- Integer validation: 334 images valid
- focused melange package build and package tests
- native amd64 image build plus version/help/manifest runtime smoke
- SPDX 2.3 package SBOM with Apache-2.0 and matching license scan
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings
- Renovate coverage validator passed

Final native PR CI (run `29460039036`):

- arm64 build: `kube-vip-1.2.1-r2`, version/build smoke, 0 strict Trivy findings
- arm64 smoke: `kube-vip-1.2.1-r2`, version/build smoke, 0 strict Trivy findings
- amd64 build: `kube-vip-1.2.1-r2`, version/build smoke, 0 strict Trivy findings
- amd64 smoke: `kube-vip-1.2.1-r2`, version/build smoke, 0 strict Trivy findings

