### PR TITLE
fix(integer): retire vulnerable metrics-server 0.8 alias

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -44,6 +44,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
+    "packages/bespoke/metrics-server.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/cmd/metrics_server_config_test.go
+++ b/cmd/metrics_server_config_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_MetricsServer_advertises_only_broad_alias_and_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in metrics-server image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "metrics-server.yaml"))
+	require.NoError(t, err)
+
+	// When: the default image variant and advertised version tracks are resolved.
+	tmpl := def.Types["default"]
+
+	// Then: only the broad alias remains and it preserves the runtime contract.
+	require.Len(t, def.Versions, 1)
+	require.Contains(t, def.Versions, "0")
+	require.NotContains(t, def.Versions, "0.8")
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "metrics-server.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"metrics-server"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/metrics-server", tmpl.Entrypoint)
+}
+
+func Test_MetricsServer_recipe_pins_clean_upstream_release(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "metrics-server.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, runtime, and license metadata are inspected.
+
+	// Then: revision r0 builds immutable Apache-2.0 v0.9.0 source with fixed dependencies.
+	require.Contains(t, text, "name: metrics-server")
+	require.Contains(t, text, "version: \"0.9.0\"")
+	require.Contains(t, text, "epoch: 0")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "archive/2a7c4b2c7d46552ff47f4aeaa3a735c582587ecd.tar.gz")
+	require.Contains(t, text, "expected-sha256: 7c3dc479484fca306297221058bf55f5d4620305b4041e729dfb497386a621fa")
+	require.Contains(t, text, "GIT_TAG=v${{package.version}}")
+	require.Contains(t, text, "GIT_COMMIT=2a7c4b2c7d46552ff47f4aeaa3a735c582587ecd")
+	require.Contains(t, text, "github.com/prometheus/prometheus\\tv0.313.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel\\tv1.44.0")
+	require.Contains(t, text, "metrics-server --version")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_MetricsServer_broad_alias_resolves_clean_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "metrics-server.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: local Melange artifacts are pinned for the surviving broad alias.
+	pinErr := pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+		Name:    "metrics-server",
+		Version: "0.9.0-r0",
+	}})
+
+	// Then: apko can only select the clean locally built revision.
+	require.NoError(t, pinErr)
+	require.Equal(t, []string{"metrics-server=0.9.0-r0@local"}, tmpl.Packages)
+}
+
+func Test_MetricsServer_explicit_retired_alias_fails_before_build(t *testing.T) {
+	// Given: an explicit request for the retired 0.8 alias with network discovery disabled.
+	output := filepath.Join(t.TempDir(), "metrics-server.tar")
+	root := &cli.Command{Commands: []*cli.Command{IntegerCommand}}
+
+	// When: the local image build command validates the requested version.
+	err := root.Run(context.Background(), []string{
+		"verity", "integer", "build",
+		"--image", "metrics-server",
+		"--version", "0.8",
+		"--type", "default",
+		"--images-dir", filepath.Join("..", "images"),
+		"--apkindex-url", "",
+		"--output", output,
+	})
+
+	// Then: it rejects the unsupported version before producing an image.
+	require.ErrorIs(t, err, errIntegerVariantNotFound)
+	require.Contains(t, err.Error(), `image "metrics-server" version "0.8" not defined for build`)
+	require.NoFileExists(t, output)
+}

--- a/cmd/metrics_server_config_test.go
+++ b/cmd/metrics_server_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,7 +51,14 @@ func Test_MetricsServer_recipe_pins_clean_upstream_release(t *testing.T) {
 	require.Contains(t, text, "GIT_COMMIT=2a7c4b2c7d46552ff47f4aeaa3a735c582587ecd")
 	require.Contains(t, text, "github.com/prometheus/prometheus\\tv0.313.0")
 	require.Contains(t, text, "go.opentelemetry.io/otel\\tv1.44.0")
-	require.Contains(t, text, "metrics-server --version")
+	testSection := strings.Index(text, "\ntest:\n")
+	versionSmoke := strings.Index(text, `"${{targets.destdir}}/usr/bin/metrics-server" --version`)
+	helpSmoke := strings.Index(text, `"${{targets.destdir}}/usr/bin/metrics-server" --help`)
+	require.NotEqual(t, -1, testSection)
+	require.NotEqual(t, -1, versionSmoke)
+	require.NotEqual(t, -1, helpSmoke)
+	require.Less(t, versionSmoke, testSection, "version smoke must run during the native build")
+	require.Less(t, helpSmoke, testSection, "help smoke must run during the native build")
 	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
 }
 

--- a/images/metrics-server.yaml
+++ b/images/metrics-server.yaml
@@ -8,12 +8,10 @@ types:
     base: wolfi-base
     packages: ["metrics-server"]
     entrypoint: /usr/bin/metrics-server
+    melange:
+      bespoke: metrics-server.yaml
 
 versions:
+  # The explicit 0.8 stream is retired: Wolfi has no 0.8.x revision fixing
+  # CVE-2026-42151, while the broad 0 stream now builds fixed v0.9.0.
   "0": {}
-  # Maintained minor stream — verity-org/verity#310 (Wave 1 of #308) pins
-  # the wrapper chart at `tag: "0.8"`, so this stream needs to keep
-  # publishing across Wolfi minor bumps rather than relying on the
-  # semver cascade alias from the `0` build (which disappears the moment
-  # Wolfi advances metrics-server to 0.9.x).
-  "0.8": {}

--- a/packages/bespoke/metrics-server.yaml
+++ b/packages/bespoke/metrics-server.yaml
@@ -1,0 +1,58 @@
+package:
+  name: metrics-server
+  version: "0.9.0"
+  epoch: 0
+  description: Scalable and efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+  resources:
+    cpu: "4"
+    memory: 8Gi
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # v0.9.0 is the first upstream release whose Wolfi security record fixes
+  # CVE-2026-42151. The tag resolves to this immutable commit.
+  - uses: fetch
+    with:
+      uri: https://github.com/kubernetes-sigs/metrics-server/archive/2a7c4b2c7d46552ff47f4aeaa3a735c582587ecd.tar.gz
+      expected-sha256: 7c3dc479484fca306297221058bf55f5d4620305b4041e729dfb497386a621fa
+
+  - runs: |
+      GIT_TAG=v${{package.version}} \
+      GIT_COMMIT=2a7c4b2c7d46552ff47f4aeaa3a735c582587ecd \
+      BUILD_DATE=2026-07-13T10:38:03Z \
+        make metrics-server ARCH="$(go env GOARCH)"
+      install -Dm755 metrics-server "${{targets.destdir}}/usr/bin/metrics-server"
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+      go version -m "${{targets.destdir}}/usr/bin/metrics-server" | grep -F $'github.com/prometheus/prometheus\tv0.313.0'
+      go version -m "${{targets.destdir}}/usr/bin/metrics-server" | grep -F $'go.opentelemetry.io/otel\tv1.44.0'
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        metrics-server --version | grep -F "v${{package.version}}"
+        metrics-server --help >/dev/null
+        test -f /usr/share/licenses/${{package.name}}/LICENSE
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/metrics-server
+    strip-prefix: v
+    tag-filter: v

--- a/packages/bespoke/metrics-server.yaml
+++ b/packages/bespoke/metrics-server.yaml
@@ -38,6 +38,8 @@ pipeline:
       install -Dm755 metrics-server "${{targets.destdir}}/usr/bin/metrics-server"
       install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
 
+      "${{targets.destdir}}/usr/bin/metrics-server" --version | grep -F "v${{package.version}}"
+      "${{targets.destdir}}/usr/bin/metrics-server" --help >/dev/null
       go version -m "${{targets.destdir}}/usr/bin/metrics-server" | grep -F $'github.com/prometheus/prometheus\tv0.313.0'
       go version -m "${{targets.destdir}}/usr/bin/metrics-server" | grep -F $'go.opentelemetry.io/otel\tv1.44.0'
 


### PR DESCRIPTION
## Summary

- own metrics-server 0.9.0 as an isolated bespoke Melange package at revision r0
- move the broad `metrics-server:0-default` stream to fixed upstream v0.9.0
- retire explicit `metrics-server:0.8-default` so discovery no longer advertises it and explicit builds fail before package/image work
- preserve the default runtime contract at `/usr/bin/metrics-server`

## Why 0.8 is retired

A fresh July 15, 2026 check of both official Wolfi APK indexes found no 0.8.x package newer than `0.8.1-r10` on either x86_64 or aarch64. Wolfi security metadata marks `CVE-2026-42151` fixed at `0.9.0-r0`, not at any 0.8.x revision.

The previous direct-revision experiment produced `0.8.1-r15` with fixed embedded Prometheus and OpenTelemetry modules, but strict Trivy still correctly enforced the Wolfi package advisory and reported one HIGH finding on both advertised aliases. Keeping or relabeling 0.8 would violate the zero-CVE invariant, so this PR uses the authorized semantic retirement.

## Provenance and license

- upstream release: v0.9.0
- immutable commit: `2a7c4b2c7d46552ff47f4aeaa3a735c582587ecd`
- archive SHA-256: `7c3dc479484fca306297221058bf55f5d4620305b4041e729dfb497386a621fa`
- license: Apache-2.0
- package revision: `metrics-server 0.9.0-r0`

## Regression coverage

- only version stream `0` remains declared
- discovery emits `0`, `0.9`, `0.9.0`, and `latest`; it does not emit `0.8`
- the broad stream resolves exactly to `metrics-server=0.9.0-r0@local`
- explicit `--version 0.8` fails early with `version/type not found` and produces no image
- no unrelated image definitions or aliases change

## Local evidence

- baseline `metrics-server:0` and `metrics-server:0.8`: `0.8.1-r10`, strict Trivy RED
- amd64 Melange package build: PASS
- amd64 image build: PASS
- runtime: `v0.9.0`, `--help` PASS
- SPDX 2.3: `metrics-server 0.9.0-r0`, Apache-2.0
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings
- `go test ./... -count=1`: PASS
- `make lint`: PASS
- focused YAML lint: PASS
- `make integer-validate`: PASS
- `git diff --check`: PASS

Native amd64 and arm64 package/image/runtime/SPDX/strict-Trivy proof remains a merge gate in PR CI. No suppression, ignore, exclusion, severity reduction, vulnerable alias publication, or architecture skip is used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the vulnerable `metrics-server` 0.8 stream and pins the image to a local `metrics-server` 0.9.0 package to clear advisories. Adds tests and native build smoke to enforce the single broad alias, local pinning, and fail-fast on `--version 0.8`, while keeping `/usr/bin/metrics-server` as the entrypoint.

- **Dependencies**
  - Adds bespoke Melange package for `metrics-server` 0.9.0 and pins the image to `metrics-server=0.9.0-r0@local`.
  - Moves the broad `0` stream to 0.9.0 and fixes `CVE-2026-42151`.
  - Runs native version/help smoke during the package build to validate the binary.
  - Includes `packages/bespoke/metrics-server.yaml` in Renovate coverage.

- **Migration**
  - Removes the `0.8` alias. Use `--version 0`, `0.9`, or `0.9.0`.
  - `--version 0.8` now errors before build, and discovery no longer advertises it.

<sup>Written for commit fd4f091839587aa73e35eebb5047131d23c4a5ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

