### PR TITLE
fix(integer): own minio-operator package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -43,7 +43,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
-    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
+    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml",
     "packages/bespoke/metrics-server.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {

--- a/cmd/minio_operator_config_test.go
+++ b/cmd/minio_operator_config_test.go
@@ -50,6 +50,7 @@ func Test_MinioOperator_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "packages: ./cmd/operator")
 	require.Contains(t, text, "output: minio-operator")
 	require.Contains(t, text, "github.com/minio/operator/pkg.Version=${{package.full-version}}")
+	require.Contains(t, text, "github.com/minio/operator/pkg.ShortCommitID=6eee6a7c\n")
 	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
 	require.Contains(t, text, "minio-operator --version")
 	require.Contains(t, text, "go version -m /usr/bin/minio-operator")

--- a/cmd/minio_operator_config_test.go
+++ b/cmd/minio_operator_config_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_MinioOperator_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in MinIO Operator image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "minio-operator.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "minio-operator.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"minio-operator"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/minio-operator", tmpl.Entrypoint)
+	require.Contains(t, def.Versions, "7")
+}
+
+func Test_MinioOperator_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "minio-operator.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, build, test, and license metadata are inspected.
+
+	// Then: direct revision r28 rebuilds immutable AGPL-3.0-only v7.1.1 source with fixed Prometheus.
+	require.Contains(t, text, "name: minio-operator")
+	require.Contains(t, text, "# renovate: datasource=github-tags depName=minio/operator versioning=semver-coerced")
+	require.Contains(t, text, "version: \"7.1.1\"")
+	require.Contains(t, text, "epoch: 28")
+	require.Contains(t, text, "license: AGPL-3.0-only")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@58777d20dc737bd1039fb43c3896604b14e4cb71")
+	require.Contains(t, text, "6eee6a7caa70555ad009e522ce04861297e9e2be.tar.gz")
+	require.Contains(t, text, "expected-sha256: 5a851e8e51fc235ece86bd4de87ddcf38b41c387b9798b8770960b865b3d654a")
+	require.Contains(t, text, "github.com/prometheus/prometheus@v0.311.3")
+	require.Contains(t, text, "github.com/go-openapi/testify/enable/yaml/v2@v2.4.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/operator")
+	require.Contains(t, text, "output: minio-operator")
+	require.Contains(t, text, "github.com/minio/operator/pkg.Version=${{package.full-version}}")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "minio-operator --version")
+	require.Contains(t, text, "go version -m /usr/bin/minio-operator")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/minio-operator")
+}
+
+func Test_MinioOperator_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "minio-operator.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "7", []apkindex.Package{{
+		Name:    "minio-operator",
+		Version: "7.1.1-r28",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"minio-operator=7.1.1-r28@local"}, tmpl.Packages)
+}

--- a/images/minio-operator.yaml
+++ b/images/minio-operator.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["minio-operator"]
     entrypoint: /usr/bin/minio-operator
+    melange:
+      bespoke: minio-operator.yaml
 
 versions:
   "7": {}

--- a/packages/bespoke/minio-operator.yaml
+++ b/packages/bespoke/minio-operator.yaml
@@ -1,0 +1,78 @@
+package:
+  name: minio-operator
+  # renovate: datasource=github-tags depName=minio/operator versioning=semver-coerced
+  version: "7.1.1"
+  # Direct revision r28 replaces vulnerable public revision 7.1.1-r24.
+  epoch: 28
+  description: MinIO Operator creates, configures, and manages MinIO on Kubernetes
+  copyright:
+    - license: AGPL-3.0-only
+  resources:
+    cpu: "4"
+    memory: 8Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@58777d20dc737bd1039fb43c3896604b14e4cb71.
+  - uses: fetch
+    with:
+      uri: https://github.com/minio/operator/archive/6eee6a7caa70555ad009e522ce04861297e9e2be.tar.gz
+      expected-sha256: 5a851e8e51fc235ece86bd4de87ddcf38b41c387b9798b8770960b865b3d654a
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/docker/cli@v29.2.0
+        github.com/go-openapi/testify/enable/yaml/v2@v2.4.0
+        github.com/prometheus/prometheus@v0.311.3
+        golang.org/x/crypto@v0.52.0
+        golang.org/x/net@v0.55.0
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      packages: ./cmd/operator
+      output: minio-operator
+      ldflags: |-
+        -X github.com/minio/operator/pkg.ReleaseTag=${{package.full-version}}
+        -X github.com/minio/operator/pkg.Version=${{package.full-version}}
+        -X github.com/minio/operator/pkg.ShortCommitID=6eee6a7caa70555ad009e522ce04861297e9e2be
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/minio-operator" --version \
+        | grep -F "${{package.full-version}}"
+      "${{targets.destdir}}/usr/bin/minio-operator" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+      install -Dm644 CREDITS \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/CREDITS"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+        - go-1.26
+  pipeline:
+    - runs: |
+        minio-operator --version | grep -F "${{package.full-version}}"
+        minio-operator --help >/dev/null
+        go version -m /usr/bin/minio-operator \
+          | grep -F "github.com/prometheus/prometheus v0.311.3"
+        apk info --who-owns /usr/bin/minio-operator \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        grep -F "GNU AFFERO GENERAL PUBLIC LICENSE" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: minio/operator
+    strip-prefix: v

--- a/packages/bespoke/minio-operator.yaml
+++ b/packages/bespoke/minio-operator.yaml
@@ -42,7 +42,7 @@ pipeline:
       ldflags: |-
         -X github.com/minio/operator/pkg.ReleaseTag=${{package.full-version}}
         -X github.com/minio/operator/pkg.Version=${{package.full-version}}
-        -X github.com/minio/operator/pkg.ShortCommitID=6eee6a7caa70555ad009e522ce04861297e9e2be
+        -X github.com/minio/operator/pkg.ShortCommitID=6eee6a7c
 
   - runs: |
       "${{targets.destdir}}/usr/bin/minio-operator" --version \


### PR DESCRIPTION
## Summary

- own `minio-operator` as a bespoke `7.1.1-r28` package from immutable upstream commit `6eee6a7caa70555ad009e522ce04861297e9e2be` and verified SHA-256
- carry the public Wolfi `r24` remediation baseline, bump Prometheus to fixed `v0.311.3`, and pin the matching YAML test module needed for reproducible tidy/build
- route `minio-operator:7-default` through the local package and add provenance/revision regression tests

## Time-sensitive evidence

- Fresh Wolfi x86_64 and aarch64 indexes on July 15, 2026 both publish `7.1.1-r24` as latest; `r28` is not yet present.
- Strict Trivy 0.72.0 scans of `ghcr.io/verity-org/minio-operator:7` reproduced two findings on both architectures:
  - `CVE-2026-42154` HIGH, installed `7.1.1-r24`, fixed `7.1.1-r28`
  - `CVE-2026-44903` MEDIUM, installed `7.1.1-r24`, fixed `7.1.1-r28`

## Verification

- `go test ./... -count=1`
- `go test ./cmd -run Test_MinioOperator -count=1`
- `go run . integer validate`
- `python3 .github/scripts/validate-renovate-coverage.py`
- `mise exec -- golangci-lint run ./...` (0 issues)
- native amd64 Melange package and apko image build
- runtime: `minio-operator version 7.1.1-r28 - 6eee6a7c`
- SPDX 2.3: package `7.1.1-r28`, declared `AGPL-3.0-only`, LICENSE and CREDITS present, Prometheus `v0.311.3`
- strict Trivy UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL: 0 findings on amd64
- native amd64/arm64 package, image, runtime, SPDX, and strict Trivy proof is delegated to the existing parallel architecture CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own `minio-operator` as a bespoke `7.1.1-r28` package to fix CVEs and ensure reproducible builds. Route the `minio-operator:7` image to the local package, preserve the upstream short commit ID, and add regression tests.

- **Bug Fixes**
  - Rebuilt `minio-operator` as `7.1.1-r28`, replacing vulnerable `r24` (fixes CVE-2026-42154, CVE-2026-44903).
  - Image now uses the bespoke recipe via `melange.bespoke: minio-operator.yaml`.
  - Preserve `pkg.ShortCommitID=6eee6a7c` in the binary and version output.
  - Added tests to enforce pinned recipe, entrypoint, version, short commit ID, and local package selection.
  - Updated renovate coverage to include `packages/bespoke/minio-operator.yaml`.

- **Dependencies**
  - Bumped `github.com/prometheus/prometheus` to `v0.311.3`.
  - Pinned `github.com/go-openapi/testify/enable/yaml/v2@v2.4.0`.
  - Bumped `golang.org/x/crypto@v0.52.0`, `golang.org/x/net@v0.55.0`, and `github.com/docker/cli@v29.2.0`.

<sup>Written for commit 45052a7fcfe8b63d6ca6924f1a6ffa210111f6d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

