### PR TITLE
fix(integer): own grafana-mimir packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -109,6 +109,30 @@
     },
     {
       "customType": "regex",
+      "description": "Grafana Mimir 3.0 package releases",
+      "managerFilePatterns": ["/^packages/bespoke/grafana-mimir-3\\.0\\.yaml$/"],
+      "matchStrings": [
+        "package:\\n\\s+name:\\s*grafana-mimir-3\\.0\\n\\s+version:\\s*[\\\"']?(?<currentValue>[\\w.+-]+)[\\\"']?"
+      ],
+      "depNameTemplate": "grafana/mimir",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver-coerced",
+      "extractVersionTemplate": "^mimir-(?<version>3\\.0\\..*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Grafana Mimir 3.1 package releases",
+      "managerFilePatterns": ["/^packages/bespoke/grafana-mimir-3\\.1\\.yaml$/"],
+      "matchStrings": [
+        "package:\\n\\s+name:\\s*grafana-mimir-3\\.1\\n\\s+version:\\s*[\\\"']?(?<currentValue>[\\w.+-]+)[\\\"']?"
+      ],
+      "depNameTemplate": "grafana/mimir",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver-coerced",
+      "extractVersionTemplate": "^mimir-(?<version>3\\.1\\..*)$"
+    },
+    {
+      "customType": "regex",
       "description": "Linkerd edge package releases",
       "managerFilePatterns": ["/^packages/bespoke/linkerd2-cli-25\\.yaml$/"],
       "matchStrings": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -109,30 +109,6 @@
     },
     {
       "customType": "regex",
-      "description": "Grafana Mimir 3.0 package releases",
-      "managerFilePatterns": ["/^packages/bespoke/grafana-mimir-3\\.0\\.yaml$/"],
-      "matchStrings": [
-        "package:\\n\\s+name:\\s*grafana-mimir-3\\.0\\n\\s+version:\\s*[\\\"']?(?<currentValue>[\\w.+-]+)[\\\"']?"
-      ],
-      "depNameTemplate": "grafana/mimir",
-      "datasourceTemplate": "github-tags",
-      "versioningTemplate": "semver-coerced",
-      "extractVersionTemplate": "^mimir-(?<version>3\\.0\\..*)$"
-    },
-    {
-      "customType": "regex",
-      "description": "Grafana Mimir 3.1 package releases",
-      "managerFilePatterns": ["/^packages/bespoke/grafana-mimir-3\\.1\\.yaml$/"],
-      "matchStrings": [
-        "package:\\n\\s+name:\\s*grafana-mimir-3\\.1\\n\\s+version:\\s*[\\\"']?(?<currentValue>[\\w.+-]+)[\\\"']?"
-      ],
-      "depNameTemplate": "grafana/mimir",
-      "datasourceTemplate": "github-tags",
-      "versioningTemplate": "semver-coerced",
-      "extractVersionTemplate": "^mimir-(?<version>3\\.1\\..*)$"
-    },
-    {
-      "customType": "regex",
       "description": "Linkerd edge package releases",
       "managerFilePatterns": ["/^packages/bespoke/linkerd2-cli-25\\.yaml$/"],
       "matchStrings": [

--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -22,7 +22,7 @@ REQUIRED_CUSTOM_MANAGERS: Final = {
     "Dex package releases",
     "PostgreSQL package releases",
     "Airflow package release",
-    "HAProxy package releases", "Grafana Mimir 3.0 package releases", "Grafana Mimir 3.1 package releases",
+    "HAProxy package releases",
     "Linkerd edge package releases",
     "Python packages embedded in bespoke recipes",
     "Go modules embedded in bespoke recipes",

--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -22,7 +22,7 @@ REQUIRED_CUSTOM_MANAGERS: Final = {
     "Dex package releases",
     "PostgreSQL package releases",
     "Airflow package release",
-    "HAProxy package releases",
+    "HAProxy package releases", "Grafana Mimir 3.0 package releases", "Grafana Mimir 3.1 package releases",
     "Linkerd edge package releases",
     "Python packages embedded in bespoke recipes",
     "Go modules embedded in bespoke recipes",
@@ -42,7 +42,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.1.yaml",
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
-    "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
+    "packages/bespoke/grafana-mimir-3.0.yaml", "packages/bespoke/grafana-mimir-3.1.yaml", "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml",
     "packages/bespoke/metrics-server.yaml",
 }

--- a/cmd/mimir_config_test.go
+++ b/cmd/mimir_config_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Mimir_uses_stream_scoped_bespoke_packages(t *testing.T) {
+	// Given: the checked-in Grafana Mimir image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "mimir.yaml"))
+	require.NoError(t, err)
+
+	// When: the default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: both supported streams select their matching local rebuild.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "grafana-mimir-{{version}}.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"grafana-mimir-{{version}}"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/mimir", tmpl.Entrypoint)
+	require.Contains(t, def.Versions, "3.0")
+	require.Contains(t, def.Versions, "3.1")
+	require.True(t, def.Versions["3.1"].Latest)
+}
+
+func Test_Mimir_recipes_pin_fixed_sources(t *testing.T) {
+	tests := []struct {
+		name     string
+		stream   string
+		version  string
+		epoch    string
+		commit   string
+		checksum string
+		branch   string
+		baseline string
+	}{
+		{
+			name:     "3.0 stream",
+			stream:   "3.0",
+			version:  "3.0.7",
+			epoch:    "3",
+			commit:   "c8a2454ab4fb93789a829890a63bc89107707114",
+			checksum: "9e108dbd5aaec06db4b1c7d7179016209926a854419bdc4b500d42e43e14371e",
+			branch:   "release-3.0",
+			baseline: "b137f48f69fd0d54416849cf09201ab5ff519562",
+		},
+		{
+			name:     "3.1 stream",
+			stream:   "3.1",
+			version:  "3.1.2",
+			epoch:    "2",
+			commit:   "e23940eb3a28c3e3f34968aa57d6a189370aa0f7",
+			checksum: "f3a556c4fb50b00e88d5093570e209ebf54bd5b9d6c2d07606c8baa68f25e9bf",
+			branch:   "release-3.1",
+			baseline: "bfb9155301a240694c98ec1f1f3e1a6fee92031f",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: the bespoke recipe selected for this Mimir stream.
+			recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "grafana-mimir-"+tt.stream+".yaml"))
+			require.NoError(t, err)
+
+			// When: its package, source, dependency, test, and license contracts are inspected.
+			text := string(recipe)
+
+			// Then: the fixed release is reproducible and carries the strict runtime evidence hooks.
+			require.Contains(t, text, "name: grafana-mimir-"+tt.stream)
+			require.Contains(t, text, "version: \""+tt.version+"\"")
+			require.Contains(t, text, "epoch: "+tt.epoch)
+			require.Contains(t, text, "license: AGPL-3.0-or-later")
+			require.Contains(t, text, "Adapted from wolfi-dev/os@"+tt.baseline)
+			require.Contains(t, text, tt.commit+".tar.gz")
+			require.Contains(t, text, "expected-sha256: "+tt.checksum)
+			require.Contains(t, text, "      - git\n")
+			require.Contains(t, text, "golang.org/x/net@v0.57.0")
+			require.Contains(t, text, "golang.org/x/text@v0.40.0")
+			require.Contains(t, text, "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.44.0")
+			require.Contains(t, text, "github.com/grafana/mimir/pkg/util/version.Branch="+tt.branch)
+			require.Contains(t, text, "github.com/grafana/mimir/pkg/util/version.Revision="+tt.commit)
+			require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+			require.Contains(t, text, "apk info --who-owns /usr/bin/grafana-mimir")
+			require.Contains(t, text, "go mod edit \\")
+			require.Contains(t, text, "rm -rf vendor")
+			require.NotContains(t, text, "- uses: go/bump")
+			require.Less(t, strings.Index(text, "rm -f .gitconfig"), strings.Index(text, "go mod edit \\"))
+		})
+	}
+}
+
+func Test_Mimir_resolves_fixed_local_packages(t *testing.T) {
+	tests := []struct {
+		name        string
+		stream      string
+		fullVersion string
+	}{
+		{name: "3.0 stream", stream: "3.0", fullVersion: "3.0.7-r3"},
+		{name: "3.1 stream", stream: "3.1", fullVersion: "3.1.2-r2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: the default image template and the package built for this stream.
+			def, err := intconfig.LoadImage(filepath.Join("..", "images", "mimir.yaml"))
+			require.NoError(t, err)
+			tmpl := def.Types["default"]
+
+			// When: the local Melange artifact is pinned for image assembly.
+			err = pinLocalPackageVersions(&tmpl, tt.stream, []apkindex.Package{{
+				Name:    "grafana-mimir-" + tt.stream,
+				Version: tt.fullVersion,
+			}})
+
+			// Then: apko can only select the approved fixed local revision.
+			require.NoError(t, err)
+			require.Equal(t, []string{"grafana-mimir-" + tt.stream + "=" + tt.fullVersion + "@local"}, tmpl.Packages)
+		})
+	}
+}

--- a/cmd/mimir_config_test.go
+++ b/cmd/mimir_config_test.go
@@ -30,6 +30,18 @@ func Test_Mimir_uses_stream_scoped_bespoke_packages(t *testing.T) {
 	require.True(t, def.Versions["3.1"].Latest)
 }
 
+func Test_Mimir_renovate_does_not_update_version_without_source_pins(t *testing.T) {
+	// Given: the repository's Renovate custom-manager configuration.
+	config, err := os.ReadFile(filepath.Join("..", ".github", "renovate.json"))
+	require.NoError(t, err)
+
+	// When: Mimir-specific update rules are inspected.
+	text := string(config)
+
+	// Then: Renovate cannot change the package version without its coupled commit and checksum pins.
+	require.NotContains(t, text, "grafana-mimir-3")
+}
+
 func Test_Mimir_recipes_pin_fixed_sources(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -80,7 +92,7 @@ func Test_Mimir_recipes_pin_fixed_sources(t *testing.T) {
 			require.Contains(t, text, "Adapted from wolfi-dev/os@"+tt.baseline)
 			require.Contains(t, text, tt.commit+".tar.gz")
 			require.Contains(t, text, "expected-sha256: "+tt.checksum)
-			require.Contains(t, text, "      - git\n")
+			require.Regexp(t, `(?m)^\s*-\s+git\s*$`, text)
 			require.Contains(t, text, "golang.org/x/net@v0.57.0")
 			require.Contains(t, text, "golang.org/x/text@v0.40.0")
 			require.Contains(t, text, "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.44.0")

--- a/images/mimir.yaml
+++ b/images/mimir.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["grafana-mimir-{{version}}"]
     entrypoint: /usr/bin/mimir
+    melange:
+      bespoke: "grafana-mimir-{{version}}.yaml"
     paths:
       - {path: /etc/mimir, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /var/lib/mimir, type: directory, uid: 65532, gid: 65532, permissions: 0o755}

--- a/packages/bespoke/grafana-mimir-3.0.yaml
+++ b/packages/bespoke/grafana-mimir-3.0.yaml
@@ -1,0 +1,101 @@
+package:
+  name: grafana-mimir-3.0
+  version: "3.0.7"
+  # Direct revision r3 meets the latest fixed version reported for this stream.
+  epoch: 3
+  description: Horizontally scalable, highly available, multi-tenant long-term storage for Prometheus
+  copyright:
+    - license: AGPL-3.0-or-later
+  dependencies:
+    provides:
+      - grafana-mimir=${{package.full-version}}
+    runtime:
+      - ca-certificates-bundle
+  resources:
+    cpu: "4"
+    memory: 7Gi
+  test-resources:
+    cpu: "1"
+    memory: 2Gi
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@b137f48f69fd0d54416849cf09201ab5ff519562.
+  - uses: fetch
+    with:
+      uri: https://github.com/grafana/mimir/archive/c8a2454ab4fb93789a829890a63bc89107707114.tar.gz
+      expected-sha256: 9e108dbd5aaec06db4b1c7d7179016209926a854419bdc4b500d42e43e14371e
+
+  # The release tree pins an SSH URL for mimir-prometheus. Remove the
+  # checkout-specific rewrite before resolving modules over HTTPS.
+  - runs: rm -f .gitconfig
+
+  # Resolve the split OpenTelemetry modules as one graph. Sequential go get
+  # calls can incorrectly prefer the shorter go.opentelemetry.io/otel module.
+  - runs: |
+      rm -f go.sum
+      go mod edit \
+        -require=go.mongodb.org/mongo-driver@v1.17.9 \
+        -require=go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp@v0.20.0 \
+        -require=go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.44.0 \
+        -require=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.44.0 \
+        -require=go.opentelemetry.io/otel/exporters/stdout/stdoutlog@v0.20.0 \
+        -require=go.opentelemetry.io/otel/exporters/stdout/stdoutmetric@v1.44.0 \
+        -require=go.opentelemetry.io/otel/exporters/stdout/stdouttrace@v1.44.0 \
+        -require=golang.org/x/crypto@v0.54.0 \
+        -require=golang.org/x/net@v0.57.0 \
+        -require=golang.org/x/term@v0.45.0 \
+        -require=golang.org/x/text@v0.40.0
+      go mod tidy
+      rm -rf vendor
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/mimir
+      output: grafana-mimir
+      go-package: go-1.26
+      ldflags: |
+        -X github.com/grafana/mimir/pkg/util/version.Branch=release-3.0
+        -X github.com/grafana/mimir/pkg/util/version.Revision=c8a2454ab4fb93789a829890a63bc89107707114
+        -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}}
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/grafana-mimir" -version | grep -F "${{package.version}}"
+      "${{targets.destdir}}/usr/bin/grafana-mimir" --version | grep -F "${{package.version}}"
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+  pipeline:
+    - runs: |
+        grafana-mimir -version | grep -F "${{package.version}}"
+        grafana-mimir --version | grep -F "${{package.version}}"
+        apk info --who-owns /usr/bin/grafana-mimir \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        grep -F "GNU AFFERO GENERAL PUBLIC LICENSE" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - distributed
+    - weekly
+  github:
+    identifier: grafana/mimir
+    strip-prefix: mimir-
+    use-tag: true
+    tag-filter-prefix: mimir-3.0

--- a/packages/bespoke/grafana-mimir-3.1.yaml
+++ b/packages/bespoke/grafana-mimir-3.1.yaml
@@ -1,0 +1,101 @@
+package:
+  name: grafana-mimir-3.1
+  version: "3.1.2"
+  # Direct revision r2 exceeds the latest fixed version reported for this stream.
+  epoch: 2
+  description: Horizontally scalable, highly available, multi-tenant long-term storage for Prometheus
+  copyright:
+    - license: AGPL-3.0-or-later
+  dependencies:
+    provides:
+      - grafana-mimir=${{package.full-version}}
+    runtime:
+      - ca-certificates-bundle
+  resources:
+    cpu: "4"
+    memory: 7Gi
+  test-resources:
+    cpu: "1"
+    memory: 2Gi
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@bfb9155301a240694c98ec1f1f3e1a6fee92031f.
+  - uses: fetch
+    with:
+      uri: https://github.com/grafana/mimir/archive/e23940eb3a28c3e3f34968aa57d6a189370aa0f7.tar.gz
+      expected-sha256: f3a556c4fb50b00e88d5093570e209ebf54bd5b9d6c2d07606c8baa68f25e9bf
+
+  # The release tree pins an SSH URL for mimir-prometheus. Remove the
+  # checkout-specific rewrite before resolving modules over HTTPS.
+  - runs: rm -f .gitconfig
+
+  # Resolve the split OpenTelemetry modules as one graph. Sequential go get
+  # calls can incorrectly prefer the shorter go.opentelemetry.io/otel module.
+  - runs: |
+      rm -f go.sum
+      go mod edit \
+        -require=go.mongodb.org/mongo-driver@v1.17.9 \
+        -require=go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp@v0.20.0 \
+        -require=go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.44.0 \
+        -require=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.44.0 \
+        -require=go.opentelemetry.io/otel/exporters/stdout/stdoutlog@v0.20.0 \
+        -require=go.opentelemetry.io/otel/exporters/stdout/stdoutmetric@v1.44.0 \
+        -require=go.opentelemetry.io/otel/exporters/stdout/stdouttrace@v1.44.0 \
+        -require=golang.org/x/crypto@v0.54.0 \
+        -require=golang.org/x/net@v0.57.0 \
+        -require=golang.org/x/term@v0.45.0 \
+        -require=golang.org/x/text@v0.40.0
+      go mod tidy
+      rm -rf vendor
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/mimir
+      output: grafana-mimir
+      go-package: go-1.26
+      ldflags: |
+        -X github.com/grafana/mimir/pkg/util/version.Branch=release-3.1
+        -X github.com/grafana/mimir/pkg/util/version.Revision=e23940eb3a28c3e3f34968aa57d6a189370aa0f7
+        -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}}
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/grafana-mimir" -version | grep -F "${{package.version}}"
+      "${{targets.destdir}}/usr/bin/grafana-mimir" --version | grep -F "${{package.version}}"
+      install -Dm644 LICENSE "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+  pipeline:
+    - runs: |
+        grafana-mimir -version | grep -F "${{package.version}}"
+        grafana-mimir --version | grep -F "${{package.version}}"
+        apk info --who-owns /usr/bin/grafana-mimir \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        grep -F "GNU AFFERO GENERAL PUBLIC LICENSE" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - distributed
+    - weekly
+  github:
+    identifier: grafana/mimir
+    strip-prefix: mimir-
+    use-tag: true
+    tag-filter-prefix: mimir-3.1


### PR DESCRIPTION
## Summary

- own `mimir:3.0-default` with `grafana-mimir-3.0=3.0.7-r3`
- own `mimir:3.1-default` with `grafana-mimir-3.1=3.1.2-r2`
- build immutable Grafana Mimir commits with verified source archive SHA-256 checksums
- retain the existing `/usr/bin/mimir` runtime contract and stream-scoped package names
- classify Mimir as a manually pinned source and add focused package/image regressions

## Current RED revalidation (2026-07-16)

The official Wolfi x86_64 and aarch64 indexes still publish:

- `grafana-mimir-3.0=3.0.6-r5`
- `grafana-mimir-3.1=3.1.0-r0`

Trivy 0.72.0 reports:

- 3.0: `CVE-2026-2303`, `CVE-2026-41178`, `CVE-2026-42505`
- 3.1: `CVE-2026-41178`

All are fixed-status findings; no NO_FIX findings were present.

## Local evidence

- `go test -race -shuffle=on -count=1 ./...`
- `make lint-workflows`
- `make lint-yaml`
- Integer config and Renovate coverage validation
- native amd64 Melange package builds for both streams
- native amd64 image builds and runtime/version smoke
- packaged AGPL license and SPDX `licenseDeclared=AGPL-3.0-or-later`
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings for both images

PR CI supplies the required native amd64/arm64 matrix evidence.
