### PR TITLE
fix(integer): own pluto package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -44,7 +44,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml",
-    "packages/bespoke/metrics-server.yaml",
+    "packages/bespoke/metrics-server.yaml", "packages/bespoke/pluto.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/cmd/pluto_config_test.go
+++ b/cmd/pluto_config_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Pluto_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Pluto image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "pluto.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "pluto.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"pluto"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/pluto", tmpl.Entrypoint)
+	require.Contains(t, def.Versions, "5")
+}
+
+func Test_Pluto_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "pluto.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, build, test, and license metadata are inspected.
+
+	// Then: revision r9 rebuilds immutable Apache-2.0 v5.24.0 source with a patched Go toolchain.
+	require.Contains(t, text, "name: pluto")
+	require.Contains(t, text, "# renovate: datasource=github-tags depName=FairwindsOps/pluto versioning=semver-coerced")
+	require.Contains(t, text, "version: \"5.24.0\"")
+	require.Contains(t, text, "epoch: 9")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@3c0cdd0d7d4d2933e3aa3cae7bde1c87319a9151")
+	require.Contains(t, text, "dd5ec8cccce5e42dfe8054b8250baa35546056a0.tar.gz")
+	require.Contains(t, text, "expected-sha256: 3abb9e72670f7466157b225ccdf68004122b4cefa54d9b7a9af687bb810cffc2")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "go get golang.org/x/net@v0.55.0")
+	require.Contains(t, text, "packages: ./cmd/pluto/main.go")
+	require.Contains(t, text, "output: pluto")
+	require.Contains(t, text, "main.version=${{package.version}}")
+	require.Contains(t, text, "main.commit=dd5ec8cccce5e42dfe8054b8250baa35546056a0")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "pluto detect")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/pluto")
+}
+
+func Test_Pluto_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "pluto.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "5", []apkindex.Package{{
+		Name:    "pluto",
+		Version: "5.24.0-r9",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"pluto=5.24.0-r9@local"}, tmpl.Packages)
+}

--- a/images/pluto.yaml
+++ b/images/pluto.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["pluto"]
     entrypoint: /usr/bin/pluto
+    melange:
+      bespoke: pluto.yaml
 
 versions:
   "5": {}

--- a/packages/bespoke/pluto.yaml
+++ b/packages/bespoke/pluto.yaml
@@ -1,0 +1,95 @@
+package:
+  name: pluto
+  # renovate: datasource=github-tags depName=FairwindsOps/pluto versioning=semver-coerced
+  version: "5.24.0"
+  # Direct revision r9 rebuilds with patched Go 1.26 for CVE-2026-42505.
+  epoch: 9
+  description: A CLI tool to discover deprecated Kubernetes apiVersions
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 5Gi
+  test-resources:
+    cpu: "1"
+    memory: 2Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@3c0cdd0d7d4d2933e3aa3cae7bde1c87319a9151.
+  # v5.24.0 resolves to dd5ec8cccce5e42dfe8054b8250baa35546056a0.
+  - uses: fetch
+    with:
+      uri: https://github.com/FairwindsOps/pluto/archive/dd5ec8cccce5e42dfe8054b8250baa35546056a0.tar.gz
+      expected-sha256: 3abb9e72670f7466157b225ccdf68004122b4cefa54d9b7a9af687bb810cffc2
+
+  - runs: |
+      go get golang.org/x/net@v0.55.0
+      go mod tidy
+
+  - uses: go/build
+    with:
+      packages: ./cmd/pluto/main.go
+      output: pluto
+      go-package: go-1.26
+      ldflags: |-
+        -X main.version=${{package.version}}
+        -X main.commit=dd5ec8cccce5e42dfe8054b8250baa35546056a0
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/pluto" version \
+        | grep -F "${{package.version}}"
+      "${{targets.destdir}}/usr/bin/pluto" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+        - jq
+  pipeline:
+    - runs: |
+        pluto version | grep -F "${{package.version}}"
+        pluto --help >/dev/null
+        pluto completion bash > /tmp/pluto-completion.bash
+        test -s /tmp/pluto-completion.bash
+        cat > /tmp/deprecated.yaml <<'EOF'
+        apiVersion: apps/v1beta1
+        kind: Deployment
+        metadata:
+          name: deprecated-deployment
+        spec:
+          template:
+            spec:
+              containers:
+                - name: nginx
+                  image: nginx
+        EOF
+        set +e
+        pluto detect /tmp/deprecated.yaml --output json > /tmp/pluto-output.json
+        status=$?
+        set -e
+        test "$status" -eq 3
+        jq -e '.items[] | select(.deprecated == true)' /tmp/pluto-output.json
+        apk info --who-owns /usr/bin/pluto \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license pluto | grep -F "Apache-2.0"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: FairwindsOps/pluto
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v


### PR DESCRIPTION
## Summary

- own Pluto 5.24.0 as a bespoke r9 package built from immutable upstream commit dd5ec8cccce5e42dfe8054b8250baa35546056a0
- retain the Wolfi x/net remediation and rebuild with patched Go 1.26
- wire Pluto images to the local signed package and add focused configuration regression coverage

## Security evidence

- official Wolfi indexes on 2026-07-16: 5.24.0-r5 on amd64 and arm64
- current Trivy/Wolfi secdb: CVE-2026-42505 MEDIUM, fixed in 5.24.0-r9; no unfixed or NO_FIX findings
- pre-fix strict scans: 1 finding on each architecture
- post-fix strict scans: 0 UNKNOWN, LOW, MEDIUM, HIGH, or CRITICAL findings on each architecture
- SPDX 2.3 image SBOMs declare pluto 5.24.0-r9 as Apache-2.0

## Verification

- focused Pluto regression: red before ownership, green after
- signed Melange package builds: x86_64 and aarch64
- image builds and version/runtime smoke: amd64 and arm64
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run ./...
- Renovate coverage validation

Native amd64 and arm64 package/image/Trivy lanes are delegated to the PR workflow runners.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own the `pluto` 5.24.0 package as a bespoke `Melange` build (r9) and pin the image to it to remediate CVE-2026-42505 and clear all scan findings. Adds focused tests to lock the image config and source revision.

- **Bug Fixes**
  - Rebuilt `pluto` 5.24.0-r9 from immutable commit dd5ec8cccce5e42dfe8054b8250baa35546056a0 with patched `go-1.26` and `golang.org/x/net@v0.55.0`.
  - Strict `Trivy`/`Wolfi` scans now report 0 findings on amd64 and arm64.

- **Dependencies**
  - Added `packages/bespoke/pluto.yaml` and wired `images/pluto.yaml` to the bespoke `Melange` recipe.
  - Added `cmd/pluto_config_test.go` to pin package/version and updated `.github/scripts/validate-renovate-coverage.py` to include the new recipe.

<sup>Written for commit 4e0f885f72cca88ebb553220e963d83f839ac3ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

