### PR TITLE
fix(integer): own nfs-subdir-external-provisioner package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -43,7 +43,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.2.yaml",
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
-    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml",
+    "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml", "packages/bespoke/nfs-subdir-external-provisioner.yaml",
     "packages/bespoke/metrics-server.yaml", "packages/bespoke/pluto.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {

--- a/cmd/nfs_subdir_external_provisioner_config_test.go
+++ b/cmd/nfs_subdir_external_provisioner_config_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_NFSSubdirExternalProvisioner_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in NFS subdir external provisioner image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "nfs-subdir-external-provisioner.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "nfs-subdir-external-provisioner.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"nfs-subdir-external-provisioner"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/nfs-subdir-external-provisioner", tmpl.Entrypoint)
+	require.Contains(t, def.Versions, "4")
+}
+
+func Test_NFSSubdirExternalProvisioner_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "nfs-subdir-external-provisioner.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, build, test, and license metadata are inspected.
+
+	// Then: direct revision r44 rebuilds immutable Apache-2.0 v4.0.18 source with fixed Go.
+	require.Contains(t, text, "name: nfs-subdir-external-provisioner")
+	require.Contains(t, text, "version: \"4.0.18\"")
+	require.Contains(t, text, "epoch: 44")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@5637ed9b389b64dbf9b76eaddcebfb09cce4e807")
+	require.Contains(t, text, "c2a2d5d544781e3d3e4d7a7e2d21a8e64cf6d9d1.tar.gz")
+	require.Contains(t, text, "expected-sha256: 63a2b7adc859ec25e98b705aadc402f1fa8de4e9fa9f0baab4ac372768bcd9f3")
+	require.Contains(t, text, "golang.org/x/crypto@v0.52.0")
+	require.Contains(t, text, "golang.org/x/net@v0.55.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/nfs-subdir-external-provisioner")
+	require.Contains(t, text, "output: nfs-subdir-external-provisioner")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "nfs-subdir-external-provisioner --help")
+	require.Contains(t, text, "go version -m /usr/bin/nfs-subdir-external-provisioner")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/nfs-subdir-external-provisioner")
+	require.Contains(t, text, "PROVISIONER_NAME=test/nfs-provisioner")
+	require.Contains(t, text, "Failed to create kubeconfig")
+}
+
+func Test_NFSSubdirExternalProvisioner_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "nfs-subdir-external-provisioner.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "4", []apkindex.Package{{
+		Name:    "nfs-subdir-external-provisioner",
+		Version: "4.0.18-r44",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"nfs-subdir-external-provisioner=4.0.18-r44@local"}, tmpl.Packages)
+}

--- a/images/nfs-subdir-external-provisioner.yaml
+++ b/images/nfs-subdir-external-provisioner.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["nfs-subdir-external-provisioner"]
     entrypoint: /usr/bin/nfs-subdir-external-provisioner
+    melange:
+      bespoke: nfs-subdir-external-provisioner.yaml
 
 versions:
   "4": {}

--- a/packages/bespoke/nfs-subdir-external-provisioner.yaml
+++ b/packages/bespoke/nfs-subdir-external-provisioner.yaml
@@ -1,0 +1,99 @@
+package:
+  name: nfs-subdir-external-provisioner
+  # renovate: datasource=github-tags depName=kubernetes-sigs/nfs-subdir-external-provisioner versioning=semver-coerced
+  version: "4.0.18"
+  # Direct revision r44 replaces vulnerable public revision 4.0.18-r42.
+  epoch: 44
+  description: Dynamic sub-dir volume provisioner on a remote NFS server
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "2"
+    memory: 5Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@5637ed9b389b64dbf9b76eaddcebfb09cce4e807.
+  # nfs-subdir-external-provisioner-4.0.18 resolves to c2a2d5d544781e3d3e4d7a7e2d21a8e64cf6d9d1.
+  - uses: fetch
+    with:
+      uri: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/archive/c2a2d5d544781e3d3e4d7a7e2d21a8e64cf6d9d1.tar.gz
+      expected-sha256: 63a2b7adc859ec25e98b705aadc402f1fa8de4e9fa9f0baab4ac372768bcd9f3
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.52.0
+      modroot: vendor/github.com/miekg/dns
+      tidy: false
+
+  - uses: go/bump
+    with:
+      deps: |-
+        golang.org/x/crypto@v0.52.0
+        golang.org/x/text@v0.37.0
+        gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e
+        google.golang.org/protobuf@v1.33.0
+        github.com/prometheus/client_golang@v1.11.1
+        github.com/golang/glog@v1.2.4
+        golang.org/x/oauth2@v0.27.0
+        golang.org/x/net@v0.55.0
+      replaces: github.com/prometheus/client_golang=github.com/prometheus/client_golang@v1.11.1
+
+  - uses: go/build
+    with:
+      packages: ./cmd/nfs-subdir-external-provisioner
+      output: nfs-subdir-external-provisioner
+      go-package: go-1.26
+      vendor: true
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/nfs-subdir-external-provisioner" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+        - go-1.26
+  pipeline:
+    - runs: |
+        nfs-subdir-external-provisioner --help >/dev/null
+        go version -m /usr/bin/nfs-subdir-external-provisioner \
+          | grep -F "go1.26"
+        go version -m /usr/bin/nfs-subdir-external-provisioner \
+          | grep -A1 -F "golang.org/x/crypto" \
+          | grep -F "v0.52.0"
+        go version -m /usr/bin/nfs-subdir-external-provisioner \
+          | grep -F "golang.org/x/net" \
+          | grep -F "v0.55.0"
+        apk info --who-owns /usr/bin/nfs-subdir-external-provisioner \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license "${{package.name}}" | grep -F "Apache-2.0"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+        output="$(env \
+          NFS_SERVER=127.0.0.1 \
+          NFS_PATH=/exports \
+          PROVISIONER_NAME=test/nfs-provisioner \
+          KUBECONFIG=/nonexistent \
+          nfs-subdir-external-provisioner 2>&1 || true)"
+        printf '%s\n' "$output" | grep -F "Failed to create kubeconfig"
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/nfs-subdir-external-provisioner
+    strip-prefix: nfs-subdir-external-provisioner-
+    tag-filter: nfs-subdir-external-provisioner-


### PR DESCRIPTION
## Summary
- own `nfs-subdir-external-provisioner` as a bespoke `4.0.18-r44` package
- build immutable upstream commit `c2a2d5d544781e3d3e4d7a7e2d21a8e64cf6d9d1` with SHA-256 verification
- preserve Apache-2.0 licensing, runtime entrypoint, and package metadata
- pin the image to the locally built APK and add focused regression coverage

## Security evidence
- July 16, 2026 official Wolfi indexes: `4.0.18-r42` is the latest published revision for both x86_64 and aarch64
- Trivy v0.72.0 / Wolfi SecDB RED on both architectures: `CVE-2026-42505` (MEDIUM), installed `4.0.18-r42`, fixed `4.0.18-r44`, status `fixed`; no NO_FIX finding
- native amd64 and arm64 package/image build jobs installed `4.0.18-r44`
- native amd64 and arm64 smoke jobs used the matching architecture and reported `Total vulnerabilities: 0`
- strict Trivy gates covered `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` with OS and library scanning
- NFS chart integration/runtime smoke passed
- embedded SPDX 2.3 declares `nfs-subdir-external-provisioner` `4.0.18-r44` as Apache-2.0 and records the immutable source checksum
- no ignores, suppressions, exclusions, severity reductions, or architecture skips

## Validation
- focused RED then green regression
- `go test -race -shuffle=on -count=1 ./...`
- `go vet ./...`
- Renovate coverage validation
- all 334 Integer configs valid
- native Integer build: amd64 + arm64
- native Integer smoke/strict Trivy: amd64 + arm64
- chart integration: passed
- Cubic review: no issues found
