### PR TITLE
fix(integer): own openbao package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -44,7 +44,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml", "packages/bespoke/nfs-subdir-external-provisioner.yaml",
-    "packages/bespoke/metrics-server.yaml", "packages/bespoke/pluto.yaml",
+    "packages/bespoke/metrics-server.yaml", "packages/bespoke/openbao.yaml", "packages/bespoke/pluto.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/cmd/openbao_config_test.go
+++ b/cmd/openbao_config_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_OpenBao_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in OpenBao image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "openbao.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and its runnable binary.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "openbao.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"openbao"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/bao server", tmpl.Entrypoint)
+	require.Contains(t, def.Versions, "2")
+}
+
+func Test_OpenBao_recipe_pins_fixed_source_revision(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "openbao.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, build, test, and license metadata are inspected.
+
+	// Then: revision r2 builds immutable MPL-2.0 v2.5.5 source with the remediated toolchain.
+	require.Contains(t, text, "name: openbao")
+	require.Contains(t, text, "# renovate: datasource=github-tags depName=openbao/openbao versioning=semver-coerced")
+	require.Contains(t, text, "version: \"2.5.5\"")
+	require.Contains(t, text, "epoch: 2")
+	require.Contains(t, text, "license: MPL-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@bc7cfd54e91daae028cc3411d5c6f9b5fa8483ea")
+	require.Contains(t, text, "028992583c693c4de6350b8aa52ff85e30375a99.tar.gz")
+	require.Contains(t, text, "expected-sha256: 92372e664f9a03968e619023cf49cf7ac8fc954c3314b545e0e1af69038ab28e")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "make ember-dist")
+	require.Contains(t, text, "output: bao")
+	require.Contains(t, text, "version.fullVersion=${{package.version}}")
+	require.Contains(t, text, "version.GitCommit=028992583c693c4de6350b8aa52ff85e30375a99")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "apk info --license openbao")
+	require.Contains(t, text, "bao server -dev")
+	require.Contains(t, text, "bao status")
+}
+
+func Test_OpenBao_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "openbao.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "2", []apkindex.Package{{
+		Name:    "openbao",
+		Version: "2.5.5-r2",
+	}})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"openbao=2.5.5-r2@local"}, tmpl.Packages)
+}

--- a/cmd/openbao_config_test.go
+++ b/cmd/openbao_config_test.go
@@ -50,6 +50,8 @@ func Test_OpenBao_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "version.fullVersion=${{package.version}}")
 	require.Contains(t, text, "version.GitCommit=028992583c693c4de6350b8aa52ff85e30375a99")
 	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "${{targets.destdir}}/usr/bin/bao\" server -dev -dev-listen-address=127.0.0.1:18200")
+	require.Contains(t, text, "BAO_ADDR=http://127.0.0.1:18200")
 	require.Contains(t, text, "apk info --license openbao")
 	require.Contains(t, text, "bao server -dev")
 	require.Contains(t, text, "bao status")

--- a/cmd/openbao_config_test.go
+++ b/cmd/openbao_config_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,6 +53,7 @@ func Test_OpenBao_recipe_pins_fixed_source_revision(t *testing.T) {
 	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
 	require.Contains(t, text, "${{targets.destdir}}/usr/bin/bao\" server -dev -dev-listen-address=127.0.0.1:18200")
 	require.Contains(t, text, "BAO_ADDR=http://127.0.0.1:18200")
+	require.Equal(t, 2, strings.Count(text, "curl --fail-with-body --silent --show-error"))
 	require.Contains(t, text, "apk info --license openbao")
 	require.Contains(t, text, "bao server -dev")
 	require.Contains(t, text, "bao status")

--- a/images/openbao.yaml
+++ b/images/openbao.yaml
@@ -7,7 +7,9 @@ types:
   default:
     base: wolfi-base
     packages: ["openbao"]
-    entrypoint: /usr/bin/openbao server
+    entrypoint: /usr/bin/bao server
+    melange:
+      bespoke: openbao.yaml
     environment:
       HOME: /home/openbao
     paths:

--- a/packages/bespoke/openbao.yaml
+++ b/packages/bespoke/openbao.yaml
@@ -72,7 +72,7 @@ pipeline:
       trap 'kill "$BAO_SERVER" 2>/dev/null || true' EXIT
       wait-for-it 127.0.0.1:18200 -t 30
       "${{targets.destdir}}/usr/bin/bao" status
-      curl --fail --silent --show-error \
+      curl --fail-with-body --silent --show-error \
         'http://127.0.0.1:18200/v1/sys/health'
       kill "$BAO_SERVER"
       wait "$BAO_SERVER" || true
@@ -102,7 +102,7 @@ test:
         trap 'kill "$BAO_SERVER" 2>/dev/null || true' EXIT
         wait-for-it 127.0.0.1:8200 -t 30
         bao status
-        curl --fail --silent --show-error \
+        curl --fail-with-body --silent --show-error \
           'http://127.0.0.1:8200/v1/sys/health'
         kill "$BAO_SERVER"
         wait "$BAO_SERVER" || true

--- a/packages/bespoke/openbao.yaml
+++ b/packages/bespoke/openbao.yaml
@@ -30,9 +30,11 @@ environment:
   contents:
     packages:
       - busybox
+      - curl
       - go-1.26
       - nodejs-${{vars.nodejs-version}}
       - npm
+      - wait-for-it
       - yarn
 
 pipeline:
@@ -63,6 +65,18 @@ pipeline:
         | grep -F "${{package.version}}"
       install -Dm644 LICENSE \
         "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+      export BAO_ADDR=http://127.0.0.1:18200
+      "${{targets.destdir}}/usr/bin/bao" server -dev -dev-listen-address=127.0.0.1:18200 \
+        >/tmp/openbao-build.log 2>&1 &
+      BAO_SERVER=$!
+      trap 'kill "$BAO_SERVER" 2>/dev/null || true' EXIT
+      wait-for-it 127.0.0.1:18200 -t 30
+      "${{targets.destdir}}/usr/bin/bao" status
+      curl --fail --silent --show-error \
+        'http://127.0.0.1:18200/v1/sys/health'
+      kill "$BAO_SERVER"
+      wait "$BAO_SERVER" || true
+      trap - EXIT
 
 test:
   environment:

--- a/packages/bespoke/openbao.yaml
+++ b/packages/bespoke/openbao.yaml
@@ -1,0 +1,101 @@
+package:
+  name: openbao
+  # renovate: datasource=github-tags depName=openbao/openbao versioning=semver-coerced
+  version: "2.5.5"
+  # Direct revision r2 replaces the stale public Wolfi 2.5.4-r2 package.
+  epoch: 2
+  description: OpenBao manages, stores, and distributes sensitive data including secrets, certificates, and keys
+  copyright:
+    - license: MPL-2.0
+  resources:
+    cpu: "4"
+    memory: 12Gi
+  dependencies:
+    runtime:
+      - merged-bin
+      - wolfi-baselayout
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+vars:
+  # Node 25 removed util.isRegExp, which clean-css needs for the Ember build.
+  nodejs-version: 22
+
+environment:
+  environment:
+    HOME: /tmp
+    NODE_OPTIONS: "--max-old-space-size=16384"
+    XDG_CONFIG_HOME: /tmp/.config
+  contents:
+    packages:
+      - busybox
+      - go-1.26
+      - nodejs-${{vars.nodejs-version}}
+      - npm
+      - yarn
+
+pipeline:
+  # Adapted from wolfi-dev/os@bc7cfd54e91daae028cc3411d5c6f9b5fa8483ea.
+  # v2.5.5 resolves to 028992583c693c4de6350b8aa52ff85e30375a99.
+  - uses: fetch
+    with:
+      uri: https://github.com/openbao/openbao/archive/028992583c693c4de6350b8aa52ff85e30375a99.tar.gz
+      expected-sha256: 92372e664f9a03968e619023cf49cf7ac8fc954c3314b545e0e1af69038ab28e
+
+  - runs: |
+      export JOBS=1
+      make ember-dist
+
+  - uses: go/build
+    with:
+      tags: openbao,ui
+      packages: .
+      output: bao
+      go-package: go-1.26
+      ldflags: |
+        -X github.com/openbao/openbao/version.fullVersion=${{package.version}}
+        -X github.com/openbao/openbao/version.GitCommit=028992583c693c4de6350b8aa52ff85e30375a99
+        -X github.com/openbao/openbao/version.BuildDate='$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")'
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/bao" --version \
+        | grep -F "${{package.version}}"
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - curl
+        - wait-for-it
+    environment:
+      BAO_ADDR: http://127.0.0.1:8200
+  pipeline:
+    - runs: |
+        bao --version | grep -F "${{package.version}}"
+        apk info --who-owns /usr/bin/bao \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license openbao | grep -F "MPL-2.0"
+        grep -F "Mozilla Public License, version 2.0" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+    - name: Run a dev server and check basic health
+      runs: |
+        bao server -dev >/tmp/openbao.log 2>&1 &
+        BAO_SERVER=$!
+        trap 'kill "$BAO_SERVER" 2>/dev/null || true' EXIT
+        wait-for-it 127.0.0.1:8200 -t 30
+        bao status
+        curl --fail --silent --show-error \
+          'http://127.0.0.1:8200/v1/sys/health'
+        kill "$BAO_SERVER"
+        wait "$BAO_SERVER" || true
+        trap - EXIT
+
+update:
+  enabled: true
+  github:
+    identifier: openbao/openbao
+    strip-prefix: v


### PR DESCRIPTION
## Summary
- own OpenBao 2.5.5-r2 from immutable upstream commit 028992583c693c4de6350b8aa52ff85e30375a99 with SHA-256 verification and MPL-2.0 license evidence
- pin openbao:2-default to the local APK and correct the runtime entrypoint to /usr/bin/bao server
- enforce version and live dev-server health during every native package build, with response-body diagnostics on HTTP failures
- add focused regressions for provenance, package pinning, entrypoint, license, and health coverage

## Current RED (2026-07-16)
- official Wolfi x86_64 and aarch64 APK indexes both top out at openbao 2.5.4-r2
- Trivy 0.72.0 reports CVE-2026-41178 (MEDIUM) on both published architecture digests
- installed: 2.5.4-r2; fixed: 2.5.5-r2; NO_FIX findings: 0

## Validation
- focused regression demonstrated RED before the recipe/image changes
- go test -race -shuffle=on -count=1 ./cmd
- go run . integer validate
- python3 .github/scripts/validate-renovate-coverage.py
- local native x86_64 package and amd64 image build
- local SPDX-2.3: openbao 2.5.5-r2, declared license MPL-2.0
- local strict Trivy UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL: 0 findings, 0 NO_FIX

## Native CI evidence
PR Test run 29467640519 on head 8768c9f08ba8717ffd811e3808a07f45697798ce:

- amd64 build and smoke: OpenBao v2.5.5; initialized=true; sealed=false; MPL-2.0; loaded amd64 image; total vulnerabilities 0
- arm64 build and smoke on ubuntu-24.04-arm: OpenBao v2.5.5; initialized=true; sealed=false; MPL-2.0; loaded arm64 image; total vulnerabilities 0
- both paths use strict Trivy exit-code enforcement for UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
- required PR Test aggregate passed
