### PR TITLE
fix(integer): own pgbouncer package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,6 +40,18 @@
     },
     {
       "customType": "regex",
+      "description": "PgBouncer package releases",
+      "managerFilePatterns": ["/^packages/bespoke/pgbouncer\\.yaml$/"],
+      "matchStrings": [
+        "package:\\n\\s+name:\\s*pgbouncer\\n\\s+#\\s*renovate:[^\\n]+\\n\\s+version:\\s*[\\\"']?(?<currentValue>[\\w.+-]+)[\\\"']?"
+      ],
+      "depNameTemplate": "pgbouncer/pgbouncer",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "regex:^(?<major>\\d+)[._](?<minor>\\d+)[._](?<patch>\\d+)$",
+      "extractVersionTemplate": "^pgbouncer_(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
       "description": "Bespoke GitHub package releases",
       "managerFilePatterns": ["/^packages/bespoke/(?:locked/)?[^/]+\\.ya?ml$/"],
       "matchStrings": [

--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -44,7 +44,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml", "packages/bespoke/nfs-subdir-external-provisioner.yaml",
-    "packages/bespoke/metrics-server.yaml", "packages/bespoke/pluto.yaml",
+    "packages/bespoke/metrics-server.yaml", "packages/bespoke/pgbouncer.yaml", "packages/bespoke/pluto.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -17,6 +17,7 @@ SYNC_WORKFLOW_PATH: Final = ROOT / ".github/workflows/integer-sync.yaml"
 
 REQUIRED_CUSTOM_MANAGERS: Final = {
     "Annotated dependencies",
+    "PgBouncer package releases",
     "Bespoke GitHub package releases",
     "Bespoke prefixed GitHub package releases",
     "Dex package releases",

--- a/cmd/pgbouncer_config_test.go
+++ b/cmd/pgbouncer_config_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_PgBouncer_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in PgBouncer image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "pgbouncer.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its nonroot runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "pgbouncer.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"pgbouncer"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/pgbouncer /etc/pgbouncer/pgbouncer.ini", tmpl.Entrypoint)
+	require.Contains(t, tmpl.Paths, intconfig.PathDef{
+		Path:        "/tmp/pgbouncer",
+		Type:        "directory",
+		UID:         65532,
+		GID:         65532,
+		Permissions: "0o755",
+	})
+	require.Contains(t, def.Versions, "1")
+}
+
+func Test_PgBouncer_recipe_pins_immutable_release(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "pgbouncer.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its source, build, runtime, test, configuration, and license metadata are inspected.
+
+	// Then: revision r0 rebuilds the immutable ISC-licensed 1.25.2 security release.
+	require.Contains(t, text, "name: pgbouncer")
+	require.Contains(t, text, "version: \"1.25.2\"")
+	require.Contains(t, text, "epoch: 0")
+	require.Contains(t, text, "license: ISC")
+	require.Contains(t, text, "515b6284d273bfd62d1b7e3931ccdce41f9bfe7b")
+	require.Contains(t, text, "pgbouncer-${{package.version}}.tar.gz")
+	require.Contains(t, text, "expected-sha256: 924ad35113fd0a71c8e2dbe85b5d03445532e2b7b37a9f8a48983beea238b332")
+	require.Contains(t, text, "make -j$(nproc) pgbouncer")
+	require.NotContains(t, text, "pandoc")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/COPYRIGHT")
+	require.Contains(t, text, "etc/pgbouncer/pgbouncer.ini")
+	require.Contains(t, text, "etc/pgbouncer/userlist.txt")
+	require.Contains(t, text, "listen_addr = 0.0.0.0")
+	require.Contains(t, text, "pgbouncer --version")
+	require.Contains(t, text, "test -S /tmp/pgbouncer/.s.PGSQL.6432")
+	require.Contains(t, text, "apk info --license pgbouncer")
+}
+
+func Test_PgBouncer_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "pgbouncer.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "pgbouncer",
+		Version: "1.25.2-r0",
+	}})
+
+	// Then: apko can only select the approved locally built security release.
+	require.NoError(t, err)
+	require.Equal(t, []string{"pgbouncer=1.25.2-r0@local"}, tmpl.Packages)
+}

--- a/cmd/pgbouncer_config_test.go
+++ b/cmd/pgbouncer_config_test.go
@@ -77,3 +77,23 @@ func Test_PgBouncer_resolves_fixed_local_package(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"pgbouncer=1.25.2-r0@local"}, tmpl.Packages)
 }
+
+func Test_PgBouncer_renovate_tracks_prefixed_release_tags(t *testing.T) {
+	// Given: the PgBouncer recipe and repository Renovate configuration.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "pgbouncer.yaml"))
+	require.NoError(t, err)
+	renovate, err := os.ReadFile(filepath.Join("..", ".github", "renovate.json"))
+	require.NoError(t, err)
+
+	// When: the dependency annotation and dedicated release manager are inspected.
+	recipeText := string(recipe)
+	renovateText := string(renovate)
+
+	// Then: dotted package versions are compared with upstream pgbouncer_N_N_N release names.
+	require.Contains(t, recipeText, "# renovate: datasource=github-releases depName=pgbouncer/pgbouncer")
+	require.Contains(t, recipeText, "extractVersion=^pgbouncer_(?<version>.*)$")
+	require.Contains(t, renovateText, "\"description\": \"PgBouncer package releases\"")
+	require.Contains(t, renovateText, "\"datasourceTemplate\": \"github-releases\"")
+	require.Contains(t, renovateText, "\"extractVersionTemplate\": \"^pgbouncer_(?<version>.*)$\"")
+	require.Contains(t, renovateText, "[._]")
+}

--- a/images/pgbouncer.yaml
+++ b/images/pgbouncer.yaml
@@ -1,5 +1,5 @@
 name: pgbouncer
-description: "PgBouncer PostgreSQL connection pooler — Wolfi rebuild targets Debian CVEs"
+description: "PgBouncer PostgreSQL connection pooler — immutable Wolfi rebuild for zero-CVE runtime"
 upstream:
   package: pgbouncer
 
@@ -7,9 +7,12 @@ types:
   default:
     base: wolfi-base
     packages: ["pgbouncer"]
-    entrypoint: pgbouncer /etc/pgbouncer/pgbouncer.ini
+    entrypoint: /usr/bin/pgbouncer /etc/pgbouncer/pgbouncer.ini
+    melange:
+      bespoke: pgbouncer.yaml
     paths:
       - {path: /etc/pgbouncer, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+      - {path: /tmp/pgbouncer, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /var/log/pgbouncer, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 
 versions:

--- a/packages/bespoke/pgbouncer.yaml
+++ b/packages/bespoke/pgbouncer.yaml
@@ -1,5 +1,6 @@
 package:
   name: pgbouncer
+  # renovate: datasource=github-releases depName=pgbouncer/pgbouncer versioning=regex:^(?<major>\d+)[._](?<minor>\d+)[._](?<patch>\d+)$ extractVersion=^pgbouncer_(?<version>.*)$
   version: "1.25.2"
   epoch: 0
   description: Lightweight connection pooler for PostgreSQL

--- a/packages/bespoke/pgbouncer.yaml
+++ b/packages/bespoke/pgbouncer.yaml
@@ -1,0 +1,107 @@
+package:
+  name: pgbouncer
+  version: "1.25.2"
+  epoch: 0
+  description: Lightweight connection pooler for PostgreSQL
+  copyright:
+    - license: ISC
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - c-ares-dev
+      - libevent-dev
+      - openssl-dev
+      - pkgconf
+
+pipeline:
+  # pgbouncer_1_25_2 resolves to 515b6284d273bfd62d1b7e3931ccdce41f9bfe7b.
+  - uses: fetch
+    with:
+      uri: https://github.com/pgbouncer/pgbouncer/releases/download/pgbouncer_${{vars.mangled-package-version}}/pgbouncer-${{package.version}}.tar.gz
+      expected-sha256: 924ad35113fd0a71c8e2dbe85b5d03445532e2b7b37a9f8a48983beea238b332
+
+  - runs: |
+      ./configure \
+        --prefix=/usr \
+        --bindir=/usr/bin \
+        --sysconfdir=/etc \
+        --with-cares
+      make -j$(nproc) pgbouncer
+      install -Dm755 pgbouncer \
+        "${{targets.destdir}}/usr/bin/pgbouncer"
+      install -Dm644 COPYRIGHT \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/COPYRIGHT"
+      install -d -m755 \
+        "${{targets.destdir}}/etc/pgbouncer"
+      cat > "${{targets.destdir}}/etc/pgbouncer/pgbouncer.ini" <<'EOF'
+      [databases]
+
+      [pgbouncer]
+      listen_addr = 0.0.0.0
+      listen_port = 6432
+      unix_socket_dir = /tmp/pgbouncer
+      auth_type = scram-sha-256
+      auth_file = /etc/pgbouncer/userlist.txt
+      pool_mode = transaction
+      pidfile = /tmp/pgbouncer/pgbouncer.pid
+      logfile =
+      EOF
+      install -Dm644 /dev/null \
+        "${{targets.destdir}}/etc/pgbouncer/userlist.txt"
+
+  - uses: strip
+
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.'
+    replace: '_'
+    to: mangled-package-version
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+        - sudo-rs
+  pipeline:
+    - runs: |
+        pgbouncer --version | grep -F "PgBouncer ${{package.version}}"
+        pgbouncer --help >/dev/null
+        apk info --who-owns /usr/bin/pgbouncer \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license pgbouncer | grep -F "ISC"
+        grep -F "ISC License" \
+          "/usr/share/licenses/${{package.name}}/COPYRIGHT"
+        grep -F "auth_type = scram-sha-256" \
+          /etc/pgbouncer/pgbouncer.ini
+        test -f /etc/pgbouncer/userlist.txt
+
+        install -d -o build -g build -m755 /tmp/pgbouncer
+        sudo -u build pgbouncer /etc/pgbouncer/pgbouncer.ini \
+          >/tmp/pgbouncer/startup.log 2>&1 &
+        pid=$!
+        trap 'kill "$pid" 2>/dev/null || true' EXIT
+        for attempt in $(seq 1 100); do
+          if test -S /tmp/pgbouncer/.s.PGSQL.6432; then
+            break
+          fi
+          kill -0 "$pid"
+          sleep 0.05
+        done
+        test -S /tmp/pgbouncer/.s.PGSQL.6432
+        echo "PgBouncer startup socket ready: /tmp/pgbouncer/.s.PGSQL.6432"
+        kill -TERM "$pid"
+        wait "$pid"
+        trap - EXIT
+
+update:
+  enabled: true
+  github:
+    identifier: pgbouncer/pgbouncer
+    strip-prefix: pgbouncer_
+    use-tag: true
+    tag-filter: pgbouncer_


### PR DESCRIPTION
## Summary
- promote `pgbouncer:1-default` to a pinned bespoke PgBouncer 1.25.2 package
- build the binary target directly from the immutable release archive without Pandoc/docs ownership
- install container-ready configuration, ISC license, and the nonroot Unix-socket runtime path
- track prefixed `pgbouncer_N_N_N` releases with a dedicated Renovate manager
- add focused regressions for source integrity, package pinning, startup layout, and release tracking

## Release evidence — 2026-07-16
- latest release: `pgbouncer_1_25_2` (published 2026-05-08)
- tag commit: `515b6284d273bfd62d1b7e3931ccdce41f9bfe7b`
- release SHA-256: `924ad35113fd0a71c8e2dbe85b5d03445532e2b7b37a9f8a48983beea238b332`
- license: ISC

## Verification
- current RED captured before implementation; startup socket and review-caught Renovate gaps each have failing-first regressions
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m`
- Integer config, Renovate coverage, JSON, and YAML validation
- native CI amd64 and arm64 package/image build and smoke jobs passed
- package tests: version, ownership, ISC, configuration, real nonroot startup and Unix socket
- image startup: UID 65532, `PgBouncer 1.25.2`, TCP listener, Unix socket
- SPDX SBOM: `pgbouncer 1.25.2-r0` declares ISC on both architectures
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings on both architecture images
- Cubic re-review: 5/5, all reported issues addressed
