### PR TITLE
fix(integer): rebuild tflint from fixed source

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -45,7 +45,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml", "packages/bespoke/nfs-subdir-external-provisioner.yaml",
-    "packages/bespoke/metrics-server.yaml", "packages/bespoke/openbao.yaml", "packages/bespoke/pgbouncer.yaml", "packages/bespoke/pluto.yaml",
+    "packages/bespoke/metrics-server.yaml", "packages/bespoke/openbao.yaml", "packages/bespoke/pgbouncer.yaml", "packages/bespoke/pluto.yaml", "packages/bespoke/tflint.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/cmd/tflint_config_test.go
+++ b/cmd/tflint_config_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_TFLint_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in TFLint image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "tflint.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "tflint.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"tflint"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/tflint", tmpl.Entrypoint)
+}
+
+func Test_TFLint_recipe_pins_immutable_fixed_source(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "tflint.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, build, test, and license metadata are inspected.
+
+	// Then: approved revision r6 rebuilds immutable MPL-2.0 v0.63.1 source with fixed dependencies and Go.
+	require.Contains(t, text, "name: tflint")
+	require.Contains(t, text, "version: \"0.63.1\"")
+	require.Contains(t, text, "epoch: 6")
+	require.Contains(t, text, "license: MPL-2.0")
+	require.Contains(t, text, "cd0cce4fa3decaabba3c0667c235651ac06a4221.tar.gz")
+	require.Contains(t, text, "expected-sha256: 8d9b5aeba7b82640fa21f80d2f490180ed72232f0158cd1e04e91260a41be1a9")
+	require.Contains(t, text, "github.com/sigstore/sigstore-go@v1.2.0")
+	require.Contains(t, text, "github.com/sigstore/timestamp-authority/v2@v2.1.2")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: .")
+	require.Contains(t, text, "output: tflint")
+	require.Contains(t, text, "TFLINT_DISABLE_VERSION_CHECK=1")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "tflint --version")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/tflint")
+}
+
+func Test_TFLint_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "tflint.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{
+		{Name: "tflint", Version: "0.63.1-r6"},
+	})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"tflint=0.63.1-r6@local"}, tmpl.Packages)
+}

--- a/images/tflint.yaml
+++ b/images/tflint.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["tflint"]
     entrypoint: /usr/bin/tflint
+    melange:
+      bespoke: tflint.yaml
 
 versions:
   "0": {}

--- a/packages/bespoke/tflint.yaml
+++ b/packages/bespoke/tflint.yaml
@@ -1,0 +1,72 @@
+package:
+  name: tflint
+  # renovate: datasource=github-tags depName=terraform-linters/tflint versioning=semver-coerced
+  version: "0.63.1"
+  # Direct revision r6 rebuilds immutable source with remediated Go dependencies and toolchain.
+  epoch: 6
+  description: A pluggable Terraform/OpenTofu linter
+  copyright:
+    - license: MPL-2.0
+  resources:
+    cpu: "2"
+    memory: 5Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/terraform-linters/tflint/archive/cd0cce4fa3decaabba3c0667c235651ac06a4221.tar.gz
+      expected-sha256: 8d9b5aeba7b82640fa21f80d2f490180ed72232f0158cd1e04e91260a41be1a9
+
+  - runs: |
+      go get \
+        github.com/sigstore/sigstore-go@v1.2.0 \
+        github.com/sigstore/timestamp-authority/v2@v2.1.2 \
+        go.opentelemetry.io/otel@v1.44.0 \
+        go.opentelemetry.io/otel/metric@v1.44.0 \
+        go.opentelemetry.io/otel/sdk@v1.44.0 \
+        go.opentelemetry.io/otel/trace@v1.44.0
+      go mod tidy
+
+  - uses: go/build
+    with:
+      packages: .
+      output: tflint
+      go-package: go-1.26
+
+  - runs: |
+      TFLINT_DISABLE_VERSION_CHECK=1 "${{targets.destdir}}/usr/bin/tflint" --version \
+        | grep -F "TFLint version ${{package.version}}"
+      "${{targets.destdir}}/usr/bin/tflint" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+  pipeline:
+    - runs: |
+        TFLINT_DISABLE_VERSION_CHECK=1 tflint --version \
+          | grep -F "TFLint version ${{package.version}}"
+        tflint --help >/dev/null
+        apk info --who-owns /usr/bin/tflint \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license tflint | grep -F "MPL-2.0"
+        grep -F "Mozilla Public License Version 2.0" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+
+update:
+  enabled: true
+  github:
+    identifier: terraform-linters/tflint
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v


### PR DESCRIPTION
## Summary

- rebuild TFLint 0.63.1-r6 from an immutable fixed upstream revision
- pin remediated Sigstore, timestamp-authority, and OpenTelemetry Go modules
- route the TFLint image through the bespoke local package and preserve its runtime contract
- add regression coverage for source, dependency, package pinning, license, and entrypoint invariants

## Validation

- `go test -race -shuffle=on -count=1 ./cmd`
- `go test -race -shuffle=on -count=1 ./internal/integer/config ./internal/integer/melange`
- `python3 .github/scripts/validate-renovate-coverage.py`
- `melange package-version packages/bespoke/tflint.yaml` -> `tflint-0.63.1-r6`
- native amd64 and arm64 Melange package builds and package tests
- package SPDX generation on both architectures; local amd64 SBOM inspected as SPDX 2.3
- native amd64 and arm64 image builds with runtime architecture guards and TFLint 0.63.1 execution
- local amd64 image SPDX 2.3 SBOM validation
- four CI Trivy reports across build/smoke and amd64/arm64, scanned strictly at `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 total findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds `tflint` 0.63.1-r6 from an immutable upstream commit and switches the image to a locally built, pinned package to harden the supply chain while preserving the CLI contract.

- **Bug Fixes**
  - Introduced bespoke `packages/bespoke/tflint.yaml` that fetches a fixed commit with SHA256 verification, builds with `go-1.26`, disables version checks, and installs MPL-2.0 license.
  - Pinned Go modules: `github.com/sigstore/sigstore-go@v1.2.0`, `github.com/sigstore/timestamp-authority/v2@v2.1.2`, and `go.opentelemetry.io/otel` (+ `metric`, `sdk`, `trace`) `@v1.44.0`.
  - Updated `images/tflint.yaml` to use the bespoke package while keeping `packages: ["tflint"]` and `/usr/bin/tflint` entrypoint.
  - Added tests to enforce image/package pinning, entrypoint, license, and version invariants; verifies selection of `tflint=0.63.1-r6@local`.
  - Updated `.github/scripts/validate-renovate-coverage.py` to include the new bespoke recipe.

<sup>Written for commit ecac370cfa49bf083234637e07f6c37b83dadc5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

