### PR TITLE
fix(integer): own thanos package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -45,7 +45,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml", "packages/bespoke/nfs-subdir-external-provisioner.yaml",
-    "packages/bespoke/metrics-server.yaml", "packages/bespoke/openbao.yaml", "packages/bespoke/pgbouncer.yaml", "packages/bespoke/pluto.yaml",
+    "packages/bespoke/metrics-server.yaml", "packages/bespoke/openbao.yaml", "packages/bespoke/pgbouncer.yaml", "packages/bespoke/pluto.yaml", "packages/bespoke/thanos.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/cmd/thanos_config_test.go
+++ b/cmd/thanos_config_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Thanos_uses_fixed_bespoke_package_for_every_variant(t *testing.T) {
+	// Given: the checked-in Thanos image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "thanos.yaml"))
+	require.NoError(t, err)
+
+	// When: every supported image variant is resolved.
+	for _, variant := range []string{"default", "fips"} {
+		t.Run(variant, func(t *testing.T) {
+			tmpl := def.Types[variant]
+
+			// Then: each variant selects the same local rebuild and runnable binary.
+			require.NotNil(t, tmpl.Melange)
+			require.Equal(t, "thanos.yaml", tmpl.Melange.Bespoke.First())
+			require.Equal(t, []string{"thanos"}, tmpl.Packages)
+			require.Equal(t, "/usr/bin/thanos", tmpl.Entrypoint)
+		})
+	}
+	require.Empty(t, def.Versions["0"].SkipTypes)
+}
+
+func Test_Thanos_recipe_pins_immutable_fixed_source(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image family.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "thanos.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, test, and license metadata are inspected.
+
+	// Then: revision r18 rebuilds immutable Apache-2.0 v0.41.0 source with both current fixes.
+	require.Contains(t, text, "name: thanos")
+	require.Contains(t, text, "# renovate: datasource=github-tags depName=thanos-io/thanos versioning=semver-coerced")
+	require.Contains(t, text, "version: \"0.41.0\"")
+	require.Contains(t, text, "epoch: 18")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@17a5c17c4c614f1e38d5b5199ba5e7810f0d3151")
+	require.Contains(t, text, "cb1396b916241f63fff75e4f5362ea65f18f2303.tar.gz")
+	require.Contains(t, text, "expected-sha256: 90ec49ab04298c9f4bfa2a08771f8d02cad6ef638baf74a1a00c5950151b53e1")
+	require.Contains(t, text, "go get \\")
+	require.Contains(t, text, "go.mongodb.org/mongo-driver@v1.17.7")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.44.0")
+	require.Contains(t, text, "golang.org/x/text@v0.37.0")
+	require.Contains(t, text, "go list -m -f '{{.Version}}' go.opentelemetry.io/otel")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "thanos tools bucket verify --objstore.config-file=/tmp/filesystem.yaml")
+	require.Contains(t, text, "thanos query --http-address=127.0.0.1:19192")
+	require.Contains(t, text, "curl --fail-with-body --silent --show-error --retry 5")
+	require.NotContains(t, text, "iamguarded")
+	require.Equal(t, 1, strings.Count(text, "apk info --license thanos"))
+}
+
+func Test_Thanos_resolves_fixed_local_package_for_every_variant(t *testing.T) {
+	// Given: the checked-in image templates and the package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "thanos.yaml"))
+	require.NoError(t, err)
+
+	for _, variant := range []string{"default", "fips"} {
+		t.Run(variant, func(t *testing.T) {
+			tmpl := def.Types[variant]
+
+			// When: the local Melange artifact is pinned for the image build.
+			pinErr := pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{{
+				Name:    "thanos",
+				Version: "0.41.0-r18",
+			}})
+
+			// Then: apko can only select the approved fixed locally built revision.
+			require.NoError(t, pinErr)
+			require.Equal(t, []string{"thanos=0.41.0-r18@local"}, tmpl.Packages)
+		})
+	}
+}

--- a/images/thanos.yaml
+++ b/images/thanos.yaml
@@ -11,6 +11,8 @@ types:
     paths:
       - {path: /etc/thanos, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /var/lib/thanos, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+    melange:
+      bespoke: "thanos.yaml"
 
   fips:
     base: wolfi-base
@@ -23,9 +25,8 @@ types:
       - {path: /etc/thanos, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
       - {path: /var/lib/thanos, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
     melange:
-      upstream: "thanos"
+      bespoke: "thanos.yaml"
       env-file: "fips.env"
 
 versions:
-  "0":
-    skip-types: [fips]  # iamguarded-compat subpackage needs metadata.google.internal; re-enable after upstream fix
+  "0": {}

--- a/packages/bespoke/thanos.yaml
+++ b/packages/bespoke/thanos.yaml
@@ -1,0 +1,118 @@
+package:
+  name: thanos
+  # renovate: datasource=github-tags depName=thanos-io/thanos versioning=semver-coerced
+  version: "0.41.0"
+  # Direct revision r18 rebuilds immutable source with the current MongoDB and OpenTelemetry fixes.
+  epoch: 18
+  description: Highly available Prometheus setup with long term storage capabilities.
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "10"
+    memory: 11Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@17a5c17c4c614f1e38d5b5199ba5e7810f0d3151.
+  - uses: fetch
+    with:
+      uri: https://github.com/thanos-io/thanos/archive/cb1396b916241f63fff75e4f5362ea65f18f2303.tar.gz
+      expected-sha256: 90ec49ab04298c9f4bfa2a08771f8d02cad6ef638baf74a1a00c5950151b53e1
+
+  - runs: |
+      go get \
+        github.com/go-jose/go-jose/v4@v4.1.4 \
+        go.mongodb.org/mongo-driver@v1.17.7 \
+        go.opentelemetry.io/otel@v1.44.0 \
+        go.opentelemetry.io/otel/metric@v1.44.0 \
+        go.opentelemetry.io/otel/trace@v1.44.0 \
+        go.opentelemetry.io/otel/sdk@v1.44.0 \
+        go.opentelemetry.io/otel/sdk/metric@v1.44.0 \
+        go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.44.0 \
+        go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.44.0 \
+        go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.44.0 \
+        golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.37.0 \
+        golang.org/x/crypto@v0.52.0
+      go mod tidy
+
+      test "$(go list -m -f '{{.Version}}' go.mongodb.org/mongo-driver)" = v1.17.7
+      test "$(go list -m -f '{{.Version}}' go.opentelemetry.io/otel)" = v1.44.0
+      test "$(go list -m -f '{{.Version}}' go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp)" = v1.44.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/thanos
+      output: thanos
+      go-package: go-1.26
+      tags: netgo,slicelabels
+      ldflags: |
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=cb1396b916241f63fff75e4f5362ea65f18f2303
+        -X github.com/prometheus/common/version.BuildDate=$(date -d @$SOURCE_DATE_EPOCH +%Y%m%d-%H:%M:%S)
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/thanos" --version 2>&1 \
+        | grep -F "version ${{package.version}}"
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+  pipeline:
+    - runs: |
+        VERSION_OUTPUT=$(thanos --version 2>&1)
+        echo "$VERSION_OUTPUT" | grep "version ${{ package.version }}"
+        thanos --help
+        thanos query --help
+        thanos sidecar --help
+        thanos tools bucket verify --help
+        apk info --license thanos | grep -Fx Apache-2.0
+        apk info --who-owns /usr/bin/thanos | grep -F 'thanos-'
+        test -s /usr/share/licenses/thanos/LICENSE
+    - name: Validate thanos with local filesystem
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          mkdir -p /tmp/bucket-test
+          echo "placeholder" > /tmp/bucket-test/obj1.txt
+
+          cat <<EOF > /tmp/filesystem.yaml
+          type: FILESYSTEM
+          config:
+            directory: /tmp/bucket-test
+          EOF
+        start: thanos tools bucket verify --objstore.config-file=/tmp/filesystem.yaml
+        timeout: 30
+        expected_output: |
+          started verifying issue
+          loading bucket configuration
+          verify task completed
+    - name: Launch Thanos Query
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          mkdir -p /tmp/data
+        start: thanos query --http-address=127.0.0.1:19192 --log.level=debug
+        timeout: 30
+        expected_output: |
+          starting query node
+          changing probe status
+          listening for requests and metrics
+          Listening on
+        post: |
+          curl --fail-with-body --silent --show-error --retry 5 \
+            http://127.0.0.1:19192/-/healthy
+          echo "Thanos query is healthy"


### PR DESCRIPTION
## Summary

- build Thanos 0.41.0-r18 from immutable Apache-2.0 source
- update mongo-driver to 1.17.7 and the OpenTelemetry module family to 1.44.0
- route both default and FIPS variants through the same local package and restore FIPS coverage
- add focused regression coverage for source, dependencies, license, package pinning, runtime, and health contracts

## Security evidence

- reproduced current RED from run 29310728994: `thanos-0.41.0-r15` had CVE-2026-2303 (fixed in r17) and CVE-2026-41178 (fixed in r18)
- confirmed neither finding was `NO_FIX`
- verified upstream v0.42.0 still carries mongo-driver 1.17.6 and OpenTelemetry 1.43.0, so this recipe fixes the dependencies rather than only relabeling the APK
- local default and FIPS amd64 images passed strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` with zero findings
- no suppressions, exclusions, ignored unfixed findings, severity reductions, or architecture skips

## Validation

- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m` (0 issues)
- `yamllint -c .yamllint.yml images/thanos.yaml packages/bespoke/thanos.yaml`
- `validate-renovate-coverage.py`
- `validate-integer-build-image-workflow.py`
- `verity integer validate`
- local amd64 package/default/FIPS image, runtime, health, SPDX, and strict Trivy checks
- PR CI is expected to run native amd64/arm64 package, image, runtime, health, SPDX, and all-severity Trivy matrices for both variants

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own and pin a local `thanos` 0.41.0-r18 package with patched dependencies, and route both `default` and `fips` images through it to clear Trivy findings and restore FIPS coverage.

- **Bug Fixes**
  - Build and pin local `thanos` 0.41.0-r18 from immutable Apache-2.0 source; route both `default` and `fips` images through it and remove the FIPS skip.
  - Add tests to enforce bespoke recipe selection, pin `thanos=0.41.0-r18@local`, and verify shared `/usr/bin/thanos` entrypoint and license/runtime checks.
  - Update `images/thanos.yaml`, add `packages/bespoke/thanos.yaml`, and register it in `validate-renovate-coverage.py`; Trivy scans for both variants are clean (fixes CVE-2026-2303, CVE-2026-41178).

- **Dependencies**
  - Bump `go.mongodb.org/mongo-driver` to 1.17.7.
  - Bump OpenTelemetry modules to 1.44.0.

<sup>Written for commit b3e5c62904f2f222e0a647b4b6ed7d10949d56ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

