### PR TITLE
fix(integer): own velero package

### DIFF
--- a/cmd/velero_config_test.go
+++ b/cmd/velero_config_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Velero_uses_fixed_bespoke_package_for_default_variant(t *testing.T) {
+	// Given: the checked-in Velero image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "velero.yaml"))
+	require.NoError(t, err)
+
+	// When: the supported image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: it selects only the local Velero rebuild and preserves the chart-compatible runtime.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "velero.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"velero"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/velero", tmpl.Entrypoint)
+	require.Contains(t, tmpl.Paths, intconfig.PathDef{Path: "/velero", Type: "symlink", Source: "/usr/bin/velero"})
+}
+
+func Test_Velero_recipe_pins_immutable_fixed_source_and_runtime_contract(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "velero.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its source, dependency, smoke, and license metadata are inspected.
+
+	// Then: revision r1 owns Apache-2.0 v1.18.2 and the OpenTelemetry security fix.
+	require.Contains(t, text, "name: velero")
+	require.Contains(t, text, "# renovate: datasource=github-tags depName=velero-io/velero versioning=semver-coerced")
+	require.Contains(t, text, "version: \"1.18.2\"")
+	require.Contains(t, text, "epoch: 1")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@080b7b160597fec7f7bfec73b8f281bb55c17117")
+	require.Contains(t, text, "repository: https://github.com/velero-io/velero")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: c253c7fe37d78c9b7e55c68544f7c5b2608712d8")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk/metric@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "version --client-only")
+	require.Contains(t, text, "velero backup create --help")
+	require.Contains(t, text, "velero install --help")
+	require.Contains(t, text, "velero completion bash")
+	require.Contains(t, text, "apk info --license velero | grep -Fx Apache-2.0")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_Velero_resolves_only_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and locally built Velero package.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "velero.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "velero",
+		Version: "1.18.2-r1",
+	}})
+
+	// Then: apko can only select the approved fixed local revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"velero=1.18.2-r1@local"}, tmpl.Packages)
+}

--- a/images/velero.yaml
+++ b/images/velero.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["velero"]
     entrypoint: /usr/bin/velero
+    melange:
+      bespoke: "velero.yaml"
     paths:
       # Published `ghcr.io/verity-org/velero:latest` ships /usr/bin/velero with
       # mode 0o000 — `runc` aborts with `exec: "/velero": permission denied`

--- a/packages/bespoke/velero.yaml
+++ b/packages/bespoke/velero.yaml
@@ -1,0 +1,80 @@
+package:
+  name: velero
+  # renovate: datasource=github-tags depName=velero-io/velero versioning=semver-coerced
+  version: "1.18.2"
+  # r1 rebuilds the latest compatible release with OpenTelemetry 1.44.0,
+  # fixing CVE-2026-41178 (GHSA-5wrp-cwcj-q835).
+  epoch: 1
+  description: Backup and migrate Kubernetes applications and their persistent volumes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - restic
+      - tzdata
+  resources:
+    cpu: "6"
+    memory: 8Gi
+  test-resources:
+    cpu: "2"
+    memory: 2Gi
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@080b7b160597fec7f7bfec73b8f281bb55c17117.
+  - uses: git-checkout
+    with:
+      repository: https://github.com/velero-io/velero
+      tag: v${{package.version}}
+      expected-commit: c253c7fe37d78c9b7e55c68544f7c5b2608712d8
+
+  - uses: go/bump
+    with:
+      deps: |-
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel/sdk/metric@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/velero
+      output: velero
+      go-package: go-1.26
+      ldflags: >-
+        -X main.version=v${{package.version}}
+        -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=v${{package.version}}
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/velero" version --client-only 2>&1 \
+        | grep -F "v${{package.version}}"
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  pipeline:
+    - runs: |
+        velero version --client-only 2>&1 | grep -F "v${{package.version}}"
+        velero --help >/dev/null
+        velero backup create --help >/dev/null
+        velero install --help >/dev/null
+        velero completion bash > /tmp/velero-completion.bash
+        grep -F "velero" /tmp/velero-completion.bash
+        apk info --license velero | grep -Fx Apache-2.0
+        apk info --who-owns /usr/bin/velero | grep -F 'velero-'
+        test -s /usr/share/licenses/${{package.name}}/LICENSE
+
+update:
+  enabled: true
+  github:
+    identifier: velero-io/velero
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
## Summary

- own Velero 1.18.2-r1 from immutable upstream commit c253c7fe37d78c9b7e55c68544f7c5b2608712d8
- force the OpenTelemetry 1.44.0 module family required for CVE-2026-41178
- route the sole Velero image variant exclusively through the local Apache-2.0 package
- add focused regression coverage for source provenance, local package pinning, runtime CLI smoke, and license metadata

## Revalidation

- July 16, 2026 Wolfi x86_64 and aarch64 indexes both still resolve velero 1.18.1-r3
- upstream v1.18.2 is the latest stable compatible release
- current RED reproduced: strict Trivy reports one MEDIUM CVE-2026-41178, fixed in 1.18.2-r1

## Verification

- focused Velero regression: pass
- all image configs and Renovate coverage: pass
- go test -race -shuffle=on -count=1 ./...: pass
- go vet, golangci-lint, gofumpt, yamllint, git diff --check: pass
- native amd64 package/image build: pass
- runtime version v1.18.2 plus backup/create and install CLI smoke: pass
- SPDX and packaged license: Apache-2.0
- strict Trivy UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL: 0 findings

Native amd64 and arm64 package/image/security legs are required from PR CI before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own the `velero` package and rebuild v1.18.2-r1 with `go.opentelemetry.io/otel` 1.44.0 to fix CVE-2026-41178. Route the `velero` image to this local package and add tests to lock provenance, pinning, and CLI behavior.

- **Bug Fixes**
  - Rebuilt and owned `velero` 1.18.2-r1 under Apache-2.0 with `go.opentelemetry.io/otel` 1.44.0 to remediate CVE-2026-41178.
  - Updated `images/velero.yaml` to use the bespoke package and pin `velero=1.18.2-r1@local`; ensured `/usr/bin/velero` entrypoint and `/velero` symlink.
  - Added tests for image/package pinning, immutable source, OTEL version pins, CLI smoke, and license metadata.

<sup>Written for commit ff472d4a80a4be35062d3c2c1e55ec8de68f52e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

