### PR TITLE
fix(integer): own trivy package

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -161,6 +161,21 @@ jobs:
             --arch "$BUILD_ARCH" \
             --staged
 
+      - name: Test Trivy package natively (${{ matrix.arch }})
+        if: inputs.image == 'trivy'
+        env:
+          BUILD_ARCH: ${{ matrix.arch }}
+        run: |
+          melange test \
+            --arch "$BUILD_ARCH" \
+            --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
+            --repository-append https://packages.wolfi.dev/os \
+            --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
+            --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+            --runner docker \
+            melange-work/specs/trivy.yaml/build.yaml \
+            trivy
+
       - name: Upload arch packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -343,6 +358,11 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_TYPE: ${{ inputs.type }}
         run: |
+          if [ "$INPUT_IMAGE" = "trivy" ]; then
+            echo "Repository-pinned external scanner"
+            trivy --version
+          fi
+
           # The verity binary owns this gate (cmd/integer_build.go
           # integerTrivyGate) — it is unit-tested and cannot silently regress,
           # unlike inline workflow bash. Build the image LOCALLY and Trivy-scan

--- a/cmd/trivy_config_test.go
+++ b/cmd/trivy_config_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Trivy_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in Trivy image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "trivy.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "trivy.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"trivy"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/trivy", tmpl.Entrypoint)
+}
+
+func Test_Trivy_recipe_pins_immutable_clean_source(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "trivy.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, remediation, smoke, and license metadata are inspected.
+
+	// Then: revision r4 rebuilds immutable Apache-2.0 v0.72.0 source with the fixed toolchain and dependencies.
+	require.Contains(t, text, "name: trivy")
+	require.Contains(t, text, "version: \"0.72.0\"")
+	require.Contains(t, text, "epoch: 4")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "expected-commit: 8a32853686209a428179bb3a1688802b25691564")
+	require.Contains(t, text, "repository: https://github.com/aquasecurity/trivy")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "github.com/sigstore/cosign/v2@v2.6.3")
+	require.Contains(t, text, "github.com/sigstore/sigstore-go@v1.2.0")
+	require.Contains(t, text, "github.com/sigstore/timestamp-authority/v2@v2.1.2")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "oras.land/oras-go/v2@v2.6.2")
+	require.Contains(t, text, "golang.org/x/net@v0.56.0")
+	require.Contains(t, text, "golang.org/x/text@v0.39.0")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "packages: ./cmd/trivy")
+	require.Contains(t, text, "output: trivy")
+	require.Contains(t, text, "trivy version -f json")
+	require.Contains(t, text, "trivy config")
+	require.Contains(t, text, "busybox")
+	require.Contains(t, text, "trivy=${{package.full-version}}")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/trivy")
+	require.Contains(t, text, "apk info --license trivy")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+}
+
+func Test_Trivy_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "trivy.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{
+		{Name: "trivy", Version: "0.72.0-r4"},
+	})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"trivy=0.72.0-r4@local"}, tmpl.Packages)
+}
+
+func Test_Trivy_CI_records_external_pinned_scanner(t *testing.T) {
+	// Given: the repository tool pin and Integer publish workflow.
+	toolConfig, err := os.ReadFile(filepath.Join("..", "mise.toml"))
+	require.NoError(t, err)
+	workflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
+	require.NoError(t, err)
+
+	// When: the Trivy-family scan gate is inspected.
+
+	// Then: CI records the independent pinned scanner before it validates the produced image.
+	require.Contains(t, string(toolConfig), "trivy = \"0.72.0\"")
+	require.Contains(t, string(workflow), "Test Trivy package natively (${{ matrix.arch }})")
+	require.Contains(t, string(workflow), "if: inputs.image == 'trivy'")
+	require.Contains(t, string(workflow), "melange test \\")
+	require.Contains(t, string(workflow), "melange-work/specs/trivy.yaml/build.yaml")
+	require.Contains(t, string(workflow), "Repository-pinned external scanner")
+	require.Contains(t, string(workflow), "trivy --version")
+	require.Contains(t, string(workflow), "trivy image \\")
+	require.Contains(t, string(workflow), "--severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
+}

--- a/images/trivy.yaml
+++ b/images/trivy.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["trivy"]
     entrypoint: /usr/bin/trivy
+    melange:
+      bespoke: trivy.yaml
     paths:
       - {path: /root/.cache/trivy, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 

--- a/packages/bespoke/trivy.yaml
+++ b/packages/bespoke/trivy.yaml
@@ -1,0 +1,94 @@
+package:
+  name: trivy
+  # renovate: datasource=github-tags depName=aquasecurity/trivy versioning=semver-coerced
+  version: "0.72.0"
+  # Direct revision r4 rebuilds the newest release with every scanner-recorded dependency fix.
+  epoch: 4
+  description: Simple and comprehensive vulnerability scanner for containers
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "8"
+    memory: 15Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # v0.72.0 resolves to 8a32853686209a428179bb3a1688802b25691564.
+  - uses: git-checkout
+    with:
+      expected-commit: 8a32853686209a428179bb3a1688802b25691564
+      repository: https://github.com/aquasecurity/trivy
+      tag: v${{package.version}}
+
+  - runs: |
+      go get \
+        github.com/sigstore/cosign/v2@v2.6.3 \
+        github.com/sigstore/sigstore-go@v1.2.0 \
+        github.com/sigstore/timestamp-authority/v2@v2.1.2 \
+        go.opentelemetry.io/otel@v1.44.0 \
+        go.opentelemetry.io/otel/metric@v1.44.0 \
+        go.opentelemetry.io/otel/sdk@v1.44.0 \
+        go.opentelemetry.io/otel/trace@v1.44.0 \
+        golang.org/x/net@v0.56.0 \
+        golang.org/x/text@v0.39.0 \
+        oras.land/oras-go/v2@v2.6.2
+      go mod tidy
+
+  - uses: go/build
+    with:
+      experiments: jsonv2
+      packages: ./cmd/trivy
+      output: trivy
+      ldflags: -X github.com/aquasecurity/trivy/pkg/version/app.ver=${{package.version}}
+      go-package: go-1.26
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}/contrib"
+      install -Dm644 contrib/*.tpl "${{targets.destdir}}/contrib/"
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+        - jq
+        - trivy=${{package.full-version}}
+  pipeline:
+    - runs: |
+        trivy version | grep -F "Version: ${{package.version}}"
+        trivy version -f json | jq -e \
+          '.Version == "${{package.version}}"' >/dev/null
+        trivy --help >/dev/null
+        apk info --who-owns /usr/bin/trivy \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license trivy | grep -F "Apache-2.0"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+    - runs: |
+        mkdir -p /tmp/trivy-config-smoke
+        printf '%s\n' \
+          'FROM alpine:3.18' \
+          'RUN apk add --no-cache curl' \
+          'CMD ["sh"]' \
+          >/tmp/trivy-config-smoke/Dockerfile
+        trivy config /tmp/trivy-config-smoke --format json \
+          | jq -e '.Results | length > 0' >/dev/null
+
+update:
+  enabled: true
+  github:
+    identifier: aquasecurity/trivy
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
## Summary

- replace the stale public Wolfi `trivy` package with a family-owned immutable `0.72.0-r4` rebuild from upstream commit `8a32853686209a428179bb3a1688802b25691564`
- carry the scanner-recorded dependency remediations, Apache-2.0 package metadata, and the upstream license payload
- run Trivy package version, ownership, license, and representative config-scan smoke tests natively on both amd64 and arm64
- record the independent repository-pinned scanner version before the existing strict two-architecture image gate

## RED baseline — July 16, 2026

Repository-pinned Trivy `0.72.0` scanned `ghcr.io/verity-org/trivy:0` with the July 16 database and found 13 vulnerabilities on each architecture: 2 CRITICAL, 1 HIGH, 8 MEDIUM, and 2 LOW. The installed package was `0.70.0-r5`; findings included CVE-2026-50195 and CVE-2026-53492.

The public Wolfi amd64 and arm64 indexes still top out at `0.70.0-r5`. Upstream's newest stable release is Trivy `v0.72.0`, published June 30, 2026. The recipe therefore rebuilds the newest compatible release instead of recreating an obsolete public revision.

## Verification

- focused regression demonstrated RED before the recipe/image change, then passed
- immutable package build and Melange runtime tests passed on amd64
- amd64 and arm64 packages and images built locally as `trivy-0.72.0-r4`
- both images reported runtime version `0.72.0` and returned results from the representative config scan
- repository-pinned external scanner: Trivy `0.72.0`; vulnerability DB updated `2026-07-16T07:27:44Z`
- strict `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` findings: amd64 `0`, arm64 `0`
- `go test ./... -race -shuffle=on -count=1`
- `make lint-workflows`
- targeted yamllint and `verity integer validate`

CI remains authoritative for the fresh native parallel amd64/arm64 package tests and produced multi-architecture image scan.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the stale public Wolfi `trivy` package with an owned, immutable `0.72.0-r4`, and update the image and CI to use and verify it on amd64 and arm64. This ensures reproducible builds, correct licensing, and a pinned external scanner for the image gate.

- **Dependencies**
  - Add bespoke `trivy` at `0.72.0-r4` (Apache-2.0) with smoke tests and recorded dependency remediations.
  - Point `images/trivy.yaml` to the bespoke `melange` recipe and keep `/usr/bin/trivy` entrypoint.
  - Record repository-pinned external scanner `trivy 0.72.0` in CI.

- **Refactors**
  - CI runs `melange test` for `trivy` natively on amd64/arm64 and prints `trivy --version` before the scan.
  - Add unit tests to assert the image uses the bespoke package and pins `trivy=0.72.0-r4@local`, and that the workflow includes the new gates.

<sup>Written for commit 679e604a0de69c86bdef69953789b59afd9d4a2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

