### PR TITLE
fix(integer): own trufflehog package

### DIFF
--- a/cmd/trufflehog_config_test.go
+++ b/cmd/trufflehog_config_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_TruffleHog_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in TruffleHog image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "trufflehog.yaml"))
+	require.NoError(t, err)
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild and preserves its runtime contract.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "trufflehog.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"trufflehog"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/trufflehog", tmpl.Entrypoint)
+}
+
+func Test_TruffleHog_recipe_pins_immutable_fixed_source(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "trufflehog.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, dependency, runtime, scan, and license metadata are inspected.
+
+	// Then: revision r1 rebuilds immutable AGPL-3.0 v3.95.9 source with the linked MongoDB fix.
+	require.Contains(t, text, "name: trufflehog")
+	require.Contains(t, text, "version: \"3.95.9\"")
+	require.Contains(t, text, "epoch: 1")
+	require.Contains(t, text, "license: AGPL-3.0")
+	require.Contains(t, text, "repository: https://github.com/trufflesecurity/trufflehog")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 27b0417c16317ca9a472a9a8092acce143b49c55")
+	require.Contains(t, text, "go.mongodb.org/mongo-driver@v1.17.7")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "BuildVersion=${{package.version}}")
+	require.Contains(t, text, "go version -m")
+	require.Contains(t, text, "trufflehog --version")
+	require.Contains(t, text, "trufflehog --help")
+	require.Contains(t, text, "trufflehog filesystem")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/trufflehog")
+	require.Contains(t, text, "apk info --license trufflehog")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "spdx.json")
+	require.Contains(t, text, "licenseDeclared == \"AGPL-3.0\"")
+}
+
+func Test_TruffleHog_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "trufflehog.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "3", []apkindex.Package{
+		{Name: "trufflehog", Version: "3.95.9-r1"},
+	})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"trufflehog=3.95.9-r1@local"}, tmpl.Packages)
+}

--- a/images/trufflehog.yaml
+++ b/images/trufflehog.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["trufflehog"]
     entrypoint: /usr/bin/trufflehog
+    melange:
+      bespoke: trufflehog.yaml
 
 versions:
   "3": {}

--- a/packages/bespoke/trufflehog.yaml
+++ b/packages/bespoke/trufflehog.yaml
@@ -1,0 +1,98 @@
+package:
+  name: trufflehog
+  # renovate: datasource=github-tags depName=trufflesecurity/trufflehog versioning=semver-coerced
+  version: "3.95.9"
+  # r1 rebuilds the latest immutable release with the MongoDB driver fixes for
+  # CVE-2026-2303 (GHSA-cp6g-7hqx-qxhp).
+  epoch: 1
+  description: Find, verify, and analyze leaked credentials
+  copyright:
+    # Upstream identifies the pinned source as AGPL-3.0 in README and LICENSE.
+    - license: AGPL-3.0
+  dependencies:
+    runtime:
+      - bash
+      - binutils
+      - ca-certificates
+      - cpio
+      - git
+      - openssh-client
+      - rpm2cpio
+  resources:
+    cpu: "3"
+    memory: 8Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/trufflesecurity/trufflehog
+      tag: v${{package.version}}
+      expected-commit: 27b0417c16317ca9a472a9a8092acce143b49c55
+
+  - uses: go/bump
+    with:
+      deps: go.mongodb.org/mongo-driver@v1.17.7
+
+  - uses: go/build
+    with:
+      packages: .
+      output: trufflehog
+      go-package: go-1.26
+      ldflags: -X github.com/trufflesecurity/trufflehog/v3/pkg/version.BuildVersion=${{package.version}}
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/trufflehog" --version \
+        | grep -F "trufflehog ${{package.version}}"
+      "${{targets.destdir}}/usr/bin/trufflehog" --help >/dev/null
+      go version -m "${{targets.destdir}}/usr/bin/trufflehog" \
+        | grep -E 'go.mongodb.org/mongo-driver[[:space:]]+v1.17.7'
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - jq
+  pipeline:
+    - name: Validate runtime, package ownership, and AGPL provenance
+      runs: |
+        trufflehog --version | grep -F "trufflehog ${{package.version}}"
+        trufflehog --help >/dev/null
+        apk info --who-owns /usr/bin/trufflehog \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license trufflehog | grep -Fx "AGPL-3.0"
+        grep -F "GNU AFFERO GENERAL PUBLIC LICENSE" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+        sbom="/var/lib/db/sbom/${{package.name}}-${{package.full-version}}.spdx.json"
+        test -s "$sbom"
+        jq -e '
+          .packages[]
+          | select(.name == "trufflehog" and .versionInfo == "3.95.9-r1")
+          | .licenseDeclared == "AGPL-3.0"
+        ' "$sbom"
+    - name: Scan a representative local filesystem
+      runs: |
+        mkdir -p /tmp/trufflehog-scan
+        printf '%s\n' 'demo-password-1234' > /tmp/trufflehog-scan/credentials.txt
+        trufflehog filesystem /tmp/trufflehog-scan \
+          --no-update --results=verified,unknown 2>&1 \
+          | grep -F "finished scanning"
+
+update:
+  enabled: true
+  github:
+    identifier: trufflesecurity/trufflehog
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
## Summary

- replace the family-wide external trufflehog package with an immutable bespoke 3.95.9-r1 build
- pin upstream v3.95.9 commit 27b0417c16317ca9a472a9a8092acce143b49c55
- bump the linked go.mongodb.org/mongo-driver module to v1.17.7 for CVE-2026-2303 / GHSA-cp6g-7hqx-qxhp
- preserve AGPL-3.0 provenance in APK metadata, the installed LICENSE, and the package SPDX SBOM
- add focused image ownership, immutable recipe, local package pinning, runtime/version, filesystem scan, and license/SPDX regression coverage

## Revalidation

On July 16, 2026:

- both Wolfi x86_64 and aarch64 indexes still select trufflehog 3.95.5-r1
- upstream latest stable is v3.95.9 (published July 9, 2026)
- upstream v3.95.9 still declares vulnerable go.mongodb.org/mongo-driver v1.17.4
- the rebuilt binary reports embedded go.mongodb.org/mongo-driver v1.17.7

## Verification

- go test -race -shuffle=on -count=1 ./...
- golangci-lint run ./...
- go run . integer validate
- yamllint -c .yamllint.yml images/trufflehog.yaml packages/bespoke/trufflehog.yaml
- native amd64 package/image build with runtime, representative filesystem scan, APK ownership/license, SPDX license declaration, and:
  - --fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
  - zero Trivy findings

PR CI supplies the native parallel amd64/arm64 package, image, smoke, SPDX, and strict all-severity Trivy evidence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced external `trufflehog` with a pinned, locally built 3.95.9‑r1 that fixes CVE-2026-2303 by upgrading `go.mongodb.org/mongo-driver` to v1.17.7. This locks down the image, preserves AGPL-3.0 provenance, and keeps the runtime contract unchanged.

- **Bug Fixes**
  - Switched the image to a bespoke `trufflehog` recipe and pinned package selection (`trufflehog=3.95.9-r1@local`).
  - Built from upstream v3.95.9 with immutable source and preserved AGPL-3.0 in APK and SPDX SBOM.
  - Added tests to verify image pinning, recipe metadata, and runtime behavior.

- **Dependencies**
  - Upgraded `go.mongodb.org/mongo-driver` to v1.17.7 to address CVE-2026-2303 (GHSA-cp6g-7hqx-qxhp).

<sup>Written for commit d1881c9ccad0cb271c2048792c88e11a0cc52fd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

