### PR TITLE
fix(integer): own victoriametrics package

### DIFF
--- a/cmd/victoriametrics_config_test.go
+++ b/cmd/victoriametrics_config_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_VictoriaMetrics_uses_fixed_bespoke_package_for_default_variant(t *testing.T) {
+	// Given: the checked-in VictoriaMetrics image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "victoriametrics.yaml"))
+	require.NoError(t, err)
+
+	// When: the only supported image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: it selects only the local rebuild and preserves the runtime contract.
+	require.Len(t, def.Types, 1)
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "victoriametrics.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"victoriametrics"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/victoria-metrics", tmpl.Entrypoint)
+	require.Contains(t, tmpl.Paths, intconfig.PathDef{Path: "/victoria-metrics-data", Type: "directory", UID: 65532, GID: 65532, Permissions: "0o755"})
+}
+
+func Test_VictoriaMetrics_recipe_pins_immutable_fixed_source_and_runtime_contract(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "victoriametrics.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its source, toolchain, smoke, and license metadata are inspected.
+
+	// Then: revision r2 owns immutable Apache-2.0 v1.147.0 built with fixed Go.
+	require.Contains(t, text, "name: victoriametrics")
+	require.Contains(t, text, "# renovate: datasource=github-tags depName=VictoriaMetrics/VictoriaMetrics versioning=semver-coerced")
+	require.Contains(t, text, "version: \"1.147.0\"")
+	require.Contains(t, text, "epoch: 2")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@448782c863407612dc8e71620583dfaa89ab8f3f")
+	require.Contains(t, text, "repository: https://github.com/VictoriaMetrics/VictoriaMetrics")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 3ac6505d7ff2c02b1c7878d92525e7b681e9cadc")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "GOTOOLCHAIN: local")
+	require.Contains(t, text, "- nodejs-22")
+	require.NotContains(t, text, "- nodejs-20")
+	require.Contains(t, text, "go version -m /usr/bin/victoria-metrics")
+	require.Contains(t, text, "- apk-tools")
+	require.Contains(t, text, "api/v1/import/prometheus")
+	require.Contains(t, text, "timestamp=$(date +%s)")
+	require.Contains(t, text, "--data \"integer_victoriametrics_smoke{source=\\\"integer\\\"} 7 $timestamp\"")
+	require.Contains(t, text, "internal/force_flush")
+	require.Contains(t, text, "prometheus/api/v1/query")
+	require.Contains(t, text, "--data-urlencode \"time=$timestamp\"")
+	require.Contains(t, text, "-search.latencyOffset=0")
+	require.Contains(t, text, "curl --fail-with-body --silent --show-error")
+	require.Contains(t, text, "apk info --license victoriametrics | grep -Fx Apache-2.0")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.NotContains(t, text, "subpackages:")
+}
+
+func Test_VictoriaMetrics_resolves_only_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and locally built VictoriaMetrics package.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "victoriametrics.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
+		Name:    "victoriametrics",
+		Version: "1.147.0-r2",
+	}})
+
+	// Then: apko can only select the approved fixed local revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"victoriametrics=1.147.0-r2@local"}, tmpl.Packages)
+}

--- a/images/victoriametrics.yaml
+++ b/images/victoriametrics.yaml
@@ -10,6 +10,8 @@ types:
     entrypoint: /usr/bin/victoria-metrics
     paths:
       - {path: /victoria-metrics-data, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
+    melange:
+      bespoke: "victoriametrics.yaml"
 
 versions:
   "1": {}

--- a/packages/bespoke/victoriametrics.yaml
+++ b/packages/bespoke/victoriametrics.yaml
@@ -1,0 +1,114 @@
+package:
+  name: victoriametrics
+  # renovate: datasource=github-tags depName=VictoriaMetrics/VictoriaMetrics versioning=semver-coerced
+  version: "1.147.0"
+  # r2 rebuilds the latest compatible release with Go 1.26.5 or newer,
+  # fixing CVE-2026-42505 (GO-2026-5856) in crypto/tls.
+  epoch: 2
+  description: Fast, cost-effective, and scalable monitoring solution and time-series database
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: "4"
+    memory: 8Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+      - nodejs-22
+      - npm
+  environment:
+    CGO_ENABLED: "0"
+    GOTOOLCHAIN: local
+
+pipeline:
+  # Adapted from wolfi-dev/os@448782c863407612dc8e71620583dfaa89ab8f3f.
+  - uses: git-checkout
+    with:
+      repository: https://github.com/VictoriaMetrics/VictoriaMetrics
+      tag: v${{package.version}}
+      expected-commit: 3ac6505d7ff2c02b1c7878d92525e7b681e9cadc
+
+  - runs: |
+      cp docs/victoriametrics/MetricsQL.md \
+        app/vmui/packages/vmui/src/assets/MetricsQL.md
+
+  - working-directory: app/vmui/packages/vmui
+    runs: |
+      npm ci
+      npm run build
+
+  - runs: |
+      rm -rf app/vmselect/vmui/*
+      mv app/vmui/packages/vmui/build/* app/vmselect/vmui/
+
+  - uses: go/build
+    with:
+      packages: ./app/victoria-metrics
+      output: victoria-metrics
+      go-package: go-1.26
+      ldflags: >-
+        -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=victoria-metrics-${{package.version}}-$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")-$(git rev-parse HEAD)
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/victoria-metrics" --version 2>&1 \
+        | grep -F "victoria-metrics-${{package.version}}"
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - curl
+        - go-1.26
+  pipeline:
+    - runs: |
+        victoria-metrics --version 2>&1 \
+          | grep -F "victoria-metrics-${{package.version}}"
+        victoria-metrics --help >/dev/null
+        go version -m /usr/bin/victoria-metrics | tee /tmp/victoria-metrics-build-info
+        grep -Eq 'go1\.26\.([5-9]|[1-9][0-9]+)' /tmp/victoria-metrics-build-info
+        apk info --license victoriametrics | grep -Fx Apache-2.0
+        apk info --who-owns /usr/bin/victoria-metrics | grep -F 'victoriametrics-'
+        test -s /usr/share/licenses/${{package.name}}/LICENSE
+    - name: Validate VictoriaMetrics health, ingestion, and query APIs
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          mkdir -p /tmp/victoria-metrics-data
+        start: >-
+          victoria-metrics
+          -storageDataPath=/tmp/victoria-metrics-data
+          -httpListenAddr=127.0.0.1:8428
+          -search.latencyOffset=0
+        expected_output: started server at http://127.0.0.1:8428/
+        post: |
+          endpoint=http://127.0.0.1:8428
+          curl --fail-with-body --silent --show-error "$endpoint/health" \
+            | grep -Fx OK
+          timestamp=$(date +%s)
+          curl --fail-with-body --silent --show-error \
+            --data "integer_victoriametrics_smoke{source=\"integer\"} 7 $timestamp" \
+            "$endpoint/api/v1/import/prometheus"
+          curl --fail-with-body --silent --show-error \
+            "$endpoint/internal/force_flush" >/dev/null
+          query=$(curl --fail-with-body --silent --show-error \
+            --data-urlencode 'query=integer_victoriametrics_smoke' \
+            --data-urlencode "time=$timestamp" \
+            "$endpoint/prometheus/api/v1/query")
+          echo "$query" | grep -F '"status":"success"'
+          echo "$query" | grep -F '"__name__":"integer_victoriametrics_smoke"'
+          echo "$query" | grep -F '"7"'
+
+update:
+  enabled: true
+  github:
+    identifier: VictoriaMetrics/VictoriaMetrics
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
## Summary

- route the sole `victoriametrics:1-default` variant through a family-exclusive bespoke package
- build `victoriametrics 1.147.0-r2` from immutable upstream tag `v1.147.0` / commit `3ac6505d7ff2c02b1c7878d92525e7b681e9cadc`
- require the fixed Go 1.26.5+ toolchain for CVE-2026-42505 and preserve Apache-2.0 source/license provenance
- add package version/license checks plus live health, Prometheus ingestion, forced flush, and query smoke coverage
- pin image assembly to the exact locally built `victoriametrics=1.147.0-r2@local` package

## July 16, 2026 revalidation

- latest compatible upstream stable release: `v1.147.0` (published July 6, 2026)
- public Wolfi x86_64 and aarch64 indexes both still resolve `victoriametrics 1.145.0-r0`
- unchanged main on both architectures: strict Trivy reports one MEDIUM finding, CVE-2026-42505, fixed in `1.147.0-r2`
- remediation contains no Trivy suppression, exclusion, severity reduction, architecture skip, retirement, or package mislabeling

## Verification

- `go test -race -shuffle=on -count=1 ./...`
- `go run . integer validate`
- Renovate and Integer workflow policy validators
- native x86_64 Melange build and package test
- native amd64 image runtime/version/health/ingest/query smoke
- SPDX 2.3 SBOM declares the APK and immutable VictoriaMetrics source as Apache-2.0
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings on local amd64 image

PR CI is dependency-scoped to this single image and runs the package/image/security matrix natively on amd64 and arm64.