### PR TITLE
fix(integer): own tempo 2.10 package

### DIFF
--- a/.github/scripts/validate-renovate-coverage.py
+++ b/.github/scripts/validate-renovate-coverage.py
@@ -45,7 +45,7 @@ SPECIAL_RECIPE_SOURCES: Final = {
     "packages/bespoke/haproxy-3.3.yaml",
     "packages/bespoke/hydra.yaml", "packages/bespoke/jaeger-2-all-in-one.yaml", "packages/bespoke/karpenter-1.11.yaml", "packages/bespoke/kor.yaml",
     "packages/bespoke/kube-bench.yaml", "packages/bespoke/kube-rbac-proxy.yaml", "packages/bespoke/kube-state-metrics.yaml", "packages/bespoke/kube-vip.yaml", "packages/bespoke/linkerd2-cli-25.yaml", "packages/bespoke/minio-operator.yaml", "packages/bespoke/nfs-subdir-external-provisioner.yaml",
-    "packages/bespoke/metrics-server.yaml", "packages/bespoke/openbao.yaml", "packages/bespoke/pgbouncer.yaml", "packages/bespoke/pluto.yaml", "packages/bespoke/tflint.yaml", "packages/bespoke/thanos.yaml",
+    "packages/bespoke/metrics-server.yaml", "packages/bespoke/openbao.yaml", "packages/bespoke/pgbouncer.yaml", "packages/bespoke/pluto.yaml", "packages/bespoke/tempo-2.10.yaml", "packages/bespoke/tflint.yaml", "packages/bespoke/thanos.yaml",
 }
 SUPPORTED_GITHUB_TAGS: Final = {
     "${{package.version}}",

--- a/images/tempo.yaml
+++ b/images/tempo.yaml
@@ -1,13 +1,15 @@
 name: tempo
-description: "Grafana Tempo trace backend — Copa can't patch distroless-based official image; Wolfi rebuild"
+description: "Grafana Tempo trace backend — family-owned immutable 2.10 Wolfi rebuild"
 upstream:
   package: tempo
 
 types:
   default:
     base: wolfi-base
-    packages: ["tempo~{{version}}"]
+    packages: ["tempo-2.10"]
     entrypoint: /usr/bin/tempo
+    melange:
+      bespoke: tempo-2.10.yaml
     paths:
       - {path: /var/tempo, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 

--- a/internal/integer/config/tempo_image_test.go
+++ b/internal/integer/config/tempo_image_test.go
@@ -50,6 +50,7 @@ func Test_Tempo_recipe_pins_immutable_security_release(t *testing.T) {
 	require.Contains(t, text, "Adapted from wolfi-dev/os@1e46ec097ff71bd5eccd13fa97a014f530eeec42")
 	require.Contains(t, text, "8100f5a7b8f0986edf1fcd2ff6552d174b25ec18.tar.gz")
 	require.Contains(t, text, "expected-sha256: 9ad4c9c6e73b67ae32e00f282dc14d81f1b1eb9b49607c58803e3d663fe1e527")
+	require.Contains(t, text, "runtime:\n      - ca-certificates-bundle")
 	require.Contains(t, text, "go-package: go-1.26")
 	require.Contains(t, text, "uses: go/bump")
 	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")

--- a/internal/integer/config/tempo_image_test.go
+++ b/internal/integer/config/tempo_image_test.go
@@ -1,33 +1,68 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestTempoImagePinsChartCompatiblePackage(t *testing.T) {
+func Test_Tempo_uses_owned_2_10_package(t *testing.T) {
+	// Given: the checked-in Tempo image definition.
 	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("locating test file")
-	}
+	require.True(t, ok, "locating test file")
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
 	def, err := LoadImage(filepath.Join(repoRoot, "images", "tempo.yaml"))
-	if err != nil {
-		t.Fatalf("load tempo image: %v", err)
-	}
-	if err := Validate(def); err != nil {
-		t.Fatalf("validate tempo image: %v", err)
-	}
-	if _, ok := def.Versions["2.9.0"]; ok {
-		t.Fatalf("tempo versions=%v must not publish vulnerable 2.9.0", def.Versions)
-	}
-	if _, ok := def.Versions["2.10.0"]; !ok {
-		t.Fatalf("tempo versions=%v, want 2.10.0", def.Versions)
-	}
-	packages := def.Types["default"].Packages
-	if !slices.Contains(packages, "tempo~{{version}}") {
-		t.Fatalf("tempo packages=%v, want Wolfi package constrained to requested Tempo stream", packages)
-	}
+	require.NoError(t, err)
+	require.NoError(t, Validate(def))
+
+	// When: the approved default image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: both published aliases use the family-owned 2.10 package without changing runtime semantics.
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "tempo-2.10.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"tempo-2.10"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/tempo", tmpl.Entrypoint)
+	require.Contains(t, def.Versions, "2")
+	require.Contains(t, def.Versions, "2.10.0")
+	require.NotContains(t, def.Versions, "2.9.0")
+}
+
+func Test_Tempo_recipe_pins_immutable_security_release(t *testing.T) {
+	// Given: the bespoke package recipe selected by the Tempo image.
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "locating test file")
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	recipe, err := os.ReadFile(filepath.Join(repoRoot, "packages", "bespoke", "tempo-2.10.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its package, source, build, test, and license metadata are inspected.
+
+	// Then: revision r0 rebuilds immutable v2.10.7 source with its declared project licenses and security fixes.
+	require.Contains(t, text, "name: tempo-2.10")
+	require.Contains(t, text, "version: \"2.10.7\"")
+	require.Contains(t, text, "epoch: 3")
+	require.Contains(t, text, "license: AGPL-3.0-only AND Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@1e46ec097ff71bd5eccd13fa97a014f530eeec42")
+	require.Contains(t, text, "8100f5a7b8f0986edf1fcd2ff6552d174b25ec18.tar.gz")
+	require.Contains(t, text, "expected-sha256: 9ad4c9c6e73b67ae32e00f282dc14d81f1b1eb9b49607c58803e3d663fe1e527")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "uses: go/bump")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "github.com/prometheus/prometheus v0.311.3")
+	require.Contains(t, text, "packages: ./cmd/tempo")
+	require.Contains(t, text, "output: tempo")
+	require.Contains(t, text, "-X main.Version=${{package.version}}")
+	require.Contains(t, text, "-X main.Revision=8100f5a7b8f0986edf1fcd2ff6552d174b25ec18")
+	require.Contains(t, text, "-X main.Branch=v${{package.version}}")
+	require.Contains(t, text, "tempo --version")
+	require.Contains(t, text, "http_listen_port: 3200")
+	require.Contains(t, text, "seq 1 200")
+	require.Contains(t, text, "http://127.0.0.1:3200/ready")
+	require.Contains(t, text, "/usr/share/licenses/${{package.name}}/LICENSING.md")
+	require.Contains(t, text, "/usr/share/licenses/${{package.name}}/LICENSE_APACHE2")
 }

--- a/packages/bespoke/tempo-2.10.yaml
+++ b/packages/bespoke/tempo-2.10.yaml
@@ -8,6 +8,8 @@ package:
   copyright:
     - license: AGPL-3.0-only AND Apache-2.0
   dependencies:
+    runtime:
+      - ca-certificates-bundle
     provides:
       - tempo=${{package.full-version}}
   resources:

--- a/packages/bespoke/tempo-2.10.yaml
+++ b/packages/bespoke/tempo-2.10.yaml
@@ -1,0 +1,130 @@
+package:
+  name: tempo-2.10
+  # renovate: datasource=github-releases depName=grafana/tempo versioning=semver-coerced
+  version: "2.10.7"
+  # Revision r3 carries the current Go toolchain and post-release OpenTelemetry security fix.
+  epoch: 3
+  description: Grafana Tempo distributed tracing backend
+  copyright:
+    - license: AGPL-3.0-only AND Apache-2.0
+  dependencies:
+    provides:
+      - tempo=${{package.full-version}}
+  resources:
+    cpu: "6"
+    memory: 12Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Adapted from wolfi-dev/os@1e46ec097ff71bd5eccd13fa97a014f530eeec42.
+  - uses: fetch
+    with:
+      uri: https://github.com/grafana/tempo/archive/8100f5a7b8f0986edf1fcd2ff6552d174b25ec18.tar.gz
+      expected-sha256: 9ad4c9c6e73b67ae32e00f282dc14d81f1b1eb9b49607c58803e3d663fe1e527
+
+  - uses: go/bump
+    with:
+      deps: |
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+
+  - runs: |
+      grep -F "github.com/prometheus/prometheus v0.311.3" go.mod
+      grep -F "go.opentelemetry.io/otel v1.44.0" go.mod
+      go version
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      packages: ./cmd/tempo
+      output: tempo
+      ldflags: |
+        -X main.Version=${{package.version}}
+        -X main.Revision=8100f5a7b8f0986edf1fcd2ff6552d174b25ec18
+        -X main.Branch=v${{package.version}}
+        -X github.com/prometheus/common/version.BuildUser=verity
+        -X github.com/prometheus/common/version.BuildDate=2026-06-12T16:10:34Z
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/tempo" --version \
+        | grep -F "${{package.version}}"
+      "${{targets.destdir}}/usr/bin/tempo" --help >/dev/null
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+      install -Dm644 LICENSING.md \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSING.md"
+      install -Dm644 operations/LICENSE_APACHE2 \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE_APACHE2"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+  pipeline:
+    - runs: |
+        tempo --version | grep -F "${{package.version}}"
+        tempo --help >/dev/null
+        apk info --who-owns /usr/bin/tempo \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license "${{package.name}}" \
+          | grep -F "AGPL-3.0-only AND Apache-2.0"
+        grep -F "GNU AFFERO GENERAL PUBLIC LICENSE" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+        grep -F "The default license for this project is [AGPL-3.0-only]" \
+          "/usr/share/licenses/${{package.name}}/LICENSING.md"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE_APACHE2"
+
+        cat >tempo.yaml <<'EOF'
+        auth_enabled: false
+        server:
+          http_listen_address: 127.0.0.1
+          http_listen_port: 3200
+        distributor:
+          receivers:
+            jaeger:
+              protocols:
+                thrift_compact:
+        storage:
+          trace:
+            backend: local
+            local:
+              path: /tmp/tempo/traces
+        EOF
+
+        tempo start -config.file=tempo.yaml >/tmp/tempo.log 2>&1 &
+        pid=$!
+        trap 'kill "$pid" 2>/dev/null || true' EXIT
+        for attempt in $(seq 1 200); do
+          if wget -q -O- http://127.0.0.1:3200/ready \
+            | grep -Fq ready; then
+            break
+          fi
+          sleep 0.1
+        done
+        wget -q -O- http://127.0.0.1:3200/ready | grep -Fq ready
+        kill -TERM "$pid"
+        wait "$pid"
+        trap - EXIT
+
+update:
+  enabled: true
+  github:
+    identifier: grafana/tempo
+    strip-prefix: v
+    tag-filter-prefix: v2.10.


### PR DESCRIPTION
## Summary

- add a Tempo-family-owned Wolfi package pinned to Grafana Tempo v2.10.7 commit `8100f5a7b8f0986edf1fcd2ff6552d174b25ec18` with immutable SHA256
- rebuild with Go 1.26.5, OpenTelemetry v1.44.0, and Prometheus v0.311.3 while preserving the `2`/`2.10.0` image aliases and `/usr/bin/tempo` entrypoint
- declare `AGPL-3.0-only AND Apache-2.0`, install all upstream license materials, and retain `ca-certificates-bundle` at runtime
- add focused provenance/config regressions, including the review-caught runtime CA dependency
- allow 20 seconds for Tempo's intentional 15-second readiness delay

## Security evidence

Pre-fix scan reproduced fixed findings CVE-2026-42151, CVE-2026-42154, CVE-2026-41178, and CVE-2026-42505.

Final native run `29507184338`:
- amd64 and arm64 package/image build jobs passed
- amd64 and arm64 smoke jobs passed for both published aliases
- runtime reports Tempo 2.10.7 at revision `8100f5a7...` with Go 1.26.5
- package health test reaches `/ready`; SPDX declares `AGPL-3.0-only AND Apache-2.0`
- six architecture-qualified Trivy JSON reports contain zero `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` findings
- six matching security completion markers were uploaded

## Validation

- `go test ./internal/integer/config -run '^Test_Tempo_' -count=1`
- `go test ./internal/integer/config -count=1`
- `go test ./scripts -count=1`
- `python3 .github/scripts/validate-renovate-coverage.py`
- `python3 .github/scripts/validate-integer-build-image-workflow.py`
- `go run . integer validate` (334 images)

## Review

- accepted CA-bundle runtime feedback with regression coverage in `8956302b19`
- retained the upstream-compatible unversioned `tempo` virtual provide; `2` and `2.10.0` are image aliases, not package provides
