### PR TITLE
fix(integer): own step-ca package

### DIFF
--- a/.github/scripts/test-step-ca-package.sh
+++ b/.github/scripts/test-step-ca-package.sh
@@ -16,6 +16,7 @@ case "$arch" in
 esac
 
 workspace=${GITHUB_WORKSPACE:-$(pwd)}
+cd "$workspace"
 timeout --signal=TERM --kill-after=1m 30m melange test \
   --arch "$arch" \
   --repository-append "$workspace/packages/repo" \

--- a/.github/scripts/test-step-ca-package.sh
+++ b/.github/scripts/test-step-ca-package.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <x86_64|aarch64>" >&2
+  exit 2
+fi
+
+arch=$1
+case "$arch" in
+  x86_64 | aarch64) ;;
+  *)
+    echo "unsupported Step CA package architecture: $arch" >&2
+    exit 2
+    ;;
+esac
+
+workspace=${GITHUB_WORKSPACE:-$(pwd)}
+timeout --signal=TERM --kill-after=1m 30m melange test \
+  --arch "$arch" \
+  --repository-append "$workspace/packages/repo" \
+  --repository-append https://packages.wolfi.dev/os \
+  --keyring-append "$workspace/melange-work/melange.rsa.pub" \
+  --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+  --runner docker \
+  --pipeline-dirs melange-work/pipelines \
+  melange-work/specs/step-ca.yaml/build.yaml \
+  step-ca

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -176,6 +176,22 @@ jobs:
             melange-work/specs/trivy.yaml/build.yaml \
             trivy
 
+      - name: Test Step CA package natively (${{ matrix.arch }})
+        if: inputs.image == 'step-ca'
+        env:
+          BUILD_ARCH: ${{ matrix.arch }}
+        run: |
+          melange test \
+            --arch "$BUILD_ARCH" \
+            --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
+            --repository-append https://packages.wolfi.dev/os \
+            --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
+            --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+            --runner docker \
+            --pipeline-dirs melange-work/pipelines \
+            melange-work/specs/step-ca.yaml/build.yaml \
+            step-ca
+
       - name: Upload arch packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -180,17 +180,7 @@ jobs:
         if: inputs.image == 'step-ca'
         env:
           BUILD_ARCH: ${{ matrix.arch }}
-        run: |
-          melange test \
-            --arch "$BUILD_ARCH" \
-            --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
-            --repository-append https://packages.wolfi.dev/os \
-            --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
-            --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
-            --runner docker \
-            --pipeline-dirs melange-work/pipelines \
-            melange-work/specs/step-ca.yaml/build.yaml \
-            step-ca
+        run: bash .github/scripts/test-step-ca-package.sh "$BUILD_ARCH"
 
       - name: Upload arch packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -195,6 +195,21 @@ jobs:
             fi
             echo "::endgroup::"
 
+            if [ "$image" = "step-ca" ]; then
+              echo "::group::Step CA package test (${INTEGER_PACKAGE_ARCH})"
+              melange test \
+                --arch "$INTEGER_PACKAGE_ARCH" \
+                --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
+                --repository-append https://packages.wolfi.dev/os \
+                --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
+                --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+                --runner docker \
+                --pipeline-dirs melange-work/pipelines \
+                melange-work/specs/step-ca.yaml/build.yaml \
+                step-ca
+              echo "::endgroup::"
+            fi
+
             arch="$INTEGER_ARCH"
             tar_path="image-${safe_image}-${version}-${type}-${arch}.tar"
             ./verity integer build \

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -197,16 +197,7 @@ jobs:
 
             if [ "$image" = "step-ca" ]; then
               echo "::group::Step CA package test (${INTEGER_PACKAGE_ARCH})"
-              melange test \
-                --arch "$INTEGER_PACKAGE_ARCH" \
-                --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
-                --repository-append https://packages.wolfi.dev/os \
-                --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
-                --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
-                --runner docker \
-                --pipeline-dirs melange-work/pipelines \
-                melange-work/specs/step-ca.yaml/build.yaml \
-                step-ca
+              bash .github/scripts/test-step-ca-package.sh "$INTEGER_PACKAGE_ARCH"
               echo "::endgroup::"
             fi
 

--- a/cmd/step_ca_config_test.go
+++ b/cmd/step_ca_config_test.go
@@ -62,6 +62,8 @@ func Test_StepCA_recipe_pins_fixed_source_runtime_and_provenance(t *testing.T) {
 	require.Contains(t, text, "apk info --license step-ca")
 	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
 	require.Contains(t, text, "spdx.json")
+	require.Contains(t, text, ".versionInfo == \"${{package.full-version}}\"")
+	require.NotContains(t, text, ".versionInfo == \"0.30.2-r15\"")
 	require.Contains(t, text, "licenseDeclared == \"Apache-2.0\"")
 }
 
@@ -82,23 +84,27 @@ func Test_StepCA_resolves_only_fixed_local_package(t *testing.T) {
 }
 
 func Test_StepCA_runs_package_smoke_in_native_dual_arch_workflows(t *testing.T) {
-	// Given: the reusable image workflow and pull-request smoke workflow.
+	// Given: the shared package-test script, reusable image workflow, and pull-request smoke workflow.
+	testScript, err := os.ReadFile(filepath.Join("..", ".github", "scripts", "test-step-ca-package.sh"))
+	require.NoError(t, err)
 	buildWorkflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
 	require.NoError(t, err)
 	prWorkflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "pr-test.yaml"))
 	require.NoError(t, err)
 
 	// When: their Step CA package-test gates are inspected.
+	scriptText := string(testScript)
 	buildText := string(buildWorkflow)
 	prText := string(prWorkflow)
 
-	// Then: both native architecture paths execute the checked-in Melange test pipeline.
+	// Then: both native architecture paths call one bounded checked-in Melange test entrypoint.
+	require.Contains(t, scriptText, "case \"$arch\" in")
+	require.Contains(t, scriptText, "timeout --signal=TERM --kill-after=1m 30m melange test")
+	require.Contains(t, scriptText, "--pipeline-dirs melange-work/pipelines")
+	require.Contains(t, scriptText, "melange-work/specs/step-ca.yaml/build.yaml")
 	require.Contains(t, buildText, "Test Step CA package natively (${{ matrix.arch }})")
 	require.Contains(t, buildText, "if: inputs.image == 'step-ca'")
-	require.Contains(t, buildText, "melange-work/specs/step-ca.yaml/build.yaml")
-	require.Contains(t, buildText, "--pipeline-dirs melange-work/pipelines")
+	require.Contains(t, buildText, "bash .github/scripts/test-step-ca-package.sh \"$BUILD_ARCH\"")
 	require.Contains(t, prText, "if [ \"$image\" = \"step-ca\" ]; then")
-	require.Contains(t, prText, "--arch \"$INTEGER_PACKAGE_ARCH\"")
-	require.Contains(t, prText, "melange-work/specs/step-ca.yaml/build.yaml")
-	require.Contains(t, prText, "--pipeline-dirs melange-work/pipelines")
+	require.Contains(t, prText, "bash .github/scripts/test-step-ca-package.sh \"$INTEGER_PACKAGE_ARCH\"")
 }

--- a/cmd/step_ca_config_test.go
+++ b/cmd/step_ca_config_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_StepCA_uses_fixed_bespoke_package_for_only_variant(t *testing.T) {
+	// Given: the checked-in Step CA image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "step-ca.yaml"))
+	require.NoError(t, err)
+
+	// When: the only supported image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: it selects only the local rebuild and preserves the runtime contract.
+	require.Len(t, def.Types, 1)
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "step-ca.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"step-ca"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/step-ca", tmpl.Entrypoint)
+}
+
+func Test_StepCA_recipe_pins_fixed_source_runtime_and_provenance(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "step-ca.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its source, dependency fixes, smoke tests, and license metadata are inspected.
+
+	// Then: revision r15 rebuilds immutable Apache-2.0 v0.30.2 with every recorded fix after public r10.
+	require.Contains(t, text, "Adapted from wolfi-dev/os@b9dcc7dc733fd3100bfd7974ea0725188abe18b2")
+	require.Contains(t, text, "name: step-ca")
+	require.Contains(t, text, "version: \"0.30.2\"")
+	require.Contains(t, text, "epoch: 15")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "repository: https://github.com/smallstep/certificates")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 6e8ec61405239cf3f37b2bbf260a587b7d2e4e31")
+	require.Contains(t, text, "go-1.26=1.26.5-r1")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/sdk/metric@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "Verify the complete fixed module graph")
+	require.Contains(t, text, "go list -m all")
+	require.Contains(t, text, "Verify linked OpenTelemetry modules")
+	require.Contains(t, text, "go version -m")
+	require.Contains(t, text, "step-ca --version")
+	require.Contains(t, text, "step-ca --help")
+	require.Contains(t, text, "step ca init")
+	require.Contains(t, text, "step ca health")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/step-ca")
+	require.Contains(t, text, "apk info --license step-ca")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "spdx.json")
+	require.Contains(t, text, "licenseDeclared == \"Apache-2.0\"")
+}
+
+func Test_StepCA_resolves_only_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "step-ca.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "0", []apkindex.Package{
+		{Name: "step-ca", Version: "0.30.2-r15"},
+	})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"step-ca=0.30.2-r15@local"}, tmpl.Packages)
+}
+
+func Test_StepCA_runs_package_smoke_in_native_dual_arch_workflows(t *testing.T) {
+	// Given: the reusable image workflow and pull-request smoke workflow.
+	buildWorkflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
+	require.NoError(t, err)
+	prWorkflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "pr-test.yaml"))
+	require.NoError(t, err)
+
+	// When: their Step CA package-test gates are inspected.
+	buildText := string(buildWorkflow)
+	prText := string(prWorkflow)
+
+	// Then: both native architecture paths execute the checked-in Melange test pipeline.
+	require.Contains(t, buildText, "Test Step CA package natively (${{ matrix.arch }})")
+	require.Contains(t, buildText, "if: inputs.image == 'step-ca'")
+	require.Contains(t, buildText, "melange-work/specs/step-ca.yaml/build.yaml")
+	require.Contains(t, buildText, "--pipeline-dirs melange-work/pipelines")
+	require.Contains(t, prText, "if [ \"$image\" = \"step-ca\" ]; then")
+	require.Contains(t, prText, "--arch \"$INTEGER_PACKAGE_ARCH\"")
+	require.Contains(t, prText, "melange-work/specs/step-ca.yaml/build.yaml")
+	require.Contains(t, prText, "--pipeline-dirs melange-work/pipelines")
+}

--- a/cmd/step_ca_config_test.go
+++ b/cmd/step_ca_config_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,10 @@ func Test_StepCA_runs_package_smoke_in_native_dual_arch_workflows(t *testing.T) 
 	require.Contains(t, scriptText, "timeout --signal=TERM --kill-after=1m 30m melange test")
 	require.Contains(t, scriptText, "--pipeline-dirs melange-work/pipelines")
 	require.Contains(t, scriptText, "melange-work/specs/step-ca.yaml/build.yaml")
+	workingDirectoryIndex := strings.Index(scriptText, "cd \"$workspace\"")
+	testCommandIndex := strings.Index(scriptText, "timeout --signal=TERM --kill-after=1m 30m melange test")
+	require.NotEqual(t, -1, workingDirectoryIndex)
+	require.Less(t, workingDirectoryIndex, testCommandIndex)
 	require.Contains(t, buildText, "Test Step CA package natively (${{ matrix.arch }})")
 	require.Contains(t, buildText, "if: inputs.image == 'step-ca'")
 	require.Contains(t, buildText, "bash .github/scripts/test-step-ca-package.sh \"$BUILD_ARCH\"")

--- a/images/step-ca.yaml
+++ b/images/step-ca.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["step-ca"]
     entrypoint: /usr/bin/step-ca
+    melange:
+      bespoke: "step-ca.yaml"
 
 versions:
   "0": {}

--- a/packages/bespoke/step-ca.yaml
+++ b/packages/bespoke/step-ca.yaml
@@ -108,7 +108,7 @@ test:
         test -s "$sbom"
         jq -e '
           .packages[]
-          | select(.name == "step-ca" and .versionInfo == "0.30.2-r15")
+          | select(.name == "step-ca" and .versionInfo == "${{package.full-version}}")
           | .licenseDeclared == "Apache-2.0"
         ' "$sbom"
     - name: Initialize and exercise a representative CA

--- a/packages/bespoke/step-ca.yaml
+++ b/packages/bespoke/step-ca.yaml
@@ -1,0 +1,137 @@
+# Adapted from wolfi-dev/os@b9dcc7dc733fd3100bfd7974ea0725188abe18b2
+# (step-ca 0.30.2-r10).
+package:
+  name: step-ca
+  # renovate: datasource=github-tags depName=smallstep/certificates versioning=semver-coerced
+  version: "0.30.2"
+  # r12 fixes CVE-2026-39883, r13 fixes CVE-2026-41178, and r15 rebuilds
+  # with Go 1.26.5 for CVE-2026-42505.
+  epoch: 15
+  description: A private certificate authority (X.509 & SSH) and ACME server
+  copyright:
+    # Upstream LICENSE at the pinned source commit is Apache License 2.0.
+    - license: Apache-2.0
+  resources:
+    cpu: "3"
+    memory: 8Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26=1.26.5-r1
+      - pcsc-lite-dev
+      - step
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/smallstep/certificates
+      tag: v${{package.version}}
+      expected-commit: 6e8ec61405239cf3f37b2bbf260a587b7d2e4e31
+
+  - uses: go/bump
+    with:
+      deps: |-
+        github.com/go-jose/go-jose/v3@v3.0.5
+        github.com/go-jose/go-jose/v4@v4.1.4
+        github.com/jackc/pgx/v5@v5.9.2
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        go.opentelemetry.io/otel/sdk@v1.44.0
+        go.opentelemetry.io/otel/sdk/metric@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+        golang.org/x/crypto@v0.52.0
+        golang.org/x/net@v0.55.0
+
+  - name: Verify the complete fixed module graph
+    runs: |
+      for module in \
+        go.opentelemetry.io/otel \
+        go.opentelemetry.io/otel/metric \
+        go.opentelemetry.io/otel/sdk \
+        go.opentelemetry.io/otel/sdk/metric \
+        go.opentelemetry.io/otel/trace; do
+        go list -m all \
+          | awk -v module="$module" \
+            '$1 == module && $2 == "v1.44.0" { found = 1 } END { exit !found }'
+      done
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/step-ca
+      output: step-ca
+      go-package: go-1.26
+      ldflags: |
+        -X main.Version=${{package.version}}
+        -X main.BuildTime=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
+
+  - name: Verify linked OpenTelemetry modules and install license
+    runs: |
+      "${{targets.destdir}}/usr/bin/step-ca" --version \
+        | grep -F "${{package.version}}"
+      "${{targets.destdir}}/usr/bin/step-ca" --help >/dev/null
+      go version -m "${{targets.destdir}}/usr/bin/step-ca" \
+        | grep -E 'go1\.26\.([5-9]|[1-9][0-9])'
+      for module in \
+        go.opentelemetry.io/otel \
+        go.opentelemetry.io/otel/metric \
+        go.opentelemetry.io/otel/trace; do
+        go version -m "${{targets.destdir}}/usr/bin/step-ca" \
+          | grep -E "${module}[[:space:]]+v1.44.0"
+      done
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - jq
+        - step
+        - wait-for-it
+  pipeline:
+    - name: Validate runtime, package ownership, and Apache provenance
+      runs: |
+        step-ca --version | grep -F "${{package.version}}"
+        step-ca --help >/dev/null
+        apk info --who-owns /usr/bin/step-ca \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license step-ca | grep -Fx "Apache-2.0"
+        grep -F "Apache License" \
+          "/usr/share/licenses/${{package.name}}/LICENSE"
+        sbom="/var/lib/db/sbom/${{package.name}}-${{package.full-version}}.spdx.json"
+        test -s "$sbom"
+        jq -e '
+          .packages[]
+          | select(.name == "step-ca" and .versionInfo == "0.30.2-r15")
+          | .licenseDeclared == "Apache-2.0"
+        ' "$sbom"
+    - name: Initialize and exercise a representative CA
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          echo $RANDOM > password.txt
+          step ca init --name "Example Inc." \
+            --dns localhost \
+            --address 127.0.0.1:8443 \
+            --provisioner=bob@example.com \
+            --password-file=password.txt 2>&1 | grep -vi root
+        start: "step-ca $(step path)/config/ca.json --password-file password.txt"
+        timeout: 30
+        expected_output: |
+          Serving HTTPS
+        post: |
+          wait-for-it -t 10 --strict localhost:8443 -- echo "Server is up"
+          step ca health | grep -qi "ok"
+
+update:
+  enabled: true
+  github:
+    identifier: smallstep/certificates
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
## Summary

- own the sole Step CA image variant with an immutable bespoke `step-ca 0.30.2-r15` package
- preserve the public Wolfi `0.30.2-r10` recipe provenance and pin Smallstep v0.30.2 commit `6e8ec61405239cf3f37b2bbf260a587b7d2e4e31`
- carry OpenTelemetry v1.44.0 and Go 1.26.5 fixes through the package, native package tests, image build, and strict Trivy gates

## July 16, 2026 evidence

- Smallstep's latest compatible release remains v0.30.2
- official Wolfi x86_64 and aarch64 indexes still publish only `step-ca 0.30.2-r10`
- Wolfi security data records CVE-2026-39883 fixed at r12, CVE-2026-41178 at r13, and CVE-2026-42505 at r15
- this package verifies the complete OpenTelemetry module graph at v1.44.0 and the linked binary modules at v1.44.0

## Verification

- focused regression: red before ownership, green after
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m`
- YAML and workflow lint
- `verity integer validate`
- native amd64 Melange package build and package test: version/help, APK ownership, Apache-2.0 SPDX, CA initialization, HTTPS startup, health 200
- amd64 image runtime: `Smallstep CA/0.30.2 (linux/amd64)`
- strict Trivy `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`: 0 findings
- PR CI runs native amd64/arm64 package tests, image builds, runtime architecture checks, and strict Trivy scans

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own the `step-ca` image with a bespoke, immutable `step-ca 0.30.2-r15` package to close open CVEs and lock the runtime. CI now runs hardened native package tests on amd64/arm64 via one script, and the image pins to the local build.

- **Bug Fixes**
  - Rebuilt `step-ca` as `0.30.2-r15` from Wolfi provenance with fixes for CVE-2026-39883, CVE-2026-41178, and CVE-2026-42505.
  - Pinned `smallstep/certificates` v0.30.2, Go `1.26.5`, and `go.opentelemetry.io/*` `v1.44.0`.
  - Image now selects only the local bespoke package; entrypoint stays `/usr/bin/step-ca`.
  - Added `.github/scripts/test-step-ca-package.sh`; both reusable and PR workflows call this single, bounded native test for x86_64/aarch64, anchored to the repo workspace, `melange-work/specs/step-ca.yaml`, and `melange-work/pipelines`.
  - Hardened tests: verify version/help, Apache-2.0 license and SBOM, linked OpenTelemetry modules, CA init, HTTPS health; added unit tests that enforce image pinning, CI gates, and the anchored test invocation.

<sup>Written for commit 59e8b2dc43c453cb7df7c4ceb5d2482fdccd54fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

