### PR TITLE
fix(integer): own pushgateway package

### DIFF
--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -248,12 +248,12 @@ jobs:
           test "$ready" = true
           curl -fsS "http://127.0.0.1:$host_port/metrics" \
             | grep -E "pushgateway_build_info\\{.*version=\"$expected_version\""
-          cat <<'EOF' | curl -fsS --data-binary @- \
-            "http://127.0.0.1:$host_port/metrics/job/integer_pushgateway_smoke"
-          # HELP integer_pushgateway_smoke Integer Pushgateway smoke metric.
-          # TYPE integer_pushgateway_smoke gauge
-          integer_pushgateway_smoke 7
-          EOF
+          printf '%s\n' \
+            '# HELP integer_pushgateway_smoke Integer Pushgateway smoke metric.' \
+            '# TYPE integer_pushgateway_smoke gauge' \
+            'integer_pushgateway_smoke 7' \
+            | curl -fsS --data-binary @- \
+              "http://127.0.0.1:$host_port/metrics/job/integer_pushgateway_smoke"
           curl -fsS "http://127.0.0.1:$host_port/metrics" \
             | grep -F 'integer_pushgateway_smoke{instance="",job="integer_pushgateway_smoke"} 7'
           docker image inspect "$image_ref" \

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -176,6 +176,103 @@ jobs:
             melange-work/specs/trivy.yaml/build.yaml \
             trivy
 
+      - name: Test Pushgateway package natively (${{ matrix.arch }})
+        if: inputs.image == 'pushgateway'
+        env:
+          BUILD_ARCH: ${{ matrix.arch }}
+        run: |
+          melange test \
+            --arch "$BUILD_ARCH" \
+            --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
+            --repository-append https://packages.wolfi.dev/os \
+            --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
+            --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+            --pipeline-dirs melange-work/pipelines \
+            --runner docker \
+            melange-work/specs/pushgateway.yaml/build.yaml \
+            prometheus-pushgateway
+
+      - name: Test Pushgateway image natively (${{ matrix.arch }})
+        if: inputs.image == 'pushgateway'
+        env:
+          BUILD_ARCH: ${{ matrix.arch }}
+          INPUT_IMAGE: ${{ inputs.image }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TYPE: ${{ inputs.type }}
+        run: |
+          case "$BUILD_ARCH" in
+            x86_64) IMAGE_ARCH=amd64 ;;
+            aarch64) IMAGE_ARCH=arm64 ;;
+            *) echo "Unsupported Pushgateway architecture: $BUILD_ARCH" >&2; exit 1 ;;
+          esac
+
+          expected_version=$(yq -r '.package.version' \
+            melange-work/specs/pushgateway.yaml/build.yaml)
+          expected_full_version=$(yq -r '.package.version + "-r" + (.package.epoch | tostring)' \
+            melange-work/specs/pushgateway.yaml/build.yaml)
+          image_tar="pushgateway-$IMAGE_ARCH.tar"
+          image_ref="integer:local-$IMAGE_ARCH"
+          container="integer-pushgateway-$IMAGE_ARCH-proof"
+          sbom="/tmp/pushgateway-$IMAGE_ARCH.spdx.json"
+          cleanup() {
+            docker rm --force "$container" >/dev/null 2>&1 || true
+            docker image rm "$image_ref" >/dev/null 2>&1 || true
+            rm -f "$image_tar" "$sbom"
+          }
+          trap cleanup EXIT
+
+          ./verity integer build \
+            --image "$INPUT_IMAGE" \
+            --version "$INPUT_VERSION" \
+            --type "$INPUT_TYPE" \
+            --arch "$IMAGE_ARCH" \
+            --fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
+            --output "$image_tar"
+
+          docker load --input "$image_tar"
+          docker run --detach --rm --name "$container" \
+            --publish 127.0.0.1::9091 \
+            "$image_ref" --web.listen-address=0.0.0.0:9091
+
+          host_port=$(docker port "$container" 9091/tcp | awk -F: 'END {print $NF}')
+          test -n "$host_port"
+          ready=false
+          for _ in $(seq 1 90); do
+            if curl -fsS "http://127.0.0.1:$host_port/-/ready" | grep -Fxq OK; then
+              ready=true
+              break
+            fi
+            docker inspect --format '{{.State.Running}}' "$container" | grep -Fx true
+            sleep 1
+          done
+          test "$ready" = true
+          curl -fsS "http://127.0.0.1:$host_port/metrics" \
+            | grep -E "pushgateway_build_info\\{.*version=\"$expected_version\""
+          cat <<'EOF' | curl -fsS --data-binary @- \
+            "http://127.0.0.1:$host_port/metrics/job/integer_pushgateway_smoke"
+          # HELP integer_pushgateway_smoke Integer Pushgateway smoke metric.
+          # TYPE integer_pushgateway_smoke gauge
+          integer_pushgateway_smoke 7
+          EOF
+          curl -fsS "http://127.0.0.1:$host_port/metrics" \
+            | grep -F 'integer_pushgateway_smoke{instance="",job="integer_pushgateway_smoke"} 7'
+          docker image inspect "$image_ref" \
+            --format '{{.Architecture}} {{.Os}} {{.Config.User}}' \
+            | grep -Fx "$IMAGE_ARCH linux 65532"
+
+          docker cp \
+            "$container:/var/lib/db/sbom/prometheus-pushgateway-${expected_full_version}.spdx.json" \
+            "$sbom"
+          jq -e --arg full_version "$expected_full_version" '
+            .spdxVersion == "SPDX-2.3"
+            and any(
+              .packages[];
+              .name == "prometheus-pushgateway"
+              and .versionInfo == $full_version
+              and .licenseDeclared == "Apache-2.0"
+            )
+          ' "$sbom"
+
       - name: Test Weaviate package natively (${{ matrix.arch }})
         if: inputs.image == 'weaviate'
         env:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -300,12 +300,12 @@ jobs:
                 test "$ready" = true
                 curl -fsS "http://127.0.0.1:$host_port/metrics" \
                   | grep -E "pushgateway_build_info\\{.*version=\"$expected_version\""
-                cat <<'EOF' | curl -fsS --data-binary @- \
-                  "http://127.0.0.1:$host_port/metrics/job/integer_pushgateway_smoke"
-                # HELP integer_pushgateway_smoke Integer Pushgateway smoke metric.
-                # TYPE integer_pushgateway_smoke gauge
-                integer_pushgateway_smoke 7
-                EOF
+                printf '%s\n' \
+                  '# HELP integer_pushgateway_smoke Integer Pushgateway smoke metric.' \
+                  '# TYPE integer_pushgateway_smoke gauge' \
+                  'integer_pushgateway_smoke 7' \
+                  | curl -fsS --data-binary @- \
+                    "http://127.0.0.1:$host_port/metrics/job/integer_pushgateway_smoke"
                 curl -fsS "http://127.0.0.1:$host_port/metrics" \
                   | grep -F 'integer_pushgateway_smoke{instance="",job="integer_pushgateway_smoke"} 7'
                 test "$runtime_user" = 65532

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -208,6 +208,24 @@ jobs:
             fi
             echo "::endgroup::"
 
+            if [ "$image" = "pushgateway" ]; then
+              expected_version=$(yq -r '.package.version' \
+                melange-work/specs/pushgateway.yaml/build.yaml)
+              expected_full_version=$(yq -r '.package.version + "-r" + (.package.epoch | tostring)' \
+                melange-work/specs/pushgateway.yaml/build.yaml)
+              timeout --signal=TERM --kill-after=1m 5m \
+                melange test \
+                  --arch "$INTEGER_PACKAGE_ARCH" \
+                  --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
+                  --repository-append https://packages.wolfi.dev/os \
+                  --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
+                  --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+                  --pipeline-dirs melange-work/pipelines \
+                  --runner docker \
+                  melange-work/specs/pushgateway.yaml/build.yaml \
+                  prometheus-pushgateway
+            fi
+
             if [ "$image" = "weaviate" ]; then
               expected_version=$(yq -r '.package.version' \
                 melange-work/specs/weaviate.yaml/build.yaml)
@@ -256,6 +274,55 @@ jobs:
             if [ "$runtime_arch" != "$arch" ]; then
               echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
               exit 1
+            fi
+
+            if [ "$image" = "pushgateway" ]; then
+              (
+                container="integer-pushgateway-${arch}-pr-smoke"
+                sbom="${RUNNER_TEMP}/pushgateway-${arch}.spdx.json"
+                trap 'docker rm --force "$container" >/dev/null 2>&1 || true; rm -f "$sbom"' EXIT
+
+                docker run --detach --rm --name "$container" \
+                  --publish 127.0.0.1::9091 \
+                  "$loaded_ref" --web.listen-address=0.0.0.0:9091
+
+                host_port=$(docker port "$container" 9091/tcp | awk -F: 'END {print $NF}')
+                test -n "$host_port"
+                ready=false
+                for _ in $(seq 1 90); do
+                  if curl -fsS "http://127.0.0.1:$host_port/-/ready" | grep -Fxq OK; then
+                    ready=true
+                    break
+                  fi
+                  docker inspect --format '{{.State.Running}}' "$container" | grep -Fx true
+                  sleep 1
+                done
+                test "$ready" = true
+                curl -fsS "http://127.0.0.1:$host_port/metrics" \
+                  | grep -E "pushgateway_build_info\\{.*version=\"$expected_version\""
+                cat <<'EOF' | curl -fsS --data-binary @- \
+                  "http://127.0.0.1:$host_port/metrics/job/integer_pushgateway_smoke"
+                # HELP integer_pushgateway_smoke Integer Pushgateway smoke metric.
+                # TYPE integer_pushgateway_smoke gauge
+                integer_pushgateway_smoke 7
+                EOF
+                curl -fsS "http://127.0.0.1:$host_port/metrics" \
+                  | grep -F 'integer_pushgateway_smoke{instance="",job="integer_pushgateway_smoke"} 7'
+                test "$runtime_user" = 65532
+
+                docker cp \
+                  "$container:/var/lib/db/sbom/prometheus-pushgateway-${expected_full_version}.spdx.json" \
+                  "$sbom"
+                jq -e --arg full_version "$expected_full_version" '
+                  .spdxVersion == "SPDX-2.3"
+                  and any(
+                    .packages[];
+                    .name == "prometheus-pushgateway"
+                    and .versionInfo == $full_version
+                    and .licenseDeclared == "Apache-2.0"
+                  )
+                ' "$sbom"
+              )
             fi
 
             if [ "$image" = "weaviate" ]; then

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -571,6 +571,24 @@ jobs:
             fi
             echo "::endgroup::"
 
+            if [ "$image" = "pushgateway" ]; then
+              expected_version=$(yq -r '.package.version' \
+                melange-work/specs/pushgateway.yaml/build.yaml)
+              expected_full_version=$(yq -r '.package.version + "-r" + (.package.epoch | tostring)' \
+                melange-work/specs/pushgateway.yaml/build.yaml)
+              timeout --signal=TERM --kill-after=1m 5m \
+                melange test \
+                  --arch "$INTEGER_PACKAGE_ARCH" \
+                  --repository-append "${GITHUB_WORKSPACE}/packages/repo" \
+                  --repository-append https://packages.wolfi.dev/os \
+                  --keyring-append "${GITHUB_WORKSPACE}/melange-work/melange.rsa.pub" \
+                  --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+                  --pipeline-dirs melange-work/pipelines \
+                  --runner docker \
+                  melange-work/specs/pushgateway.yaml/build.yaml \
+                  prometheus-pushgateway
+            fi
+
             if [ "$image" = linkerd ] && [ "$version" = 25 ] && [ "$type" = default ]; then
               if timeout --signal=TERM --kill-after=1m 30m \
                 ./verity integer melange build \
@@ -635,6 +653,54 @@ jobs:
             if [ "$runtime_arch" != "$arch" ]; then
               echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
               exit 1
+            fi
+
+            if [ "$image" = "pushgateway" ]; then
+              (
+                container="integer-pushgateway-${arch}-pr-build"
+                sbom="${RUNNER_TEMP}/pushgateway-${arch}.spdx.json"
+                trap 'docker rm --force "$container" >/dev/null 2>&1 || true; rm -f "$sbom"' EXIT
+
+                docker run --detach --rm --name "$container" \
+                  --publish 127.0.0.1::9091 \
+                  "$loaded_ref" --web.listen-address=0.0.0.0:9091
+
+                host_port=$(docker port "$container" 9091/tcp | awk -F: 'END {print $NF}')
+                test -n "$host_port"
+                ready=false
+                for _ in $(seq 1 90); do
+                  if curl -fsS "http://127.0.0.1:$host_port/-/ready" | grep -Fxq OK; then
+                    ready=true
+                    break
+                  fi
+                  docker inspect --format '{{.State.Running}}' "$container" | grep -Fx true
+                  sleep 1
+                done
+                test "$ready" = true
+                curl -fsS "http://127.0.0.1:$host_port/metrics" \
+                  | grep -E "pushgateway_build_info\\{.*version=\"$expected_version\""
+                printf '%s\n' \
+                  '# HELP integer_pushgateway_smoke Integer Pushgateway smoke metric.' \
+                  '# TYPE integer_pushgateway_smoke gauge' \
+                  'integer_pushgateway_smoke 7' \
+                  | curl -fsS --data-binary @- \
+                    "http://127.0.0.1:$host_port/metrics/job/integer_pushgateway_smoke"
+                curl -fsS "http://127.0.0.1:$host_port/metrics" \
+                  | grep -F 'integer_pushgateway_smoke{instance="",job="integer_pushgateway_smoke"} 7'
+
+                docker cp \
+                  "$container:/var/lib/db/sbom/prometheus-pushgateway-${expected_full_version}.spdx.json" \
+                  "$sbom"
+                jq -e --arg full_version "$expected_full_version" '
+                  .spdxVersion == "SPDX-2.3"
+                  and any(
+                    .packages[];
+                    .name == "prometheus-pushgateway"
+                    and .versionInfo == $full_version
+                    and .licenseDeclared == "Apache-2.0"
+                  )
+                ' "$sbom"
+              )
             fi
 
             trivy image \

--- a/cmd/pushgateway_config_test.go
+++ b/cmd/pushgateway_config_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -111,7 +112,8 @@ func Test_Pushgateway_PR_smoke_verifies_runtime_and_provenance_natively(t *testi
 	// When: the Pushgateway-family native smoke gate is inspected.
 
 	// Then: PR CI runs package tests plus image health, metrics, SPDX, and strict Trivy validation.
-	require.Contains(t, text, "if [ \"$image\" = \"pushgateway\" ]; then")
+	const pushgatewayGate = "if [ \"$image\" = \"pushgateway\" ]; then"
+	require.GreaterOrEqual(t, strings.Count(text, pushgatewayGate), 4)
 	require.Contains(t, text, "melange test \\")
 	require.Contains(t, text, "--fail-on-severity \"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL\"")
 	require.Contains(t, text, "/-/ready")

--- a/cmd/pushgateway_config_test.go
+++ b/cmd/pushgateway_config_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Pushgateway_uses_fixed_bespoke_package_and_preserves_alias(t *testing.T) {
+	// Given: the checked-in Pushgateway image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "pushgateway.yaml"))
+	require.NoError(t, err)
+
+	// When: the only supported image variant and version family are resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects the local rebuild without changing the 1.11 alias.
+	require.Len(t, def.Types, 1)
+	require.Len(t, def.Versions, 1)
+	require.Contains(t, def.Versions, "1.11")
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "pushgateway.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"prometheus-pushgateway"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/pushgateway", tmpl.Entrypoint)
+}
+
+func Test_Pushgateway_recipe_pins_immutable_fixed_source_and_provenance(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "pushgateway.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its source, fixed revision, runtime smoke, and license metadata are inspected.
+
+	// Then: r2 rebuilds immutable Apache-2.0 v1.11.3 source containing both Prometheus fixes.
+	require.Contains(t, text, "name: prometheus-pushgateway")
+	require.Contains(t, text, "version: \"1.11.3\"")
+	require.Contains(t, text, "epoch: 2")
+	require.Contains(t, text, "license: Apache-2.0")
+	require.Contains(t, text, "Adapted from wolfi-dev/os@c18151bd0f768439d4e969ec5472e6844f33cc70")
+	require.Contains(t, text, "repository: https://github.com/prometheus/pushgateway")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: e803ebd81be5867ff17a21205030611fa033af13")
+	require.Contains(t, text, "CVE-2026-42151")
+	require.Contains(t, text, "CVE-2026-42154")
+	require.Contains(t, text, "go-package: go-1.26")
+	require.Contains(t, text, "GOTOOLCHAIN: local")
+	require.NotContains(t, text, "tags: netgo,osusergo")
+	require.Contains(t, text, "github.com/prometheus/prometheus[[:space:]]+v0.311.3")
+	require.Contains(t, text, "pushgateway --version")
+	require.Contains(t, text, "test/daemon-check-output")
+	require.Contains(t, text, "/-/ready")
+	require.Contains(t, text, "/metrics/job/integer_pushgateway_smoke")
+	require.Contains(t, text, "integer_pushgateway_smoke 7")
+	require.Contains(t, text, "apk info --license prometheus-pushgateway | grep -Fx Apache-2.0")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/LICENSE")
+	require.Contains(t, text, "spdx.json")
+	require.Contains(t, text, "licenseDeclared == \"Apache-2.0\"")
+	require.NotContains(t, text, "subpackages:")
+}
+
+func Test_Pushgateway_resolves_only_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and locally built Pushgateway package.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "pushgateway.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1.11", []apkindex.Package{{
+		Name:    "prometheus-pushgateway",
+		Version: "1.11.3-r2",
+	}})
+
+	// Then: apko can only select the approved fixed local revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"prometheus-pushgateway=1.11.3-r2@local"}, tmpl.Packages)
+}
+
+func Test_Pushgateway_CI_verifies_package_and_image_natively(t *testing.T) {
+	// Given: the native package and image workflow used for publish builds.
+	workflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
+	require.NoError(t, err)
+	text := string(workflow)
+
+	// When: the Pushgateway-family gates are inspected.
+
+	// Then: both native legs test the package and image with strict security and provenance checks.
+	require.Contains(t, text, "Test Pushgateway package natively (${{ matrix.arch }})")
+	require.Contains(t, text, "Test Pushgateway image natively (${{ matrix.arch }})")
+	require.Contains(t, text, "if: inputs.image == 'pushgateway'")
+	require.Contains(t, text, "melange-work/specs/pushgateway.yaml/build.yaml")
+	require.Contains(t, text, "--fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
+	require.Contains(t, text, "/-/ready")
+	require.Contains(t, text, "/metrics/job/integer_pushgateway_smoke")
+	require.Contains(t, text, "prometheus-pushgateway-${expected_full_version}.spdx.json")
+	require.Contains(t, text, "licenseDeclared == \"Apache-2.0\"")
+}
+
+func Test_Pushgateway_PR_smoke_verifies_runtime_and_provenance_natively(t *testing.T) {
+	// Given: the pull-request smoke workflow used by both architecture runners.
+	workflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "pr-test.yaml"))
+	require.NoError(t, err)
+	text := string(workflow)
+
+	// When: the Pushgateway-family native smoke gate is inspected.
+
+	// Then: PR CI runs package tests plus image health, metrics, SPDX, and strict Trivy validation.
+	require.Contains(t, text, "if [ \"$image\" = \"pushgateway\" ]; then")
+	require.Contains(t, text, "melange test \\")
+	require.Contains(t, text, "--fail-on-severity \"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL\"")
+	require.Contains(t, text, "/-/ready")
+	require.Contains(t, text, "/metrics/job/integer_pushgateway_smoke")
+	require.Contains(t, text, "prometheus-pushgateway-${expected_full_version}.spdx.json")
+	require.Contains(t, text, ".spdxVersion == \"SPDX-2.3\"")
+	require.Contains(t, text, "licenseDeclared == \"Apache-2.0\"")
+}

--- a/cmd/pushgateway_config_test.go
+++ b/cmd/pushgateway_config_test.go
@@ -97,6 +97,7 @@ func Test_Pushgateway_CI_verifies_package_and_image_natively(t *testing.T) {
 	require.Contains(t, text, "--fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
 	require.Contains(t, text, "/-/ready")
 	require.Contains(t, text, "/metrics/job/integer_pushgateway_smoke")
+	require.Contains(t, text, "printf '%s\\n'")
 	require.Contains(t, text, "prometheus-pushgateway-${expected_full_version}.spdx.json")
 	require.Contains(t, text, "licenseDeclared == \"Apache-2.0\"")
 }
@@ -115,6 +116,7 @@ func Test_Pushgateway_PR_smoke_verifies_runtime_and_provenance_natively(t *testi
 	require.Contains(t, text, "--fail-on-severity \"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL\"")
 	require.Contains(t, text, "/-/ready")
 	require.Contains(t, text, "/metrics/job/integer_pushgateway_smoke")
+	require.Contains(t, text, "printf '%s\\n'")
 	require.Contains(t, text, "prometheus-pushgateway-${expected_full_version}.spdx.json")
 	require.Contains(t, text, ".spdxVersion == \"SPDX-2.3\"")
 	require.Contains(t, text, "licenseDeclared == \"Apache-2.0\"")

--- a/images/pushgateway.yaml
+++ b/images/pushgateway.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["prometheus-pushgateway"]
     entrypoint: /usr/bin/pushgateway
+    melange:
+      bespoke: pushgateway.yaml
     paths:
       - {path: /tmp, type: directory, uid: 65532, gid: 65532, permissions: 0o755}
 

--- a/packages/bespoke/pushgateway.yaml
+++ b/packages/bespoke/pushgateway.yaml
@@ -1,0 +1,120 @@
+package:
+  name: prometheus-pushgateway
+  # renovate: datasource=github-tags depName=prometheus/pushgateway versioning=semver-coerced
+  version: "1.11.3"
+  # r2 rebuilds the latest immutable release with its fixed Prometheus v3.11.3
+  # dependency for CVE-2026-42151 and CVE-2026-42154. Trivy marks r2 fixed.
+  epoch: 2
+  description: Push acceptor for ephemeral and batch jobs
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - merged-usrsbin
+      - wolfi-baselayout
+  resources:
+    cpu: "4"
+    memory: 7Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+    GOTOOLCHAIN: local
+
+pipeline:
+  # Adapted from wolfi-dev/os@c18151bd0f768439d4e969ec5472e6844f33cc70.
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus/pushgateway
+      tag: v${{package.version}}
+      expected-commit: e803ebd81be5867ff17a21205030611fa033af13
+
+  - uses: go/build
+    with:
+      packages: .
+      output: prometheus-pushgateway
+      go-package: go-1.26
+      ldflags: |-
+        -X github.com/prometheus/common/version.Version=${{package.version}}
+        -X github.com/prometheus/common/version.Revision=e803ebd81be5867ff17a21205030611fa033af13
+        -X github.com/prometheus/common/version.Branch=HEAD
+        -X github.com/prometheus/common/version.BuildUser=reproducible@reproducible
+        -X github.com/prometheus/common/version.BuildDate=$(date -u -d "@$SOURCE_DATE_EPOCH" +%Y-%m-%d-%H:%M)
+
+  - runs: |
+      binary="${{targets.destdir}}/usr/bin/prometheus-pushgateway"
+      "$binary" --version 2>&1 | grep -F "version ${{package.version}}"
+      go version -m "$binary" \
+        | grep -E 'github.com/prometheus/prometheus[[:space:]]+v0.311.3'
+      ln -sf /usr/bin/prometheus-pushgateway \
+        "${{targets.destdir}}/usr/bin/pushgateway"
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - curl
+        - go-1.26
+        - jq
+  pipeline:
+    - name: Validate runtime, fixed dependency, and Apache-2.0 provenance
+      runs: |
+        pushgateway --version 2>&1 | grep -F "version ${{package.version}}"
+        pushgateway --help >/dev/null
+        test "$(readlink /usr/bin/pushgateway)" = "/usr/bin/prometheus-pushgateway"
+        go version -m /usr/bin/prometheus-pushgateway \
+          | grep -E 'github.com/prometheus/prometheus[[:space:]]+v0.311.3'
+        apk info --who-owns /usr/bin/prometheus-pushgateway \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license prometheus-pushgateway | grep -Fx Apache-2.0
+        test -s "/usr/share/licenses/${{package.name}}/LICENSE"
+        sbom="/var/lib/db/sbom/${{package.name}}-${{package.full-version}}.spdx.json"
+        test -s "$sbom"
+        jq -e --arg full_version "${{package.full-version}}" '
+          .spdxVersion == "SPDX-2.3"
+          and any(
+            .packages[];
+            .name == "prometheus-pushgateway"
+            and .versionInfo == $full_version
+            and .licenseDeclared == "Apache-2.0"
+          )
+        ' "$sbom"
+    - name: Validate Pushgateway health and metrics push/read behavior
+      uses: test/daemon-check-output
+      with:
+        start: pushgateway --web.listen-address=0.0.0.0:9091
+        timeout: 30
+        expected_output: |
+          msg="starting pushgateway"
+          msg="Listening on"
+        post: |
+          curl --fail-with-body --silent --show-error \
+            http://127.0.0.1:9091/-/ready \
+            | grep -Fx OK
+          cat <<'EOF' | curl --fail-with-body --silent --show-error \
+            --data-binary @- \
+            http://127.0.0.1:9091/metrics/job/integer_pushgateway_smoke
+          # HELP integer_pushgateway_smoke Integer Pushgateway smoke metric.
+          # TYPE integer_pushgateway_smoke gauge
+          integer_pushgateway_smoke 7
+          EOF
+          curl --fail-with-body --silent --show-error \
+            http://127.0.0.1:9091/metrics \
+            | grep -F 'integer_pushgateway_smoke{instance="",job="integer_pushgateway_smoke"} 7'
+
+update:
+  enabled: true
+  github:
+    identifier: prometheus/pushgateway
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
## Summary

- rebuild Prometheus Pushgateway 1.11.3-r2 from immutable upstream commit e803ebd81be5867ff17a21205030611fa033af13 with Apache-2.0 provenance
- preserve the existing latest, 1.11, and 1.11.3 image alias semantics while routing the default family through the local package
- add native amd64/arm64 package and image validation with runtime/version, health, representative metrics push/read, SPDX-2.3/license, and strict UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL Trivy zero-finding gates

## Security evidence

Current ghcr.io/verity-org/pushgateway:1.11.3 is RED on both architectures: prometheus-pushgateway 1.11.3-r1 is reported with CVE-2026-42151 and CVE-2026-42154, both fixed in 1.11.3-r2. The live Wolfi indexes still publish r1, so this PR owns the immutable r2 rebuild.

## Validation

- go test -race -shuffle=on -count=1 ./cmd
- go test -shuffle=on -count=1 ./...
- actionlint .github/workflows/integer-build-image.yaml .github/workflows/pr-test.yaml
- python3 .github/scripts/validate-pr-test-workflow.py
- ./verity integer validate
- native amd64 Melange build/test and image runtime smoke
- strict amd64 Trivy: 0 findings across UNKNOWN through CRITICAL
- SPDX-2.3 package version 1.11.3-r2, licenseDeclared Apache-2.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own and rebuild the `prometheus-pushgateway` image as a local package (1.11.3-r2) to remove CVEs and keep provenance, while preserving tag aliases. CI adds native amd64/arm64 package and image tests with strict vuln gates and SBOM/license checks, and now covers the strict build path in PRs.

- **Bug Fixes**
  - Rebuild `prometheus-pushgateway` 1.11.3-r2 and route `pushgateway` to the local package.
  - Remediates CVE-2026-42151 and CVE-2026-42154 present in r1.
  - Preserves `latest`, `1.11`, and `1.11.3` tag behavior.
  - Makes Pushgateway CI smoke scripts shellcheck-safe.

- **New Features**
  - Add bespoke recipe `packages/bespoke/pushgateway.yaml` and wire `images/pushgateway.yaml` to use it.
  - Add native amd64/arm64 CI for `melange test` and runtime smoke with strict `Trivy` zero findings and `SPDX-2.3`/`Apache-2.0` checks; extend PR CI to cover the strict build path (health/metrics, non-root user, SBOM), plus Go tests to verify wiring and provenance.

<sup>Written for commit 5a1e0f0c4fe5d4a6f57ca95ae8a708abe2ba63b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

