### PR TITLE
fix(integer): own rclone package

### DIFF
--- a/.github/scripts/test-rclone-package.sh
+++ b/.github/scripts/test-rclone-package.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <x86_64|aarch64>" >&2
+  exit 2
+fi
+
+arch=$1
+case "$arch" in
+  x86_64 | aarch64) ;;
+  *)
+    echo "unsupported rclone package architecture: $arch" >&2
+    exit 2
+    ;;
+esac
+
+workspace=${GITHUB_WORKSPACE:-$(pwd)}
+cd "$workspace"
+timeout --signal=TERM --kill-after=1m 30m melange test \
+  --arch "$arch" \
+  --repository-append "$workspace/packages/repo" \
+  --repository-append https://packages.wolfi.dev/os \
+  --keyring-append "$workspace/melange-work/melange.rsa.pub" \
+  --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+  --runner docker \
+  --pipeline-dirs melange-work/pipelines \
+  melange-work/specs/rclone.yaml/build.yaml \
+  rclone

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -196,6 +196,11 @@ jobs:
             *) echo "Unsupported rclone architecture: $BUILD_ARCH" >&2; exit 1 ;;
           esac
 
+          rclone_version=$(yq -r '.package.version' \
+            melange-work/specs/rclone.yaml/build.yaml)
+          rclone_full_version=$(yq -r '.package.version + "-r" + (.package.epoch | tostring)' \
+            melange-work/specs/rclone.yaml/build.yaml)
+
           image_tar="rclone-$IMAGE_ARCH.tar"
           image_ref="integer:local-$IMAGE_ARCH"
           container="integer-rclone-$IMAGE_ARCH-proof"
@@ -218,7 +223,7 @@ jobs:
 
           docker load --input "$image_tar"
           docker run --rm "$image_ref" --version \
-            | grep -E '^rclone v?1.74.4$'
+            | grep -E "^rclone v?${rclone_version}$"
 
           mkdir -p "$smoke/source" "$smoke/destination"
           chmod 0755 "$smoke" "$smoke/source"
@@ -243,14 +248,14 @@ jobs:
             | grep -Fx "$IMAGE_ARCH linux"
           docker create --name "$container" "$image_ref" --version >/dev/null
           docker cp \
-            "$container:/var/lib/db/sbom/rclone-1.74.4-r0.spdx.json" \
+            "$container:/var/lib/db/sbom/rclone-${rclone_full_version}.spdx.json" \
             "$sbom"
-          jq -e '
+          jq -e --arg full_version "$rclone_full_version" '
             .spdxVersion == "SPDX-2.3"
             and any(
               .packages[];
               .name == "rclone"
-              and .versionInfo == "1.74.4-r0"
+              and .versionInfo == $full_version
               and .licenseDeclared == "MIT"
             )
           ' "$sbom"

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -176,6 +176,85 @@ jobs:
             melange-work/specs/trivy.yaml/build.yaml \
             trivy
 
+      - name: Test rclone package natively (${{ matrix.arch }})
+        if: inputs.image == 'rclone'
+        env:
+          BUILD_ARCH: ${{ matrix.arch }}
+        run: bash .github/scripts/test-rclone-package.sh "$BUILD_ARCH"
+
+      - name: Test rclone image natively (${{ matrix.arch }})
+        if: inputs.image == 'rclone'
+        env:
+          BUILD_ARCH: ${{ matrix.arch }}
+          INPUT_IMAGE: ${{ inputs.image }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TYPE: ${{ inputs.type }}
+        run: |
+          case "$BUILD_ARCH" in
+            x86_64) IMAGE_ARCH=amd64 ;;
+            aarch64) IMAGE_ARCH=arm64 ;;
+            *) echo "Unsupported rclone architecture: $BUILD_ARCH" >&2; exit 1 ;;
+          esac
+
+          image_tar="rclone-$IMAGE_ARCH.tar"
+          image_ref="integer:local-$IMAGE_ARCH"
+          container="integer-rclone-$IMAGE_ARCH-proof"
+          smoke=$(mktemp -d)
+          sbom="/tmp/rclone-$IMAGE_ARCH.spdx.json"
+          cleanup() {
+            docker rm --force "$container" >/dev/null 2>&1 || true
+            docker image rm "$image_ref" >/dev/null 2>&1 || true
+            rm -rf "$image_tar" "$smoke" "$sbom"
+          }
+          trap cleanup EXIT
+
+          ./verity integer build \
+            --image "$INPUT_IMAGE" \
+            --version "$INPUT_VERSION" \
+            --type "$INPUT_TYPE" \
+            --arch "$IMAGE_ARCH" \
+            --fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
+            --output "$image_tar"
+
+          docker load --input "$image_tar"
+          docker run --rm "$image_ref" --version \
+            | grep -E '^rclone v?1.74.4$'
+
+          mkdir -p "$smoke/source" "$smoke/destination"
+          chmod 0755 "$smoke" "$smoke/source"
+          chmod 0777 "$smoke/destination"
+          printf '%s\n' 'verity rclone image checksum smoke' \
+            >"$smoke/source/payload.txt"
+          (
+            cd "$smoke/source"
+            sha256sum payload.txt >../payload.sha256
+          )
+          docker run --rm --volume "$smoke:/work" "$image_ref" \
+            copy /work/source /work/destination
+          docker run --rm --volume "$smoke:/work" "$image_ref" \
+            check --checksum /work/source /work/destination
+          (
+            cd "$smoke/destination"
+            sha256sum --check ../payload.sha256
+          )
+
+          docker image inspect "$image_ref" \
+            --format '{{.Architecture}} {{.Os}}' \
+            | grep -Fx "$IMAGE_ARCH linux"
+          docker create --name "$container" "$image_ref" --version >/dev/null
+          docker cp \
+            "$container:/var/lib/db/sbom/rclone-1.74.4-r0.spdx.json" \
+            "$sbom"
+          jq -e '
+            .spdxVersion == "SPDX-2.3"
+            and any(
+              .packages[];
+              .name == "rclone"
+              and .versionInfo == "1.74.4-r0"
+              and .licenseDeclared == "MIT"
+            )
+          ' "$sbom"
+
       - name: Test Weaviate package natively (${{ matrix.arch }})
         if: inputs.image == 'weaviate'
         env:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -226,6 +226,12 @@ jobs:
                   weaviate
             fi
 
+            if [ "$image" = "rclone" ]; then
+              echo "::group::rclone package test (${INTEGER_PACKAGE_ARCH})"
+              bash .github/scripts/test-rclone-package.sh "$INTEGER_PACKAGE_ARCH"
+              echo "::endgroup::"
+            fi
+
             if [ "$image" = "step-ca" ]; then
               echo "::group::Step CA package test (${INTEGER_PACKAGE_ARCH})"
               bash .github/scripts/test-step-ca-package.sh "$INTEGER_PACKAGE_ARCH"
@@ -256,6 +262,53 @@ jobs:
             if [ "$runtime_arch" != "$arch" ]; then
               echo "::error::runtime architecture mismatch: expected ${arch}, got ${runtime_arch}"
               exit 1
+            fi
+
+            if [ "$image" = "rclone" ]; then
+              (
+                rclone_version=$(yq -r '.package.version' \
+                  melange-work/specs/rclone.yaml/build.yaml)
+                rclone_full_version=$(yq -r '.package.version + "-r" + (.package.epoch | tostring)' \
+                  melange-work/specs/rclone.yaml/build.yaml)
+                container="integer-rclone-${arch}-pr-smoke"
+                smoke=$(mktemp -d)
+                sbom="${RUNNER_TEMP}/rclone-${arch}.spdx.json"
+                trap 'docker rm --force "$container" >/dev/null 2>&1 || true; rm -rf "$smoke" "$sbom"' EXIT
+
+                docker run --rm "$loaded_ref" --version \
+                  | grep -E "^rclone v?${rclone_version}$"
+                mkdir -p "$smoke/source" "$smoke/destination"
+                chmod 0755 "$smoke" "$smoke/source"
+                chmod 0777 "$smoke/destination"
+                printf '%s\n' 'verity rclone PR checksum smoke' \
+                  >"$smoke/source/payload.txt"
+                (
+                  cd "$smoke/source"
+                  sha256sum payload.txt >../payload.sha256
+                )
+                docker run --rm --volume "$smoke:/work" "$loaded_ref" \
+                  copy /work/source /work/destination
+                docker run --rm --volume "$smoke:/work" "$loaded_ref" \
+                  check --checksum /work/source /work/destination
+                (
+                  cd "$smoke/destination"
+                  sha256sum --check ../payload.sha256
+                )
+
+                docker create --name "$container" "$loaded_ref" --version >/dev/null
+                docker cp \
+                  "$container:/var/lib/db/sbom/rclone-${rclone_full_version}.spdx.json" \
+                  "$sbom"
+                jq -e --arg full_version "$rclone_full_version" '
+                  .spdxVersion == "SPDX-2.3"
+                  and any(
+                    .packages[];
+                    .name == "rclone"
+                    and .versionInfo == $full_version
+                    and .licenseDeclared == "MIT"
+                  )
+                ' "$sbom"
+              )
             fi
 
             if [ "$image" = "weaviate" ]; then

--- a/cmd/rclone_config_test.go
+++ b/cmd/rclone_config_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/verity-org/verity/internal/integer/apkindex"
+	intconfig "github.com/verity-org/verity/internal/integer/config"
+)
+
+func Test_Rclone_uses_pinned_bespoke_package(t *testing.T) {
+	// Given: the checked-in rclone image definition.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "rclone.yaml"))
+	require.NoError(t, err)
+
+	// When: the only supported image variant is resolved.
+	tmpl := def.Types["default"]
+
+	// Then: the image selects only the local rebuild and preserves its runtime contract.
+	require.Len(t, def.Types, 1)
+	require.NotNil(t, tmpl.Melange)
+	require.Equal(t, "rclone.yaml", tmpl.Melange.Bespoke.First())
+	require.Equal(t, []string{"rclone"}, tmpl.Packages)
+	require.Equal(t, "/usr/bin/rclone", tmpl.Entrypoint)
+}
+
+func Test_Rclone_recipe_pins_latest_immutable_fixed_source(t *testing.T) {
+	// Given: the bespoke package recipe selected by the image.
+	recipe, err := os.ReadFile(filepath.Join("..", "packages", "bespoke", "rclone.yaml"))
+	require.NoError(t, err)
+	text := string(recipe)
+
+	// When: its source, dependency fix, smoke tests, and provenance are inspected.
+
+	// Then: v1.74.4 is immutable, MIT-licensed, and links the fixed x/image release.
+	require.Contains(t, text, "Adapted from wolfi-dev/os@cfc19ff702dda08c0d9fef924b0ccdf2009c2698")
+	require.Contains(t, text, "name: rclone")
+	require.Contains(t, text, "version: \"1.74.4\"")
+	require.Contains(t, text, "epoch: 0")
+	require.Contains(t, text, "license: MIT")
+	require.Contains(t, text, "repository: https://github.com/rclone/rclone")
+	require.Contains(t, text, "tag: v${{package.version}}")
+	require.Contains(t, text, "expected-commit: 5bc93a2a7ab0ebd0a11352bc4968eabeffb18027")
+	require.Contains(t, text, "CVE-2026-33813")
+	require.Contains(t, text, "CVE-2026-41178")
+	require.Contains(t, text, "CVE-2026-46601")
+	require.Contains(t, text, "CVE-2026-46602")
+	require.Contains(t, text, "CVE-2026-46604")
+	require.Contains(t, text, "go.opentelemetry.io/otel@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/metric@v1.44.0")
+	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "golang.org/x/image@v0.43.0")
+	require.Contains(t, text, "go-1.26=1.26.5-r1")
+	require.Contains(t, text, "go version -m")
+	require.Contains(t, text, "rclone --version")
+	require.Contains(t, text, "rclone copy")
+	require.Contains(t, text, "rclone check --checksum")
+	require.Contains(t, text, "- coreutils")
+	require.Contains(t, text, "sha256sum --check")
+	require.Contains(t, text, "apk info --who-owns /usr/bin/rclone")
+	require.Contains(t, text, "apk info --license rclone")
+	require.Contains(t, text, "usr/share/licenses/${{package.name}}/COPYING")
+	require.Contains(t, text, "spdx.json")
+	require.Contains(t, text, "licenseDeclared == \"MIT\"")
+}
+
+func Test_Rclone_resolves_fixed_local_package(t *testing.T) {
+	// Given: the checked-in image template and package produced by the bespoke recipe.
+	def, err := intconfig.LoadImage(filepath.Join("..", "images", "rclone.yaml"))
+	require.NoError(t, err)
+	tmpl := def.Types["default"]
+
+	// When: the local Melange artifact is pinned for the image build.
+	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{
+		{Name: "rclone", Version: "1.74.4-r0"},
+	})
+
+	// Then: apko can only select the approved fixed locally built revision.
+	require.NoError(t, err)
+	require.Equal(t, []string{"rclone=1.74.4-r0@local"}, tmpl.Packages)
+}
+
+func Test_Rclone_CI_tests_package_and_image_natively(t *testing.T) {
+	// Given: the Integer package workflow used by both architecture runners.
+	workflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
+	require.NoError(t, err)
+	text := string(workflow)
+
+	// When: the rclone-family native gates are inspected.
+
+	// Then: each native leg tests the package and its strictly scanned image.
+	require.Contains(t, text, "Test rclone package natively (${{ matrix.arch }})")
+	require.Contains(t, text, "Test rclone image natively (${{ matrix.arch }})")
+	require.Contains(t, text, "if: inputs.image == 'rclone'")
+	require.Contains(t, text, "test-rclone-package.sh")
+	require.Contains(t, text, "--fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
+	require.Contains(t, text, "^rclone v?1.74.4$")
+	require.Contains(t, text, "copy /work/source /work/destination")
+	require.Contains(t, text, "check --checksum /work/source /work/destination")
+	require.Contains(t, text, "sha256sum --check")
+	require.Contains(t, text, "rclone-1.74.4-r0.spdx.json")
+	require.Contains(t, text, "licenseDeclared == \"MIT\"")
+}
+
+func Test_Rclone_PR_smoke_tests_runtime_copy_checksum_and_provenance_natively(t *testing.T) {
+	// Given: the pull-request smoke workflow used by both architecture runners.
+	workflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "pr-test.yaml"))
+	require.NoError(t, err)
+	text := string(workflow)
+
+	// When: the rclone-family native smoke gate is inspected.
+
+	// Then: PR CI validates runtime, local copy/checksum behavior, SPDX, and strict Trivy.
+	require.Contains(t, text, "if [ \"$image\" = \"rclone\" ]; then")
+	require.Contains(t, text, "rclone_version=$(yq -r '.package.version'")
+	require.Contains(t, text, "rclone_full_version=$(yq -r '.package.version + \"-r\"")
+	require.Contains(t, text, "^rclone v?${rclone_version}$")
+	require.Contains(t, text, "copy /work/source /work/destination")
+	require.Contains(t, text, "check --checksum /work/source /work/destination")
+	require.Contains(t, text, "sha256sum --check")
+	require.Contains(t, text, "rclone-${rclone_full_version}.spdx.json")
+	require.Contains(t, text, ".spdxVersion == \"SPDX-2.3\"")
+	require.Contains(t, text, ".versionInfo == $full_version")
+	require.Contains(t, text, "licenseDeclared == \"MIT\"")
+	require.Contains(t, text, "--severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
+}

--- a/cmd/rclone_config_test.go
+++ b/cmd/rclone_config_test.go
@@ -97,12 +97,29 @@ func Test_Rclone_CI_tests_package_and_image_natively(t *testing.T) {
 	require.Contains(t, text, "if: inputs.image == 'rclone'")
 	require.Contains(t, text, "test-rclone-package.sh")
 	require.Contains(t, text, "--fail-on-severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
-	require.Contains(t, text, "^rclone v?1.74.4$")
+	require.Contains(t, text, "^rclone v?${rclone_version}$")
 	require.Contains(t, text, "copy /work/source /work/destination")
 	require.Contains(t, text, "check --checksum /work/source /work/destination")
 	require.Contains(t, text, "sha256sum --check")
-	require.Contains(t, text, "rclone-1.74.4-r0.spdx.json")
+	require.Contains(t, text, "rclone-${rclone_full_version}.spdx.json")
 	require.Contains(t, text, "licenseDeclared == \"MIT\"")
+}
+
+func Test_Rclone_native_image_proof_derives_package_version(t *testing.T) {
+	// Given: the native image proof maintained alongside the package recipe.
+	workflow, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
+	require.NoError(t, err)
+	text := string(workflow)
+
+	// When: routine package version or epoch bumps change the generated SBOM name.
+
+	// Then: runtime and SPDX assertions follow the built recipe instead of a stale literal.
+	require.Contains(t, text, "rclone_version=$(yq -r '.package.version'")
+	require.Contains(t, text, "rclone_full_version=$(yq -r '.package.version + \"-r\"")
+	require.Contains(t, text, "--arg full_version \"$rclone_full_version\"")
+	require.Contains(t, text, ".versionInfo == $full_version")
+	require.NotContains(t, text, "rclone-1.74.4-r0.spdx.json")
+	require.NotContains(t, text, ".versionInfo == \"1.74.4-r0\"")
 }
 
 func Test_Rclone_PR_smoke_tests_runtime_copy_checksum_and_provenance_natively(t *testing.T) {

--- a/images/rclone.yaml
+++ b/images/rclone.yaml
@@ -8,6 +8,8 @@ types:
     base: wolfi-base
     packages: ["rclone"]
     entrypoint: /usr/bin/rclone
+    melange:
+      bespoke: rclone.yaml
 
 versions:
   "1": {}

--- a/packages/bespoke/rclone.yaml
+++ b/packages/bespoke/rclone.yaml
@@ -1,0 +1,138 @@
+# Adapted from wolfi-dev/os@cfc19ff702dda08c0d9fef924b0ccdf2009c2698
+# (rclone 1.74.3-r0).
+package:
+  name: rclone
+  # renovate: datasource=github-tags depName=rclone/rclone versioning=semver-coerced
+  version: "1.74.4"
+  # v1.74.4 supersedes public 1.74.3-r0, for which current Trivy data records
+  # fixed package revisions r3 (CVE-2026-41178), r4 (CVE-2026-33813), and r5
+  # (CVE-2026-46601, CVE-2026-46602, CVE-2026-46604). Build with the fixed
+  # OpenTelemetry 1.44.0 and x/image 0.43.0 module graph rather than relying
+  # only on the newer APK version to clear package-level advisories.
+  epoch: 0
+  description: Rsync for cloud storage
+  copyright:
+    # Upstream COPYING at the pinned source commit is the MIT license.
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates
+      - fuse3
+      - tzdata
+  resources:
+    cpu: "2"
+    memory: 8Gi
+  test-resources:
+    cpu: "1"
+    memory: 1Gi
+
+environment:
+  contents:
+    packages:
+      - go-1.26=1.26.5-r1
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rclone/rclone
+      tag: v${{package.version}}
+      expected-commit: 5bc93a2a7ab0ebd0a11352bc4968eabeffb18027
+
+  - uses: go/bump
+    with:
+      deps: |-
+        go.opentelemetry.io/otel@v1.44.0
+        go.opentelemetry.io/otel/metric@v1.44.0
+        go.opentelemetry.io/otel/trace@v1.44.0
+        golang.org/x/image@v0.43.0
+
+  - runs: |
+      for module in \
+        go.opentelemetry.io/otel \
+        go.opentelemetry.io/otel/metric \
+        go.opentelemetry.io/otel/trace; do
+        go list -m all \
+          | awk -v module="$module" \
+            '$1 == module && $2 == "v1.44.0" { found = 1 } END { exit !found }'
+      done
+      go list -m all \
+        | awk '$1 == "golang.org/x/image" && $2 == "v0.43.0" { found = 1 } END { exit !found }'
+
+  - uses: go/build
+    with:
+      go-package: go-1.26
+      ldflags: -X github.com/rclone/rclone/fs.Version=${{package.version}}
+      packages: .
+      output: rclone
+
+  - runs: |
+      binary="${{targets.destdir}}/usr/bin/rclone"
+      "$binary" --version | grep -E '^rclone v?${{package.version}}$'
+      go version -m "$binary" \
+        | grep -E 'go.opentelemetry.io/otel[[:space:]]+v1.44.0'
+      go version -m "$binary" \
+        | grep -E 'go.opentelemetry.io/otel/metric[[:space:]]+v1.44.0'
+      go version -m "$binary" \
+        | grep -E 'go.opentelemetry.io/otel/trace[[:space:]]+v1.44.0'
+      go version -m "$binary" \
+        | grep -E 'golang.org/x/image[[:space:]]+v0.43.0'
+      mkdir -p "${{targets.destdir}}/etc"
+      printf '%s\n' user_allow_other >"${{targets.destdir}}/etc/fuse.conf"
+      install -Dm644 COPYING \
+        "${{targets.destdir}}/usr/share/licenses/${{package.name}}/COPYING"
+
+test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
+        - busybox
+        - coreutils
+        - jq
+        - rclone=${{package.full-version}}
+  pipeline:
+    - name: Validate runtime, package ownership, and MIT provenance
+      runs: |
+        rclone --version | grep -E '^rclone v?${{package.version}}$'
+        rclone --help >/dev/null
+        apk info --who-owns /usr/bin/rclone \
+          | grep -F "${{package.name}}-${{package.full-version}}"
+        apk info --license rclone | grep -Fx MIT
+        grep -F "Permission is hereby granted, free of charge" \
+          "/usr/share/licenses/${{package.name}}/COPYING"
+        sbom="/var/lib/db/sbom/${{package.name}}-${{package.full-version}}.spdx.json"
+        test -s "$sbom"
+        jq -e --arg full_version "${{package.full-version}}" '
+          .spdxVersion == "SPDX-2.3"
+          and any(
+            .packages[];
+            .name == "rclone"
+            and .versionInfo == $full_version
+            and .licenseDeclared == "MIT"
+          )
+        ' "$sbom"
+    - name: Copy and checksum representative local data
+      runs: |
+        mkdir -p /tmp/rclone-source /tmp/rclone-destination
+        printf '%s\n' 'verity rclone checksum smoke' \
+          >/tmp/rclone-source/payload.txt
+        (
+          cd /tmp/rclone-source
+          sha256sum payload.txt >../payload.sha256
+        )
+        rclone copy /tmp/rclone-source /tmp/rclone-destination
+        rclone check --checksum /tmp/rclone-source /tmp/rclone-destination
+        (
+          cd /tmp/rclone-destination
+          sha256sum --check ../payload.sha256
+        )
+
+update:
+  enabled: true
+  github:
+    identifier: rclone/rclone
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
## Summary

- own rclone 1.74.4 from immutable upstream commit 5bc93a2a7ab0ebd0a11352bc4968eabeffb18027 with MIT provenance
- force the fixed OpenTelemetry 1.44.0 and golang.org/x/image 0.43.0 module graph
- add native amd64/arm64 package and image runtime, local copy/checksum, SPDX, and strict all-severity Trivy gates

## Security evidence

- current Wolfi indexes still serve rclone 1.74.3-r0 on x86_64 and aarch64
- Trivy 0.72.0 database from July 16, 2026 reports five RED findings on that package: CVE-2026-41178 fixed in r3, CVE-2026-33813 fixed in r4, and CVE-2026-46601/CVE-2026-46602/CVE-2026-46604 fixed in r5
- rebuilt amd64 and arm64 images each report zero UNKNOWN, LOW, MEDIUM, HIGH, or CRITICAL findings, and the binary links OpenTelemetry 1.44.0 plus x/image 0.43.0

## Validation

- native amd64 and arm64 Melange builds and package tests
- amd64 and arm64 image runtime/version, local copy, rclone checksum, SHA-256, architecture/user, and SPDX MIT proof
- go test ./...
- golangci-lint, actionlint, shellcheck, Integer config validation, and workflow validators
- both native architecture PR jobs passed with strict zero-finding Trivy reports

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own and ship `rclone` 1.74.4 as a bespoke package and dual-arch image with pinned deps and strict CI to remediate CVEs and prove MIT/SPDX provenance. CI derives the `rclone` version and SBOM filename from the Melange spec and adds native package/image tests plus Go assertions to keep config in sync.

- **New Features**
  - Added `packages/bespoke/rclone.yaml` to build `rclone` 1.74.4 from an immutable commit with SBOM and MIT checks, plus local copy/checksum smoke tests.
  - Updated `images/rclone.yaml` to reference the bespoke Melange spec; entrypoint stays `/usr/bin/rclone`.
  - Added native package and image tests for both arches in build and PR workflows, with strict Trivy (fail on all severities) and SPDX MIT gates; version/epoch and SBOM name are derived via `yq`; added `.github/scripts/test-rclone-package.sh` and Go tests in `cmd/rclone_config_test.go`.

- **Dependencies**
  - Pinned `go.opentelemetry.io/otel` (and `metric`, `trace`) to `v1.44.0` and `golang.org/x/image` to `v0.43.0`.
  - Build uses `go-1.26=1.26.5-r1`.

<sup>Written for commit 9c6da9a7f1b921d95bd4eb4eaae15b4c2548ce45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

