### PR TITLE
fix(ci): harden nightly producer reliability

### DIFF
--- a/.github/scripts/aggregate-integer-results.sh
+++ b/.github/scripts/aggregate-integer-results.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+  echo "Usage: aggregate-integer-results.sh <expected-json> <results-dir> <child-result> <repository> <run-id>" >&2
+  exit 2
+fi
+
+expected_json=$1
+results_dir=$2
+child_result=$3
+repository=$4
+run_id=$5
+run_url="https://github.com/${repository}/actions/runs/${run_id}"
+
+if [ "$child_result" = "success" ] || [ "$child_result" = "skipped" ]; then
+  echo "All dispatched Integer child builds succeeded."
+  exit 0
+fi
+
+if ! jq -e 'type == "array" and all(.[]; (.name | type == "string") and (.version | type == "string") and (.type | type == "string"))' "$expected_json" >/dev/null; then
+  echo "Invalid or missing Integer build plan; inspect ${run_url}" >&2
+  exit 1
+fi
+
+reports=$(mktemp)
+trap 'rm -f "$reports"' EXIT
+mapfile -d '' report_files < <(find "$results_dir" -type f -name 'report.json' -print0 2>/dev/null || true)
+if [ "${#report_files[@]}" -eq 0 ]; then
+  printf '[]\n' > "$reports"
+else
+  jq -s '.' "${report_files[@]}" > "$reports"
+fi
+
+expected_count=$(jq 'length' "$expected_json")
+missing_stage="matrix-dispatch-or-report"
+if [ "$expected_count" -gt 256 ] && [ "${#report_files[@]}" -eq 0 ]; then
+  missing_stage="matrix-expansion-limit"
+  echo "Integer plan contains ${expected_count} entries; GitHub Actions permits at most 256 matrix jobs." >&2
+fi
+
+mapfile -t failures < <(
+  jq -r \
+    --arg missing_stage "$missing_stage" \
+    --arg default_run_id "$run_id" \
+    --slurpfile reports "$reports" '
+    .[] as $expected |
+    ($reports[0] | map(select(
+      .image == $expected.name and
+      .version == $expected.version and
+      .type == $expected.type
+    )) | first) as $report |
+    if $report == null then
+      [$expected.name, $expected.version, $expected.type,
+       $missing_stage, $default_run_id, ($expected.name | gsub("/"; "-"))] | @tsv
+    elif $report.status != "success" then
+      [$expected.name, $expected.version, $expected.type,
+       ($report.failure_stage // "unknown"),
+       (if (($report.run_id // "") | length) > 0 then $report.run_id else $default_run_id end),
+       ($expected.name | gsub("/"; "-"))] | @tsv
+    else empty end
+  ' "$expected_json"
+)
+
+echo "Integer child build matrix concluded: ${child_result}" >&2
+if [ "${#failures[@]}" -eq 0 ]; then
+  echo "No failed child report was available; inspect ${run_url}" >&2
+  exit 1
+fi
+
+summary="## Failed Integer matrix entries"
+for failure in "${failures[@]}"; do
+  IFS=$'\t' read -r image version type stage report_run_id safe_image <<< "$failure"
+  entry_run_id=${report_run_id:-$run_id}
+  entry_url="https://github.com/${repository}/actions/runs/${entry_run_id}"
+  artifact="integer-build-result-${safe_image}-${version}-${type}"
+  line="- ${image}:${version}-${type} — stage=${stage}; run=${entry_url}; artifact=${artifact}"
+  echo "$line" >&2
+  summary+=$'\n'"$line"
+done
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
+fi
+exit 1

--- a/.github/scripts/aggregate-integer-results.sh
+++ b/.github/scripts/aggregate-integer-results.sh
@@ -13,7 +13,7 @@ repository=$4
 run_id=$5
 run_url="https://github.com/${repository}/actions/runs/${run_id}"
 
-if [ "$child_result" = "success" ] || [ "$child_result" = "skipped" ]; then
+if [ "$child_result" = "success" ]; then
   echo "All dispatched Integer child builds succeeded."
   exit 0
 fi
@@ -21,6 +21,12 @@ fi
 if ! jq -e 'type == "array" and all(.[]; (.name | type == "string") and (.version | type == "string") and (.type | type == "string"))' "$expected_json" >/dev/null; then
   echo "Invalid or missing Integer build plan; inspect ${run_url}" >&2
   exit 1
+fi
+
+expected_count=$(jq 'length' "$expected_json")
+if [ "$child_result" = "skipped" ] && [ "$expected_count" -eq 0 ]; then
+  echo "No Integer child builds were dispatched."
+  exit 0
 fi
 
 reports=$(mktemp)
@@ -32,7 +38,6 @@ else
   jq -s '.' "${report_files[@]}" > "$reports"
 fi
 
-expected_count=$(jq 'length' "$expected_json")
 missing_stage="matrix-dispatch-or-report"
 if [ "$expected_count" -gt 256 ] && [ "${#report_files[@]}" -eq 0 ]; then
   missing_stage="matrix-expansion-limit"

--- a/.github/scripts/archive-metrics.sh
+++ b/.github/scripts/archive-metrics.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: archive-metrics.sh <metrics-dir> <run-id> <run-attempt> <run-created-at>" >&2
+  exit 2
+fi
+
+metrics_dir=$1
+run_id=$2
+run_attempt=$3
+run_created_at=$4
+attempts=${METRICS_ARCHIVE_ATTEMPTS:-5}
+retry_delay=${METRICS_ARCHIVE_RETRY_DELAY_SECONDS:-2}
+
+case "$attempts" in
+  ''|*[!0-9]*|0*) echo "METRICS_ARCHIVE_ATTEMPTS must be a positive integer" >&2; exit 2 ;;
+esac
+case "$retry_delay" in
+  ''|*[!0-9]*) echo "METRICS_ARCHIVE_RETRY_DELAY_SECONDS must be a non-negative integer" >&2; exit 2 ;;
+esac
+
+date=$(date -u -d "$run_created_at" +%Y-%m-%d)
+target_dir="_metrics/runs/${date}/${run_id}-attempt-${run_attempt}"
+start_ref=$(git rev-parse HEAD)
+stash=$(mktemp -d)
+trap 'rm -rf "$stash"' EXIT
+
+shopt -s nullglob
+metrics=("$metrics_dir"/metrics-*.json)
+if [ "${#metrics[@]}" -eq 0 ]; then
+  echo "No metrics JSON files found in ${metrics_dir}" >&2
+  exit 1
+fi
+cp "${metrics[@]}" "$stash/"
+
+for attempt in $(seq 1 "$attempts"); do
+  echo "::group::Attempt ${attempt}"
+  bootstrap_branch=""
+
+  if git fetch origin '+refs/heads/_metrics:refs/remotes/origin/_metrics'; then
+    git switch --detach refs/remotes/origin/_metrics
+  elif git ls-remote --exit-code --heads origin _metrics >/dev/null 2>&1; then
+    echo "::error::Failed to fetch existing _metrics branch"
+    exit 1
+  else
+    bootstrap_branch="metrics-bootstrap-${run_id}-${run_attempt}-${attempt}"
+    git switch --orphan "$bootstrap_branch"
+    git rm -rf --ignore-unmatch .
+  fi
+
+  mkdir -p "$target_dir"
+  for file in "$stash"/metrics-*.json; do
+    base=$(basename "$file" .json)
+    image=${base#metrics-}
+    cp "$file" "$target_dir/${image}.json"
+  done
+
+  git add _metrics/
+  if git diff --cached --quiet; then
+    echo "::notice::No changes to commit"
+    echo "::endgroup::"
+    exit 0
+  fi
+
+  count=$(find "$target_dir" -maxdepth 1 -type f -name '*.json' | wc -l)
+  git commit -m "metrics: run ${run_id} attempt ${run_attempt}" -m "${count} image(s)"
+
+  if git push origin HEAD:refs/heads/_metrics; then
+    echo "::notice::Pushed on attempt ${attempt}"
+    echo "::endgroup::"
+    exit 0
+  fi
+
+  git switch --detach "$start_ref"
+  if [ -n "$bootstrap_branch" ]; then
+    git branch -D "$bootstrap_branch"
+  fi
+
+  if [ "$attempt" -eq "$attempts" ]; then
+    echo "::error::Failed to push metrics after ${attempts} attempts"
+    echo "::endgroup::"
+    exit 1
+  fi
+
+  echo "::warning::Push failed; refetching origin/_metrics before retry"
+  echo "::endgroup::"
+  sleep "$retry_delay"
+done

--- a/.github/scripts/validate-nightly-workflows.py
+++ b/.github/scripts/validate-nightly-workflows.py
@@ -89,8 +89,10 @@ def main() -> None:
         and "fromJSON(needs.discover.outputs.images)" in integer_orchestrator
         and "fail-fast: false" in integer_orchestrator
         and "CHILD_RESULT: ${{ needs.build.result }}" in integer_orchestrator
+        and "pattern: integer-build-result-*" in integer_orchestrator
+        and "bash .github/scripts/aggregate-integer-results.sh" in integer_orchestrator
         and "nightly dispatch" not in integer_orchestrator,
-        "Integer orchestrator must await every reusable child and fail the parent when the matrix fails",
+        "Integer orchestrator must await every reusable child and identify failed matrix entries",
     )
     require(
         "batch_id: ${{ github.run_id }}-${{ github.run_attempt }}" in integer_orchestrator

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -220,6 +220,12 @@ def main() -> None:
         "No metrics artifacts found" in metrics_uncommented,
         "missing metrics artifacts must fail finalization",
     )
+    require(
+        "group: metrics-archive-_metrics" in metrics_uncommented
+        and "cancel-in-progress: false" in metrics_uncommented
+        and "bash .github/scripts/archive-metrics.sh" in metrics_uncommented,
+        "metrics finalization must serialize one archive writer and use fresh-fetch retries",
+    )
     failure_metrics = job_body(uncommented, "metrics-on-failure")
     finalize_upload = named_step_body(finalize, "Upload metrics artifact")
     failure_upload = named_step_body(failure_metrics, "Upload metrics artifact")

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -859,6 +859,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Push current build report to reports branch
+        id: report
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_IMAGE: ${{ inputs.image }}
@@ -906,10 +907,21 @@ jobs:
               failure_stage: $failure_stage, built_at: $built_at, run_id: $run_id,
               batch_id: $batch_id}')
 
+          safe_image="${INPUT_IMAGE//\//-}"
+          echo "artifact_name=integer-build-result-${safe_image}-${INPUT_VERSION}-${INPUT_TYPE}" >> "$GITHUB_OUTPUT"
           echo "$report" > report.json
           bash .github/scripts/push-reports.sh \
             "reports/${INPUT_IMAGE}/${INPUT_VERSION}/${INPUT_TYPE}/latest.json" \
             report.json
+
+      - name: Upload current build report
+        if: always() && steps.report.outputs.artifact_name != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.report.outputs.artifact_name }}
+          path: report.json
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Update preflight manifest
         if: needs.build.result == 'success'

--- a/.github/workflows/integer-orchestrator.yaml
+++ b/.github/workflows/integer-orchestrator.yaml
@@ -148,6 +148,13 @@ jobs:
           echo "✓ Planned $(jq 'length' images.json) Integer remediation run(s)"
           jq -r '.[] | "  - \(.name):\(.version)-\(.type) → \(.registry)/\(.name):\(.tags[0])"' images.json
 
+      - name: Upload Integer build plan
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integer-build-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: images.json
+          retention-days: 7
+
   build:
     name: Build ${{ matrix.name }}:${{ matrix.version }}-${{ matrix.type }}
     needs: discover
@@ -173,18 +180,34 @@ jobs:
 
   aggregate:
     name: Aggregate build results
-    needs: build
+    needs: [discover, build]
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download Integer build plan
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: integer-build-plan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: integer-build-plan
+
+      - name: Download Integer child reports
+        if: needs.build.result != 'success' && needs.build.result != 'skipped'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: integer-build-result-*
+          path: integer-build-results
+
       - name: Fail when any child build failed
+        if: always()
         env:
           CHILD_RESULT: ${{ needs.build.result }}
-        run: |
-          if [ "$CHILD_RESULT" = "success" ] || [ "$CHILD_RESULT" = "skipped" ]; then
-            echo "All dispatched Integer child builds succeeded."
-            exit 0
-          fi
-
-          echo "Integer child build matrix concluded: $CHILD_RESULT" >&2
-          exit 1
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: >-
+          bash .github/scripts/aggregate-integer-results.sh
+          integer-build-plan/images.json integer-build-results
+          "$CHILD_RESULT" "$REPOSITORY" "$RUN_ID"

--- a/.github/workflows/metrics-finalize.yaml
+++ b/.github/workflows/metrics-finalize.yaml
@@ -21,7 +21,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: metrics-finalize-${{ inputs.run-id }}
+  group: metrics-archive-_metrics
   cancel-in-progress: false
 
 jobs:
@@ -90,60 +90,6 @@ jobs:
           RUN_ID: ${{ inputs.run-id }}
           RUN_ATTEMPT: ${{ inputs.run-attempt }}
           RUN_CREATED_AT: ${{ steps.metadata.outputs.created-at }}
-        run: |
-          set -euo pipefail
-          DATE=$(date -u -d "${RUN_CREATED_AT}" +%Y-%m-%d)
-          TARGET_DIR="_metrics/runs/${DATE}/${RUN_ID}-attempt-${RUN_ATTEMPT}"
-
-          STASH=$(mktemp -d)
-          cp ./downloaded-metrics/metrics-*.json "$STASH/"
-
-          for attempt in 1 2 3 4 5; do
-            echo "::group::Attempt ${attempt}"
-
-            if git fetch origin _metrics:_metrics 2>/dev/null; then
-              git switch _metrics
-              git reset --hard origin/_metrics
-            else
-              echo "::notice::_metrics branch missing — initializing as orphan"
-              git switch --orphan _metrics
-              git rm -rf . 2>/dev/null || true
-            fi
-
-            mkdir -p "$TARGET_DIR"
-            for f in "$STASH"/metrics-*.json; do
-              [ -e "$f" ] || continue
-              base=$(basename "$f" .json)
-              image="${base#metrics-}"
-              cp "$f" "$TARGET_DIR/${image}.json"
-            done
-
-            git add _metrics/
-            if git diff --cached --quiet; then
-              echo "::notice::No changes to commit"
-              echo "::endgroup::"
-              break
-            fi
-
-            COUNT=$(find "$TARGET_DIR" -maxdepth 1 -type f -name '*.json' | wc -l)
-            git commit -m "metrics: run ${RUN_ID} attempt ${RUN_ATTEMPT}" -m "${COUNT} image(s)"
-
-            if git push origin _metrics; then
-              echo "::notice::Pushed on attempt ${attempt}"
-              echo "::endgroup::"
-              break
-            fi
-
-            if [ "$attempt" -eq 5 ]; then
-              echo "::error::Failed to push metrics after 5 attempts"
-              echo "::endgroup::"
-              exit 1
-            fi
-
-            sleep_time=$((RANDOM % 10 + 1))
-            echo "::warning::Push failed, retrying in ${sleep_time}s"
-            sleep "$sleep_time"
-
-            git switch -
-            echo "::endgroup::"
-          done
+        run: >-
+          bash .github/scripts/archive-metrics.sh
+          ./downloaded-metrics "$RUN_ID" "$RUN_ATTEMPT" "$RUN_CREATED_AT"

--- a/scripts/nightly_reliability_test.go
+++ b/scripts/nightly_reliability_test.go
@@ -1,0 +1,148 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveMetricsRetriesFromFreshRemoteWhenAnotherWriterAdvancesBranch(t *testing.T) {
+	// Given: an archive clone and a competing writer sharing a bare remote.
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	tmp := t.TempDir()
+	remote := filepath.Join(tmp, "remote.git")
+	seed := filepath.Join(tmp, "seed")
+	archive := filepath.Join(tmp, "archive")
+	competitor := filepath.Join(tmp, "competitor")
+
+	runGit(t, realGit, "", "init", "--bare", remote)
+	runGit(t, realGit, "", "init", "-b", "main", seed)
+	configureGit(t, realGit, seed)
+	writeFile(t, filepath.Join(seed, "README.md"), "seed\n")
+	runGit(t, realGit, seed, "add", "README.md")
+	runGit(t, realGit, seed, "commit", "-m", "seed main")
+	runGit(t, realGit, seed, "remote", "add", "origin", remote)
+	runGit(t, realGit, seed, "push", "origin", "main")
+	runGit(t, realGit, seed, "switch", "--orphan", "_metrics")
+	runGit(t, realGit, seed, "rm", "-rf", "--ignore-unmatch", "README.md")
+	writeFile(t, filepath.Join(seed, "_metrics", "runs", "2026-07-16", "seed", "seed.json"), "{}\n")
+	runGit(t, realGit, seed, "add", "_metrics")
+	runGit(t, realGit, seed, "commit", "-m", "seed metrics")
+	runGit(t, realGit, seed, "push", "origin", "_metrics")
+	runGit(t, realGit, "", "clone", "--branch", "main", remote, archive)
+	runGit(t, realGit, "", "clone", "--branch", "_metrics", remote, competitor)
+	configureGit(t, realGit, archive)
+	configureGit(t, realGit, competitor)
+
+	downloaded := filepath.Join(tmp, "downloaded")
+	writeFile(t, filepath.Join(downloaded, "metrics-alpha.json"), `{"image":"alpha"}`+"\n")
+	wrapperDir := filepath.Join(tmp, "bin")
+	require.NoError(t, os.MkdirAll(wrapperDir, 0o755))
+	marker := filepath.Join(tmp, "advanced")
+	wrapper := `#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "push" ] && [ ! -e "$ADVANCE_MARKER" ]; then
+  touch "$ADVANCE_MARKER"
+  "$REAL_GIT" -C "$COMPETITOR" fetch origin _metrics
+  "$REAL_GIT" -C "$COMPETITOR" switch -C _metrics origin/_metrics
+  mkdir -p "$COMPETITOR/_metrics/runs/2026-07-17/competing"
+  printf '{"image":"competing"}\n' > "$COMPETITOR/_metrics/runs/2026-07-17/competing/competing.json"
+  "$REAL_GIT" -C "$COMPETITOR" add _metrics
+  "$REAL_GIT" -C "$COMPETITOR" commit -m 'competing metrics'
+  "$REAL_GIT" -C "$COMPETITOR" push origin HEAD:refs/heads/_metrics
+fi
+exec "$REAL_GIT" "$@"
+`
+	writeExecutable(t, filepath.Join(wrapperDir, "git"), wrapper)
+
+	// When: the archival writer's first push races with the competing commit.
+	archiveScript, err := filepath.Abs(filepath.Join("..", ".github", "scripts", "archive-metrics.sh"))
+	require.NoError(t, err)
+	cmd := exec.CommandContext(t.Context(), "bash", archiveScript, downloaded, "123", "1", "2026-07-17T06:00:00Z")
+	cmd.Dir = archive
+	cmd.Env = append(
+		os.Environ(),
+		"PATH="+wrapperDir+":"+os.Getenv("PATH"),
+		"REAL_GIT="+realGit,
+		"COMPETITOR="+competitor,
+		"ADVANCE_MARKER="+marker,
+		"METRICS_ARCHIVE_ATTEMPTS=3",
+		"METRICS_ARCHIVE_RETRY_DELAY_SECONDS=0",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	// Then: retry two preserves both writers and never creates local `_metrics`.
+	verify := filepath.Join(tmp, "verify")
+	runGit(t, realGit, "", "clone", "--branch", "_metrics", remote, verify)
+	assert.FileExists(t, filepath.Join(verify, "_metrics", "runs", "2026-07-17", "competing", "competing.json"))
+	assert.FileExists(t, filepath.Join(verify, "_metrics", "runs", "2026-07-17", "123-attempt-1", "alpha.json"))
+	branches := runGit(t, realGit, archive, "branch", "--list", "_metrics")
+	assert.Empty(t, strings.TrimSpace(branches))
+	assert.Contains(t, string(output), "Pushed on attempt 2")
+}
+
+func TestAggregateIntegerResultsNamesFailedAndMissingMatrixEntries(t *testing.T) {
+	// Given: one failed child report and one planned child with no report artifact.
+	tmp := t.TempDir()
+	expected := filepath.Join(tmp, "expected.json")
+	results := filepath.Join(tmp, "results")
+	writeFile(t, expected, `[
+  {"name":"alpha","version":"1.2.3","type":"default"},
+  {"name":"beta/tools","version":"4.5.6","type":"fips"}
+]`+"\n")
+	writeFile(t, filepath.Join(results, "integer-build-result-alpha", "report.json"), `{
+  "image":"alpha","version":"1.2.3","type":"default",
+  "status":"failure","failure_stage":"trivy","run_id":"42"
+}`+"\n")
+
+	// When: the failed reusable matrix is aggregated.
+	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "failure", "verity-org/verity", "42")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err)
+
+	// Then: every failed or unreported entry has identity, stage, run URL, and artifact reference.
+	text := string(output)
+	assert.Contains(t, text, "alpha:1.2.3-default")
+	assert.Contains(t, text, "stage=trivy")
+	assert.Contains(t, text, "integer-build-result-alpha-1.2.3-default")
+	assert.Contains(t, text, "beta/tools:4.5.6-fips")
+	assert.Contains(t, text, "stage=matrix-dispatch-or-report")
+	assert.Contains(t, text, "integer-build-result-beta-tools-4.5.6-fips")
+	assert.Contains(t, text, "https://github.com/verity-org/verity/actions/runs/42")
+}
+
+func configureGit(t *testing.T, gitPath, dir string) {
+	t.Helper()
+	runGit(t, gitPath, dir, "config", "user.name", "test")
+	runGit(t, gitPath, dir, "config", "user.email", "test@example.com")
+}
+
+func runGit(t *testing.T, gitPath, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), gitPath, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s: %s", strings.Join(args, " "), output)
+	return string(output)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	writeFile(t, path, content)
+	require.NoError(t, os.Chmod(path, 0o755))
+}

--- a/scripts/nightly_reliability_test.go
+++ b/scripts/nightly_reliability_test.go
@@ -118,6 +118,41 @@ func TestAggregateIntegerResultsNamesFailedAndMissingMatrixEntries(t *testing.T)
 	assert.Contains(t, text, "https://github.com/verity-org/verity/actions/runs/42")
 }
 
+func TestAggregateIntegerResultsFailsClosedWhenNonEmptyPlanIsSkipped(t *testing.T) {
+	// Given: a planned matrix entry whose reusable workflow was skipped.
+	tmp := t.TempDir()
+	expected := filepath.Join(tmp, "expected.json")
+	results := filepath.Join(tmp, "results")
+	writeFile(t, expected, `[{"name":"alpha","version":"1.2.3","type":"default"}]`+"\n")
+	require.NoError(t, os.MkdirAll(results, 0o755))
+
+	// When: aggregation receives the skipped matrix result.
+	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "skipped", "verity-org/verity", "42")
+	output, err := cmd.CombinedOutput()
+
+	// Then: the undispatched entry is reported instead of accepted as success.
+	require.Error(t, err)
+	assert.Contains(t, string(output), "alpha:1.2.3-default")
+	assert.Contains(t, string(output), "stage=matrix-dispatch-or-report")
+}
+
+func TestAggregateIntegerResultsAcceptsSkippedEmptyPlan(t *testing.T) {
+	// Given: discovery intentionally produced no Integer matrix entries.
+	tmp := t.TempDir()
+	expected := filepath.Join(tmp, "expected.json")
+	results := filepath.Join(tmp, "results")
+	writeFile(t, expected, "[]\n")
+	require.NoError(t, os.MkdirAll(results, 0o755))
+
+	// When: the empty matrix is reported as skipped.
+	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "skipped", "verity-org/verity", "42")
+	output, err := cmd.CombinedOutput()
+
+	// Then: the intentional no-op remains successful.
+	require.NoError(t, err, string(output))
+	assert.Contains(t, string(output), "No Integer child builds were dispatched.")
+}
+
 func configureGit(t *testing.T, gitPath, dir string) {
 	t.Helper()
 	runGit(t, gitPath, dir, "config", "user.name", "test")

--- a/scripts/workflow_interpolation_test.go
+++ b/scripts/workflow_interpolation_test.go
@@ -304,8 +304,9 @@ func TestIntegerNightlyWorkflowAggregatesChildFailuresAndPublishesCurrentReports
 	assert.Contains(t, parent, `github.event_name }}" = "schedule"`)
 	assert.Contains(t, parent, "PLAN_ARGS+=(--force)")
 	assert.Contains(t, parent, "CHILD_RESULT: ${{ needs.build.result }}")
-	assert.Contains(t, parent, `[ "$CHILD_RESULT" = "skipped" ]`)
-	assert.Contains(t, parent, "exit 1")
+	assert.Contains(t, parent, "integer-build-plan-${{ github.run_id }}-${{ github.run_attempt }}")
+	assert.Contains(t, parent, "pattern: integer-build-result-*")
+	assert.Contains(t, parent, "bash .github/scripts/aggregate-integer-results.sh")
 
 	assert.Contains(t, child, "workflow_call:")
 	assert.Contains(t, child, "batch_id:")
@@ -316,4 +317,6 @@ func TestIntegerNightlyWorkflowAggregatesChildFailuresAndPublishesCurrentReports
 	assert.Contains(t, child, "BUILD_RESULT")
 	assert.Contains(t, child, "BATCH_ID")
 	assert.Contains(t, child, "batch_id: $batch_id")
+	assert.Contains(t, child, "integer-build-result-${safe_image}-${INPUT_VERSION}-${INPUT_TYPE}")
+	assert.Contains(t, child, "Upload current build report")
 }


### PR DESCRIPTION
## Summary

- serialize `_metrics` archival across all Patch Image runs and retry from a freshly fetched `origin/_metrics` in detached HEAD state
- persist Integer plans and per-child result artifacts so parent aggregation names every failed or undispatched image/version/type with stage, run URL, and artifact reference
- keep chart generation and site publication fail-closed on failed producers

## Regression coverage

- real bare-Git race: a competing writer advances `_metrics` immediately before the first push; retry preserves both writers without force-pushing or creating a local `_metrics` branch
- failed reusable matrix: aggregation executes against failed and missing child reports and verifies exact identities, stages, URLs, and artifact names
- actual current force plan: 673 entries produce 673 `matrix-expansion-limit` diagnostics instead of an opaque `needs.build.result=failure`

## Verification

- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run ./...`
- `make lint-workflows`
- `make lint-yaml`
- `make lint-shell`
- `git diff --check`

## Remaining limitation

Integer Orchestrator run 29558142324 planned 673 entries, above GitHub Actions' 256-job matrix limit, so no reusable child jobs were created. This PR makes that failure exact and actionable; it does not shard the matrix or weaken forced nightly, dual-arch, or zero-CVE behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve reliability of nightly metrics and Integer builds. Metrics archiving now retries safely on races, and the orchestrator names exact failures, undispatched images, and fails closed when a non‑empty plan is skipped.

- **Bug Fixes**
  - Serialize `_metrics` archiving with `concurrency: group: metrics-archive-_metrics`, and push with retries from fresh `origin/_metrics` via `.github/scripts/archive-metrics.sh` without creating a local `_metrics` branch.
  - Integer child builds upload `report.json` as `integer-build-result-<image>-<version>-<type>`; the orchestrator uploads the plan as `integer-build-plan-<run>-<attempt>`, downloads both, and runs `.github/scripts/aggregate-integer-results.sh` to list each failed or missing image with stage, run URL, and artifact.
  - Fail closed when `needs.build.result` is `skipped` but the plan is non-empty; accept `skipped` only when the plan is empty.
  - If the plan exceeds 256 jobs, report `matrix-expansion-limit` instead of an opaque failure.
  - Updated validators to enforce plan/report artifacts and metrics archive behavior; added tests for the bare-Git `_metrics` race and for skipped/non-empty plan and aggregation clarity.

<sup>Written for commit 4e170ad3173adc9cda29d40b1f418878b1d5c135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

