### PR TITLE
fix(ci): prevent metrics archive cancellation

### DIFF
--- a/.github/scripts/archive-metrics.sh
+++ b/.github/scripts/archive-metrics.sh
@@ -10,14 +10,18 @@ metrics_dir=$1
 run_id=$2
 run_attempt=$3
 run_created_at=$4
-attempts=${METRICS_ARCHIVE_ATTEMPTS:-5}
-retry_delay=${METRICS_ARCHIVE_RETRY_DELAY_SECONDS:-2}
+attempts=${METRICS_ARCHIVE_ATTEMPTS:-256}
+retry_delay=${METRICS_ARCHIVE_RETRY_DELAY_SECONDS:-1}
+retry_jitter=${METRICS_ARCHIVE_RETRY_JITTER_SECONDS:-3}
 
 case "$attempts" in
   ''|*[!0-9]*|0*) echo "METRICS_ARCHIVE_ATTEMPTS must be a positive integer" >&2; exit 2 ;;
 esac
 case "$retry_delay" in
   ''|*[!0-9]*) echo "METRICS_ARCHIVE_RETRY_DELAY_SECONDS must be a non-negative integer" >&2; exit 2 ;;
+esac
+case "$retry_jitter" in
+  ''|*[!0-9]*) echo "METRICS_ARCHIVE_RETRY_JITTER_SECONDS must be a non-negative integer" >&2; exit 2 ;;
 esac
 
 date=$(date -u -d "$run_created_at" +%Y-%m-%d)
@@ -85,5 +89,9 @@ for attempt in $(seq 1 "$attempts"); do
 
   echo "::warning::Push failed; refetching origin/_metrics before retry"
   echo "::endgroup::"
-  sleep "$retry_delay"
+  delay=$retry_delay
+  if [ "$retry_jitter" -gt 0 ]; then
+    delay=$((retry_delay + RANDOM % (retry_jitter + 1)))
+  fi
+  sleep "$delay"
 done

--- a/.github/scripts/validate-patch-image-workflow.py
+++ b/.github/scripts/validate-patch-image-workflow.py
@@ -221,10 +221,9 @@ def main() -> None:
         "missing metrics artifacts must fail finalization",
     )
     require(
-        "group: metrics-archive-_metrics" in metrics_uncommented
-        and "cancel-in-progress: false" in metrics_uncommented
+        "concurrency:" not in metrics_uncommented
         and "bash .github/scripts/archive-metrics.sh" in metrics_uncommented,
-        "metrics finalization must serialize one archive writer and use fresh-fetch retries",
+        "metrics finalization must not replace pending writers and must use fresh-fetch retries",
     )
     failure_metrics = job_body(uncommented, "metrics-on-failure")
     finalize_upload = named_step_body(finalize, "Upload metrics artifact")

--- a/.github/workflows/metrics-finalize.yaml
+++ b/.github/workflows/metrics-finalize.yaml
@@ -20,10 +20,6 @@ permissions:
   contents: write
   actions: read
 
-concurrency:
-  group: metrics-archive-_metrics
-  cancel-in-progress: false
-
 jobs:
   commit-metrics:
     runs-on: ubuntu-24.04

--- a/scripts/metrics_finalize_workflow_test.go
+++ b/scripts/metrics_finalize_workflow_test.go
@@ -1,0 +1,33 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMetricsFinalizeWorkflowHasNoLossyConcurrencyQueue(t *testing.T) {
+	// Given: the reusable metrics writer workflow.
+	data, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "metrics-finalize.yaml"))
+	require.NoError(t, err)
+	type concurrencyConfig struct {
+		Group            string `yaml:"group"`
+		CancelInProgress bool   `yaml:"cancel-in-progress"`
+	}
+	var workflow struct {
+		Concurrency *concurrencyConfig `yaml:"concurrency"`
+		Jobs        map[string]struct {
+			Concurrency *concurrencyConfig `yaml:"concurrency"`
+		} `yaml:"jobs"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &workflow))
+
+	// Then: GitHub cannot replace an older pending archive producer.
+	require.Nil(t, workflow.Concurrency)
+	for name, job := range workflow.Jobs {
+		require.Nil(t, job.Concurrency, "job %s must not use a replacing concurrency queue", name)
+	}
+}

--- a/scripts/nightly_reliability_test.go
+++ b/scripts/nightly_reliability_test.go
@@ -1,6 +1,8 @@
 package scripts_test
 
 import (
+	"bufio"
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,14 +14,14 @@ import (
 )
 
 func TestArchiveMetricsRetriesFromFreshRemoteWhenAnotherWriterAdvancesBranch(t *testing.T) {
-	// Given: an archive clone and a competing writer sharing a bare remote.
+	// Given: two archive producers sharing a bare remote.
 	realGit, err := exec.LookPath("git")
 	require.NoError(t, err)
 	tmp := t.TempDir()
 	remote := filepath.Join(tmp, "remote.git")
 	seed := filepath.Join(tmp, "seed")
-	archive := filepath.Join(tmp, "archive")
-	competitor := filepath.Join(tmp, "competitor")
+	archiveAlpha := filepath.Join(tmp, "archive-alpha")
+	archiveBeta := filepath.Join(tmp, "archive-beta")
 
 	runGit(t, realGit, "", "init", "--bare", remote)
 	runGit(t, realGit, "", "init", "-b", "main", seed)
@@ -35,57 +37,94 @@ func TestArchiveMetricsRetriesFromFreshRemoteWhenAnotherWriterAdvancesBranch(t *
 	runGit(t, realGit, seed, "add", "_metrics")
 	runGit(t, realGit, seed, "commit", "-m", "seed metrics")
 	runGit(t, realGit, seed, "push", "origin", "_metrics")
-	runGit(t, realGit, "", "clone", "--branch", "main", remote, archive)
-	runGit(t, realGit, "", "clone", "--branch", "_metrics", remote, competitor)
-	configureGit(t, realGit, archive)
-	configureGit(t, realGit, competitor)
+	runGit(t, realGit, "", "clone", "--branch", "main", remote, archiveAlpha)
+	runGit(t, realGit, "", "clone", "--branch", "main", remote, archiveBeta)
+	configureGit(t, realGit, archiveAlpha)
+	configureGit(t, realGit, archiveBeta)
 
-	downloaded := filepath.Join(tmp, "downloaded")
-	writeFile(t, filepath.Join(downloaded, "metrics-alpha.json"), `{"image":"alpha"}`+"\n")
+	downloadedAlpha := filepath.Join(tmp, "downloaded-alpha")
+	downloadedBeta := filepath.Join(tmp, "downloaded-beta")
+	writeFile(t, filepath.Join(downloadedAlpha, "metrics-alpha.json"), `{"image":"alpha"}`+"\n")
+	writeFile(t, filepath.Join(downloadedBeta, "metrics-beta.json"), `{"image":"beta"}`+"\n")
 	wrapperDir := filepath.Join(tmp, "bin")
 	require.NoError(t, os.MkdirAll(wrapperDir, 0o755))
-	marker := filepath.Join(tmp, "advanced")
+	readyFIFO := filepath.Join(tmp, "alpha-push-ready")
+	releaseFIFO := filepath.Join(tmp, "release-alpha-push")
+	mkfifo, err := exec.LookPath("mkfifo")
+	require.NoError(t, err)
+	for _, fifo := range []string{readyFIFO, releaseFIFO} {
+		cmd := exec.CommandContext(t.Context(), mkfifo, fifo)
+		output, commandErr := cmd.CombinedOutput()
+		require.NoError(t, commandErr, string(output))
+	}
+	ready, err := os.OpenFile(readyFIFO, os.O_RDWR, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ready.Close()) })
+	release, err := os.OpenFile(releaseFIFO, os.O_RDWR, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, release.Close()) })
+
+	barrierUsed := filepath.Join(tmp, "barrier-used")
 	wrapper := `#!/usr/bin/env bash
 set -euo pipefail
-if [ "${1:-}" = "push" ] && [ ! -e "$ADVANCE_MARKER" ]; then
-  touch "$ADVANCE_MARKER"
-  "$REAL_GIT" -C "$COMPETITOR" fetch origin _metrics
-  "$REAL_GIT" -C "$COMPETITOR" switch -C _metrics origin/_metrics
-  mkdir -p "$COMPETITOR/_metrics/runs/2026-07-17/competing"
-  printf '{"image":"competing"}\n' > "$COMPETITOR/_metrics/runs/2026-07-17/competing/competing.json"
-  "$REAL_GIT" -C "$COMPETITOR" add _metrics
-  "$REAL_GIT" -C "$COMPETITOR" commit -m 'competing metrics'
-  "$REAL_GIT" -C "$COMPETITOR" push origin HEAD:refs/heads/_metrics
+if [ "${1:-}" = "push" ] && [ ! -e "$BARRIER_USED" ]; then
+  touch "$BARRIER_USED"
+  printf 'ready\n' > "$READY_FIFO"
+  IFS= read -r _ < "$RELEASE_FIFO"
 fi
 exec "$REAL_GIT" "$@"
 `
 	writeExecutable(t, filepath.Join(wrapperDir, "git"), wrapper)
 
-	// When: the archival writer's first push races with the competing commit.
+	// When: alpha reaches push first, beta advances the branch, then alpha retries.
 	archiveScript, err := filepath.Abs(filepath.Join("..", ".github", "scripts", "archive-metrics.sh"))
 	require.NoError(t, err)
-	cmd := exec.CommandContext(t.Context(), "bash", archiveScript, downloaded, "123", "1", "2026-07-17T06:00:00Z")
-	cmd.Dir = archive
-	cmd.Env = append(
+	alpha := exec.CommandContext(t.Context(), "bash", archiveScript, downloadedAlpha, "123", "1", "2026-07-17T06:00:00Z")
+	alpha.Dir = archiveAlpha
+	alpha.Env = append(
 		os.Environ(),
 		"PATH="+wrapperDir+":"+os.Getenv("PATH"),
 		"REAL_GIT="+realGit,
-		"COMPETITOR="+competitor,
-		"ADVANCE_MARKER="+marker,
+		"READY_FIFO="+readyFIFO,
+		"RELEASE_FIFO="+releaseFIFO,
+		"BARRIER_USED="+barrierUsed,
 		"METRICS_ARCHIVE_ATTEMPTS=3",
 		"METRICS_ARCHIVE_RETRY_DELAY_SECONDS=0",
+		"METRICS_ARCHIVE_RETRY_JITTER_SECONDS=0",
 	)
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(output))
+	var alphaOutput bytes.Buffer
+	alpha.Stdout = &alphaOutput
+	alpha.Stderr = &alphaOutput
+	require.NoError(t, alpha.Start())
+	readySignal, err := bufio.NewReader(ready).ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "ready\n", readySignal)
 
-	// Then: retry two preserves both writers and never creates local `_metrics`.
+	beta := exec.CommandContext(t.Context(), "bash", archiveScript, downloadedBeta, "456", "1", "2026-07-17T06:01:00Z")
+	beta.Dir = archiveBeta
+	beta.Env = append(
+		os.Environ(),
+		"METRICS_ARCHIVE_ATTEMPTS=3",
+		"METRICS_ARCHIVE_RETRY_DELAY_SECONDS=0",
+		"METRICS_ARCHIVE_RETRY_JITTER_SECONDS=0",
+	)
+	betaOutput, err := beta.CombinedOutput()
+	require.NoError(t, err, string(betaOutput))
+	_, err = release.WriteString("release\n")
+	require.NoError(t, err)
+	require.NoError(t, alpha.Wait(), alphaOutput.String())
+
+	// Then: both real producers survive and neither creates a local `_metrics` branch.
 	verify := filepath.Join(tmp, "verify")
 	runGit(t, realGit, "", "clone", "--branch", "_metrics", remote, verify)
-	assert.FileExists(t, filepath.Join(verify, "_metrics", "runs", "2026-07-17", "competing", "competing.json"))
 	assert.FileExists(t, filepath.Join(verify, "_metrics", "runs", "2026-07-17", "123-attempt-1", "alpha.json"))
-	branches := runGit(t, realGit, archive, "branch", "--list", "_metrics")
-	assert.Empty(t, strings.TrimSpace(branches))
-	assert.Contains(t, string(output), "Pushed on attempt 2")
+	assert.FileExists(t, filepath.Join(verify, "_metrics", "runs", "2026-07-17", "456-attempt-1", "beta.json"))
+	for _, archive := range []string{archiveAlpha, archiveBeta} {
+		branches := runGit(t, realGit, archive, "branch", "--list", "_metrics")
+		assert.Empty(t, strings.TrimSpace(branches))
+	}
+	assert.Contains(t, alphaOutput.String(), "Pushed on attempt 2")
+	assert.Contains(t, string(betaOutput), "Pushed on attempt 1")
 }
 
 func TestAggregateIntegerResultsNamesFailedAndMissingMatrixEntries(t *testing.T) {


### PR DESCRIPTION
## Summary

- remove the global reusable-workflow concurrency group that replaced older pending metrics writers
- keep every producer active and serialize `_metrics` history through fresh-fetch, normal-push retries with a 256-attempt jittered contention budget
- strengthen regression coverage with two real concurrent archive producers and parsed-YAML protection against reintroducing workflow/job concurrency

## Evidence

Post-merge verification of #1013 exposed the scheduler failure mode in Patch Image run `29581999828`: `Archive Metrics / commit-metrics` job `87891380110` was cancelled before runner assignment (`runner_name=""`, `steps=[]`) when a newer writer entered the same group. Its metrics artifact was never committed.

GitHub documents that `cancel-in-progress: false` protects the running member but still replaces an existing pending member. `queue: max` is currently gated behind Actions NGA, and the repository's actionlint version rejects that key, so this PR uses the supported no-cancellation fallback.

## Verification

- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run ./...`
- `make lint-workflows`
- `make lint-yaml`
- `make lint-shell`
- `make lint`
- `git diff --check`

The behavioral test holds producer A at its first push, lets producer B advance `_metrics`, then releases A. Both real `archive-metrics.sh` processes succeed; the final branch contains both runs and A reports success on attempt 2.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent metrics loss by removing the lossy GitHub Actions concurrency queue and allowing all archive producers to run. Archiving now serializes via fresh fetch and retrying pushes with jitter, so pending jobs aren’t canceled.

- **Bug Fixes**
  - Removed workflow-level concurrency from `metrics-finalize.yaml`.
  - Hardened `archive-metrics.sh`: 256 attempts, 1s base delay with optional jitter, and refetch-before-retry.
  - Added safeguards and tests: the Python validator forbids concurrency; a YAML test ensures no queue; a reliability test runs two real producers and verifies both commits are preserved.

<sup>Written for commit 978d4074bd67d5f477538adea65f5f8243491d83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

