### PR TITLE
fix(ci): shard Integer nightly matrices

### DIFF
--- a/.github/scripts/aggregate-integer-results.sh
+++ b/.github/scripts/aggregate-integer-results.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 5 ]; then
-  echo "Usage: aggregate-integer-results.sh <expected-json> <results-dir> <child-result> <repository> <run-id>" >&2
+if [ "$#" -ne 6 ]; then
+  echo "Usage: aggregate-integer-results.sh <expected-json> <results-dir> <child-result> <repository> <run-id> <batch-id>" >&2
   exit 2
 fi
 
@@ -11,22 +11,32 @@ results_dir=$2
 child_result=$3
 repository=$4
 run_id=$5
+batch_id=$6
 run_url="https://github.com/${repository}/actions/runs/${run_id}"
+shard_size=250
 
-if [ "$child_result" = "success" ]; then
-  echo "All dispatched Integer child builds succeeded."
-  exit 0
-fi
-
-if ! jq -e 'type == "array" and all(.[]; (.name | type == "string") and (.version | type == "string") and (.type | type == "string"))' "$expected_json" >/dev/null; then
-  echo "Invalid or missing Integer build plan; inspect ${run_url}" >&2
+if ! jq -e '
+  type == "array"
+  and all(.[];
+    (.name | type == "string")
+    and (.version | type == "string")
+    and (.type | type == "string")
+  )
+  and ((map([.name, .version, .type] | @tsv) | length)
+    == (map([.name, .version, .type] | @tsv) | unique | length))
+' "$expected_json" >/dev/null; then
+  echo "Invalid or duplicate Integer build plan; inspect ${run_url}" >&2
   exit 1
 fi
 
 expected_count=$(jq 'length' "$expected_json")
-if [ "$child_result" = "skipped" ] && [ "$expected_count" -eq 0 ]; then
-  echo "No Integer child builds were dispatched."
-  exit 0
+if [ "$expected_count" -eq 0 ]; then
+  if [ "$child_result" = "skipped" ]; then
+    echo "No Integer child builds were dispatched."
+    exit 0
+  fi
+  echo "Empty Integer plan concluded ${child_result}, expected skipped; inspect ${run_url}" >&2
+  exit 1
 fi
 
 reports=$(mktemp)
@@ -34,52 +44,88 @@ trap 'rm -f "$reports"' EXIT
 mapfile -d '' report_files < <(find "$results_dir" -type f -name 'report.json' -print0 2>/dev/null || true)
 if [ "${#report_files[@]}" -eq 0 ]; then
   printf '[]\n' > "$reports"
-else
-  jq -s '.' "${report_files[@]}" > "$reports"
-fi
-
-missing_stage="matrix-dispatch-or-report"
-if [ "$expected_count" -gt 256 ] && [ "${#report_files[@]}" -eq 0 ]; then
-  missing_stage="matrix-expansion-limit"
-  echo "Integer plan contains ${expected_count} entries; GitHub Actions permits at most 256 matrix jobs." >&2
+elif ! jq -s '.' "${report_files[@]}" > "$reports"; then
+  echo "Invalid Integer child report JSON; inspect ${run_url}" >&2
+  exit 1
 fi
 
 mapfile -t failures < <(
   jq -r \
-    --arg missing_stage "$missing_stage" \
+    --arg batch_id "$batch_id" \
     --arg default_run_id "$run_id" \
+    --argjson shard_size "$shard_size" \
     --slurpfile reports "$reports" '
-    .[] as $expected |
-    ($reports[0] | map(select(
-      .image == $expected.name and
-      .version == $expected.version and
-      .type == $expected.type
-    )) | first) as $report |
-    if $report == null then
-      [$expected.name, $expected.version, $expected.type,
-       $missing_stage, $default_run_id, ($expected.name | gsub("/"; "-"))] | @tsv
-    elif $report.status != "success" then
-      [$expected.name, $expected.version, $expected.type,
-       ($report.failure_stage // "unknown"),
+    def same_entry($report; $expected):
+      $report.image == $expected.name
+      and $report.version == $expected.version
+      and $report.type == $expected.type;
+    def failure_row($entry; $shard; $stage; $report):
+      [$entry.name, $entry.version, $entry.type, ($shard | tostring), $stage,
        (if (($report.run_id // "") | length) > 0 then $report.run_id else $default_run_id end),
-       ($expected.name | gsub("/"; "-"))] | @tsv
-    else empty end
+       ($entry.name | gsub("/"; "-"))];
+
+    . as $expected_entries |
+    $reports[0] as $all_reports |
+    [
+      ($expected_entries | to_entries[] |
+        .key as $index |
+        .value as $expected |
+        (($index / $shard_size | floor) + 1) as $expected_shard |
+        ($all_reports | map(select(same_entry(.; $expected)))) as $identity_reports |
+        ($identity_reports | map(select((.batch_id // "") == $batch_id))) as $current_reports |
+        if ($current_reports | length) == 0 then
+          ($identity_reports | first) as $stale |
+          failure_row(
+            $expected;
+            $expected_shard;
+            (if $stale == null then "matrix-dispatch-or-report" else "batch-mismatch" end);
+            ($stale // {})
+          )
+        elif ($current_reports | length) > 1 then
+          failure_row($expected; $expected_shard; "duplicate-child-report"; $current_reports[0])
+        elif (($current_reports[0].shard // 0) | tostring) != ($expected_shard | tostring) then
+          failure_row($expected; $expected_shard; "wrong-shard-report"; $current_reports[0])
+        elif $current_reports[0].status != "success" then
+          failure_row(
+            $expected;
+            $expected_shard;
+            ($current_reports[0].failure_stage // "unknown");
+            $current_reports[0]
+          )
+        else empty end
+      ),
+      ($all_reports[] as $report |
+        select(($report.batch_id // "") == $batch_id) |
+        select(($expected_entries | map(select(same_entry($report; .))) | length) == 0) |
+        failure_row(
+          {name: ($report.image // "unknown"), version: ($report.version // "unknown"), type: ($report.type // "unknown")};
+          ($report.shard // 0);
+          "unexpected-child-report";
+          $report
+        )
+      )
+    ] | .[] | @tsv
   ' "$expected_json"
 )
 
-echo "Integer child build matrix concluded: ${child_result}" >&2
+echo "Integer child shard matrix concluded: ${child_result}" >&2
 if [ "${#failures[@]}" -eq 0 ]; then
-  echo "No failed child report was available; inspect ${run_url}" >&2
-  exit 1
+  if [ "$child_result" != "success" ]; then
+    echo "No failed child report explains shard result ${child_result}; batch=${batch_id}; inspect ${run_url}" >&2
+    exit 1
+  fi
+  shard_count=$(((expected_count + shard_size - 1) / shard_size))
+  echo "All ${expected_count} planned Integer child builds succeeded across ${shard_count} shard(s)."
+  exit 0
 fi
 
 summary="## Failed Integer matrix entries"
 for failure in "${failures[@]}"; do
-  IFS=$'\t' read -r image version type stage report_run_id safe_image <<< "$failure"
+  IFS=$'\t' read -r image version type shard stage report_run_id safe_image <<< "$failure"
   entry_run_id=${report_run_id:-$run_id}
   entry_url="https://github.com/${repository}/actions/runs/${entry_run_id}"
   artifact="integer-build-result-${safe_image}-${version}-${type}"
-  line="- ${image}:${version}-${type} — stage=${stage}; run=${entry_url}; artifact=${artifact}"
+  line="- ${image}:${version}-${type} — shard=${shard}; stage=${stage}; batch=${batch_id}; run=${entry_url}; artifact=${artifact}"
   echo "$line" >&2
   summary+=$'\n'"$line"
 done

--- a/.github/scripts/validate-integer-build-image-workflow.py
+++ b/.github/scripts/validate-integer-build-image-workflow.py
@@ -71,8 +71,8 @@ def main() -> None:
         "Integer Trivy scans must not be report-only",
     )
     require(
-        "workflow_call:" in workflow and "batch_id:" in workflow,
-        "Integer Build Image must accept an explicit parent batch identifier",
+        "workflow_call:" in workflow and "batch_id:" in workflow and "shard:" in workflow,
+        "Integer Build Image must accept explicit parent batch and shard identifiers",
     )
     require(
         "needs: [melange-prep, melange-build, build]" in workflow
@@ -84,8 +84,9 @@ def main() -> None:
     )
     require(
         "batch_id: $batch_id" in workflow
+        and "shard: $shard" in workflow
         and '"reports/${INPUT_IMAGE}/${INPUT_VERSION}/${INPUT_TYPE}/latest.json"' in workflow,
-        "Integer reports must replace latest.json with the current batch result",
+        "Integer reports must replace latest.json with current batch and shard correlation",
     )
     require(
         workflow.index("--exit-code 1 \\") < workflow.index('"crane copy"'),

--- a/.github/scripts/validate-nightly-workflows.py
+++ b/.github/scripts/validate-nightly-workflows.py
@@ -68,6 +68,7 @@ def main() -> None:
     self_test()
     orchestrator = uncomment(".github/workflows/orchestrator.yaml")
     integer_orchestrator = uncomment(".github/workflows/integer-orchestrator.yaml")
+    integer_shard = uncomment(".github/workflows/integer-build-shard.yaml")
     chart_gen = uncomment(".github/workflows/chart-gen.yaml")
     build_site = uncomment(".github/workflows/build-site.yaml")
     chart_integration = uncomment(".github/workflows/chart-integration.yaml")
@@ -85,14 +86,22 @@ def main() -> None:
     require(
         "nightly plan" in integer_orchestrator
         and "--family integer" in integer_orchestrator
-        and "uses: ./.github/workflows/integer-build-image.yaml" in integer_orchestrator
-        and "fromJSON(needs.discover.outputs.images)" in integer_orchestrator
+        and "uses: ./.github/workflows/integer-build-shard.yaml" in integer_orchestrator
+        and "fromJSON(needs.discover.outputs.shards)" in integer_orchestrator
         and "fail-fast: false" in integer_orchestrator
-        and "CHILD_RESULT: ${{ needs.build.result }}" in integer_orchestrator
+        and "CHILD_RESULT: ${{ needs.build-shards.result }}" in integer_orchestrator
         and "pattern: integer-build-result-*" in integer_orchestrator
         and "bash .github/scripts/aggregate-integer-results.sh" in integer_orchestrator
         and "nightly dispatch" not in integer_orchestrator,
-        "Integer orchestrator must await every reusable child and identify failed matrix entries",
+        "Integer orchestrator must await every bounded shard and identify failed matrix entries",
+    )
+    require(
+        "fromJSON(inputs.entries)" in integer_shard
+        and "uses: ./.github/workflows/integer-build-image.yaml" in integer_shard
+        and "fail-fast: false" in integer_shard
+        and "batch_id: ${{ inputs.batch_id }}" in integer_shard
+        and "shard: ${{ inputs.shard }}" in integer_shard,
+        "Integer shard workflow must reuse every existing child build and preserve correlation",
     )
     require(
         "batch_id: ${{ github.run_id }}-${{ github.run_attempt }}" in integer_orchestrator
@@ -103,9 +112,9 @@ def main() -> None:
     )
     require(
         "permissions:\n  contents: read" in integer_orchestrator
-        and "build:\n" in integer_orchestrator
+        and "build-shards:\n" in integer_orchestrator
         and "      packages: write" in integer_orchestrator,
-        "Integer publishing permissions must be scoped to the reusable build job",
+        "Integer publishing permissions must be scoped to the reusable shard job",
     )
     require(
         "bash .github/scripts/wait-for-workflows.sh patch-image.yaml" in chart_gen

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -23,6 +23,10 @@ on:
         required: false
         type: string
         default: ""
+      shard:
+        required: false
+        type: number
+        default: 0
   workflow_dispatch:
     inputs:
       image:
@@ -46,6 +50,11 @@ on:
         description: "Parent nightly run freshness identifier (empty = this run)"
         required: false
         default: ""
+      shard:
+        description: "Parent Integer matrix shard (0 = direct dispatch)"
+        required: false
+        type: number
+        default: 0
 
 permissions:
   contents: write          # push-reports.sh writes to reports branch via GitHub API
@@ -873,6 +882,7 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
           BUILD_FAILURE_STAGE: ${{ needs.build.outputs.failure_stage }}
           BATCH_ID: ${{ inputs.batch_id }}
+          SHARD: ${{ inputs.shard }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
@@ -902,10 +912,11 @@ jobs:
             --arg built_at       "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg run_id         "$RUN_ID" \
             --arg batch_id       "$batch_id" \
+            --argjson shard      "$SHARD" \
             '{image: $image, version: $version, type: $type, tags: ($tags | split(",")),
               registry: $registry, digest: $digest, status: $status,
               failure_stage: $failure_stage, built_at: $built_at, run_id: $run_id,
-              batch_id: $batch_id}')
+              batch_id: $batch_id, shard: $shard}')
 
           safe_image="${INPUT_IMAGE//\//-}"
           echo "artifact_name=integer-build-result-${safe_image}-${INPUT_VERSION}-${INPUT_TYPE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/integer-build-shard.yaml
+++ b/.github/workflows/integer-build-shard.yaml
@@ -1,0 +1,41 @@
+name: Integer Build Shard
+run-name: "Integer shard ${{ inputs.shard }}"
+
+on:
+  workflow_call:
+    inputs:
+      shard:
+        required: true
+        type: number
+      entries:
+        required: true
+        type: string
+      batch_id:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}:${{ matrix.version }}-${{ matrix.type }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(inputs.entries) }}
+    uses: ./.github/workflows/integer-build-image.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
+    with:
+      image: ${{ matrix.name }}
+      version: ${{ matrix.version }}
+      type: ${{ matrix.type }}
+      tags: ${{ join(matrix.tags, ',') }}
+      registry: ${{ matrix.registry }}
+      batch_id: ${{ inputs.batch_id }}
+      shard: ${{ inputs.shard }}
+    secrets: inherit

--- a/.github/workflows/integer-orchestrator.yaml
+++ b/.github/workflows/integer-orchestrator.yaml
@@ -12,6 +12,7 @@ on:
       - "images/_base/*.yaml"
       - "integer.yaml"
       - ".github/workflows/integer-orchestrator.yaml"
+      - ".github/workflows/integer-build-shard.yaml"
       - ".github/workflows/integer-build-image.yaml"
   workflow_dispatch:
     inputs:
@@ -81,6 +82,8 @@ jobs:
     outputs:
       images: ${{ steps.discover.outputs.images }}
       count: ${{ steps.discover.outputs.count }}
+      shards: ${{ steps.discover.outputs.shards }}
+      shard_count: ${{ steps.discover.outputs.shard_count }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -155,32 +158,29 @@ jobs:
           path: images.json
           retention-days: 7
 
-  build:
-    name: Build ${{ matrix.name }}:${{ matrix.version }}-${{ matrix.type }}
+  build-shards:
+    name: Shard ${{ matrix.shard }} (${{ matrix.count }} entries)
     needs: discover
     if: always() && !failure() && !cancelled() && needs.discover.outputs.count != '0'
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.discover.outputs.images) }}
-    uses: ./.github/workflows/integer-build-image.yaml
+        include: ${{ fromJSON(needs.discover.outputs.shards) }}
+    uses: ./.github/workflows/integer-build-shard.yaml
     permissions:
       contents: write
       packages: write
       id-token: write
       attestations: write
     with:
-      image: ${{ matrix.name }}
-      version: ${{ matrix.version }}
-      type: ${{ matrix.type }}
-      tags: ${{ join(matrix.tags, ',') }}
-      registry: ${{ matrix.registry }}
+      shard: ${{ matrix.shard }}
+      entries: ${{ matrix.entries }}
       batch_id: ${{ github.run_id }}-${{ github.run_attempt }}
     secrets: inherit
 
   aggregate:
     name: Aggregate build results
-    needs: [discover, build]
+    needs: [discover, build-shards]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -194,7 +194,7 @@ jobs:
           path: integer-build-plan
 
       - name: Download Integer child reports
-        if: needs.build.result != 'success' && needs.build.result != 'skipped'
+        if: needs.discover.outputs.count != '0'
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -204,10 +204,11 @@ jobs:
       - name: Fail when any child build failed
         if: always()
         env:
-          CHILD_RESULT: ${{ needs.build.result }}
+          CHILD_RESULT: ${{ needs.build-shards.result }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
+          BATCH_ID: ${{ github.run_id }}-${{ github.run_attempt }}
         run: >-
           bash .github/scripts/aggregate-integer-results.sh
           integer-build-plan/images.json integer-build-results
-          "$CHILD_RESULT" "$REPOSITORY" "$RUN_ID"
+          "$CHILD_RESULT" "$REPOSITORY" "$RUN_ID" "$BATCH_ID"

--- a/cmd/nightly.go
+++ b/cmd/nightly.go
@@ -86,6 +86,7 @@ var nightlyPlanCmd = &cli.Command{
 
 		var data []byte
 		var count int
+		var integerShards []integerMatrixShard
 		var err error
 		switch family {
 		case nightlyFamilyCopa:
@@ -110,6 +111,9 @@ var nightlyPlanCmd = &cli.Command{
 			}
 			count = len(items)
 			data, err = json.Marshal(items)
+			if err == nil {
+				integerShards, err = shardIntegerImages(items)
+			}
 		default:
 			return fmt.Errorf("%w: %q; want %q or %q", errUnsupportedNightlyFamily, family, nightlyFamilyCopa, nightlyFamilyInteger)
 		}
@@ -125,6 +129,11 @@ var nightlyPlanCmd = &cli.Command{
 		if ghOut := cmd.String("github-output"); ghOut != "" {
 			if err := appendGitHubMatrixOutput(ghOut, count, data); err != nil {
 				return err
+			}
+			if family == nightlyFamilyInteger {
+				if err := appendGitHubShardOutput(ghOut, integerShards); err != nil {
+					return err
+				}
 			}
 		}
 		fmt.Fprintln(os.Stdout, string(data))

--- a/cmd/nightly_shards.go
+++ b/cmd/nightly_shards.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
+)
+
+const integerMatrixShardSize = 250
+
+type integerMatrixShard struct {
+	Shard   int    `json:"shard"`
+	Count   int    `json:"count"`
+	Entries string `json:"entries"`
+}
+
+func shardIntegerImages(images []intdiscovery.DiscoveredImage) ([]integerMatrixShard, error) {
+	shards := make([]integerMatrixShard, 0, (len(images)+integerMatrixShardSize-1)/integerMatrixShardSize)
+	for start := 0; start < len(images); start += integerMatrixShardSize {
+		end := min(start+integerMatrixShardSize, len(images))
+		entries, err := json.Marshal(images[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("marshalling Integer matrix shard %d: %w", len(shards)+1, err)
+		}
+		shards = append(shards, integerMatrixShard{
+			Shard:   len(shards) + 1,
+			Count:   end - start,
+			Entries: string(entries),
+		})
+	}
+	return shards, nil
+}
+
+func appendGitHubShardOutput(path string, shards []integerMatrixShard) error {
+	data, err := json.Marshal(shards)
+	if err != nil {
+		return fmt.Errorf("marshalling Integer shard matrix: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening GitHub output %s: %w", path, err)
+	}
+	return appendGitHubShardOutputTo(f, path, len(shards), data)
+}
+
+func appendGitHubShardOutputTo(w io.WriteCloser, path string, count int, data []byte) (retErr error) {
+	defer func() {
+		if closeErr := w.Close(); closeErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("closing GitHub output %s: %w", path, closeErr))
+		}
+	}()
+	if _, err := fmt.Fprintf(w, "shard_count=%d\nshards<<__VERITY_INTEGER_SHARDS__\n%s\n__VERITY_INTEGER_SHARDS__\n", count, data); err != nil {
+		return fmt.Errorf("writing GitHub output %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/nightly_shards_test.go
+++ b/cmd/nightly_shards_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	intdiscovery "github.com/verity-org/verity/internal/integer/discovery"
+)
+
+func TestShardIntegerImages_preserves673EntriesInStableBoundedOrder(t *testing.T) {
+	// Given
+	images := syntheticIntegerImages(673)
+
+	// When
+	first, err := shardIntegerImages(images)
+	require.NoError(t, err)
+	second, err := shardIntegerImages(images)
+	require.NoError(t, err)
+
+	// Then
+	require.Equal(t, first, second)
+	require.Len(t, first, 3)
+	assert.Equal(t, []int{250, 250, 173}, []int{first[0].Count, first[1].Count, first[2].Count})
+
+	flattened := flattenIntegerShards(t, first)
+	require.Equal(t, images, flattened)
+	seen := make(map[string]int, len(flattened))
+	for _, image := range flattened {
+		seen[image.Name+"\x00"+image.Version+"\x00"+image.Type]++
+	}
+	require.Len(t, seen, len(images))
+	for identity, count := range seen {
+		assert.Equal(t, 1, count, identity)
+	}
+}
+
+func TestShardIntegerImages_preservesExistingSmallerMatrices(t *testing.T) {
+	for _, count := range []int{0, 1, 249, 250} {
+		t.Run(fmt.Sprintf("count_%d", count), func(t *testing.T) {
+			// Given
+			images := syntheticIntegerImages(count)
+
+			// When
+			shards, err := shardIntegerImages(images)
+			require.NoError(t, err)
+
+			// Then
+			if count == 0 {
+				assert.Empty(t, shards)
+				return
+			}
+			require.Len(t, shards, 1)
+			assert.Equal(t, 1, shards[0].Shard)
+			assert.Equal(t, count, shards[0].Count)
+			assert.Equal(t, images, flattenIntegerShards(t, shards))
+		})
+	}
+}
+
+func TestShardIntegerImages_keepsWorkflowDispatchImageFilterScoped(t *testing.T) {
+	// Given
+	images := syntheticIntegerImages(673)
+	filtered := filterIntegerImagesByName(images, "image-0042")
+
+	// When
+	shards, err := shardIntegerImages(filtered)
+	require.NoError(t, err)
+
+	// Then
+	flattened := flattenIntegerShards(t, shards)
+	require.Len(t, flattened, 1)
+	assert.Equal(t, "image-0042", flattened[0].Name)
+}
+
+func TestAppendGitHubShardOutputTo_writesBoundedShardMatrix(t *testing.T) {
+	// Given
+	writer := &closeBuffer{}
+	shards, err := shardIntegerImages(syntheticIntegerImages(251))
+	require.NoError(t, err)
+	data, err := json.Marshal(shards)
+	require.NoError(t, err)
+
+	// When
+	err = appendGitHubShardOutputTo(writer, "out", len(shards), data)
+
+	// Then
+	require.NoError(t, err)
+	assert.True(t, bytes.HasPrefix(writer.Bytes(), []byte("shard_count=2\nshards<<__VERITY_INTEGER_SHARDS__\n")))
+	assert.Contains(t, writer.String(), `"count":250`)
+	assert.Contains(t, writer.String(), `"count":1`)
+}
+
+func syntheticIntegerImages(count int) []intdiscovery.DiscoveredImage {
+	images := make([]intdiscovery.DiscoveredImage, 0, count)
+	for index := range count {
+		images = append(images, intdiscovery.DiscoveredImage{
+			Name:     fmt.Sprintf("image-%04d", index),
+			Version:  strconv.Itoa(index),
+			Type:     "default",
+			Tags:     []string{strconv.Itoa(index)},
+			Registry: "ghcr.io/verity-org",
+		})
+	}
+	return images
+}
+
+func flattenIntegerShards(t *testing.T, shards []integerMatrixShard) []intdiscovery.DiscoveredImage {
+	t.Helper()
+	capacity := 0
+	for _, shard := range shards {
+		capacity += shard.Count
+	}
+	flattened := make([]intdiscovery.DiscoveredImage, 0, capacity)
+	for _, shard := range shards {
+		assert.LessOrEqual(t, shard.Count, integerMatrixShardSize)
+		var entries []intdiscovery.DiscoveredImage
+		require.NoError(t, json.Unmarshal([]byte(shard.Entries), &entries))
+		require.Len(t, entries, shard.Count)
+		flattened = append(flattened, entries...)
+	}
+	return flattened
+}

--- a/scripts/integer_sharding_workflow_test.go
+++ b/scripts/integer_sharding_workflow_test.go
@@ -1,0 +1,88 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegerNightlyWorkflowDispatchesEveryBoundedShard(t *testing.T) {
+	// Given
+	data, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-orchestrator.yaml"))
+	require.NoError(t, err)
+	workflow := string(data)
+
+	// Then
+	assert.Contains(t, workflow, "shards: ${{ steps.discover.outputs.shards }}")
+	assert.Contains(t, workflow, "shard_count: ${{ steps.discover.outputs.shard_count }}")
+	assert.Contains(t, workflow, "include: ${{ fromJSON(needs.discover.outputs.shards) }}")
+	assert.Contains(t, workflow, "uses: ./.github/workflows/integer-build-shard.yaml")
+	assert.Contains(t, workflow, "entries: ${{ matrix.entries }}")
+	assert.Contains(t, workflow, "shard: ${{ matrix.shard }}")
+	assert.Contains(t, workflow, "CHILD_RESULT: ${{ needs.build-shards.result }}")
+	assert.Contains(t, workflow, "BATCH_ID: ${{ github.run_id }}-${{ github.run_attempt }}")
+	assert.NotContains(t, workflow, "include: ${{ fromJSON(needs.discover.outputs.images) }}")
+}
+
+func TestIntegerShardWorkflowReusesBuildWorkflowAndPropagatesFailures(t *testing.T) {
+	// Given
+	data, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-shard.yaml"))
+	require.NoError(t, err)
+	workflow := string(data)
+
+	// Then
+	assert.Contains(t, workflow, "include: ${{ fromJSON(inputs.entries) }}")
+	assert.Contains(t, workflow, "fail-fast: false")
+	assert.Contains(t, workflow, "uses: ./.github/workflows/integer-build-image.yaml")
+	assert.Contains(t, workflow, "batch_id: ${{ inputs.batch_id }}")
+	assert.Contains(t, workflow, "shard: ${{ inputs.shard }}")
+	assert.Contains(t, workflow, "secrets: inherit")
+}
+
+func TestIntegerNightlyWorkflowAggregatesChildFailuresAndPublishesCurrentReports(t *testing.T) {
+	// Given: the nightly parent, shard, and reusable Integer child workflows.
+	parentData, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-orchestrator.yaml"))
+	require.NoError(t, err)
+	shardData, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-shard.yaml"))
+	require.NoError(t, err)
+	childData, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
+	require.NoError(t, err)
+	parent := string(parentData)
+	shard := string(shardData)
+	child := string(childData)
+
+	// Then: every shard and child is awaited, while terminal reports retain correlation.
+	assert.Contains(t, parent, "uses: ./.github/workflows/integer-build-shard.yaml")
+	assert.Contains(t, parent, "fromJSON(needs.discover.outputs.shards)")
+	assert.Contains(t, parent, "fail-fast: false")
+	assert.Contains(t, parent, "secrets: inherit")
+	assert.Contains(t, parent, "batch_id: ${{ github.run_id }}-${{ github.run_attempt }}")
+	assert.Contains(t, parent, `github.event_name }}" = "schedule"`)
+	assert.Contains(t, parent, "PLAN_ARGS+=(--force)")
+	assert.Contains(t, parent, "CHILD_RESULT: ${{ needs.build-shards.result }}")
+	assert.Contains(t, parent, "integer-build-plan-${{ github.run_id }}-${{ github.run_attempt }}")
+	assert.Contains(t, parent, "pattern: integer-build-result-*")
+	assert.Contains(t, parent, "bash .github/scripts/aggregate-integer-results.sh")
+
+	assert.Contains(t, shard, "fromJSON(inputs.entries)")
+	assert.Contains(t, shard, "uses: ./.github/workflows/integer-build-image.yaml")
+	assert.Contains(t, shard, "batch_id: ${{ inputs.batch_id }}")
+	assert.Contains(t, shard, "shard: ${{ inputs.shard }}")
+
+	assert.Contains(t, child, "workflow_call:")
+	assert.Contains(t, child, "batch_id:")
+	assert.Contains(t, child, "shard:")
+	assert.Contains(t, child, "needs: [melange-prep, melange-build, build]")
+	assert.Contains(t, child, "if: always()")
+	assert.Contains(t, child, "MELANGE_PREP_RESULT")
+	assert.Contains(t, child, "MELANGE_BUILD_RESULT")
+	assert.Contains(t, child, "BUILD_RESULT")
+	assert.Contains(t, child, "BATCH_ID")
+	assert.Contains(t, child, "batch_id: $batch_id")
+	assert.Contains(t, child, "shard: $shard")
+	assert.Contains(t, child, "integer-build-result-${safe_image}-${INPUT_VERSION}-${INPUT_TYPE}")
+	assert.Contains(t, child, "Upload current build report")
+}

--- a/scripts/nightly_reliability_test.go
+++ b/scripts/nightly_reliability_test.go
@@ -138,11 +138,12 @@ func TestAggregateIntegerResultsNamesFailedAndMissingMatrixEntries(t *testing.T)
 ]`+"\n")
 	writeFile(t, filepath.Join(results, "integer-build-result-alpha", "report.json"), `{
   "image":"alpha","version":"1.2.3","type":"default",
-  "status":"failure","failure_stage":"trivy","run_id":"42"
+	  "status":"failure","failure_stage":"trivy","run_id":"42",
+	  "batch_id":"42-1","shard":1
 }`+"\n")
 
 	// When: the failed reusable matrix is aggregated.
-	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "failure", "verity-org/verity", "42")
+	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "failure", "verity-org/verity", "42", "42-1")
 	output, err := cmd.CombinedOutput()
 	require.Error(t, err)
 
@@ -150,6 +151,8 @@ func TestAggregateIntegerResultsNamesFailedAndMissingMatrixEntries(t *testing.T)
 	text := string(output)
 	assert.Contains(t, text, "alpha:1.2.3-default")
 	assert.Contains(t, text, "stage=trivy")
+	assert.Contains(t, text, "shard=1")
+	assert.Contains(t, text, "batch=42-1")
 	assert.Contains(t, text, "integer-build-result-alpha-1.2.3-default")
 	assert.Contains(t, text, "beta/tools:4.5.6-fips")
 	assert.Contains(t, text, "stage=matrix-dispatch-or-report")
@@ -166,7 +169,7 @@ func TestAggregateIntegerResultsFailsClosedWhenNonEmptyPlanIsSkipped(t *testing.
 	require.NoError(t, os.MkdirAll(results, 0o755))
 
 	// When: aggregation receives the skipped matrix result.
-	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "skipped", "verity-org/verity", "42")
+	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "skipped", "verity-org/verity", "42", "42-1")
 	output, err := cmd.CombinedOutput()
 
 	// Then: the undispatched entry is reported instead of accepted as success.
@@ -184,12 +187,63 @@ func TestAggregateIntegerResultsAcceptsSkippedEmptyPlan(t *testing.T) {
 	require.NoError(t, os.MkdirAll(results, 0o755))
 
 	// When: the empty matrix is reported as skipped.
-	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "skipped", "verity-org/verity", "42")
+	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "skipped", "verity-org/verity", "42", "42-1")
 	output, err := cmd.CombinedOutput()
 
 	// Then: the intentional no-op remains successful.
 	require.NoError(t, err, string(output))
 	assert.Contains(t, string(output), "No Integer child builds were dispatched.")
+}
+
+func TestAggregateIntegerResultsRejectsSuccessfulPartialDispatch(t *testing.T) {
+	// Given: a successful shard result that omitted one planned entry.
+	tmp := t.TempDir()
+	expected := filepath.Join(tmp, "expected.json")
+	results := filepath.Join(tmp, "results")
+	writeFile(t, expected, `[
+  {"name":"alpha","version":"1","type":"default"},
+  {"name":"beta","version":"2","type":"default"}
+]`+"\n")
+	writeFile(t, filepath.Join(results, "integer-build-result-alpha", "report.json"), `{
+  "image":"alpha","version":"1","type":"default","status":"success",
+  "run_id":"42","batch_id":"42-1","shard":1
+}`+"\n")
+
+	// When
+	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "success", "verity-org/verity", "42", "42-1")
+	output, err := cmd.CombinedOutput()
+
+	// Then
+	require.Error(t, err)
+	assert.Contains(t, string(output), "beta:2-default")
+	assert.Contains(t, string(output), "stage=matrix-dispatch-or-report")
+}
+
+func TestAggregateIntegerResultsAcceptsCompleteSuccessfulShards(t *testing.T) {
+	// Given: every planned entry has one current-batch successful report.
+	tmp := t.TempDir()
+	expected := filepath.Join(tmp, "expected.json")
+	results := filepath.Join(tmp, "results")
+	writeFile(t, expected, `[
+  {"name":"alpha","version":"1","type":"default"},
+  {"name":"beta","version":"2","type":"fips"}
+]`+"\n")
+	writeFile(t, filepath.Join(results, "alpha", "report.json"), `{
+  "image":"alpha","version":"1","type":"default","status":"success",
+  "run_id":"42","batch_id":"42-1","shard":1
+}`+"\n")
+	writeFile(t, filepath.Join(results, "beta", "report.json"), `{
+  "image":"beta","version":"2","type":"fips","status":"success",
+  "run_id":"42","batch_id":"42-1","shard":1
+}`+"\n")
+
+	// When
+	cmd := exec.CommandContext(t.Context(), "bash", filepath.Join("..", ".github", "scripts", "aggregate-integer-results.sh"), expected, results, "success", "verity-org/verity", "42", "42-1")
+	output, err := cmd.CombinedOutput()
+
+	// Then
+	require.NoError(t, err, string(output))
+	assert.Contains(t, string(output), "All 2 planned Integer child builds succeeded across 1 shard(s).")
 }
 
 func configureGit(t *testing.T, gitPath, dir string) {

--- a/scripts/workflow_interpolation_test.go
+++ b/scripts/workflow_interpolation_test.go
@@ -220,7 +220,8 @@ func TestPRWorkflowAggregateRejectsIncompleteIntegerArchitectureCoverage(t *test
 	require.NotEmpty(t, aggregate)
 
 	matrix := `{"include":[{"image":"demo","version":"1","type":"default"}]}`
-	baseEnv := append(os.Environ(),
+	baseEnv := append(
+		os.Environ(),
 		"CHANGES_RESULT=success", "INTEGER=true", "COPA=false",
 		"DISCOVER_RESULT=success", "VALIDATE_RESULT=success",
 		"DETECT_INTEGER_RESULT=success", "INTEGER_HAS_CHANGES=true",
@@ -283,40 +284,4 @@ func TestPRWorkflowAggregateRejectsIncompleteIntegerArchitectureCoverage(t *test
 			assert.Contains(t, output, "invalid expected Integer build matrix")
 		})
 	}
-}
-
-func TestIntegerNightlyWorkflowAggregatesChildFailuresAndPublishesCurrentReports(t *testing.T) {
-	// Given: the nightly parent and reusable Integer child workflows.
-	parentData, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-orchestrator.yaml"))
-	require.NoError(t, err)
-	childData, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
-	require.NoError(t, err)
-	parent := string(parentData)
-	child := string(childData)
-
-	// When: nightly builds are dispatched through the parent matrix.
-	// Then: each child is awaited, failures reach the parent conclusion, and
-	// every terminal child state replaces any stale successful report.
-	assert.Contains(t, parent, "uses: ./.github/workflows/integer-build-image.yaml")
-	assert.Contains(t, parent, "fail-fast: false")
-	assert.Contains(t, parent, "secrets: inherit")
-	assert.Contains(t, parent, "batch_id: ${{ github.run_id }}-${{ github.run_attempt }}")
-	assert.Contains(t, parent, `github.event_name }}" = "schedule"`)
-	assert.Contains(t, parent, "PLAN_ARGS+=(--force)")
-	assert.Contains(t, parent, "CHILD_RESULT: ${{ needs.build.result }}")
-	assert.Contains(t, parent, "integer-build-plan-${{ github.run_id }}-${{ github.run_attempt }}")
-	assert.Contains(t, parent, "pattern: integer-build-result-*")
-	assert.Contains(t, parent, "bash .github/scripts/aggregate-integer-results.sh")
-
-	assert.Contains(t, child, "workflow_call:")
-	assert.Contains(t, child, "batch_id:")
-	assert.Contains(t, child, "needs: [melange-prep, melange-build, build]")
-	assert.Contains(t, child, "if: always()")
-	assert.Contains(t, child, "MELANGE_PREP_RESULT")
-	assert.Contains(t, child, "MELANGE_BUILD_RESULT")
-	assert.Contains(t, child, "BUILD_RESULT")
-	assert.Contains(t, child, "BATCH_ID")
-	assert.Contains(t, child, "batch_id: $batch_id")
-	assert.Contains(t, child, "integer-build-result-${safe_image}-${INPUT_VERSION}-${INPUT_TYPE}")
-	assert.Contains(t, child, "Upload current build report")
 }


### PR DESCRIPTION
## Summary
- split Integer discovery plans into deterministic 250-entry reusable-workflow shards
- reuse the existing Integer Build Image workflow for every entry and fail closed on missing, duplicate, stale-batch, wrong-shard, unexpected, or failed reports
- retain entry/shard/batch/run correlation and preserve strict dual-architecture Trivy behavior
- add 673-entry RED-to-GREEN coverage plus workflow validators

## Verification
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run ./...
- go vet ./...
- actionlint
- yamllint .github/workflows
- nightly and Integer workflow validators
- branch dispatch 29587140845 expanded 250/250/173 shards (2,691 jobs) and was force-canceled before execution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shards the Integer nightly build matrix into deterministic 250-entry chunks and enforces batch/shard correlation, keeping runs within GitHub limits and failing closed on inconsistencies. The orchestrator now dispatches bounded shards and aggregates results with clear, per-entry failure reporting.

- **New Features**
  - Added `integer-build-shard.yaml` to run each shard via `integer-build-image.yaml`, passing `batch_id` and `shard`.
  - Orchestrator now emits `shards`/`shard_count`, runs `build-shards`, and aggregates all child reports.
  - `nightly` CLI computes shard matrices and writes them to GitHub outputs; added shard tests.
  - `integer-build-image.yaml` accepts a `shard` input and writes it to the report JSON for correlation.

- **Bug Fixes**
  - Aggregation script now validates batch/shard, and flags missing, duplicate, wrong-shard, unexpected, or stale reports; accepts skipped only for empty plans.
  - Clear success message when all planned entries succeed across shards.
  - Updated validators to require `batch_id` and `shard`, and to scope publishing permissions to the shard job.
  - Added 673-entry coverage and workflow tests to prevent regressions.

<sup>Written for commit 0265802dd36186ea7bc984c5bd5dba4e82f3c098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

