### PR TITLE
fix(ci): isolate Integer build artifacts

### DIFF
--- a/.github/scripts/validate-integer-build-image-workflow.py
+++ b/.github/scripts/validate-integer-build-image-workflow.py
@@ -75,6 +75,13 @@ def main() -> None:
         "Integer Build Image must accept explicit parent batch and shard identifiers",
     )
     require(
+        "artifact_key: ${{ steps.artifact-key.outputs.artifact_key }}" in workflow
+        and "id: artifact-key" in workflow
+        and "name: melange-work" not in workflow
+        and "name: melange-packages-" not in workflow,
+        "Integer Melange intermediates must be isolated by image/version/type artifact key",
+    )
+    require(
         "needs: [melange-prep, melange-build, build]" in workflow
         and "MELANGE_PREP_RESULT" in workflow
         and "MELANGE_BUILD_RESULT" in workflow

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       needed: ${{ steps.check.outputs.needed }}
+      artifact_key: ${{ steps.artifact-key.outputs.artifact_key }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -91,6 +92,21 @@ jobs:
 
       - name: Build verity CLI
         run: go build -o verity .
+
+      - name: Generate unique artifact key
+        id: artifact-key
+        env:
+          INPUT_IMAGE: ${{ inputs.image }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TYPE: ${{ inputs.type }}
+        run: |
+          prefix=$(printf '%s-%s-%s' "$INPUT_IMAGE" "$INPUT_VERSION" "$INPUT_TYPE" \
+            | tr -c 'A-Za-z0-9._-' '-' \
+            | cut -c1-120)
+          digest=$(printf '%s\0%s\0%s' "$INPUT_IMAGE" "$INPUT_VERSION" "$INPUT_TYPE" \
+            | sha256sum \
+            | cut -c1-12)
+          echo "artifact_key=${prefix}-${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare bespoke package
         id: check
@@ -109,7 +125,7 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: melange-work
+          name: ${{ steps.artifact-key.outputs.artifact_key }}-melange-work
           path: |
             melange-work/
             packages/overrides/
@@ -153,7 +169,7 @@ jobs:
       - name: Download melange work artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: melange-work
+          name: ${{ needs.melange-prep.outputs.artifact_key }}-melange-work
           path: .
 
       - name: Build melange package (${{ matrix.arch }})
@@ -512,7 +528,7 @@ jobs:
       - name: Upload arch packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: melange-packages-${{ matrix.arch }}
+          name: ${{ needs.melange-prep.outputs.artifact_key }}-melange-packages-${{ matrix.arch }}
           path: packages/repo/
           retention-days: 1
 
@@ -637,21 +653,21 @@ jobs:
         if: needs.melange-prep.outputs.needed == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: melange-packages-x86_64
+          name: ${{ needs.melange-prep.outputs.artifact_key }}-melange-packages-x86_64
           path: packages/repo
 
       - name: Download melange packages (aarch64)
         if: needs.melange-prep.outputs.needed == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: melange-packages-aarch64
+          name: ${{ needs.melange-prep.outputs.artifact_key }}-melange-packages-aarch64
           path: packages/repo
 
       - name: Download melange signing key
         if: needs.melange-prep.outputs.needed == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: melange-work
+          name: ${{ needs.melange-prep.outputs.artifact_key }}-melange-work
           path: .
 
       - name: Verify melange package merge

--- a/scripts/integer_artifact_isolation_test.go
+++ b/scripts/integer_artifact_isolation_test.go
@@ -1,0 +1,79 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestIntegerBuildWorkflowIsolatesMelangeArtifactsPerEntry(t *testing.T) {
+	// Given
+	data, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
+	require.NoError(t, err)
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				ID   string            `yaml:"id"`
+				Uses string            `yaml:"uses"`
+				Run  string            `yaml:"run"`
+				With map[string]string `yaml:"with"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &workflow))
+
+	// When
+	var keyCommand string
+	var intermediateNames []string
+	for _, job := range workflow.Jobs {
+		for _, step := range job.Steps {
+			if step.ID == "artifact-key" {
+				keyCommand = step.Run
+			}
+			name := step.With["name"]
+			if strings.Contains(step.Uses, "artifact") &&
+				(strings.Contains(name, "melange-work") || strings.Contains(name, "melange-packages")) {
+				intermediateNames = append(intermediateNames, name)
+			}
+		}
+	}
+
+	// Then
+	require.NotEmpty(t, keyCommand)
+	require.Len(t, intermediateNames, 6)
+	for _, name := range intermediateNames {
+		assert.Contains(t, name, "artifact_key", name)
+	}
+
+	first := runArtifactKeyCommand(t, keyCommand, "team/a-b", "1", "default")
+	repeat := runArtifactKeyCommand(t, keyCommand, "team/a-b", "1", "default")
+	collisionCandidate := runArtifactKeyCommand(t, keyCommand, "team-a/b", "1", "default")
+	assert.Equal(t, first, repeat)
+	assert.NotEqual(t, first, collisionCandidate)
+	assert.Regexp(t, regexp.MustCompile(`^[A-Za-z0-9._-]+-[0-9a-f]{12}$`), first)
+}
+
+func runArtifactKeyCommand(t *testing.T, command, image, version, imageType string) string {
+	t.Helper()
+	outputPath := filepath.Join(t.TempDir(), "github-output")
+	cmd := exec.CommandContext(t.Context(), "bash", "-c", command)
+	cmd.Env = append(
+		os.Environ(),
+		"INPUT_IMAGE="+image,
+		"INPUT_VERSION="+version,
+		"INPUT_TYPE="+imageType,
+		"GITHUB_OUTPUT="+outputPath,
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	return strings.TrimPrefix(strings.TrimSpace(string(data)), "artifact_key=")
+}


### PR DESCRIPTION
## Summary
- isolate every Integer Melange work and package artifact by image/version/type
- add a deterministic hash suffix so flattened image names cannot collide
- update workflow validation and add behavioral regression coverage

## Runtime evidence
- post-merge run 29588342258 expanded 250/250/28 shards
- trivy and weaviate downloaded the shared melange-work artifact containing blackbox-exporter.yaml and failed with missing build.yaml

## Verification
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run ./...
- go vet ./...
- actionlint and yamllint
- Integer/nightly workflow validators

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates Integer Melange build artifacts per image/version/type and adds a deterministic hash suffix to prevent collisions across shards. Fixes flaky artifact downloads in the Integer image build workflow.

- **Bug Fixes**
  - Generate `artifact_key` from `image`, `version`, and `type` with a sanitized prefix + 12-char sha256 digest.
  - Use `artifact_key` in all `melange-work` and `melange-packages-{arch}` upload/download names.
  - Expose `artifact_key` from the prep job and reference it via `needs` in downstream steps.
  - Enforce isolation in `.github/scripts/validate-integer-build-image-workflow.py` and block legacy artifact names.
  - Add `scripts/integer_artifact_isolation_test.go` to verify determinism, pattern, and usage across six artifact names.

<sup>Written for commit 1508112647947c56d8decc3f60540c6ac23f5083. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

