### PR TITLE
fix(ci): retry Integer CLI builds

### DIFF
--- a/.github/scripts/retry-go-build.sh
+++ b/.github/scripts/retry-go-build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+exec bash "$script_dir/retry-registry-command.sh" \
+  "go build verity" \
+  go build -o verity .

--- a/.github/scripts/validate-integer-build-image-workflow.py
+++ b/.github/scripts/validate-integer-build-image-workflow.py
@@ -82,6 +82,11 @@ def main() -> None:
         "Integer Melange intermediates must be isolated by image/version/type artifact key",
     )
     require(
+        workflow.count("bash .github/scripts/retry-go-build.sh") == 3
+        and "run: go build -o verity ." not in workflow,
+        "Every per-entry Verity build must retry transient module download failures",
+    )
+    require(
         "needs: [melange-prep, melange-build, build]" in workflow
         and "MELANGE_PREP_RESULT" in workflow
         and "MELANGE_BUILD_RESULT" in workflow

--- a/.github/workflows/integer-build-image.yaml
+++ b/.github/workflows/integer-build-image.yaml
@@ -91,7 +91,7 @@ jobs:
           cache: true
 
       - name: Build verity CLI
-        run: go build -o verity .
+        run: bash .github/scripts/retry-go-build.sh
 
       - name: Generate unique artifact key
         id: artifact-key
@@ -164,7 +164,7 @@ jobs:
           cache: true
 
       - name: Build verity CLI
-        run: go build -o verity .
+        run: bash .github/scripts/retry-go-build.sh
 
       - name: Download melange work artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -601,7 +601,7 @@ jobs:
           restore-keys: go-${{ runner.os }}-
 
       - name: Build verity CLI
-        run: go build -o verity .
+        run: bash .github/scripts/retry-go-build.sh
 
       - name: Generate apko configs
         id: gen

--- a/scripts/integer_artifact_isolation_test.go
+++ b/scripts/integer_artifact_isolation_test.go
@@ -77,3 +77,58 @@ func runArtifactKeyCommand(t *testing.T, command, image, version, imageType stri
 	require.NoError(t, err)
 	return strings.TrimPrefix(strings.TrimSpace(string(data)), "artifact_key=")
 }
+
+func TestIntegerBuildWorkflowRetriesEveryVerityBuild(t *testing.T) {
+	// Given
+	data, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "integer-build-image.yaml"))
+	require.NoError(t, err)
+	workflow := string(data)
+
+	// Then
+	assert.Equal(t, 3, strings.Count(workflow, "bash .github/scripts/retry-go-build.sh"))
+	assert.NotContains(t, workflow, "run: go build -o verity .")
+}
+
+func TestRetryGoBuildRetriesTransientModuleDownloadFailure(t *testing.T) {
+	// Given
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	attemptPath := filepath.Join(tmp, "attempts")
+	writeExecutable(t, filepath.Join(binDir, "go"), `#!/usr/bin/env bash
+set -euo pipefail
+attempt=0
+if [ -f "$GO_ATTEMPT_FILE" ]; then
+  attempt=$(cat "$GO_ATTEMPT_FILE")
+fi
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$GO_ATTEMPT_FILE"
+if [ "$attempt" -eq 1 ]; then
+  echo 'transient proxy failure' >&2
+  exit 1
+fi
+test "$*" = 'build -o verity .'
+touch verity
+`)
+	helper, err := filepath.Abs(filepath.Join("..", ".github", "scripts", "retry-go-build.sh"))
+	require.NoError(t, err)
+
+	// When
+	cmd := exec.CommandContext(t.Context(), "bash", helper)
+	cmd.Dir = tmp
+	cmd.Env = append(
+		os.Environ(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GO_ATTEMPT_FILE="+attemptPath,
+		"REGISTRY_COMMAND_ATTEMPTS=2",
+		"REGISTRY_COMMAND_BASE_DELAY_SECONDS=1",
+	)
+	output, err := cmd.CombinedOutput()
+
+	// Then
+	require.NoError(t, err, string(output))
+	assert.FileExists(t, filepath.Join(tmp, "verity"))
+	attempts, err := os.ReadFile(attemptPath)
+	require.NoError(t, err)
+	assert.Equal(t, "2", strings.TrimSpace(string(attempts)))
+	assert.Contains(t, string(output), "attempt 2/2")
+}


### PR DESCRIPTION
## Summary
- retry all three per-entry Verity CLI builds through the existing bounded retry primitive
- absorb transient Go module proxy failures without weakening child build or security gates
- add a fake-Go RED-to-GREEN retry test and workflow validator coverage

## Runtime evidence
- all-images run 29591652769 failed calico-apiserver preparation when proxy.golang.org returned HTTP/2 INTERNAL_ERROR for BuildKit

## Verification
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run ./...
- go vet ./...
- actionlint and yamllint
- Integer/nightly workflow validators

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry Verity CLI builds in the Integer image workflow to reduce flakiness from transient Go module proxy errors. Applies bounded retries to all three build steps and adds tests/validation without loosening build or security gates.

- **Bug Fixes**
  - Added `.github/scripts/retry-go-build.sh` to wrap `go build` with bounded retries via `retry-registry-command.sh`.
  - Replaced direct `go build -o verity .` with `bash .github/scripts/retry-go-build.sh` in all three Verity build steps.
  - Added workflow validator and a red-to-green test to enforce three retry invocations and verify success after a transient module download failure.

<sup>Written for commit a4a5e1e587f2100a9a8006797c46cdb313e9554c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

