### PR TITLE
fix(ci): correlate nightly producer batches

### DIFF
--- a/.github/scripts/validate-nightly-workflows.py
+++ b/.github/scripts/validate-nightly-workflows.py
@@ -117,9 +117,10 @@ def main() -> None:
         "Integer publishing permissions must be scoped to the reusable shard job",
     )
     require(
-        "bash .github/scripts/wait-for-workflows.sh patch-image.yaml" in chart_gen
+        "bash .github/scripts/wait-for-workflows.sh orchestrator.yaml" in chart_gen
+        and "WAIT_TIMEOUT_SECONDS: 21600" in chart_gen
         and "actions: read" in chart_gen,
-        "chart generation must wait for active patch-image producer runs",
+        "chart generation must wait for the completed Copa orchestrator batch",
     )
     require(
         "--method GET" in wait_helper
@@ -128,10 +129,18 @@ def main() -> None:
         "wait helper must use GET pagination and REST run ids",
     )
     require(
-        "bash .github/scripts/wait-for-workflows.sh patch-image.yaml integer-orchestrator.yaml chart-gen.yaml"
+        "bash .github/scripts/wait-for-workflows.sh orchestrator.yaml integer-orchestrator.yaml chart-gen.yaml"
         in build_site
+        and "WAIT_TIMEOUT_SECONDS: 21600" in build_site
         and "actions: read" in build_site,
-        "site build must wait for active patch, Integer orchestration, and chart generation producer runs",
+        "site build must wait for Copa, Integer, and chart producer workflows",
+    )
+    require(
+        '--batch-id "${{ github.run_id }}-${{ github.run_attempt }}"' in orchestrator
+        and "WAIT_BATCH_ID:" in orchestrator
+        and "WAIT_EXPECTED_RUNS:" in orchestrator
+        and "bash .github/scripts/wait-for-workflows.sh patch-image.yaml" in orchestrator,
+        "Copa orchestration must correlate and await only its own patch runs",
     )
     require(
         "  schedule:" not in chart_integration,

--- a/.github/scripts/validate-wait-for-workflows.sh
+++ b/.github/scripts/validate-wait-for-workflows.sh
@@ -24,6 +24,11 @@ for required in "--method GET" "--paginate" "-f branch=main" "--jq"; do
   fi
 done
 
+if [ -n "${WAIT_EXPECT_SUFFIX:-}" ] && [[ "$args" != *"display_title"*"${WAIT_EXPECT_SUFFIX}"* ]]; then
+  echo "wait helper must filter runs by the requested display-title suffix" >&2
+  exit 1
+fi
+
 status_arg_found=0
 for arg in "$@"; do
   case "$arg" in
@@ -80,6 +85,20 @@ if ! grep -qx "integer_orchestrator_batch_id=424242-3" "$tmpdir/github-output"; 
   echo "wait helper should publish the successful producer batch id" >&2
   exit 1
 fi
+
+FAKE_GH_CALLS="$tmpdir/suffix-calls" \
+FAKE_GH_STATUSES="$tmpdir/suffix-statuses" \
+WAIT_EXPECT_SUFFIX="[batch 12345-2]" \
+PATH="$tmpdir:$PATH" \
+GITHUB_REPOSITORY="verity-org/verity" \
+WAIT_BRANCH="main" \
+WAIT_BATCH_ID="12345-2" \
+WAIT_EXPECTED_RUNS=1 \
+WAIT_EVENT="workflow_dispatch" \
+WAIT_LOOKBACK_HOURS=1 \
+WAIT_TIMEOUT_SECONDS=1 \
+WAIT_INTERVAL_SECONDS=1 \
+  bash .github/scripts/wait-for-workflows.sh patch-image.yaml > "$tmpdir/suffix-out"
 
 if FAKE_GH_CONCLUSION="failure" \
   FAKE_GH_CALLS="$tmpdir/failed-calls" \

--- a/.github/scripts/wait-for-workflows.sh
+++ b/.github/scripts/wait-for-workflows.sh
@@ -10,6 +10,9 @@ BRANCH="${WAIT_BRANCH:-${GITHUB_REF_NAME:-main}}"
 LOOKBACK_HOURS="${WAIT_LOOKBACK_HOURS:-8}"
 TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-7200}"
 INTERVAL_SECONDS="${WAIT_INTERVAL_SECONDS:-60}"
+EVENT="${WAIT_EVENT:-}"
+BATCH_ID="${WAIT_BATCH_ID:-}"
+EXPECTED_RUNS="${WAIT_EXPECTED_RUNS:-}"
 
 case "$LOOKBACK_HOURS" in
   ''|*[!0-9]*|0*) echo "WAIT_LOOKBACK_HOURS must be a positive integer" >&2; exit 2 ;;
@@ -20,6 +23,18 @@ esac
 case "$INTERVAL_SECONDS" in
   ''|*[!0-9]*|0*) echo "WAIT_INTERVAL_SECONDS must be a positive integer" >&2; exit 2 ;;
 esac
+if [ -n "$EVENT" ] && [[ ! "$EVENT" =~ ^[a-z_]+$ ]]; then
+  echo "WAIT_EVENT contains unsupported characters" >&2
+  exit 2
+fi
+if [ -n "$BATCH_ID" ] && [[ ! "$BATCH_ID" =~ ^[0-9]+-[0-9]+$ ]]; then
+  echo "WAIT_BATCH_ID must have the form RUN_ID-RUN_ATTEMPT" >&2
+  exit 2
+fi
+if [ -n "$BATCH_ID" ] && [[ ! "$EXPECTED_RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "WAIT_EXPECTED_RUNS must be a positive integer when WAIT_BATCH_ID is set" >&2
+  exit 2
+fi
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "gh CLI is required" >&2
@@ -29,6 +44,13 @@ fi
 repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 cutoff="$(date -u -d "-${LOOKBACK_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ)"
 deadline=$((SECONDS + TIMEOUT_SECONDS))
+selector="select(.created_at >= \"${cutoff}\")"
+if [ -n "$EVENT" ]; then
+  selector="${selector} | select(.event == \"${EVENT}\")"
+fi
+if [ -n "$BATCH_ID" ]; then
+  selector="${selector} | select(.display_title | endswith(\" [batch ${BATCH_ID}]\"))"
+fi
 
 echo "Waiting for active workflow runs on ${BRANCH} since ${cutoff}: $*"
 
@@ -41,7 +63,7 @@ while true; do
           --paginate \
           -f branch="${BRANCH}" \
           -f status="${status}" \
-          --jq ".workflow_runs[] | select(.created_at >= \"${cutoff}\") | [\"${workflow}\", .id, .status, .created_at, .html_url] | @tsv"
+          --jq ".workflow_runs[] | ${selector} | [\"${workflow}\", .id, .status, .created_at, .html_url] | @tsv"
       done
     done | sort -u
   )"
@@ -50,17 +72,40 @@ while true; do
     echo "No active producer workflow runs remain."
 
     for workflow in "$@"; do
+      if [ -n "$BATCH_ID" ]; then
+        completed="$(
+          gh api "repos/${repo}/actions/workflows/${workflow}/runs" \
+            --method GET \
+            --paginate \
+            -f branch="${BRANCH}" \
+            --jq ".workflow_runs[] | ${selector} | select(.status == \"completed\") | [.id, .run_attempt, .conclusion, .created_at, .html_url] | @tsv"
+        )"
+        completed_count="$(grep -c . <<< "$completed" || true)"
+        if [ "$completed_count" -lt "$EXPECTED_RUNS" ]; then
+          echo "Waiting for ${workflow} batch ${BATCH_ID}: ${completed_count}/${EXPECTED_RUNS} completed."
+          break
+        fi
+        while IFS=$'\t' read -r run_id run_attempt conclusion created_at run_url; do
+          if [ "$conclusion" != "success" ]; then
+            echo "${workflow} batch ${BATCH_ID} run did not succeed: ${conclusion} (${run_url})" >&2
+            exit 1
+          fi
+        done <<< "$completed"
+        echo "All ${EXPECTED_RUNS} ${workflow} batch ${BATCH_ID} runs succeeded."
+        continue
+      fi
+
       latest="$(
         gh api "repos/${repo}/actions/workflows/${workflow}/runs" \
           --method GET \
           --paginate \
           -f branch="${BRANCH}" \
-          --jq ".workflow_runs | map(select(.created_at >= \"${cutoff}\" and .status == \"completed\")) | sort_by(.created_at) | last | if . == null then empty else [.id, .run_attempt, .conclusion, .created_at, .html_url] | @tsv end"
+          --jq ".workflow_runs | map(${selector} | select(.status == \"completed\")) | sort_by(.created_at) | last | if . == null then empty else [.id, .run_attempt, .conclusion, .created_at, .html_url] | @tsv end"
       )"
 
       if [ -z "$latest" ]; then
-        echo "No completed ${workflow} producer run found since ${cutoff}." >&2
-        exit 1
+        echo "Waiting for a completed ${workflow} producer run since ${cutoff}."
+        break
       fi
 
       IFS=$'\t' read -r run_id run_attempt conclusion created_at run_url <<< "$latest"
@@ -77,7 +122,13 @@ while true; do
       echo "Latest ${workflow} producer succeeded at ${created_at}: ${run_id}-${run_attempt}"
     done
 
-    exit 0
+    if [ -n "$BATCH_ID" ] && [ "${completed_count:-0}" -lt "$EXPECTED_RUNS" ]; then
+      :
+    elif [ -z "$BATCH_ID" ] && [ -z "${latest:-}" ]; then
+      :
+    else
+      exit 0
+    fi
   fi
 
   if [ "$SECONDS" -ge "$deadline" ]; then

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -48,7 +48,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WAIT_BRANCH: main
-        run: bash .github/scripts/wait-for-workflows.sh patch-image.yaml integer-orchestrator.yaml chart-gen.yaml
+          WAIT_EVENT: schedule
+          WAIT_TIMEOUT_SECONDS: 21600
+        run: bash .github/scripts/wait-for-workflows.sh orchestrator.yaml integer-orchestrator.yaml chart-gen.yaml
 
       - name: Checkout reports branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/chart-gen.yaml
+++ b/.github/workflows/chart-gen.yaml
@@ -40,11 +40,13 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Wait for nightly patch producers
+      - name: Wait for nightly Copa producer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WAIT_BRANCH: ${{ github.ref_name }}
-        run: bash .github/scripts/wait-for-workflows.sh patch-image.yaml
+          WAIT_EVENT: schedule
+          WAIT_TIMEOUT_SECONDS: 21600
+        run: bash .github/scripts/wait-for-workflows.sh orchestrator.yaml
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -272,4 +272,15 @@ jobs:
             --family copa \
             --input "$RUNNER_TEMP/patch-images.json" \
             --repo "${{ github.repository }}" \
-            --ref "${{ github.ref_name }}"
+            --ref "${{ github.ref_name }}" \
+            --batch-id "${{ github.run_id }}-${{ github.run_attempt }}"
+
+      - name: Wait for this batch's patch runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WAIT_BRANCH: ${{ github.ref_name }}
+          WAIT_EVENT: workflow_dispatch
+          WAIT_BATCH_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          WAIT_EXPECTED_RUNS: ${{ needs.discover.outputs.count }}
+          WAIT_TIMEOUT_SECONDS: 21600
+        run: bash .github/scripts/wait-for-workflows.sh patch-image.yaml

--- a/.github/workflows/patch-image.yaml
+++ b/.github/workflows/patch-image.yaml
@@ -1,5 +1,5 @@
 name: Patch Image
-run-name: "Patch ${{ inputs.image-name }} (${{ inputs.source-ref }})"
+run-name: "Patch ${{ inputs.image-name }} (${{ inputs.source-ref }})${{ inputs.batch-id != '' && format(' [batch {0}]', inputs.batch-id) || '' }}"
 
 # Reusable per-image lifecycle: scan → patch (matrix) → finalize.
 # Supports both workflow_call (PR inline) and workflow_dispatch (orchestrator).
@@ -39,6 +39,11 @@ on:
         required: false
         type: string
         default: ""
+      batch-id:
+        description: "Parent orchestrator run ID and attempt"
+        required: false
+        type: string
+        default: ""
 
   workflow_dispatch:
     inputs:
@@ -61,6 +66,11 @@ on:
         default: "linux/amd64,linux/arm64"
       go-vcs-url:
         description: "Go VCS URL for binary patching (e.g., https://github.com/org/repo@v1.0.0)"
+        required: false
+        type: string
+        default: ""
+      batch-id:
+        description: "Parent orchestrator run ID and attempt"
         required: false
         type: string
         default: ""

--- a/cmd/nightly.go
+++ b/cmd/nightly.go
@@ -150,6 +150,7 @@ var nightlyDispatchCmd = &cli.Command{
 		&cli.StringFlag{Name: "repo", Usage: "GitHub repository owner/name", Required: true},
 		&cli.StringFlag{Name: "ref", Usage: "Git ref for workflow dispatch", Required: true},
 		&cli.StringFlag{Name: "workflow", Usage: "Workflow file name; defaults from --family"},
+		&cli.StringFlag{Name: "batch-id", Usage: "Correlation identifier passed to dispatched workflows"},
 		&cli.IntFlag{Name: "retries", Usage: "Dispatch retries per item", Value: 5},
 		&cli.DurationFlag{Name: "throttle", Usage: "Delay between successful dispatches", Value: 2 * time.Second},
 	},
@@ -173,7 +174,7 @@ var nightlyDispatchCmd = &cli.Command{
 			return errMissingGitHubToken
 		}
 
-		inputs, err := nightlyDispatchInputs(cmd.String("family"), cmd.String("input"))
+		inputs, err := nightlyDispatchInputs(cmd.String("family"), cmd.String("input"), cmd.String("batch-id"))
 		if err != nil {
 			return err
 		}
@@ -477,7 +478,7 @@ func appendGitHubMatrixOutputTo(w io.WriteCloser, path string, count int, data [
 	return nil
 }
 
-func nightlyDispatchInputs(family, inputPath string) ([]map[string]string, error) {
+func nightlyDispatchInputs(family, inputPath, batchID string) ([]map[string]string, error) {
 	data, err := os.ReadFile(inputPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading dispatch matrix %s: %w", inputPath, err)
@@ -498,6 +499,9 @@ func nightlyDispatchInputs(family, inputPath string) ([]map[string]string, error
 			}
 			if item.GoVcsURL != "" {
 				in["go-vcs-url"] = item.GoVcsURL
+			}
+			if batchID != "" {
+				in["batch-id"] = batchID
 			}
 			out = append(out, in)
 		}

--- a/cmd/nightly_test.go
+++ b/cmd/nightly_test.go
@@ -126,7 +126,7 @@ func TestNightlyDispatchInputs(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(copaPath, copaData, 0o644))
 
-	copa, err := nightlyDispatchInputs(nightlyFamilyCopa, copaPath)
+	copa, err := nightlyDispatchInputs(nightlyFamilyCopa, copaPath, "12345-2")
 	require.NoError(t, err)
 	require.Equal(t, []map[string]string{{
 		"image-name":      "library/nginx",
@@ -134,6 +134,7 @@ func TestNightlyDispatchInputs(t *testing.T) {
 		"target-registry": "ghcr.io/verity-org",
 		"platforms":       "linux/amd64,linux/arm64",
 		"go-vcs-url":      "https://github.com/nginx/nginx@release-1.29.3",
+		"batch-id":        "12345-2",
 	}}, copa)
 
 	integerPath := filepath.Join(dir, "integer.json")
@@ -147,7 +148,7 @@ func TestNightlyDispatchInputs(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(integerPath, integerData, 0o644))
 
-	integer, err := nightlyDispatchInputs(nightlyFamilyInteger, integerPath)
+	integer, err := nightlyDispatchInputs(nightlyFamilyInteger, integerPath, "")
 	require.NoError(t, err)
 	require.Equal(t, []map[string]string{{
 		"image":    "node",
@@ -504,7 +505,7 @@ func TestDispatchWorkflowReportsTransportError(t *testing.T) {
 func TestNightlyDispatchInputsRejectsUnsupportedFamily(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "matrix.json")
 	require.NoError(t, os.WriteFile(path, []byte(`[]`), 0o644))
-	_, err := nightlyDispatchInputs("bad", path)
+	_, err := nightlyDispatchInputs("bad", path, "")
 	require.ErrorIs(t, err, errUnsupportedNightlyFamily)
 	assert.True(t, strings.Contains(err.Error(), "bad"))
 }


### PR DESCRIPTION
## Summary
- correlate Copa patch dispatches with their parent orchestrator batch
- make the orchestrator wait for every correlated patch run and fail if any child fails
- make downstream scheduled workflows wait on scheduled producer workflows instead of unrelated manual runs
- extend producer wait ceilings from two to six hours

## Context
The July 20 nightly run timed out while waiting on repository-wide patch activity. Chart Generation failed first, followed by Build Site, even though unrelated/manual patch runs were part of the wait set.

## Verification
- `go test ./... -count=1`
- `make lint-workflows`
- `bash -n .github/scripts/wait-for-workflows.sh .github/scripts/validate-wait-for-workflows.sh`
- targeted actionlint checks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correlates nightly Copa patch runs to their orchestrator batch and makes downstream jobs wait on the correct scheduled workflows. Extends wait timeouts to 6 hours to avoid premature failures and stops waiting on unrelated/manual runs.

- **New Features**
  - Batch correlation: orchestrator injects `--batch-id`, patch runs add "[batch RUN_ID-RUN_ATTEMPT]" to run-name, and the wait script supports `WAIT_BATCH_ID` and `WAIT_EXPECTED_RUNS`.
  - Event filtering: `WAIT_EVENT` lets the wait script target only `schedule` or `workflow_dispatch`.

- **Bug Fixes**
  - Chart Generation and Build Site now wait on the orchestrator and scheduled producers only, with a 6-hour ceiling.
  - Orchestrator waits for its own patch batch and fails if any child fails, preventing nightlies from hanging on unrelated runs.

<sup>Written for commit d2a76d80acd6dc608b38415d8e892be0967da707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

