### PR TITLE
fix(apk): pin signer source to protected main

### DIFF
--- a/packages/bespoke/apk-repository-signer.yaml
+++ b/packages/bespoke/apk-repository-signer.yaml
@@ -18,15 +18,13 @@ environment:
     CGO_ENABLED: "0"
     GOTOOLCHAIN: local
 
-# Bootstrap source is pinned to this PR branch so pre-merge Integer validation
-# can build it. Rotate branch and expected-commit to protected main before the
-# signer lock becomes runnable.
+# Signer source is pinned to the protected main revision that introduced the
+# audited signer implementation; no mutable branch participates in resolution.
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/verity-org/verity
-      branch: apk-repository-publish
-      expected-commit: 69b4bec7ee2a1f89162dd4e4250b953c6e654a29
+      expected-commit: fffeadbbadd3bfc3c682479aad6648adc4a71d79
 
   - uses: go/build
     with:


### PR DESCRIPTION
## Summary

- pin the APK repository signer recipe to the exact protected-main commit that introduced the audited signer
- remove the mutable feature-branch checkout
- keep the signer lock non-runnable during bootstrap

## Verification

- focused race/shuffle tests for Integer Melange, signer lock, workflow policy, and cmd
- workflow policy validation
- diff check

This PR does not expose the signing key or enable publication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the APK signer bootstrap by removing mutable branch resolution and keeping the signer lock non-runnable. Improves reproducibility and prevents accidental signing.

- **Bug Fixes**
  - Pinned signer source to protected main commit `fffeadbbadd3bfc3c682479aad6648adc4a71d79` in `verity-org/verity` to match the audited signer.
  - Removed checkout of the `apk-repository-publish` branch; no mutable refs in build resolution.
  - Kept signing disabled during bootstrap; no key exposure or publication.

<sup>Written for commit c5cf98479277ce4c69269878fe5723eed88d542d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

