### PR TITLE
fix(ci): use compatible attestation identity flags

### DIFF
--- a/.github/actions/setup-verity/action.yml
+++ b/.github/actions/setup-verity/action.yml
@@ -96,7 +96,6 @@ runs:
       run: >-
         gh attestation verify "$VERITY_BINARY"
         --repo "$GITHUB_REPOSITORY"
-        --signer-repo "verity-org/verity"
         --signer-workflow "github.com/verity-org/verity/.github/workflows/build-verity-protected.yaml"
         --signer-digest "$VERITY_SOURCE_SHA"
         --source-digest "$VERITY_SOURCE_SHA"

--- a/cmd/setup_verity_action_test.go
+++ b/cmd/setup_verity_action_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupVerityAction_usesOneAttestationIdentitySelector(t *testing.T) {
+	// Given the protected Verity activation action.
+	data, err := os.ReadFile(filepath.Join("..", ".github", "actions", "setup-verity", "action.yml"))
+	require.NoError(t, err)
+	action := string(data)
+
+	// When its GitHub attestation command is inspected.
+	require.Contains(t, action, `--signer-workflow "github.com/verity-org/verity/.github/workflows/build-verity-protected.yaml"`)
+
+	// Then it selects the exact workflow without combining mutually exclusive identity flags.
+	require.Equal(t, 0, strings.Count(action, "--signer-repo"))
+}

--- a/internal/ci/workflowpolicy/build_once_action.go
+++ b/internal/ci/workflowpolicy/build_once_action.go
@@ -187,7 +187,7 @@ func validateAttestationStep(name string, step *workflowStep) []Violation {
 		violations = append(violations, buildOnceViolation(name, "composite", "attestation verification must use the helper-normalized strict boolean"))
 	}
 	markers := []string{
-		`--repo "$GITHUB_REPOSITORY"`, `--signer-repo "verity-org/verity"`,
+		`--repo "$GITHUB_REPOSITORY"`,
 		`--signer-workflow "` + setupSignerWorkflow + `"`,
 		`--signer-digest "$VERITY_SOURCE_SHA"`, `--source-digest "$VERITY_SOURCE_SHA"`, `--deny-self-hosted-runners`,
 		`--predicate-type "https://slsa.dev/provenance/v1"`,
@@ -197,6 +197,9 @@ func validateAttestationStep(name string, step *workflowStep) []Violation {
 			violations = append(violations, buildOnceViolation(name, "composite", "signer workflow, repository, source SHA, and binary digest must be verified"))
 			break
 		}
+	}
+	if strings.Contains(step.Run, "--signer-repo") {
+		violations = append(violations, buildOnceViolation(name, "composite", "mutually exclusive attestation identity selectors are forbidden"))
 	}
 	return violations
 }

--- a/internal/ci/workflowpolicy/testdata/build-once/.github/actions/consume-verity/action.yml
+++ b/internal/ci/workflowpolicy/testdata/build-once/.github/actions/consume-verity/action.yml
@@ -91,7 +91,6 @@ runs:
       run: >-
         gh attestation verify "$VERITY_BINARY"
         --repo "$GITHUB_REPOSITORY"
-        --signer-repo "verity-org/verity"
         --signer-workflow "github.com/verity-org/verity/.github/workflows/build-verity-protected.yaml"
         --signer-digest "$VERITY_SOURCE_SHA"
         --source-digest "$VERITY_SOURCE_SHA"

--- a/internal/ci/workflowpolicy/testdata/build-once/action-mutations.yaml
+++ b/internal/ci/workflowpolicy/testdata/build-once/action-mutations.yaml
@@ -27,9 +27,13 @@
   replacement: "--run-attempt \"1\""
   want: current run
 - name: wrong signer repository
-  old: "--signer-repo \"verity-org/verity\""
-  replacement: "--signer-repo \"attacker/verity\""
+  old: "--repo \"$GITHUB_REPOSITORY\""
+  replacement: "--repo \"attacker/verity\""
   want: signer workflow
+- name: conflicting signer repository selector
+  old: "--signer-workflow \"github.com/verity-org/verity/.github/workflows/build-verity-protected.yaml\""
+  replacement: "--signer-repo \"verity-org/verity\"\n        --signer-workflow \"github.com/verity-org/verity/.github/workflows/build-verity-protected.yaml\""
+  want: mutually exclusive
 - name: wrong attestation predicate
   old: "--predicate-type \"https://slsa.dev/provenance/v1\""
   replacement: "--predicate-type \"https://example.test/weak\""


### PR DESCRIPTION
## Summary

- remove the redundant mutually exclusive `--signer-repo` selector from protected Verity attestation verification
- retain exact repository scope, fully qualified signer workflow, signer/source digest, predicate, and hosted-runner enforcement
- make workflow policy reject conflicting identity selectors

## Runtime evidence

Signer build run 30253748248 failed before package preparation because the installed GitHub CLI rejects `--signer-repo` and `--signer-workflow` together.

## Verification

- red/green command-shape regression test
- full race/shuffle Go suite
- golangci-lint
- actionlint
- workflow policy validation
- diff check

No signing secret was accessed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix attestation verification by using compatible identity flags. Remove `--signer-repo` and rely on the exact `--signer-workflow` to prevent `gh` CLI errors while keeping strict checks.

- **Bug Fixes**
  - Removed `--signer-repo` from `.github/actions/setup-verity` and related test fixture.
  - Added a test to ensure only one attestation identity selector is used.
  - Updated workflow policy to forbid mixing `--signer-repo` with `--signer-workflow`, while retaining repo scope, exact signer workflow, digests, predicate type, and denial of self-hosted runners.

<sup>Written for commit a3c2395a48d2c1cdcdae6806c6e2f9105af2382a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

