### PR TITLE
fix(apk): fetch immutable signer source history

### DIFF
--- a/internal/integer/melange/signer_checkout_test.go
+++ b/internal/integer/melange/signer_checkout_test.go
@@ -1,0 +1,24 @@
+package melange
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPKRepositorySignerCheckout_fetchesPinnedAncestor_withoutMutableBranch(t *testing.T) {
+	// Given the repository signer recipe.
+	paths := repositoryTestPaths(t)
+	data, err := os.ReadFile(filepath.Join(paths.BespokeDir, "apk-repository-signer.yaml"))
+	require.NoError(t, err)
+	recipe := string(data)
+
+	// When its source checkout contract is inspected.
+	require.Regexp(t, `(?m)^\s+expected-commit: [0-9a-f]{40}$`, recipe)
+
+	// Then Melange can reset to the immutable ancestor without resolving a mutable branch.
+	require.Contains(t, recipe, "      depth: -1\n")
+	require.NotRegexp(t, `(?m)^\s+branch:`, recipe)
+}

--- a/packages/bespoke/apk-repository-signer.yaml
+++ b/packages/bespoke/apk-repository-signer.yaml
@@ -25,6 +25,7 @@ pipeline:
     with:
       repository: https://github.com/verity-org/verity
       expected-commit: fffeadbbadd3bfc3c682479aad6648adc4a71d79
+      depth: -1
 
   - uses: go/build
     with:


### PR DESCRIPTION
## Summary
- fetch full repository history for the immutable signer source checkout
- retain exact expected-commit verification without a mutable branch
- add a contract test for the checkout policy

## Verification
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch full git history for the APK repository signer source to allow resetting to the pinned ancestor without relying on a mutable branch. Maintains strict `expected-commit` verification to prevent drift.

- **Bug Fixes**
  - Set depth: -1 in packages/bespoke/apk-repository-signer.yaml to fetch full history.
  - Added a contract test to ensure a pinned `expected-commit`, full-history fetch, and no `branch` field.

<sup>Written for commit ec847d7540554f3c5d29bdc9c721715124602534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

