### PR TITLE
fix(apk): consume staged signer keyrings

### DIFF
--- a/cmd/integer_build_melange.go
+++ b/cmd/integer_build_melange.go
@@ -16,7 +16,6 @@ import (
 const (
 	integerMelangeRepoDir    = "packages/repo"
 	integerMelangeRepository = "@local " + integerMelangeRepoDir
-	integerMelangeKeyPath    = "melange-work/melange.rsa.pub"
 	integerMelangePackageTag = "@local"
 )
 
@@ -67,7 +66,7 @@ func integerPrepareMelangeBuild(ctx context.Context, configSpec *intconfig.Melan
 	}
 	return integerMelangeArtifacts{
 		Repositories: []string{integerMelangeRepository},
-		Keyrings:     []string{integerMelangeKeyPath},
+		Keyrings:     []string{filepath.ToSlash(filepath.Join(integerMelangeRepoDir, "melange-"+string(architecture)+".rsa.pub"))},
 		Packages:     packages,
 	}, nil
 }

--- a/cmd/integer_build_melange_test.go
+++ b/cmd/integer_build_melange_test.go
@@ -46,7 +46,7 @@ func TestIntegerPrepareMelangeBuild_ResolvesVersionAndBuildsLocally(t *testing.T
 	// Then: placeholders are resolved before the Go build and local repository paths are returned.
 	require.NoError(t, err)
 	assert.Equal(t, []string{integerMelangeRepository}, artifacts.Repositories)
-	assert.Equal(t, []string{integerMelangeKeyPath}, artifacts.Keyrings)
+	assert.Equal(t, []string{"packages/repo/melange-aarch64.rsa.pub"}, artifacts.Keyrings)
 	assert.Equal(t, []apkindex.Package{{Name: "cilium-1.19", Version: "1.0-r0"}}, artifacts.Packages)
 	assert.Equal(t, melange.Spec{
 		Upstream:    "cilium-1.19",
@@ -66,6 +66,7 @@ func TestIntegerPrepareMelangeBuild_ReusesExistingArtifacts(t *testing.T) {
 		Spec:  spec,
 		Arch:  melange.ArchitectureAArch64,
 	}))
+	require.NoError(t, os.RemoveAll(paths.WorkDir))
 	chdirIntegerMelangeTest(t, repoRoot)
 	buildCalls := 0
 	originalBuild := integerMelangeBuild
@@ -85,7 +86,7 @@ func TestIntegerPrepareMelangeBuild_ReusesExistingArtifacts(t *testing.T) {
 	// Then: the existing artifacts are reused without rebuilding.
 	require.NoError(t, err)
 	assert.Equal(t, []string{integerMelangeRepository}, artifacts.Repositories)
-	assert.Equal(t, []string{integerMelangeKeyPath}, artifacts.Keyrings)
+	assert.Equal(t, []string{"packages/repo/melange-aarch64.rsa.pub"}, artifacts.Keyrings)
 	assert.Equal(t, []apkindex.Package{{Name: "custom", Version: "1.0-r0"}}, artifacts.Packages)
 	assert.Zero(t, buildCalls)
 }

--- a/internal/integer/melange/artifact_error_paths_test.go
+++ b/internal/integer/melange/artifact_error_paths_test.go
@@ -226,7 +226,7 @@ func newArtifactErrorFixture(t *testing.T) (Paths, lockFile, Spec) {
 	writeTestFile(t, filepath.Join(paths.LockedDir, entry.File), recipe)
 	writeTestFile(t, paths.LockFile, fmt.Sprintf(`{"packages":{"sentinel":{"file":"sentinel.yaml","sha256":%q,"assets":{}}},"pipeline_files":{}}`, entry.SHA256))
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(ArchitectureX8664), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(ArchitectureX8664)+".rsa.pub"), "public")
 	return paths, lock, Spec{Upstream: "sentinel"}
 }
 

--- a/internal/integer/melange/artifacts.go
+++ b/internal/integer/melange/artifacts.go
@@ -221,7 +221,8 @@ func artifactOutputDigests(paths *Paths, arch Architecture) (map[string]string, 
 	if _, ok := outputs["package/APKINDEX.tar.gz"]; !ok {
 		return nil, errNoPackageIndex
 	}
-	keyData, err := readRegularFile(paths.WorkDir, "melange.rsa.pub")
+	publicName := "melange-" + string(arch) + ".rsa.pub"
+	keyData, err := readRegularFile(paths.RepoDir, publicName)
 	if err != nil {
 		return nil, fmt.Errorf("verify public key: %w", err)
 	}

--- a/internal/integer/melange/artifacts_test.go
+++ b/internal/integer/melange/artifacts_test.go
@@ -26,7 +26,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 	}
 	writeInputs(root)
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 
 	assert.True(t, ArtifactsExist(&paths, spec, arch))
@@ -40,7 +40,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 			return filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz")
 		}},
 		{name: "public key", path: func(paths *Paths) string {
-			return filepath.Join(paths.WorkDir, "melange.rsa.pub")
+			return filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub")
 		}},
 		{name: "marker", path: func(paths *Paths) string {
 			return artifactMarkerPath(paths, arch)
@@ -52,7 +52,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 			symlinkPaths := testPaths(symlinkRoot)
 			writeInputs(symlinkRoot)
 			writeTestFile(t, filepath.Join(symlinkPaths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-			writeTestFile(t, filepath.Join(symlinkPaths.WorkDir, "melange.rsa.pub"), "public")
+			writeTestFile(t, filepath.Join(symlinkPaths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 			require.NoError(t, writeArtifactMarker(&symlinkPaths, spec, arch))
 			path := target.path(&symlinkPaths)
 			require.NoError(t, os.Remove(path))
@@ -79,7 +79,7 @@ func TestArtifactsExistInvalidatesChangedBuildInputs(t *testing.T) {
 	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), lock)
 	writeTestFile(t, testPath(root, "packages/overrides/fips.env"), "GOFIPS140=v1.0.0\n")
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 	require.True(t, ArtifactsExist(&paths, spec, arch))
 
@@ -100,7 +100,7 @@ func TestArtifactsExistInvalidatesChangedBespokeRecipe(t *testing.T) {
 	writeTestFile(t, testPath(root, "packages/bespoke/custom.yaml"), "package:\n  name: custom\n")
 	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), `{"packages":{},"pipeline_files":{}}`)
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 	require.True(t, ArtifactsExist(&paths, spec, arch))
 
@@ -126,7 +126,7 @@ func TestArtifactsExistRejectsSymlinkedRootsAndChangedOutputs(t *testing.T) {
 }`, testSHA(recipe)))
 		writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
 		writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "caddy.apk"), "package")
-		writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+		writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 		require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 		require.True(t, ArtifactsExist(&paths, spec, arch))
 		return root, paths, spec, arch
@@ -138,23 +138,14 @@ func TestArtifactsExistRejectsSymlinkedRootsAndChangedOutputs(t *testing.T) {
 		assert.False(t, ArtifactsExist(&paths, spec, arch))
 	})
 
-	for _, field := range []string{"repository", "work"} {
-		t.Run(field+" root", func(t *testing.T) {
-			root, paths, spec, arch := setup(t)
-			var target string
-			switch field {
-			case "repository":
-				target = paths.RepoDir
-			case "work":
-				target = paths.WorkDir
-			}
-			backing := testPath(root, "external/"+field)
-			require.NoError(t, os.MkdirAll(filepath.Dir(backing), 0o755))
-			require.NoError(t, os.Rename(target, backing))
-			require.NoError(t, os.Symlink(backing, target))
-			assert.False(t, ArtifactsExist(&paths, spec, arch))
-		})
-	}
+	t.Run("repository root", func(t *testing.T) {
+		root, paths, spec, arch := setup(t)
+		backing := testPath(root, "external/repository")
+		require.NoError(t, os.MkdirAll(filepath.Dir(backing), 0o755))
+		require.NoError(t, os.Rename(paths.RepoDir, backing))
+		require.NoError(t, os.Symlink(backing, paths.RepoDir))
+		assert.False(t, ArtifactsExist(&paths, spec, arch))
+	})
 
 	t.Run("repository ancestor", func(t *testing.T) {
 		root, paths, spec, arch := setup(t)


### PR DESCRIPTION
## Summary
- validate transferred Melange artifacts with their architecture-specific published public keys
- pass the matching architecture keyring into APKO
- prove staged artifacts remain reusable after the private/work directory is removed

## Runtime evidence
Run 30257394049 built and natively tested both signer APK architectures. The AMD64 Trivy image had zero vulnerabilities, but the ARM64 gate rebuilt because artifact validation required the intentionally absent melange-work key.

## Verification
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use staged, arch‑specific public keys in `packages/repo` to validate and build APKs. Removes reliance on `melange-work` and prevents rebuilds when the work dir is cleaned.

- **Bug Fixes**
  - Read `melange-<arch>.rsa.pub` from `packages/repo/`.
  - Pass the matching keyring to the APK build tool.
  - Update artifact checks and tests to use repo keys and allow reuse after work dir removal.

<sup>Written for commit a3c8dc345ca4a24857d400fdfe0eb2789013fff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

