### PR TITLE
fix(apk): preserve signer key basename

### DIFF
--- a/cmd/integer_build_melange.go
+++ b/cmd/integer_build_melange.go
@@ -66,7 +66,7 @@ func integerPrepareMelangeBuild(ctx context.Context, configSpec *intconfig.Melan
 	}
 	return integerMelangeArtifacts{
 		Repositories: []string{integerMelangeRepository},
-		Keyrings:     []string{filepath.ToSlash(filepath.Join(integerMelangeRepoDir, "melange-"+string(architecture)+".rsa.pub"))},
+		Keyrings:     []string{filepath.ToSlash(filepath.Join(integerMelangeRepoDir, string(architecture), "melange.rsa.pub"))},
 		Packages:     packages,
 	}, nil
 }

--- a/cmd/integer_build_melange_test.go
+++ b/cmd/integer_build_melange_test.go
@@ -46,7 +46,7 @@ func TestIntegerPrepareMelangeBuild_ResolvesVersionAndBuildsLocally(t *testing.T
 	// Then: placeholders are resolved before the Go build and local repository paths are returned.
 	require.NoError(t, err)
 	assert.Equal(t, []string{integerMelangeRepository}, artifacts.Repositories)
-	assert.Equal(t, []string{"packages/repo/melange-aarch64.rsa.pub"}, artifacts.Keyrings)
+	assert.Equal(t, []string{"packages/repo/aarch64/melange.rsa.pub"}, artifacts.Keyrings)
 	assert.Equal(t, []apkindex.Package{{Name: "cilium-1.19", Version: "1.0-r0"}}, artifacts.Packages)
 	assert.Equal(t, melange.Spec{
 		Upstream:    "cilium-1.19",
@@ -86,7 +86,7 @@ func TestIntegerPrepareMelangeBuild_ReusesExistingArtifacts(t *testing.T) {
 	// Then: the existing artifacts are reused without rebuilding.
 	require.NoError(t, err)
 	assert.Equal(t, []string{integerMelangeRepository}, artifacts.Repositories)
-	assert.Equal(t, []string{"packages/repo/melange-aarch64.rsa.pub"}, artifacts.Keyrings)
+	assert.Equal(t, []string{"packages/repo/aarch64/melange.rsa.pub"}, artifacts.Keyrings)
 	assert.Equal(t, []apkindex.Package{{Name: "custom", Version: "1.0-r0"}}, artifacts.Packages)
 	assert.Zero(t, buildCalls)
 }

--- a/internal/integer/melange/artifact_error_paths_test.go
+++ b/internal/integer/melange/artifact_error_paths_test.go
@@ -226,7 +226,7 @@ func newArtifactErrorFixture(t *testing.T) (Paths, lockFile, Spec) {
 	writeTestFile(t, filepath.Join(paths.LockedDir, entry.File), recipe)
 	writeTestFile(t, paths.LockFile, fmt.Sprintf(`{"packages":{"sentinel":{"file":"sentinel.yaml","sha256":%q,"assets":{}}},"pipeline_files":{}}`, entry.SHA256))
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(ArchitectureX8664), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(ArchitectureX8664)+".rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, string(ArchitectureX8664), "melange.rsa.pub"), "public")
 	return paths, lock, Spec{Upstream: "sentinel"}
 }
 

--- a/internal/integer/melange/artifacts.go
+++ b/internal/integer/melange/artifacts.go
@@ -208,7 +208,7 @@ func artifactOutputDigests(paths *Paths, arch Architecture) (map[string]string, 
 	}
 	outputs := map[string]string{}
 	for _, file := range files {
-		if file == artifactMarkerName {
+		if file == artifactMarkerName || file == "melange.rsa.pub" {
 			continue
 		}
 		data, err := readRegularFile(archDir, file)
@@ -221,8 +221,7 @@ func artifactOutputDigests(paths *Paths, arch Architecture) (map[string]string, 
 	if _, ok := outputs["package/APKINDEX.tar.gz"]; !ok {
 		return nil, errNoPackageIndex
 	}
-	publicName := "melange-" + string(arch) + ".rsa.pub"
-	keyData, err := readRegularFile(paths.RepoDir, publicName)
+	keyData, err := readRegularFile(archDir, "melange.rsa.pub")
 	if err != nil {
 		return nil, fmt.Errorf("verify public key: %w", err)
 	}

--- a/internal/integer/melange/artifacts_test.go
+++ b/internal/integer/melange/artifacts_test.go
@@ -26,7 +26,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 	}
 	writeInputs(root)
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 
 	assert.True(t, ArtifactsExist(&paths, spec, arch))
@@ -40,7 +40,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 			return filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz")
 		}},
 		{name: "public key", path: func(paths *Paths) string {
-			return filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub")
+			return filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub")
 		}},
 		{name: "marker", path: func(paths *Paths) string {
 			return artifactMarkerPath(paths, arch)
@@ -52,7 +52,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 			symlinkPaths := testPaths(symlinkRoot)
 			writeInputs(symlinkRoot)
 			writeTestFile(t, filepath.Join(symlinkPaths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-			writeTestFile(t, filepath.Join(symlinkPaths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
+			writeTestFile(t, filepath.Join(symlinkPaths.RepoDir, string(arch), "melange.rsa.pub"), "public")
 			require.NoError(t, writeArtifactMarker(&symlinkPaths, spec, arch))
 			path := target.path(&symlinkPaths)
 			require.NoError(t, os.Remove(path))
@@ -79,7 +79,7 @@ func TestArtifactsExistInvalidatesChangedBuildInputs(t *testing.T) {
 	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), lock)
 	writeTestFile(t, testPath(root, "packages/overrides/fips.env"), "GOFIPS140=v1.0.0\n")
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 	require.True(t, ArtifactsExist(&paths, spec, arch))
 
@@ -100,7 +100,7 @@ func TestArtifactsExistInvalidatesChangedBespokeRecipe(t *testing.T) {
 	writeTestFile(t, testPath(root, "packages/bespoke/custom.yaml"), "package:\n  name: custom\n")
 	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), `{"packages":{},"pipeline_files":{}}`)
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 	require.True(t, ArtifactsExist(&paths, spec, arch))
 
@@ -126,7 +126,7 @@ func TestArtifactsExistRejectsSymlinkedRootsAndChangedOutputs(t *testing.T) {
 }`, testSHA(recipe)))
 		writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
 		writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "caddy.apk"), "package")
-		writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
+		writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub"), "public")
 		require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 		require.True(t, ArtifactsExist(&paths, spec, arch))
 		return root, paths, spec, arch

--- a/internal/integer/melange/build.go
+++ b/internal/integer/melange/build.go
@@ -185,6 +185,9 @@ func signPackageIndexes(ctx context.Context, options *BuildOptions) error {
 	if err := copyFile(options.Paths.Root, publicKey, filepath.Join(options.Paths.RepoDir, publicName)); err != nil {
 		return fmt.Errorf("copy public key: %w", err)
 	}
+	if err := copyFile(options.Paths.Root, publicKey, filepath.Join(options.Paths.RepoDir, string(options.Arch), "melange.rsa.pub")); err != nil {
+		return fmt.Errorf("copy architecture public key: %w", err)
+	}
 	if err := copyFile(options.Paths.Root, publicKey, filepath.Join(options.Paths.RepoDir, "melange.rsa.pub")); err != nil {
 		return fmt.Errorf("copy compatibility public key: %w", err)
 	}

--- a/internal/integer/melange/build_test.go
+++ b/internal/integer/melange/build_test.go
@@ -84,7 +84,7 @@ func TestBuildStagesRunsAndSigns(t *testing.T) {
 	assert.Contains(t, runner.commands[1].args, "fips")
 	assert.Equal(t, "sign-index", runner.commands[2].args[0])
 
-	publicKey, err := os.ReadFile(testPath(root, "packages/repo/melange.rsa.pub"))
+	publicKey, err := os.ReadFile(testPath(root, "packages/repo/x86_64/melange.rsa.pub"))
 	require.NoError(t, err)
 	assert.Equal(t, "public", string(publicKey))
 	assert.True(t, ArtifactsExist(&paths, spec, ArchitectureX8664))


### PR DESCRIPTION
## Summary
- store each architecture public key at its architecture directory with basename melange.rsa.pub
- preserve the key basename embedded in APKINDEX signatures
- keep architecture isolation while allowing APKO verification

## Runtime evidence
Run 30259605039 consumed the staged artifacts but APKO rejected the x86_64 index because its signature names melange.rsa.pub while the selected key was renamed melange-x86_64.rsa.pub.

## Verification
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes APKO verification failures by preserving the signer key basename in APKINDEX signatures. Per-arch public keys now live at <repo>/<arch>/melange.rsa.pub to match the signature while keeping architecture isolation.

- **Bug Fixes**
  - Store the public key at `<repo>/<arch>/melange.rsa.pub` and use it as the keyring.
  - Keep compatibility copies at `<repo>/melange.rsa.pub` and `<repo>/melange-<arch>.rsa.pub`.
  - Exclude `melange.rsa.pub` from output digests and verify from the arch directory.

<sup>Written for commit e524e5b78bdd49ffbf18d5da58adab67ecef1a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

