### PR TITLE
fix(apk): publish with canonical signer keyrings

### DIFF
--- a/internal/ci/integer_image_publish.go
+++ b/internal/ci/integer_image_publish.go
@@ -80,8 +80,8 @@ func PublishIntegerImage(ctx context.Context, options *IntegerImagePublishOption
 		apkoArgs = append(
 			apkoArgs,
 			"--repository-append", "@local "+filepath.Join(options.Workspace, "packages", "repo"),
-			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "melange-x86_64.rsa.pub"),
-			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "melange-aarch64.rsa.pub"),
+			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "x86_64", "melange.rsa.pub"),
+			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "aarch64", "melange.rsa.pub"),
 		)
 	}
 	apkoArgs = append(apkoArgs, configPath, stagingRef)

--- a/internal/ci/integer_image_publish_test.go
+++ b/internal/ci/integer_image_publish_test.go
@@ -38,6 +38,22 @@ func TestPublishIntegerImage_runsStagingTrivyBeforeEveryFinalPromotion(t *testin
 	assert.Contains(t, runner.calls[0].Args[len(runner.calls[0].Args)-1], "integer-publication-42-3")
 }
 
+func TestPublishIntegerImage_usesCanonicalArchitectureKeyBasenames_whenMelangeEnabled(t *testing.T) {
+	// Given: a multi-architecture image publication using staged Melange packages.
+	runner := &recordingIntegerImageRunner{}
+	options := integerImagePublishFixture(t, runner)
+	options.Melange = true
+
+	// When: the exact image publication command stages the image.
+	_, err := PublishIntegerImage(t.Context(), &options)
+
+	// Then: each architecture keeps the basename embedded in its APKINDEX signature.
+	require.NoError(t, err)
+	require.NotEmpty(t, runner.calls)
+	assert.Contains(t, runner.calls[0].Args, filepath.Join(options.Workspace, "packages", "repo", "x86_64", "melange.rsa.pub"))
+	assert.Contains(t, runner.calls[0].Args, filepath.Join(options.Workspace, "packages", "repo", "aarch64", "melange.rsa.pub"))
+}
+
 func TestPublishIntegerImage_stopsBeforePromotion_whenStagingTrivyFails(t *testing.T) {
 	// Given: a runner whose exact staged-image Trivy command fails.
 	runner := &recordingIntegerImageRunner{failID: "trivy:image"}


### PR DESCRIPTION
## Summary
- select canonical per-architecture signer keyrings during multi-arch publication
- retain the melange.rsa.pub basename embedded in APKINDEX signatures
- add a focused command-contract regression test

## Runtime evidence
Run 30261181158 passed both all-severity Trivy architecture gates, then failed because multi-arch publication still selected legacy root key names.

## Verification
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-arch APK publish to use canonical per-architecture signer keyrings so APKINDEX signatures retain the `melange.rsa.pub` basename. Adds a regression test to ensure the correct `apko` keyring args are used.

- **Bug Fixes**
  - Update `apko` `--keyring-append` to `packages/repo/x86_64/melange.rsa.pub` and `packages/repo/aarch64/melange.rsa.pub`.
  - Avoids failures from legacy root key names and aligns with Trivy gate expectations.

<sup>Written for commit 11d9cbfab7e513bde058c8e78f35c58fce633402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

