### PR TITLE
fix(apk): isolate signing keys by architecture

### DIFF
--- a/cmd/integer_build_melange.go
+++ b/cmd/integer_build_melange.go
@@ -66,7 +66,7 @@ func integerPrepareMelangeBuild(ctx context.Context, configSpec *intconfig.Melan
 	}
 	return integerMelangeArtifacts{
 		Repositories: []string{integerMelangeRepository},
-		Keyrings:     []string{filepath.ToSlash(filepath.Join(integerMelangeRepoDir, string(architecture), "melange.rsa.pub"))},
+		Keyrings:     []string{filepath.ToSlash(filepath.Join(integerMelangeRepoDir, "melange-"+string(architecture)+".rsa.pub"))},
 		Packages:     packages,
 	}, nil
 }

--- a/cmd/integer_build_melange_test.go
+++ b/cmd/integer_build_melange_test.go
@@ -46,7 +46,7 @@ func TestIntegerPrepareMelangeBuild_ResolvesVersionAndBuildsLocally(t *testing.T
 	// Then: placeholders are resolved before the Go build and local repository paths are returned.
 	require.NoError(t, err)
 	assert.Equal(t, []string{integerMelangeRepository}, artifacts.Repositories)
-	assert.Equal(t, []string{"packages/repo/aarch64/melange.rsa.pub"}, artifacts.Keyrings)
+	assert.Equal(t, []string{"packages/repo/melange-aarch64.rsa.pub"}, artifacts.Keyrings)
 	assert.Equal(t, []apkindex.Package{{Name: "cilium-1.19", Version: "1.0-r0"}}, artifacts.Packages)
 	assert.Equal(t, melange.Spec{
 		Upstream:    "cilium-1.19",
@@ -86,7 +86,7 @@ func TestIntegerPrepareMelangeBuild_ReusesExistingArtifacts(t *testing.T) {
 	// Then: the existing artifacts are reused without rebuilding.
 	require.NoError(t, err)
 	assert.Equal(t, []string{integerMelangeRepository}, artifacts.Repositories)
-	assert.Equal(t, []string{"packages/repo/aarch64/melange.rsa.pub"}, artifacts.Keyrings)
+	assert.Equal(t, []string{"packages/repo/melange-aarch64.rsa.pub"}, artifacts.Keyrings)
 	assert.Equal(t, []apkindex.Package{{Name: "custom", Version: "1.0-r0"}}, artifacts.Packages)
 	assert.Zero(t, buildCalls)
 }

--- a/internal/ci/integer_image_publish.go
+++ b/internal/ci/integer_image_publish.go
@@ -80,8 +80,8 @@ func PublishIntegerImage(ctx context.Context, options *IntegerImagePublishOption
 		apkoArgs = append(
 			apkoArgs,
 			"--repository-append", "@local "+filepath.Join(options.Workspace, "packages", "repo"),
-			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "x86_64", "melange.rsa.pub"),
-			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "aarch64", "melange.rsa.pub"),
+			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "melange-x86_64.rsa.pub"),
+			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "melange-aarch64.rsa.pub"),
 		)
 	}
 	apkoArgs = append(apkoArgs, configPath, stagingRef)

--- a/internal/ci/integer_image_publish_test.go
+++ b/internal/ci/integer_image_publish_test.go
@@ -38,7 +38,7 @@ func TestPublishIntegerImage_runsStagingTrivyBeforeEveryFinalPromotion(t *testin
 	assert.Contains(t, runner.calls[0].Args[len(runner.calls[0].Args)-1], "integer-publication-42-3")
 }
 
-func TestPublishIntegerImage_usesCanonicalArchitectureKeyBasenames_whenMelangeEnabled(t *testing.T) {
+func TestPublishIntegerImage_usesUniqueArchitectureKeyBasenames_whenMelangeEnabled(t *testing.T) {
 	// Given: a multi-architecture image publication using staged Melange packages.
 	runner := &recordingIntegerImageRunner{}
 	options := integerImagePublishFixture(t, runner)
@@ -47,11 +47,11 @@ func TestPublishIntegerImage_usesCanonicalArchitectureKeyBasenames_whenMelangeEn
 	// When: the exact image publication command stages the image.
 	_, err := PublishIntegerImage(t.Context(), &options)
 
-	// Then: each architecture keeps the basename embedded in its APKINDEX signature.
+	// Then: each architecture selects the unique basename embedded in its APKINDEX signature.
 	require.NoError(t, err)
 	require.NotEmpty(t, runner.calls)
-	assert.Contains(t, runner.calls[0].Args, filepath.Join(options.Workspace, "packages", "repo", "x86_64", "melange.rsa.pub"))
-	assert.Contains(t, runner.calls[0].Args, filepath.Join(options.Workspace, "packages", "repo", "aarch64", "melange.rsa.pub"))
+	assert.Contains(t, runner.calls[0].Args, filepath.Join(options.Workspace, "packages", "repo", "melange-x86_64.rsa.pub"))
+	assert.Contains(t, runner.calls[0].Args, filepath.Join(options.Workspace, "packages", "repo", "melange-aarch64.rsa.pub"))
 }
 
 func TestPublishIntegerImage_stopsBeforePromotion_whenStagingTrivyFails(t *testing.T) {

--- a/internal/integer/melange/artifact_error_paths_test.go
+++ b/internal/integer/melange/artifact_error_paths_test.go
@@ -226,7 +226,7 @@ func newArtifactErrorFixture(t *testing.T) (Paths, lockFile, Spec) {
 	writeTestFile(t, filepath.Join(paths.LockedDir, entry.File), recipe)
 	writeTestFile(t, paths.LockFile, fmt.Sprintf(`{"packages":{"sentinel":{"file":"sentinel.yaml","sha256":%q,"assets":{}}},"pipeline_files":{}}`, entry.SHA256))
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(ArchitectureX8664), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.RepoDir, string(ArchitectureX8664), "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(ArchitectureX8664)+".rsa.pub"), "public")
 	return paths, lock, Spec{Upstream: "sentinel"}
 }
 

--- a/internal/integer/melange/artifacts.go
+++ b/internal/integer/melange/artifacts.go
@@ -208,7 +208,7 @@ func artifactOutputDigests(paths *Paths, arch Architecture) (map[string]string, 
 	}
 	outputs := map[string]string{}
 	for _, file := range files {
-		if file == artifactMarkerName || file == "melange.rsa.pub" {
+		if file == artifactMarkerName {
 			continue
 		}
 		data, err := readRegularFile(archDir, file)
@@ -221,7 +221,8 @@ func artifactOutputDigests(paths *Paths, arch Architecture) (map[string]string, 
 	if _, ok := outputs["package/APKINDEX.tar.gz"]; !ok {
 		return nil, errNoPackageIndex
 	}
-	keyData, err := readRegularFile(archDir, "melange.rsa.pub")
+	publicName := "melange-" + string(arch) + ".rsa.pub"
+	keyData, err := readRegularFile(paths.RepoDir, publicName)
 	if err != nil {
 		return nil, fmt.Errorf("verify public key: %w", err)
 	}

--- a/internal/integer/melange/artifacts_test.go
+++ b/internal/integer/melange/artifacts_test.go
@@ -26,7 +26,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 	}
 	writeInputs(root)
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 
 	assert.True(t, ArtifactsExist(&paths, spec, arch))
@@ -40,7 +40,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 			return filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz")
 		}},
 		{name: "public key", path: func(paths *Paths) string {
-			return filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub")
+			return filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub")
 		}},
 		{name: "marker", path: func(paths *Paths) string {
 			return artifactMarkerPath(paths, arch)
@@ -52,7 +52,7 @@ func TestArtifactsExistRequiresMatchingSpecAndRegularFiles(t *testing.T) {
 			symlinkPaths := testPaths(symlinkRoot)
 			writeInputs(symlinkRoot)
 			writeTestFile(t, filepath.Join(symlinkPaths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-			writeTestFile(t, filepath.Join(symlinkPaths.RepoDir, string(arch), "melange.rsa.pub"), "public")
+			writeTestFile(t, filepath.Join(symlinkPaths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 			require.NoError(t, writeArtifactMarker(&symlinkPaths, spec, arch))
 			path := target.path(&symlinkPaths)
 			require.NoError(t, os.Remove(path))
@@ -79,7 +79,7 @@ func TestArtifactsExistInvalidatesChangedBuildInputs(t *testing.T) {
 	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), lock)
 	writeTestFile(t, testPath(root, "packages/overrides/fips.env"), "GOFIPS140=v1.0.0\n")
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 	require.True(t, ArtifactsExist(&paths, spec, arch))
 
@@ -100,7 +100,7 @@ func TestArtifactsExistInvalidatesChangedBespokeRecipe(t *testing.T) {
 	writeTestFile(t, testPath(root, "packages/bespoke/custom.yaml"), "package:\n  name: custom\n")
 	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), `{"packages":{},"pipeline_files":{}}`)
 	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
-	writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 	require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 	require.True(t, ArtifactsExist(&paths, spec, arch))
 
@@ -126,7 +126,7 @@ func TestArtifactsExistRejectsSymlinkedRootsAndChangedOutputs(t *testing.T) {
 }`, testSHA(recipe)))
 		writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "APKINDEX.tar.gz"), "index")
 		writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "caddy.apk"), "package")
-		writeTestFile(t, filepath.Join(paths.RepoDir, string(arch), "melange.rsa.pub"), "public")
+		writeTestFile(t, filepath.Join(paths.RepoDir, "melange-"+string(arch)+".rsa.pub"), "public")
 		require.NoError(t, writeArtifactMarker(&paths, spec, arch))
 		require.True(t, ArtifactsExist(&paths, spec, arch))
 		return root, paths, spec, arch

--- a/internal/integer/melange/build.go
+++ b/internal/integer/melange/build.go
@@ -15,6 +15,14 @@ type ExecRunner struct{}
 
 var errIncompleteSigningKeyPair = errors.New("incomplete ephemeral signing key pair")
 
+func signingKeyName(options *BuildOptions) string {
+	return "melange-" + string(options.Arch) + ".rsa"
+}
+
+func signingKeyPath(options *BuildOptions) string {
+	return filepath.ToSlash(filepath.Join("melange-work", signingKeyName(options)))
+}
+
 func (ExecRunner) Run(ctx context.Context, command *Command, stdout, stderr io.Writer) error {
 	cmd := exec.CommandContext(ctx, command.Name, command.Args...)
 	cmd.Dir = command.Dir
@@ -32,22 +40,16 @@ func Prepare(ctx context.Context, options *BuildOptions) error {
 	if err := Stage(&options.Paths, options.Spec); err != nil {
 		return err
 	}
-	keyPairExists, err := signingKeyPairExists(&options.Paths)
-	if err != nil {
-		return err
-	}
-	if keyPairExists {
-		return restrictStagedPrivateKey(&options.Paths)
-	}
-	if err := runMelange(ctx, options, "keygen", "melange-work/melange.rsa"); err != nil {
-		return err
-	}
-	return restrictStagedPrivateKey(&options.Paths)
+	return nil
 }
 
 func signingKeyPairExists(paths *Paths) (bool, error) {
+	return signingKeyPairExistsNamed(paths, "melange.rsa")
+}
+
+func signingKeyPairExistsNamed(paths *Paths, privateName string) (bool, error) {
 	found := 0
-	for _, name := range []string{"melange.rsa", "melange.rsa.pub"} {
+	for _, name := range []string{privateName, privateName + ".pub"} {
 		path := filepath.Join(paths.WorkDir, name)
 		info, err := os.Lstat(path)
 		if os.IsNotExist(err) {
@@ -84,7 +86,7 @@ func Build(ctx context.Context, options *BuildOptions) (err error) {
 	}
 	if generatedKey {
 		defer func() {
-			err = errors.Join(err, removeEphemeralSigningKey(&options.Paths))
+			err = errors.Join(err, removeEphemeralSigningKeyNamed(&options.Paths, signingKeyName(options)))
 		}()
 	}
 	if err := clearBuildOutput(&options.Paths, options.Arch); err != nil {
@@ -114,26 +116,30 @@ func clearBuildOutput(paths *Paths, arch Architecture) error {
 
 func prepareBuildInputs(ctx context.Context, options *BuildOptions) (bool, error) {
 	if !options.Staged {
-		if err := Prepare(ctx, options); err != nil {
+		if err := Stage(&options.Paths, options.Spec); err != nil {
 			return false, err
 		}
-		return false, nil
 	}
-	keyPairExists, err := signingKeyPairExists(&options.Paths)
+	privateName := signingKeyName(options)
+	keyPairExists, err := signingKeyPairExistsNamed(&options.Paths, privateName)
 	if err != nil {
 		return false, err
 	}
 	if keyPairExists {
-		return false, restrictStagedPrivateKey(&options.Paths)
+		return false, restrictStagedPrivateKeyNamed(&options.Paths, privateName)
 	}
-	if err := runMelange(ctx, options, "keygen", "melange-work/melange.rsa"); err != nil {
+	if err := runMelange(ctx, options, "keygen", signingKeyPath(options)); err != nil {
 		return false, fmt.Errorf("generate ephemeral package signing key: %w", err)
 	}
-	return true, restrictStagedPrivateKey(&options.Paths)
+	return true, restrictStagedPrivateKeyNamed(&options.Paths, privateName)
 }
 
 func restrictStagedPrivateKey(paths *Paths) error {
-	privateKey := filepath.Join(paths.WorkDir, "melange.rsa")
+	return restrictStagedPrivateKeyNamed(paths, "melange.rsa")
+}
+
+func restrictStagedPrivateKeyNamed(paths *Paths, privateName string) error {
+	privateKey := filepath.Join(paths.WorkDir, privateName)
 	info, err := os.Lstat(privateKey)
 	if err != nil {
 		return fmt.Errorf("staged signing key: %w", err)
@@ -148,8 +154,12 @@ func restrictStagedPrivateKey(paths *Paths) error {
 }
 
 func removeEphemeralSigningKey(paths *Paths) error {
+	return removeEphemeralSigningKeyNamed(paths, "melange.rsa")
+}
+
+func removeEphemeralSigningKeyNamed(paths *Paths, privateName string) error {
 	var result error
-	for _, name := range []string{"melange.rsa", "melange.rsa.pub"} {
+	for _, name := range []string{privateName, privateName + ".pub"} {
 		path := filepath.Join(paths.WorkDir, name)
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			result = errors.Join(result, fmt.Errorf("remove ephemeral signing key %q: %w", path, err))
@@ -180,13 +190,13 @@ func buildStagedRecipes(ctx context.Context, options *BuildOptions, builds []str
 }
 
 func signPackageIndexes(ctx context.Context, options *BuildOptions) error {
-	publicKey := filepath.Join(options.Paths.WorkDir, "melange.rsa.pub")
-	publicName := "melange-" + string(options.Arch) + ".rsa.pub"
-	if err := copyFile(options.Paths.Root, publicKey, filepath.Join(options.Paths.RepoDir, publicName)); err != nil {
-		return fmt.Errorf("copy public key: %w", err)
-	}
-	if err := copyFile(options.Paths.Root, publicKey, filepath.Join(options.Paths.RepoDir, string(options.Arch), "melange.rsa.pub")); err != nil {
-		return fmt.Errorf("copy architecture public key: %w", err)
+	privateKey := signingKeyPath(options)
+	publicKey := filepath.Join(options.Paths.Root, filepath.FromSlash(privateKey+".pub"))
+	publicName := filepath.Base(privateKey) + ".pub"
+	if publicName != "melange.rsa.pub" {
+		if err := copyFile(options.Paths.Root, publicKey, filepath.Join(options.Paths.RepoDir, publicName)); err != nil {
+			return fmt.Errorf("copy public key: %w", err)
+		}
 	}
 	if err := copyFile(options.Paths.Root, publicKey, filepath.Join(options.Paths.RepoDir, "melange.rsa.pub")); err != nil {
 		return fmt.Errorf("copy compatibility public key: %w", err)
@@ -204,7 +214,7 @@ func signPackageIndexes(ctx context.Context, options *BuildOptions) error {
 		if err != nil {
 			return err
 		}
-		if err := runMelange(ctx, options, "sign-index", "--signing-key", "melange-work/melange.rsa", filepath.ToSlash(relative), "--force"); err != nil {
+		if err := runMelange(ctx, options, "sign-index", "--signing-key", privateKey, filepath.ToSlash(relative), "--force"); err != nil {
 			return fmt.Errorf("sign package index: %w", err)
 		}
 	}
@@ -222,7 +232,7 @@ func runBuild(ctx context.Context, options *BuildOptions, buildFile string) erro
 	args := []string{
 		"build", filepath.ToSlash(relative),
 		"--arch", string(options.Arch),
-		"--signing-key", "melange-work/melange.rsa",
+		"--signing-key", signingKeyPath(options),
 		"--out-dir", "packages/repo",
 		"--repository-append", RepositoryURL,
 		"--keyring-append", KeyringURL,

--- a/internal/integer/melange/build_helper_boundaries_test.go
+++ b/internal/integer/melange/build_helper_boundaries_test.go
@@ -213,6 +213,7 @@ func Test_buildAndSign_helpers_stop_on_runner_and_path_errors(t *testing.T) {
 
 	index := filepath.Join(paths.RepoDir, string(ArchitectureX8664), "APKINDEX.tar.gz")
 	writeTestFile(t, index, "index")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa.pub"), "public")
 	signRunner := &orchestrationRunner{failVerb: "sign-index"}
 	signErr := signPackageIndexes(context.Background(), &BuildOptions{
 		Paths:  paths,

--- a/internal/integer/melange/build_orchestration_paths_test.go
+++ b/internal/integer/melange/build_orchestration_paths_test.go
@@ -44,8 +44,12 @@ func Test_Build_removes_ephemeral_staged_key_after_success(t *testing.T) {
 
 	// Then
 	require.NoError(t, err)
-	assert.NoFileExists(t, filepath.Join(paths.WorkDir, "melange.rsa"))
-	assert.NoFileExists(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"))
+	require.Len(t, runner.commands, 3)
+	assert.Equal(t, recordedCommand{name: "melange", args: []string{"keygen", "melange-work/melange-x86_64.rsa"}}, runner.commands[0])
+	assert.Contains(t, runner.commands[1].args, "melange-work/melange-x86_64.rsa")
+	assert.Contains(t, runner.commands[2].args, "melange-work/melange-x86_64.rsa")
+	assert.NoFileExists(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa"))
+	assert.NoFileExists(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa.pub"))
 	assert.FileExists(t, artifactMarkerPath(&paths, ArchitectureX8664))
 }
 
@@ -66,8 +70,8 @@ func Test_Build_removes_ephemeral_staged_key_when_recipe_build_fails(t *testing.
 
 	// Then
 	require.ErrorIs(t, err, errSentinelBuildRunner)
-	assert.NoFileExists(t, filepath.Join(paths.WorkDir, "melange.rsa"))
-	assert.NoFileExists(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"))
+	assert.NoFileExists(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa"))
+	assert.NoFileExists(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa.pub"))
 }
 
 func Test_Build_stops_at_missing_recipes_index_and_marker_boundaries(t *testing.T) {
@@ -171,6 +175,6 @@ func setupStagedUpstreamBuild(t *testing.T, root string) (Paths, Spec) {
 
 func writeSigningPair(t *testing.T, paths *Paths) {
 	t.Helper()
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa"), "private")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa"), "private")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa.pub"), "public")
 }

--- a/internal/integer/melange/build_test.go
+++ b/internal/integer/melange/build_test.go
@@ -77,14 +77,14 @@ func TestBuildStagesRunsAndSigns(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, runner.commands, 3)
-	assert.Equal(t, recordedCommand{name: "melange", args: []string{"keygen", "melange-work/melange.rsa"}}, runner.commands[0])
+	assert.Equal(t, recordedCommand{name: "melange", args: []string{"keygen", "melange-work/melange-x86_64.rsa"}}, runner.commands[0])
 	assert.Contains(t, runner.commands[1].args, "--env-file")
 	assert.Contains(t, runner.commands[1].args, "packages/overrides/fips.env")
 	assert.Contains(t, runner.commands[1].args, "--build-option")
 	assert.Contains(t, runner.commands[1].args, "fips")
 	assert.Equal(t, "sign-index", runner.commands[2].args[0])
 
-	publicKey, err := os.ReadFile(testPath(root, "packages/repo/x86_64/melange.rsa.pub"))
+	publicKey, err := os.ReadFile(testPath(root, "packages/repo/melange.rsa.pub"))
 	require.NoError(t, err)
 	assert.Equal(t, "public", string(publicKey))
 	assert.True(t, ArtifactsExist(&paths, spec, ArchitectureX8664))
@@ -101,8 +101,8 @@ func TestBuildSignsOnlyRequestedArchitectureIndex(t *testing.T) {
   "pipeline_files":{}
 }`, testSHA(recipe)))
 	writeTestFile(t, testPath(paths.WorkDir, "specs/caddy/build.yaml"), recipe)
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa"), "private")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa"), "private")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa.pub"), "public")
 	writeTestFile(t, testPath(root, "packages/repo/aarch64/APKINDEX.tar.gz"), "arm-index")
 	runner := &fakeRunner{}
 
@@ -124,11 +124,11 @@ func TestBuildSignsOnlyRequestedArchitectureIndex(t *testing.T) {
 	assert.Equal(t, []string{"packages/repo/x86_64/APKINDEX.tar.gz"}, signedIndexes)
 }
 
-func TestPrepareRestrictsGeneratedPrivateKeyPermissions(t *testing.T) {
+func TestPrepareStages_withoutGeneratingSigningKey(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, testPath(root, "packages/bespoke/custom.yaml"), "package:\n  name: custom\n")
 	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), `{"packages":{},"pipeline_files":{}}`)
-	runner := &fakeRunner{keyMode: 0o666}
+	runner := &fakeRunner{}
 
 	err := Prepare(context.Background(), &BuildOptions{
 		Paths:  testPaths(root),
@@ -137,13 +137,12 @@ func TestPrepareRestrictsGeneratedPrivateKeyPermissions(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	info, err := os.Stat(testPath(root, "melange-work/melange.rsa"))
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	assert.Empty(t, runner.commands)
+	assert.NoFileExists(t, testPath(root, "melange-work/melange.rsa"))
 }
 
-func TestPrepareReusesExistingSigningKeyPair(t *testing.T) {
-	// Given: one workspace used to build packages for multiple architectures.
+func TestPrepareStagesIdempotently_withoutSigningKeys(t *testing.T) {
+	// Given: one workspace whose recipes will be built independently per architecture.
 	root := t.TempDir()
 	writeTestFile(t, testPath(root, "packages/bespoke/custom.yaml"), "package:\n  name: custom\n")
 	writeTestFile(t, testPath(root, "packages/upstream.lock.json"), `{"packages":{},"pipeline_files":{}}`)
@@ -154,18 +153,11 @@ func TestPrepareReusesExistingSigningKeyPair(t *testing.T) {
 		Runner: runner,
 	}
 
-	// When: preparation runs once per architecture.
+	// When: preparation runs repeatedly before architecture builds.
 	require.NoError(t, Prepare(context.Background(), options))
 	require.NoError(t, Prepare(context.Background(), options))
-
-	// Then: both architecture indexes will share the same signing key.
-	var keygenCount int
-	for _, command := range runner.commands {
-		if len(command.args) > 0 && command.args[0] == "keygen" {
-			keygenCount++
-		}
-	}
-	assert.Equal(t, 1, keygenCount)
+	assert.Empty(t, runner.commands)
+	assert.NoFileExists(t, testPath(root, "melange-work/melange.rsa"))
 }
 
 func TestBuildRejectsUnsafeArchitectureBeforeRemovingOutput(t *testing.T) {
@@ -192,8 +184,8 @@ func TestBuildRejectsSymlinkedRepositoryAncestorBeforeRemovingOutput(t *testing.
 	writeTestFile(t, sentinel, "keep")
 	require.NoError(t, os.Symlink(backing, testPath(root, "packages")))
 	writeTestFile(t, testPath(paths.WorkDir, "specs/custom/build.yaml"), "package:\n  name: custom\n")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa"), "private")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa"), "private")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa.pub"), "public")
 
 	err := Build(context.Background(), &BuildOptions{
 		Paths:  paths,
@@ -217,15 +209,15 @@ func TestBuildStagedRestrictsPrivateKeyPermissions(t *testing.T) {
   "pipeline_files":{}
 }`, testSHA(recipe)))
 	writeTestFile(t, testPath(paths.WorkDir, "specs/caddy/build.yaml"), "package:\n  name: caddy\n")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa"), "private")
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
-	require.NoError(t, os.Chmod(filepath.Join(paths.WorkDir, "melange.rsa"), 0o644))
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa"), "private")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa.pub"), "public")
+	require.NoError(t, os.Chmod(filepath.Join(paths.WorkDir, "melange-x86_64.rsa"), 0o644))
 	var mode os.FileMode
 	runner := &fakeRunner{beforeRun: func(command Command) {
 		if len(command.Args) == 0 || command.Args[0] != "build" {
 			return
 		}
-		info, err := os.Stat(filepath.Join(paths.WorkDir, "melange.rsa"))
+		info, err := os.Stat(filepath.Join(paths.WorkDir, "melange-x86_64.rsa"))
 		require.NoError(t, err)
 		mode = info.Mode().Perm()
 	}}

--- a/internal/integer/melange/stage_build_error_paths_test.go
+++ b/internal/integer/melange/stage_build_error_paths_test.go
@@ -85,7 +85,7 @@ func Test_Build_and_Prepare_report_incomplete_keys_prepare_and_keygen_errors(t *
 	// Given
 	root := t.TempDir()
 	paths, spec := setupStagedUpstreamBuild(t, root)
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa"), "private")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa"), "private")
 
 	// When / Then
 	require.ErrorIs(t, Build(context.Background(), &BuildOptions{
@@ -105,7 +105,7 @@ func Test_Build_and_Prepare_report_incomplete_keys_prepare_and_keygen_errors(t *
 	require.ErrorIs(t, err, errSentinelBuildRunner)
 }
 
-func Test_Prepare_reports_incomplete_key_after_successful_staging(t *testing.T) {
+func Test_Prepare_leaves_signingKeys_toArchitectureBuild(t *testing.T) {
 	// Given
 	root := t.TempDir()
 	paths := testPaths(root)
@@ -119,7 +119,7 @@ func Test_Prepare_reports_incomplete_key_after_successful_staging(t *testing.T) 
 	})
 
 	// Then
-	require.ErrorIs(t, err, errIncompleteSigningKeyPair)
+	require.NoError(t, err)
 }
 
 func Test_signPackageIndexes_reports_public_key_and_compatibility_copy_errors(t *testing.T) {
@@ -130,7 +130,7 @@ func Test_signPackageIndexes_reports_public_key_and_compatibility_copy_errors(t 
 	err := signPackageIndexes(context.Background(), &BuildOptions{Paths: paths, Arch: ArchitectureX8664, Runner: &orchestrationRunner{}})
 	require.ErrorContains(t, err, "copy public key")
 
-	writeTestFile(t, filepath.Join(paths.WorkDir, "melange.rsa.pub"), "public")
+	writeTestFile(t, filepath.Join(paths.WorkDir, "melange-x86_64.rsa.pub"), "public")
 	require.NoError(t, os.MkdirAll(filepath.Join(paths.RepoDir, "melange.rsa.pub"), 0o755))
 	err = signPackageIndexes(context.Background(), &BuildOptions{Paths: paths, Arch: ArchitectureX8664, Runner: &orchestrationRunner{}})
 	require.ErrorContains(t, err, "copy compatibility public key")


### PR DESCRIPTION
## Summary
- generate ephemeral RSA signing keys independently per package architecture
- embed unique key basenames in each APKINDEX signature
- publish matching unique public keys for multi-architecture APKO verification
- keep preparation keyless and remove generated private/public keys after each build

## Runtime evidence
Run 30262630256 passed both zero-CVE gates but showed APKO key lookup is basename-based; two different keys named melange.rsa.pub collide.

## Verification
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate APK signing keys per architecture to prevent basename collisions during multi-arch verification and ensure correct `APKO` key lookup. Keys are generated per-arch at build time, embedded in `APKINDEX`, and cleaned up after each build.

- **Bug Fixes**
  - Generate ephemeral RSA keys per arch during build; `Prepare` no longer creates keys.
  - Use per-arch key names `melange-<arch>.rsa` and publish `melange-<arch>.rsa.pub` at the repo root; keep `melange.rsa.pub` for compatibility.
  - Sign each `APKINDEX` with its arch-specific key and embed the unique basename.
  - Update `apko` publish to append per-arch keyrings (`melange-x86_64.rsa.pub`, `melange-aarch64.rsa.pub`).
  - Adjust artifact checks and tests to new key locations; remove arch-local `melange.rsa.pub` paths.

<sup>Written for commit f79e4884971319602da65716e466ae3dde194d82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

