### PR TITLE
fix(ci): use supported cosign annotations flag

### DIFF
--- a/.github/workflows/integer-build-image-reusable.yaml
+++ b/.github/workflows/integer-build-image-reusable.yaml
@@ -400,7 +400,7 @@ jobs:
           INPUT_REGISTRY: ${{ inputs.registry }}
           DIGEST: ${{ steps.build.outputs.digest }}
           PUBLICATION_ID: ${{ needs.melange-prep.outputs.publication_id }}
-        run: cosign sign --yes --annotation "verity.publication_id=${PUBLICATION_ID}" "${INPUT_REGISTRY}/${INPUT_IMAGE}@${DIGEST}"
+        run: cosign sign --yes --annotations "verity.publication_id=${PUBLICATION_ID}" "${INPUT_REGISTRY}/${INPUT_IMAGE}@${DIGEST}"
 
       - name: Attest SBOM
         if: hashFiles('sbom-amd64.spdx.json') != ''

--- a/internal/ci/workflowpolicy/integer_exact_test.go
+++ b/internal/ci/workflowpolicy/integer_exact_test.go
@@ -128,6 +128,17 @@ func TestIntegerWorkflows_useExactNeeds_andReadOnlyDefaults(t *testing.T) {
 	assert.False(t, image.On.PullRequest)
 }
 
+func TestIntegerBuildImage_usesSupportedCosignAnnotationsFlag(t *testing.T) {
+	// Given: the exact image producer text.
+	workflow := readRepositoryIntegerWorkflowText(t, "integer-build-image-reusable.yaml")
+
+	// When: the keyless image-signing command is inspected.
+
+	// Then: Cosign receives its supported plural annotations flag.
+	require.Contains(t, workflow, "cosign sign --yes --annotations ")
+	require.NotContains(t, workflow, "cosign sign --yes --annotation ")
+}
+
 func TestIntegerBuildImage_usesGoOwnedPackageAndPublicationGates_beforeAttestation(t *testing.T) {
 	// Given: the exact image producer text.
 	workflow := readRepositoryIntegerWorkflowText(t, "integer-build-image-reusable.yaml")

--- a/internal/ci/workflowpolicy/testdata/valid/integer-build-image-reusable.yaml
+++ b/internal/ci/workflowpolicy/testdata/valid/integer-build-image-reusable.yaml
@@ -400,7 +400,7 @@ jobs:
           INPUT_REGISTRY: ${{ inputs.registry }}
           DIGEST: ${{ steps.build.outputs.digest }}
           PUBLICATION_ID: ${{ needs.melange-prep.outputs.publication_id }}
-        run: cosign sign --yes --annotation "verity.publication_id=${PUBLICATION_ID}" "${INPUT_REGISTRY}/${INPUT_IMAGE}@${DIGEST}"
+        run: cosign sign --yes --annotations "verity.publication_id=${PUBLICATION_ID}" "${INPUT_REGISTRY}/${INPUT_IMAGE}@${DIGEST}"
 
       - name: Attest SBOM
         if: hashFiles('sbom-amd64.spdx.json') != ''


### PR DESCRIPTION
## Summary
- use Cosign supported plural `--annotations` flag
- add a workflow contract test preventing regression
- keep validated workflow fixture synchronized

## Verification
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m`
- `actionlint`
- `go run . ci workflow validate .github/workflows`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix image signing in the reusable workflow by using `--annotations` (plural) with `cosign`. Adds a contract test to prevent regressions and syncs the validated workflow fixture.

- **Bug Fixes**
  - Use `cosign sign --yes --annotations` in `.github/workflows/integer-build-image-reusable.yaml`.
  - Add a test that requires the plural flag and rejects the singular flag.
  - Update the validated workflow fixture to match.

<sup>Written for commit dd6a1f1a5d3ee6b642fb9c62686df7b21513c03b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

