### PR TITLE
fix(apk): verify signer provenance and attest sbom

### DIFF
--- a/.github/workflows/integer-build-image-reusable.yaml
+++ b/.github/workflows/integer-build-image-reusable.yaml
@@ -403,13 +403,12 @@ jobs:
         run: cosign sign --yes --annotations "verity.publication_id=${PUBLICATION_ID}" "${INPUT_REGISTRY}/${INPUT_IMAGE}@${DIGEST}"
 
       - name: Attest SBOM
-        if: hashFiles('sbom-amd64.spdx.json') != ''
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image }}
           subject-digest: ${{ steps.build.outputs.digest }}
           predicate-type: https://spdx.dev/Document
-          predicate-path: sbom-amd64.spdx.json
+          predicate-path: sbom-index.spdx.json
           push-to-registry: "true"
 
       - name: Download exact Integer plan

--- a/ci/apk-signer.lock.json
+++ b/ci/apk-signer.lock.json
@@ -1,7 +1,7 @@
 {
   "image": "ghcr.io/verity-org/apk-repository-signer",
   "digest": "",
-  "workflow": "github.com/verity-org/verity/.github/workflows/integer-build-image.yaml",
+  "workflow": "github.com/verity-org/verity/.github/workflows/integer-build-image-reusable.yaml",
   "source_sha": "",
   "bootstrap": true,
   "runnable": false

--- a/internal/apkrepository/download_approved.go
+++ b/internal/apkrepository/download_approved.go
@@ -64,7 +64,7 @@ func DownloadApproved(ctx context.Context, options *DownloadApprovedOptions) err
 	if len(packages) == 0 {
 		return fmt.Errorf("%w: %s", errNoApprovedArtifacts, options.BatchID)
 	}
-	signerWorkflow := "github.com/" + options.Repository + "/.github/workflows/integer-build-image.yaml"
+	signerWorkflow := "github.com/" + options.Repository + "/.github/workflows/integer-build-image-reusable.yaml"
 	for _, packagePath := range packages {
 		_, err := runRequired(ctx, runner, &command{
 			name: "gh",

--- a/internal/apkrepository/github_artifacts_test.go
+++ b/internal/apkrepository/github_artifacts_test.go
@@ -41,7 +41,7 @@ func TestDownloadApproved_downloads_exact_batch_and_verifies_every_attestation(t
 	require.NoError(t, err)
 	require.Len(t, runner.calls, 2)
 	assert.Equal(t, []string{"run", "download", "1234", "--repo", "verity-org/verity", "--pattern", "apk-repository-1234-2-*", "--dir", output}, runner.calls[0].args)
-	assert.Contains(t, runner.calls[1].args, "github.com/verity-org/verity/.github/workflows/integer-build-image.yaml")
+	assert.Contains(t, runner.calls[1].args, "github.com/verity-org/verity/.github/workflows/integer-build-image-reusable.yaml")
 	assert.Contains(t, runner.calls[1].args, "refs/heads/main")
 	assert.Contains(t, runner.calls[1].args, "--deny-self-hosted-runners")
 	assert.Contains(t, stdout.String(), "Downloaded and verified 1 approved APK packages")

--- a/internal/ci/signerlock/bootstrap_test.go
+++ b/internal/ci/signerlock/bootstrap_test.go
@@ -11,7 +11,7 @@ func TestBootstrapLock_failsClosedBeforeItCanRun(t *testing.T) {
 	data := []byte(`{
   "image": "ghcr.io/verity-org/apk-repository-signer",
   "digest": "sha256:REPLACE_WITH_REAL_DIGEST",
-  "workflow": "github.com/verity-org/verity/.github/workflows/integer-build-image.yaml",
+  "workflow": "github.com/verity-org/verity/.github/workflows/integer-build-image-reusable.yaml",
   "source_sha": "REPLACE_WITH_REAL_SOURCE_SHA",
   "bootstrap": true,
   "runnable": false

--- a/internal/ci/signerlock/lock.go
+++ b/internal/ci/signerlock/lock.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	SignerImageRepository   = "ghcr.io/verity-org/apk-repository-signer"
-	TrustedWorkflowIdentity = "github.com/verity-org/verity/.github/workflows/integer-build-image.yaml"
+	TrustedWorkflowIdentity = "github.com/verity-org/verity/.github/workflows/integer-build-image-reusable.yaml"
 	digestPrefix            = "sha256:"
 	digestHexLength         = 64
 	sourceSHAHexLength      = 40

--- a/internal/ci/sitepublication/signer.go
+++ b/internal/ci/sitepublication/signer.go
@@ -154,6 +154,7 @@ func buildSignerSteps(plan *SignerPlan) ([]SignerStep, error) {
 		{Name: "pull", Command: ExecutionCommand{Name: runtime, Args: []string{"pull", plan.ImageReference}}},
 		{Name: "attest", Command: ExecutionCommand{Name: trustedGHBinary, Args: []string{
 			"attestation", "verify", "oci://" + plan.ImageReference,
+			"--bundle-from-oci",
 			"--repo", plan.Execution.Repository,
 			"--signer-workflow", signerlock.TrustedWorkflowIdentity,
 			"--source-ref", "refs/heads/main", "--source-digest", string(plan.SignerSourceSHA),

--- a/internal/ci/sitepublication/signer_test.go
+++ b/internal/ci/sitepublication/signer_test.go
@@ -64,8 +64,11 @@ func TestBuildSignerPlan_constructs_ordered_isolated_minimal_commands(t *testing
 	assert.NotContains(t, strings.Join(signArgs, " "), request.KeyDirectory)
 	assert.NotContains(t, signArgs, "--signing-key")
 	assert.Equal(t, request.Plan.SignerReference, signerPlan.ImageReference)
-	assert.Contains(t, signerPlan.Steps[1].Command.Args, "--source-digest")
-	assert.Contains(t, signerPlan.Steps[1].Command.Args, testSignerSourceSHA)
+	attestationArgs := signerPlan.Steps[1].Command.Args
+	assert.Contains(t, attestationArgs, "--bundle-from-oci")
+	assert.Contains(t, attestationArgs, "github.com/verity-org/verity/.github/workflows/integer-build-image-reusable.yaml")
+	assert.Contains(t, attestationArgs, "--source-digest")
+	assert.Contains(t, attestationArgs, testSignerSourceSHA)
 }
 
 func TestExecuteSigner_passes_key_on_stdin_only_after_attestation(t *testing.T) {

--- a/internal/ci/workflowpolicy/integer_exact_test.go
+++ b/internal/ci/workflowpolicy/integer_exact_test.go
@@ -139,6 +139,17 @@ func TestIntegerBuildImage_usesSupportedCosignAnnotationsFlag(t *testing.T) {
 	require.NotContains(t, workflow, "cosign sign --yes --annotation ")
 }
 
+func TestIntegerBuildImage_attestsIndexSBOMFailClosed(t *testing.T) {
+	// Given: the exact image producer text.
+	workflow := readRepositoryIntegerWorkflowText(t, "integer-build-image-reusable.yaml")
+
+	// When: the SBOM attestation step is inspected.
+
+	// Then: the multi-arch index SBOM is mandatory rather than conditionally skipped.
+	require.Contains(t, workflow, "predicate-path: sbom-index.spdx.json")
+	require.NotContains(t, workflow, "if: hashFiles('sbom-")
+}
+
 func TestIntegerBuildImage_usesGoOwnedPackageAndPublicationGates_beforeAttestation(t *testing.T) {
 	// Given: the exact image producer text.
 	workflow := readRepositoryIntegerWorkflowText(t, "integer-build-image-reusable.yaml")

--- a/internal/ci/workflowpolicy/testdata/valid/integer-build-image-reusable.yaml
+++ b/internal/ci/workflowpolicy/testdata/valid/integer-build-image-reusable.yaml
@@ -403,13 +403,12 @@ jobs:
         run: cosign sign --yes --annotations "verity.publication_id=${PUBLICATION_ID}" "${INPUT_REGISTRY}/${INPUT_IMAGE}@${DIGEST}"
 
       - name: Attest SBOM
-        if: hashFiles('sbom-amd64.spdx.json') != ''
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image }}
           subject-digest: ${{ steps.build.outputs.digest }}
           predicate-type: https://spdx.dev/Document
-          predicate-path: sbom-amd64.spdx.json
+          predicate-path: sbom-index.spdx.json
           push-to-registry: "true"
 
       - name: Download exact Integer plan


### PR DESCRIPTION
## Summary
- verify signer provenance from its OCI bundle using the reusable workflow identity
- use the same exact reusable producer identity for approved APK attestations
- attest the mandatory multi-architecture index SBOM instead of silently skipping a nonexistent path

## Runtime evidence
- Cosign 3.1.1 verifies the published signer digest and transparency-log entry
- GitHub provenance verifies the exact digest/source SHA with the reusable workflow identity and `--bundle-from-oci`
- top-level caller identity fails, confirming the previous lock was incorrect
- APKO runtime logs show `sbom-index.spdx.json`

## Verification
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m`
- `actionlint`
- `go run . ci workflow validate .github/workflows`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies APK signer provenance from the OCI bundle using the trusted reusable workflow identity, and makes SBOM attestation mandatory. Also switches SBOM to the multi-arch index file to ensure consistent attestation.

- **Bug Fixes**
  - Verify signer with `--bundle-from-oci` and lock trust to `github.com/verity-org/verity/.github/workflows/integer-build-image-reusable.yaml` on main.
  - Replace top-level caller trust with the exact reusable producer identity.
  - Make SBOM attestation fail-closed and target `sbom-index.spdx.json`; remove the conditional `hashFiles(...)` guard.
  - Update `ci/apk-signer.lock.json`, workflow policy, and tests to reference the reusable workflow.

<sup>Written for commit 3cc65b4087db38af9ed9d3aab7af55be82680ae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

