### PR TITLE
feat(apk): enable signed repository publication

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,41 @@
 name: Publish
 
 on:
+  schedule:
+    - cron: "0 4 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "integer.yaml"
+      - "images/**"
+      - "packages/bespoke/**"
+      - "packages/pipelines/**"
+      - "packages/overrides/**"
+      - "packages/upstream.lock.json"
+      - "copa-config.yaml"
+      - "Chart.yaml"
+      - "verity.yaml"
+      - "site/**"
+      - "keys/apk/**"
+      - "ci/apk-signer.lock.json"
+      - "ci/apk-signing-key-state.json"
+      - "*.go"
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "mise.toml"
+      - "mise.lock"
+      - ".github/actions/setup-verity/**"
+      - ".github/workflows/publish.yaml"
+      - ".github/workflows/build-site.yaml"
+      - ".github/workflows/build-verity.yaml"
+      - ".github/workflows/build-verity-protected.yaml"
+      - ".github/workflows/orchestrator.yaml"
+      - ".github/workflows/patch-image.yaml"
+      - ".github/workflows/integer-orchestrator-reusable.yaml"
+      - ".github/workflows/integer-build-shard.yaml"
+      - ".github/workflows/integer-build-image.yaml"
+      - ".github/workflows/integer-build-image-reusable.yaml"
   workflow_dispatch:
     inputs:
       mode:

--- a/ci/apk-signer.lock.json
+++ b/ci/apk-signer.lock.json
@@ -1,8 +1,8 @@
 {
   "image": "ghcr.io/verity-org/apk-repository-signer",
-  "digest": "",
+  "digest": "sha256:5cdee221056dffe73ce87fa1c2520f60c0f3b84aab6ee19e140e6f62fba80e41",
   "workflow": "github.com/verity-org/verity/.github/workflows/integer-build-image-reusable.yaml",
-  "source_sha": "",
-  "bootstrap": true,
-  "runnable": false
+  "source_sha": "63bb93bdeed6e0089bd3fa021d97b3f0eacb1296",
+  "bootstrap": false,
+  "runnable": true
 }

--- a/internal/ci/signerlock/validate_test.go
+++ b/internal/ci/signerlock/validate_test.go
@@ -2,7 +2,6 @@ package signerlock
 
 import (
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -139,28 +138,24 @@ func TestParse_rejectsUnknownFields(t *testing.T) {
 	require.ErrorIs(t, err, ErrMalformed)
 }
 
-func TestLoad_bootstrapTemplateFailsClosed(t *testing.T) {
-	// Given the checked-in bootstrap lock template.
+func TestLoad_checkedInLockIsRunnableAndImmutable(t *testing.T) {
+	// Given the checked-in production signer lock.
 	_, testFile, _, ok := runtime.Caller(0)
 	require.True(t, ok)
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", "..", ".."))
 	path := filepath.Join(repoRoot, "ci", "apk-signer.lock.json")
-	data, err := os.ReadFile(path)
+
+	// When the lock is strictly loaded and validated.
+	lock, err := Load(path)
+
+	// Then publication is bound to immutable trusted signer coordinates.
 	require.NoError(t, err)
-	var sentinel struct {
-		Bootstrap bool `json:"bootstrap"`
-		Runnable  bool `json:"runnable"`
-	}
-	require.NoError(t, json.Unmarshal(data, &sentinel))
-	require.True(t, sentinel.Bootstrap)
-	require.False(t, sentinel.Runnable)
-
-	// When the template is loaded as a runnable lock.
-	_, err = Load(path)
-
-	// Then the explicit bootstrap sentinel prevents use until replaced.
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrBootstrap)
+	assert.False(t, lock.Bootstrap)
+	assert.True(t, lock.Runnable)
+	assert.Equal(t, SignerImageRepository, lock.Image)
+	assert.Equal(t, TrustedWorkflowIdentity, lock.Workflow)
+	assert.NotEmpty(t, lock.Digest)
+	assert.NotEmpty(t, lock.SourceSHA)
 }
 
 func validLock() Lock {

--- a/internal/ci/workflowpolicy/publication_trigger_contract_test.go
+++ b/internal/ci/workflowpolicy/publication_trigger_contract_test.go
@@ -1,0 +1,37 @@
+package workflowpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishWorkflow_triggersOnlyRelevantProtectedChanges(t *testing.T) {
+	// Given: the production publication workflow.
+	workflow := readRepositoryIntegerWorkflow(t, "publish.yaml")
+	workflowText := readRepositoryIntegerWorkflowText(t, "publish.yaml")
+
+	// When: its automatic trigger contract is inspected.
+	paths := workflow.On.Push.Paths
+
+	// Then: protected main, nightly publication, and every producer input class are covered.
+	require.True(t, workflow.On.Push.Present)
+	require.Contains(t, workflowText, "branches: [main]")
+	require.True(t, workflow.On.Schedule)
+	for _, required := range []string{
+		"integer.yaml", "images/**", "packages/bespoke/**", "packages/pipelines/**",
+		"packages/overrides/**", "packages/upstream.lock.json", "copa-config.yaml", "Chart.yaml",
+		"verity.yaml", "site/**", "keys/apk/**", "ci/apk-signer.lock.json",
+		"ci/apk-signing-key-state.json", "*.go", "**/*.go", "go.mod", "go.sum",
+		"mise.toml", "mise.lock", ".github/actions/setup-verity/**", ".github/workflows/publish.yaml",
+		".github/workflows/build-site.yaml", ".github/workflows/build-verity.yaml",
+		".github/workflows/build-verity-protected.yaml", ".github/workflows/orchestrator.yaml",
+		".github/workflows/patch-image.yaml", ".github/workflows/integer-orchestrator-reusable.yaml",
+		".github/workflows/integer-build-shard.yaml", ".github/workflows/integer-build-image.yaml",
+		".github/workflows/integer-build-image-reusable.yaml",
+	} {
+		assert.Contains(t, paths, required)
+	}
+	assert.NotContains(t, paths, "**")
+}


### PR DESCRIPTION
## Summary
- pin the independently verified dual-architecture signer image by immutable digest and exact source SHA
- enable relevant protected-main publication triggers and a 04:00 UTC nightly snapshot
- update checked-in lock and trigger contracts for steady-state publication

## Signer verification
- run: `30269187935`
- digest: `sha256:5cdee221056dffe73ce87fa1c2520f60c0f3b84aab6ee19e140e6f62fba80e41`
- source: `63bb93bdeed6e0089bd3fa021d97b3f0eacb1296`
- zero-CVE gates: AMD64 and ARM64 passed
- Cosign 3.1.1: verified
- GitHub provenance: verified from OCI against reusable workflow, protected main, exact source SHA, hosted runner
- SPDX SBOM attestation: verified

## Verification
- `go test -race -shuffle=on -count=1 ./...`
- `golangci-lint run --timeout=5m`
- `actionlint`
- `go run . ci workflow validate .github/workflows`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable signed APK repository publication with a pinned, verified dual-arch signer. Publishes from protected main and a 04:00 UTC nightly snapshot.

- New Features
  - Pin signer image by immutable digest and exact source SHA; zero-CVE gates passed for amd64/arm64; Cosign, provenance, and SBOM attestation verified.
  - Enable publication on `main` and a nightly schedule; restrict triggers to relevant paths; add policy tests to enforce the trigger contract.
  - Make `ci/apk-signer.lock.json` runnable and immutable to bind publication to the trusted signer image/workflow; update validation to require digest and source SHA.

<sup>Written for commit acc2e5e68ed1c5407ab4a0ad2380eb6ed5e32f57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

