### PR TITLE
fix(ci): pass typed reusable workflow inputs

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -137,7 +137,7 @@ jobs:
       publication_id: ${{ format('build-site-{0}-{1}', github.run_id, github.run_attempt) }}
       batch_id: ${{ format('{0}-{1}', github.run_id, github.run_attempt) }}
       image: ""
-      preflight: "false"
+      preflight: false
       verity_artifact_name: ${{ needs.build-verity.outputs.artifact-name }}
       verity_artifact_digest: ${{ needs.build-verity.outputs.artifact-digest }}
       verity_build_key: ${{ needs.build-verity.outputs.build-key }}

--- a/internal/ci/workflowpolicy/publication_trigger_contract_test.go
+++ b/internal/ci/workflowpolicy/publication_trigger_contract_test.go
@@ -35,3 +35,14 @@ func TestPublishWorkflow_triggersOnlyRelevantProtectedChanges(t *testing.T) {
 	}
 	assert.NotContains(t, paths, "**")
 }
+
+func TestBuildSite_passesTypedBooleanPreflightInput(t *testing.T) {
+	// Given: the exact Build Site reusable caller text.
+	workflow := readRepositoryIntegerWorkflowText(t, "build-site.yaml")
+
+	// When: the chart producer's boolean input is inspected.
+
+	// Then: GitHub receives a boolean scalar rather than a rejected string.
+	require.Contains(t, workflow, "      preflight: false\n")
+	require.NotContains(t, workflow, "      preflight: \"false\"\n")
+}

--- a/internal/ci/workflowpolicy/scalar_types_test.go
+++ b/internal/ci/workflowpolicy/scalar_types_test.go
@@ -111,6 +111,12 @@ jobs:
       contents: read
     steps:
       - run: echo valid
+  call:
+    uses: ./.github/workflows/reusable.yaml
+    with:
+      enabled: false
+      count: 2
+      name: publication
 `
 
 	// When the typed scalar forms cross the workflow boundary.
@@ -118,4 +124,22 @@ jobs:
 
 	// Then deliberate booleans, numbers, and heterogeneous matrix values remain valid.
 	assert.NoError(t, err)
+}
+
+func TestDecodeWorkflow_rejects_nonScalarReusableInputs(t *testing.T) {
+	tests := []string{
+		"null",
+		"[one, two]",
+		"{nested: value}",
+	}
+	for _, value := range tests {
+		// Given: a reusable workflow input with a non-supported value shape.
+		input := fmt.Sprintf("on: workflow_dispatch\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yaml\n    with: {value: %s}\n", value)
+
+		// When: the strict schema validates the input mapping.
+		_, err := decodeWorkflow([]byte(input))
+
+		// Then: only GitHub-supported scalar input values are accepted.
+		assert.Error(t, err)
+	}
 }

--- a/internal/ci/workflowpolicy/strict_schema.go
+++ b/internal/ci/workflowpolicy/strict_schema.go
@@ -60,7 +60,7 @@ func validateJobNode(node *yaml.Node, path string) error {
 		"services":          validateServicesNode,
 		"strategy":          validateStrategyNode,
 		"uses":              validateString,
-		"with":              validateExtensionScalars,
+		"with":              validateInputScalars,
 		"secrets":           validateSecretsNode,
 	}}); err != nil {
 		return err

--- a/internal/ci/workflowpolicy/strict_yaml.go
+++ b/internal/ci/workflowpolicy/strict_yaml.go
@@ -145,6 +145,10 @@ func validateExtensionScalars(node *yaml.Node, path string) error {
 	return validateMapping(node, path, yamlMappingSchema{extension: validateString})
 }
 
+func validateInputScalars(node *yaml.Node, path string) error {
+	return validateMapping(node, path, yamlMappingSchema{extension: validateInputScalar})
+}
+
 func childPath(path, key string) string {
 	return path + "." + key
 }


### PR DESCRIPTION
## Summary

- pass the reusable chart preflight input as a typed boolean
- teach strict workflow validation to accept GitHub-supported scalar reusable inputs
- reject null, sequence, and mapping reusable inputs

## Verification

- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- actionlint
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass typed boolean inputs to reusable workflows and enforce scalar-only `with` values. This fixes `build-site` preflight to send a boolean and blocks null, arrays, and maps.

- **Bug Fixes**
  - `preflight` in `build-site` now passes `false` as a boolean, not a string.
  - Strict schema validates reusable `with` inputs as scalars only; rejects null, sequences, and mappings.
  - Added tests to confirm boolean `preflight` and to reject non-scalar reusable inputs.

<sup>Written for commit dd08f1fac95ad3b3fb4f97798264adf12b269cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

