### PR TITLE
fix(apk): use architecture-specific test keyring

### DIFF
--- a/internal/ci/integer_image_packages.go
+++ b/internal/ci/integer_image_packages.go
@@ -55,7 +55,7 @@ func TestIntegerPackages(ctx context.Context, options *IntegerPackageTestOptions
 			"test", "--arch", string(options.Architecture),
 			"--repository-append", filepath.Join(options.Workspace, "packages", "repo"),
 			"--repository-append", melange.RepositoryURL,
-			"--keyring-append", filepath.Join(options.Workspace, "melange-work", "melange.rsa.pub"),
+			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "melange-"+string(options.Architecture)+".rsa.pub"),
 			"--keyring-append", melange.KeyringURL,
 			"--runner", "docker",
 		}

--- a/internal/ci/integer_image_packages_test.go
+++ b/internal/ci/integer_image_packages_test.go
@@ -30,7 +30,7 @@ func TestTestIntegerPackages_runsEveryStagedRecipeNatively(t *testing.T) {
 	for _, call := range runner.calls {
 		assert.Contains(t, call.Args, "aarch64")
 		assert.Contains(t, call.Args, filepath.Join(root, "packages", "repo"))
-		assert.Contains(t, call.Args, filepath.Join(root, "melange-work", "melange.rsa.pub"))
+		assert.Contains(t, call.Args, filepath.Join(root, "packages", "repo", "melange-aarch64.rsa.pub"))
 		assert.Contains(t, call.Args, "melange-work/pipelines")
 	}
 }


### PR DESCRIPTION
## Summary

- test staged APKs with the exact architecture-specific Melange public key
- prevent every aarch64 package test from looking for the removed generic worktree key

## Runtime evidence

Caddy, blackbox-exporter, and alertmanager built and signed successfully, then failed package tests opening `melange-work/melange.rsa.pub`. The build publishes `packages/repo/melange-aarch64.rsa.pub`.

## Verification

- red-first focused regression test
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- actionlint
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the architecture-specific Melange public key for APK test keyring to match staged repo keys. Fixes failing aarch64 package tests that looked for the removed generic key.

- **Bug Fixes**
  - Point `--keyring-append` to `packages/repo/melange-<arch>.rsa.pub` instead of `melange-work/melange.rsa.pub`.
  - Update the test to assert the new key path.

<sup>Written for commit 977cb6980226aa7aef8f22bb9ad3c2f58a570703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

