### PR TITLE
fix(apk): provide shell for FIPS package tests

### DIFF
--- a/internal/integer/melange/openssl_provider_recipe_test.go
+++ b/internal/integer/melange/openssl_provider_recipe_test.go
@@ -1,0 +1,32 @@
+package melange
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestOpenSSLProviderFIPSRecipe_includesShellInTestEnvironment(t *testing.T) {
+	// Given: the shared FIPS provider recipe used by every OpenSSL FIPS image.
+	paths := repositoryTestPaths(t)
+	data, err := os.ReadFile(filepath.Join(paths.BespokeDir, "openssl-provider-fips.yaml"))
+	require.NoError(t, err)
+	var recipe struct {
+		Test struct {
+			Environment struct {
+				Contents struct {
+					Packages []string `yaml:"packages"`
+				} `yaml:"contents"`
+			} `yaml:"environment"`
+		} `yaml:"test"`
+	}
+
+	// When: the Melange test environment is parsed.
+	require.NoError(t, yaml.Unmarshal(data, &recipe))
+
+	// Then: Melange can start its shell-based test pipeline.
+	require.Contains(t, recipe.Test.Environment.Contents.Packages, "busybox")
+}

--- a/packages/bespoke/openssl-provider-fips.yaml
+++ b/packages/bespoke/openssl-provider-fips.yaml
@@ -171,6 +171,10 @@ subpackages:
             grep -q 'exec /usr/bin/openssl-fips-entrypoint /usr/bin/valkey-server' /usr/local/bin/valkey-server
 
 test:
+  environment:
+    contents:
+      packages:
+        - busybox
   pipeline:
     - runs: |
         test -s /usr/lib/ossl-modules/fips.so


### PR DESCRIPTION
## Summary

- add busybox to the shared OpenSSL FIPS provider test environment
- ensure Melange can start the shell-based package test pipeline
- lock the recipe contract with parsed YAML coverage

## Runtime evidence

Valkey and Ruby FIPS aarch64 builds both failed before the test pipeline with `exec: /bin/sh: no such file or directory`. The top-level recipe test environment had no packages.

## Verification

- red-first focused recipe contract
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- yamllint packages/bespoke/openssl-provider-fips.yaml
- actionlint
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the OpenSSL FIPS test environment has a working shell so Melange can run shell-based package tests.

- **Bug Fixes**
  - Include `busybox` in the shared test environment to provide /bin/sh and prevent pre-test failures.
  - Add a YAML-parsing recipe test to ensure `busybox` remains included.

<sup>Written for commit 64d68ef6523005490b6262c56a15c9759f7c7282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

