### PR TITLE
fix(apk): provide shell for native package tests

### DIFF
--- a/internal/ci/integer_image_packages.go
+++ b/internal/ci/integer_image_packages.go
@@ -57,6 +57,7 @@ func TestIntegerPackages(ctx context.Context, options *IntegerPackageTestOptions
 			"--repository-append", melange.RepositoryURL,
 			"--keyring-append", filepath.Join(options.Workspace, "packages", "repo", "melange-"+string(options.Architecture)+".rsa.pub"),
 			"--keyring-append", melange.KeyringURL,
+			"--test-package-append", "busybox",
 			"--runner", "docker",
 		}
 		if usePipelines {

--- a/internal/ci/integer_image_packages_test.go
+++ b/internal/ci/integer_image_packages_test.go
@@ -3,6 +3,7 @@ package ci
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -32,6 +33,10 @@ func TestTestIntegerPackages_runsEveryStagedRecipeNatively(t *testing.T) {
 		assert.Contains(t, call.Args, filepath.Join(root, "packages", "repo"))
 		assert.Contains(t, call.Args, filepath.Join(root, "packages", "repo", "melange-aarch64.rsa.pub"))
 		assert.Contains(t, call.Args, "melange-work/pipelines")
+		testPackage := slices.Index(call.Args, "--test-package-append")
+		require.GreaterOrEqual(t, testPackage, 0)
+		require.Less(t, testPackage+1, len(call.Args))
+		assert.Equal(t, "busybox", call.Args[testPackage+1])
 	}
 }
 


### PR DESCRIPTION
## Summary

- append busybox to every isolated Melange test environment using the supported `--test-package-append` flag
- keep package runtime dependencies and APK payloads unchanged
- lock the exact native test command contract

## Runtime evidence

Caddy `caddy-src`, blackbox-exporter, and other unrelated packages failed before their test pipelines because the OCI test container had no `/bin/sh`.

## Verification

- red-first focused command contract
- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- actionlint
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure native package tests have a shell by appending `busybox` via `--test-package-append` to all isolated Melange test runs, fixing failures when `/bin/sh` was missing.
Package runtime dependencies and APK payloads remain unchanged; tests now assert the flag to lock the native test command contract.

<sup>Written for commit e6b2c9e469401948cb8346e6501ff1278742b169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

