### PR TITLE
fix(apk): declare native test tools

### DIFF
--- a/cmd/ci_pr_test_integer_build.go
+++ b/cmd/ci_pr_test_integer_build.go
@@ -75,7 +75,12 @@ func runPRMelangePackageTest(
 			"test", "--arch", request.PackageArchitecture,
 			"--repository-append", filepath.Join(request.RepoRoot, "packages", "repo"),
 			"--repository-append", "https://packages.wolfi.dev/os",
-			"--keyring-append", filepath.Join(request.RepoRoot, "melange-work", "melange.rsa.pub"),
+			"--keyring-append", filepath.Join(
+				request.RepoRoot,
+				"packages",
+				"repo",
+				"melange-"+request.PackageArchitecture+".rsa.pub",
+			),
 			"--keyring-append", "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
 			"--pipeline-dirs", "melange-work/pipelines", "--runner", "docker",
 			filepath.ToSlash(filepath.Join("melange-work", "specs", buildDir, "build.yaml")), packageName,

--- a/cmd/ci_pr_test_integer_build_test.go
+++ b/cmd/ci_pr_test_integer_build_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPRMelangePackageTest_usesArchitectureKeyring(t *testing.T) {
+	// Given: an aarch64 package test and a recording command runner.
+	runner := &canaryPRIntegerRunner{}
+	request := prIntegerBatchRequest{
+		PackageArchitecture: "aarch64",
+		RepoRoot:            t.TempDir(),
+	}
+
+	// When: the package test command is assembled.
+	err := runPRMelangePackageTest(
+		t.Context(),
+		&prIntegerDependencies{Commands: runner},
+		&request,
+		"tempo-2.10.yaml",
+		"tempo-2.10",
+		time.Minute,
+	)
+
+	// Then: Melange trusts the staged key for the requested architecture.
+	require.NoError(t, err)
+	require.Len(t, runner.calls, 1)
+	require.True(t, containsArguments(
+		runner.calls[0].Args,
+		"--keyring-append",
+		filepath.Join(request.RepoRoot, "packages", "repo", "melange-aarch64.rsa.pub"),
+	))
+}

--- a/cmd/ci_pr_test_integer_canary.go
+++ b/cmd/ci_pr_test_integer_canary.go
@@ -46,7 +46,8 @@ func runPRLinkerdCanary(
 		Name: "apko", Dir: request.RepoRoot,
 		Args: []string{
 			"build", "--arch", request.Architecture, "--repository-append", "@local packages/repo",
-			"--keyring-append", "melange-work/melange.rsa.pub", config, "integer:pin-config-canary", imagePath,
+			"--keyring-append", filepath.Join("packages", "repo", "melange-"+request.PackageArchitecture+".rsa.pub"),
+			config, "integer:pin-config-canary", imagePath,
 		},
 	}); err != nil {
 		return fmt.Errorf("build pin-config canary: %w", err)

--- a/cmd/ci_pr_test_integer_canary_test.go
+++ b/cmd/ci_pr_test_integer_canary_test.go
@@ -52,13 +52,19 @@ func TestRunPRLinkerdCanary_uses_staged_local_pin_and_strict_scan(t *testing.T) 
 
 	// Then: staged Melange, @local pinning, native apko, and all-severity Trivy are retained.
 	require.NoError(t, err)
-	var staged, pinConfig, strictScan bool
+	var staged, pinConfig, architectureKeyring, strictScan bool
 	for _, call := range runner.calls {
 		staged = staged || containsArguments(call.Args, "--staged")
 		pinConfig = pinConfig || containsArguments(call.Args, "integer", "melange", "pin-config")
+		architectureKeyring = architectureKeyring || (call.Name == "apko" && containsArguments(
+			call.Args,
+			"--keyring-append",
+			filepath.Join("packages", "repo", "melange-aarch64.rsa.pub"),
+		))
 		strictScan = strictScan || (call.Name == "trivy" && containsArguments(call.Args, "--severity", prIntegerSeverities))
 	}
 	require.True(t, staged)
 	require.True(t, pinConfig)
+	require.True(t, architectureKeyring)
 	require.True(t, strictScan)
 }

--- a/cmd/velero_config_test.go
+++ b/cmd/velero_config_test.go
@@ -35,11 +35,11 @@ func Test_Velero_recipe_pins_immutable_fixed_source_and_runtime_contract(t *test
 
 	// When: its source, dependency, smoke, and license metadata are inspected.
 
-	// Then: revision r1 owns Apache-2.0 v1.18.2 and the OpenTelemetry security fix.
+	// Then: revision r4 owns Apache-2.0 v1.18.2 and both dependency security fixes.
 	require.Contains(t, text, "name: velero")
 	require.Contains(t, text, "# renovate: datasource=github-tags depName=velero-io/velero versioning=semver-coerced")
 	require.Contains(t, text, "version: \"1.18.2\"")
-	require.Contains(t, text, "epoch: 1")
+	require.Contains(t, text, "epoch: 4")
 	require.Contains(t, text, "license: Apache-2.0")
 	require.Contains(t, text, "Adapted from wolfi-dev/os@080b7b160597fec7f7bfec73b8f281bb55c17117")
 	require.Contains(t, text, "repository: https://github.com/velero-io/velero")
@@ -50,6 +50,7 @@ func Test_Velero_recipe_pins_immutable_fixed_source_and_runtime_contract(t *test
 	require.Contains(t, text, "go.opentelemetry.io/otel/sdk@v1.44.0")
 	require.Contains(t, text, "go.opentelemetry.io/otel/sdk/metric@v1.44.0")
 	require.Contains(t, text, "go.opentelemetry.io/otel/trace@v1.44.0")
+	require.Contains(t, text, "golang.org/x/text@v0.39.0")
 	require.Contains(t, text, "go-package: go-1.26")
 	require.Contains(t, text, "version --client-only")
 	require.Contains(t, text, "velero backup create --help")
@@ -68,10 +69,10 @@ func Test_Velero_resolves_only_fixed_local_package(t *testing.T) {
 	// When: the local Melange artifact is pinned for the image build.
 	err = pinLocalPackageVersions(&tmpl, "1", []apkindex.Package{{
 		Name:    "velero",
-		Version: "1.18.2-r1",
+		Version: "1.18.2-r4",
 	}})
 
 	// Then: apko can only select the approved fixed local revision.
 	require.NoError(t, err)
-	require.Equal(t, []string{"velero=1.18.2-r1@local"}, tmpl.Packages)
+	require.Equal(t, []string{"velero=1.18.2-r4@local"}, tmpl.Packages)
 }

--- a/internal/ci/repositoryops/native_package.go
+++ b/internal/ci/repositoryops/native_package.go
@@ -78,7 +78,12 @@ func (s NativeService) TestPackage(ctx context.Context, request *NativePackageRe
 			"test", "--arch", request.architecture,
 			"--repository-append", filepath.Join(request.repoRoot, "packages", "repo"),
 			"--repository-append", "https://packages.wolfi.dev/os",
-			"--keyring-append", filepath.Join(request.repoRoot, "melange-work", "melange.rsa.pub"),
+			"--keyring-append", filepath.Join(
+				request.repoRoot,
+				"packages",
+				"repo",
+				"melange-"+request.architecture+".rsa.pub",
+			),
 			"--keyring-append", "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
 			"--runner", "docker", "--pipeline-dirs", "melange-work/pipelines",
 			request.buildFile, request.packageName,

--- a/internal/ci/repositoryops/native_test.go
+++ b/internal/ci/repositoryops/native_test.go
@@ -34,7 +34,7 @@ func TestNativeService_TestPackage_buildsExactRcloneCommand(t *testing.T) {
 		"test", "--arch", "x86_64",
 		"--repository-append", filepath.Join(root, "packages", "repo"),
 		"--repository-append", "https://packages.wolfi.dev/os",
-		"--keyring-append", filepath.Join(root, "melange-work", "melange.rsa.pub"),
+		"--keyring-append", filepath.Join(root, "packages", "repo", "melange-x86_64.rsa.pub"),
 		"--keyring-append", "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
 		"--runner", "docker", "--pipeline-dirs", "melange-work/pipelines",
 		"melange-work/specs/rclone.yaml/build.yaml", "rclone",

--- a/internal/integer/melange/native_recipe_test.go
+++ b/internal/integer/melange/native_recipe_test.go
@@ -1,0 +1,45 @@
+package melange
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNativePackageRecipes_includeInvokedTestTools(t *testing.T) {
+	// Given: native package recipes whose test pipelines invoke external tools.
+	tests := []struct {
+		recipe string
+		tool   string
+	}{
+		{recipe: "velero.yaml", tool: "apk-tools"},
+		{recipe: "thanos.yaml", tool: "apk-tools"},
+		{recipe: "tempo-2.10.yaml", tool: "wget"},
+	}
+	paths := repositoryTestPaths(t)
+
+	for _, test := range tests {
+		t.Run(test.recipe, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(paths.BespokeDir, test.recipe))
+			require.NoError(t, err)
+			var recipe struct {
+				Test struct {
+					Environment struct {
+						Contents struct {
+							Packages []string `yaml:"packages"`
+						} `yaml:"contents"`
+					} `yaml:"environment"`
+				} `yaml:"test"`
+			}
+
+			// When: the Melange test environment is parsed.
+			require.NoError(t, yaml.Unmarshal(data, &recipe))
+
+			// Then: every command invoked by the test is installed explicitly.
+			require.Contains(t, recipe.Test.Environment.Contents.Packages, test.tool)
+		})
+	}
+}

--- a/packages/bespoke/tempo-2.10.yaml
+++ b/packages/bespoke/tempo-2.10.yaml
@@ -77,6 +77,7 @@ test:
       packages:
         - apk-tools
         - busybox
+        - wget
   pipeline:
     - runs: |
         tempo --version | grep -F "${{package.version}}"

--- a/packages/bespoke/thanos.yaml
+++ b/packages/bespoke/thanos.yaml
@@ -70,6 +70,7 @@ test:
   environment:
     contents:
       packages:
+        - apk-tools
         - curl
   pipeline:
     - runs: |

--- a/packages/bespoke/velero.yaml
+++ b/packages/bespoke/velero.yaml
@@ -2,9 +2,9 @@ package:
   name: velero
   # renovate: datasource=github-tags depName=velero-io/velero versioning=semver-coerced
   version: "1.18.2"
-  # r1 rebuilds the latest compatible release with OpenTelemetry 1.44.0,
-  # fixing CVE-2026-41178 (GHSA-5wrp-cwcj-q835).
-  epoch: 1
+  # r4 rebuilds the latest compatible release with OpenTelemetry 1.44.0 and
+  # golang.org/x/text 0.39.0, fixing CVE-2026-41178 and CVE-2026-56852.
+  epoch: 4
   description: Backup and migrate Kubernetes applications and their persistent volumes
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,7 @@ pipeline:
         go.opentelemetry.io/otel/sdk@v1.44.0
         go.opentelemetry.io/otel/sdk/metric@v1.44.0
         go.opentelemetry.io/otel/trace@v1.44.0
+        golang.org/x/text@v0.39.0
 
   - uses: go/build
     with:

--- a/packages/bespoke/velero.yaml
+++ b/packages/bespoke/velero.yaml
@@ -60,6 +60,10 @@ pipeline:
         "${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE"
 
 test:
+  environment:
+    contents:
+      packages:
+        - apk-tools
   pipeline:
     - runs: |
         velero version --client-only 2>&1 | grep -F "v${{package.version}}"


### PR DESCRIPTION
## Summary

- declare apk-tools for Velero and Thanos package tests that invoke apk info
- declare wget for Tempo readiness probes
- migrate every active Go consumer from the obsolete generic Melange key to packages/repo/melange-<arch>.rsa.pub
- update Velero to revision r4 with golang.org/x/text v0.39.0 for CVE-2026-56852
- lock recipe and command contracts with regression tests

## Runtime evidence

- bootstrap run 30284191297 exposed undeclared apk/wget test tools
- PR live smoke batches passed on amd64 and arm64 after declaring the test tools
- PR live build batches exposed and then cleared the generic pin-config keyring failure
- the next dual-architecture build reached the strict Trivy gate and rejected Velero 1.18.2-r1 for CVE-2026-56852; the Go vulnerability database fixes golang.org/x/text in v0.39.0 and Wolfi metadata marks Velero 1.18.2-r4 fixed
- Python 3.11-dev prep remains a separate transient Sigstore TUF timeout

## Verification

- go test -race -shuffle=on -count=1 ./...
- golangci-lint run --timeout=5m
- actionlint
- go run . ci workflow validate .github/workflows
- yamllint packages/bespoke/velero.yaml packages/bespoke/thanos.yaml packages/bespoke/tempo-2.10.yaml