### PR TITLE
fix(apk): repair bootstrap package tests

### DIFF
--- a/cmd/actions_runner_controller_config_test.go
+++ b/cmd/actions_runner_controller_config_test.go
@@ -57,7 +57,11 @@ func Test_ActionsRunnerController_recipe_tests_ghalistener_configuration_rejecti
 	// When: the listener smoke-test contract is inspected.
 
 	// Then: the non-CLI binary is exercised offline through its required configuration boundary.
-	require.Contains(t, text, `ghalistener 2>&1 | grep -F "LISTENER_CONFIG_PATH environment variable is not set"`)
+	require.Contains(t, text, `if output="$(ghalistener 2>&1)"; then
+          exit 1
+        fi
+        printf '%s\n' "$output" | grep -F "LISTENER_CONFIG_PATH environment variable is not set"`)
+	require.NotContains(t, text, `ghalistener 2>&1 | grep`)
 	require.NotContains(t, text, "ghalistener --help")
 }
 

--- a/internal/integer/melange/native_recipe_test.go
+++ b/internal/integer/melange/native_recipe_test.go
@@ -47,8 +47,8 @@ func TestNativePackageRecipes_includeInvokedTestTools(t *testing.T) {
 	}
 }
 
-func TestCiliumCompatRecipe_includesAPKToolsForVirtualPackageTest(t *testing.T) {
-	// Given: the locked Cilium recipe containing the compatibility subpackage.
+func TestCiliumRecipe_includesAPKToolsForEveryAPKInspectingSubpackageTest(t *testing.T) {
+	// Given: the locked Cilium recipe containing reusable tests that invoke apk.
 	paths := repositoryTestPaths(t)
 	data, err := os.ReadFile(filepath.Join(paths.LockedDir, "cilium-1.19.yaml"))
 	require.NoError(t, err)
@@ -61,22 +61,28 @@ func TestCiliumCompatRecipe_includesAPKToolsForVirtualPackageTest(t *testing.T) 
 						Packages []string `yaml:"packages"`
 					} `yaml:"contents"`
 				} `yaml:"environment"`
+				Pipeline []struct {
+					Uses string `yaml:"uses"`
+				} `yaml:"pipeline"`
 			} `yaml:"test"`
 		} `yaml:"subpackages"`
 	}
 	require.NoError(t, yaml.Unmarshal(data, &recipe))
 
-	// When: the compatibility subpackage test environment is selected.
-	var packages []string
+	// When: subpackage tests using APK-inspection pipelines are selected.
+	var inspected []string
 	for _, subpackage := range recipe.Subpackages {
-		if subpackage.Name == "${{package.name}}-compat" {
-			packages = subpackage.Test.Environment.Contents.Packages
-			break
+		for _, step := range subpackage.Test.Pipeline {
+			if step.Uses != "test/virtualpackage" && step.Uses != "test/emptypackage" {
+				continue
+			}
+			inspected = append(inspected, subpackage.Name)
+			require.Contains(t, subpackage.Test.Environment.Contents.Packages, "apk-tools", subpackage.Name)
 		}
 	}
 
-	// Then: the reusable virtual-package test can invoke apk explicitly.
-	require.Contains(t, packages, "apk-tools")
+	// Then: both current APK-inspection tests remain covered by the contract.
+	require.ElementsMatch(t, []string{"${{package.name}}-compat", "${{package.name}}-iptables"}, inspected)
 }
 
 func TestCraneRecipe_retainsCoverageFloorWithConfigProbe(t *testing.T) {

--- a/packages/bespoke/actions-runner-controller.yaml
+++ b/packages/bespoke/actions-runner-controller.yaml
@@ -58,6 +58,9 @@ test:
   pipeline:
     - runs: |
         manager --help
-        ghalistener 2>&1 | grep -F "LISTENER_CONFIG_PATH environment variable is not set"
+        if output="$(ghalistener 2>&1)"; then
+          exit 1
+        fi
+        printf '%s\n' "$output" | grep -F "LISTENER_CONFIG_PATH environment variable is not set"
         github-webhook-server --help
         actions-metrics-server --help

--- a/packages/bespoke/locked/cilium-1.19.yaml
+++ b/packages/bespoke/locked/cilium-1.19.yaml
@@ -175,6 +175,10 @@ subpackages:
       provides:
         - cilium-iptables=${{package.full-version}}
     test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
       pipeline:
         - uses: test/emptypackage
 

--- a/packages/upstream.lock.json
+++ b/packages/upstream.lock.json
@@ -125,7 +125,7 @@
     "cilium-1.19": {
       "file": "cilium-1.19.yaml",
       "version": "1.19.5",
-      "sha256": "99be4428ad399b8c8f877534b2594cf6a0658a60fef3b98d03972c20feb5ebd7",
+      "sha256": "3a80f74c9e5922c9fdec89f2f2bfb7a28f61ddca9e53e7c17a37d13afc40b157",
       "source": "public-recipe-baseline@3bc1a15922962c2ffbc0844b7f98672b79c5fd71",
       "upstream": "cilium/cilium@v1.19.5",
       "cve_tracking": "package version bumped from 1.19.1 public recipe to 1.19.5; epoch 5 carries real bundled Go dependency remediation for CVE-2026-39882, CVE-2026-39883, CVE-2026-41178 via go.opentelemetry.io/otel core modules and CVE-2026-2303 via go.mongodb.org/mongo-driver, with vendor/modules.txt regenerated during build; /var/lib path chmod and writable /var/lib/db/sbom creation added in main and clustermesh subpackage so melange can preserve workspace xattrs and write SBOM metadata on aarch64",


### PR DESCRIPTION
## Summary
- install `apk-tools` for every Cilium subpackage test that invokes APK inspection
- handle the expected non-zero `ghalistener` configuration rejection without failing under Melange `pipefail`
- lock both failures with parsed recipe regression tests

## Evidence
- protected bootstrap run 30308154502:
  - Cilium aarch64 job 90121602022 exited 127 in `test/emptypackage` because `apk` was absent
  - Actions Runner Controller aarch64 job 90121658426 emitted the expected diagnostic, then failed because `pipefail` preserved the expected producer exit code
- red-to-green focused tests for both defects
- `go test -race -shuffle=on -count=1 ./...`
- golangci-lint, actionlint, yamllint, workflow policy validation, and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing bootstrap tests by ensuring APK inspection tools are present and by safely asserting the expected `ghalistener` config error under `pipefail`.

- **Bug Fixes**
  - Install `apk-tools` in Cilium subpackage tests that use `test/emptypackage`/`test/virtualpackage` (covers `cilium-compat` and `cilium-iptables`).
  - Capture `ghalistener` output and assert the expected config message without breaking `pipefail`.
  - Add regression tests to lock both behaviors.

- **Dependencies**
  - Update `cilium-1.19` lock SHA in `packages/upstream.lock.json`.

<sup>Written for commit 3ad4fb210f47da5c04e2cc307f0c15c61872ff10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

