### PR TITLE
fix(apk): harden etcd native smoke test

### DIFF
--- a/internal/integer/melange/bootstrap_recipe_test.go
+++ b/internal/integer/melange/bootstrap_recipe_test.go
@@ -38,6 +38,22 @@ func Test_NativeBootstrapRecipes_useReliableOfflineSmokeCommands(t *testing.T) {
 			required:  []string{`grep -F "Permission is hereby granted, free of charge"`},
 			forbidden: []string{`grep -F "MIT License"`},
 		},
+		testCase{
+			name:     "etcd waits for readiness and preserves server logs",
+			filename: "locked/etcd-3.6.yaml",
+			required: []string{
+				`DATA_DIR=$(mktemp -d)`,
+				`LOG_FILE=$(mktemp)`,
+				`wait "$ETCD_PID" 2>/dev/null || true`,
+				`for attempt in $(seq 1 30)`,
+				`cat "$LOG_FILE"`,
+				`--endpoints="$ENDPOINT" put`,
+			},
+			forbidden: []string{
+				`sleep 5 # Wait for etcd to start`,
+				`> /dev/null 2>&1 &`,
+			},
+		},
 	)
 	for _, version := range []string{"1.14", "1.15", "1.16", "1.17", "1.18"} {
 		tests = append(tests, testCase{

--- a/packages/bespoke/locked/etcd-3.6.yaml
+++ b/packages/bespoke/locked/etcd-3.6.yaml
@@ -164,22 +164,36 @@ test:
         etcdctl --help
         etcdutl version
         etcdutl --help
-    - name: Start etcd server and perform health check
+    - name: Exercise etcd runtime
       runs: |
-        # Start etcd in the background
-        etcd > /dev/null 2>&1 &
+        set -euo pipefail
+        ENDPOINT="http://127.0.0.1:12379"
+        PEER_ENDPOINT="http://127.0.0.1:12380"
+        DATA_DIR=$(mktemp -d)
+        LOG_FILE=$(mktemp)
+
+        etcd \
+          --name default \
+          --data-dir "$DATA_DIR" \
+          --listen-client-urls "$ENDPOINT" \
+          --advertise-client-urls "$ENDPOINT" \
+          --listen-peer-urls "$PEER_ENDPOINT" \
+          --initial-advertise-peer-urls "$PEER_ENDPOINT" \
+          --initial-cluster "default=$PEER_ENDPOINT" \
+          > "$LOG_FILE" 2>&1 &
         ETCD_PID=$!
-        sleep 5 # Wait for etcd to start
-        # Perform a health check
-        etcdctl endpoint health
-        kill $ETCD_PID
-    - name: Set and get a key-value pair
-      runs: |
-        etcd > /dev/null 2>&1 &
-        ETCD_PID=$!
-        sleep 5 # Wait for etcd to start
-        # Set a key-value pair
-        etcdctl put mykey "Hello, etcd"
-        # Get the value
-        etcdctl get mykey | grep -q "Hello, etcd"
-        kill $ETCD_PID
+        trap 'kill "$ETCD_PID" 2>/dev/null || true; wait "$ETCD_PID" 2>/dev/null || true; rm -rf "$DATA_DIR" "$LOG_FILE"' EXIT
+
+        for attempt in $(seq 1 30); do
+          if etcdctl --endpoints="$ENDPOINT" endpoint health; then
+            break
+          fi
+          if ! kill -0 "$ETCD_PID" 2>/dev/null || [ "$attempt" -eq 30 ]; then
+            cat "$LOG_FILE"
+            exit 1
+          fi
+          sleep 1
+        done
+
+        etcdctl --endpoints="$ENDPOINT" put mykey "Hello, etcd"
+        test "$(etcdctl --endpoints="$ENDPOINT" get mykey --print-value-only)" = "Hello, etcd"

--- a/packages/upstream.lock.json
+++ b/packages/upstream.lock.json
@@ -137,7 +137,7 @@
     "etcd": {
       "file": "etcd-3.6.yaml",
       "version": "3.6.13",
-      "sha256": "aae0634d9f939cb9c0761e2b93ec0b7ccd6470931a705866792cb7c62c547484",
+      "sha256": "e74bd6f3c6175c8db730ae8cdfb21e08ef4ef106426b87f3f8f3dbd3cd2c674b",
       "source": "public-recipe-baseline@3bc1a15922962c2ffbc0844b7f98672b79c5fd71",
       "cve_tracking": "bumped to 3.6.13-r1 for CVE-2026-41178 and forced go.opentelemetry.io/otel/sdk v1.44.0 in every module; retained public-build compatibility and writable SBOM output fixes; publication remains contingent on the strict zero-vulnerability gate",
       "assets": {}


### PR DESCRIPTION
## Summary

- replace fixed sleeps and shared etcd defaults with bounded readiness polling
- preserve server logs on failure and guarantee process/data cleanup
- lock the native recipe contract and update the exact recipe digest

## Verification

- `go test -race -shuffle=on -count=1 ./internal/integer/melange`
- `go run . integer validate` (335 images)
- `mise exec -- yamllint packages/bespoke/locked/etcd-3.6.yaml`
- real published Verity etcd binaries: endpoint health, put, and get passed in Alpine

Bootstrap evidence: run `30327775654`, job `90179392581` reached health on the first launch then failed the weak second launch with loopback connection refused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the native `etcd` smoke test by replacing fixed sleeps with a bounded readiness check, capturing logs on failure, and ensuring clean teardown. Updates the locked recipe and digest to reduce CI flakiness and keep builds deterministic.

- **Bug Fixes**
  - In `packages/bespoke/locked/etcd-3.6.yaml`: start `etcd` with explicit loopback URLs, poll `etcdctl endpoint health` up to 30s, dump server logs on failure, and trap cleanup for process and temp dirs; use `--endpoints` for put/get.
  - In `internal/integer/melange/bootstrap_recipe_test.go`: added assertions for readiness polling, log preservation, and removal of fixed sleeps/background redirection.
  - In `packages/upstream.lock.json`: updated `etcd-3.6.yaml` `sha256` to lock the exact recipe content.

<sup>Written for commit a72d400eb98362da9aff5caf4cfa97d36b973216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

