### PR TITLE
fix(apk): isolate kyverno package tests

### DIFF
--- a/internal/integer/melange/bootstrap_recipe_test.go
+++ b/internal/integer/melange/bootstrap_recipe_test.go
@@ -57,10 +57,17 @@ func Test_NativeBootstrapRecipes_useReliableOfflineSmokeCommands(t *testing.T) {
 	)
 	for _, version := range []string{"1.14", "1.15", "1.16", "1.17", "1.18"} {
 		tests = append(tests, testCase{
-			name:      "kyverno " + version + " uses root help",
-			filename:  "kyverno-" + version + ".yaml",
-			required:  []string{"kyverno --help"},
-			forbidden: []string{"kyverno version --help"},
+			name:     "kyverno " + version + " tests only its package binary",
+			filename: "kyverno-" + version + ".yaml",
+			required: []string{"kyverno --help"},
+			forbidden: []string{
+				"kyverno version --help",
+				"/usr/bin/background-controller",
+				"/usr/bin/cleanup-controller",
+				"/usr/bin/reports-controller",
+				"/usr/bin/kubectl-kyverno",
+				"/usr/bin/kyvernopre",
+			},
 		})
 	}
 

--- a/packages/bespoke/kyverno-1.14.yaml
+++ b/packages/bespoke/kyverno-1.14.yaml
@@ -86,8 +86,3 @@ test:
   pipeline:
     - runs: |
         kyverno --help
-        /usr/bin/background-controller --help
-        /usr/bin/cleanup-controller --help
-        /usr/bin/reports-controller --help
-        /usr/bin/kubectl-kyverno --help
-        /usr/bin/kyvernopre --help

--- a/packages/bespoke/kyverno-1.15.yaml
+++ b/packages/bespoke/kyverno-1.15.yaml
@@ -86,8 +86,3 @@ test:
   pipeline:
     - runs: |
         kyverno --help
-        /usr/bin/background-controller --help
-        /usr/bin/cleanup-controller --help
-        /usr/bin/reports-controller --help
-        /usr/bin/kubectl-kyverno --help
-        /usr/bin/kyvernopre --help

--- a/packages/bespoke/kyverno-1.16.yaml
+++ b/packages/bespoke/kyverno-1.16.yaml
@@ -86,8 +86,3 @@ test:
   pipeline:
     - runs: |
         kyverno --help
-        /usr/bin/background-controller --help
-        /usr/bin/cleanup-controller --help
-        /usr/bin/reports-controller --help
-        /usr/bin/kubectl-kyverno --help
-        /usr/bin/kyvernopre --help

--- a/packages/bespoke/kyverno-1.17.yaml
+++ b/packages/bespoke/kyverno-1.17.yaml
@@ -86,8 +86,3 @@ test:
   pipeline:
     - runs: |
         kyverno --help
-        /usr/bin/background-controller --help
-        /usr/bin/cleanup-controller --help
-        /usr/bin/reports-controller --help
-        /usr/bin/kubectl-kyverno --help
-        /usr/bin/kyvernopre --help

--- a/packages/bespoke/kyverno-1.18.yaml
+++ b/packages/bespoke/kyverno-1.18.yaml
@@ -87,8 +87,3 @@ test:
   pipeline:
     - runs: |
         kyverno --help
-        /usr/bin/background-controller --help
-        /usr/bin/cleanup-controller --help
-        /usr/bin/reports-controller --help
-        /usr/bin/kubectl-kyverno --help
-        /usr/bin/kyvernopre --help


### PR DESCRIPTION
## Summary

- make each main Kyverno recipe test only the binary owned by its APK
- keep background, cleanup, reports, CLI, and init binaries covered by their separate package recipes
- add a parsed regression contract across Kyverno 1.14 through 1.18

## Verification

- failing-first ownership regression reproduced `/usr/bin/background-controller: not found`
- `go test -race -shuffle=on -count=1 ./internal/integer/melange`
- `go run . integer validate` (335 images)
- yamllint and `git diff --check`
- focused real `kyverno:1.17-default` x86_64 prepare/build/test-packages passed all five isolated main APK tests

Bootstrap evidence: run `30332722053` failed all six Kyverno aliases on the same cross-package assertion after 713 other jobs succeeded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated `kyverno` APK tests so each versioned package only checks its own `kyverno` binary, preventing cross-package test failures. Added a regression contract across 1.14–1.18 to enforce binary ownership.

- **Bug Fixes**
  - For each `kyverno` 1.14–1.18 recipe, forbid non-owned binaries (`background-controller`, `cleanup-controller`, `reports-controller`, `kubectl-kyverno`, `kyvernopre`) in tests.
  - Removed those commands from `packages/bespoke/kyverno-1.14.yaml`–`-1.18.yaml`; their coverage stays in their own package recipes.
  - Extended `bootstrap_recipe_test.go` to validate the new constraints for 1.14–1.18.

<sup>Written for commit 93fea2bc9872045a6876b3b7ed4e3f07e475911f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

