### PR TITLE
fix(ci): name Integer jobs by target

### DIFF
--- a/.github/workflows/integer-build-image-reusable.yaml
+++ b/.github/workflows/integer-build-image-reusable.yaml
@@ -79,7 +79,7 @@ permissions:
 
 jobs:
   validate-coordinates:
-    name: Validate reusable-call coordinates
+    name: "Validate ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }} coordinates"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -120,7 +120,7 @@ jobs:
         run: "true"
 
   melange-prep:
-    name: Melange prep
+    name: "Prepare ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }} recipe"
     needs: validate-coordinates
     if: needs.validate-coordinates.result == 'success'
     runs-on: ubuntu-latest
@@ -183,7 +183,7 @@ jobs:
           retention-days: "1"
 
   melange-build:
-    name: "Melange build (${{ matrix.arch }})"
+    name: "Build ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }} APKs (${{ matrix.arch }})"
     needs: [melange-prep]
     if: needs.melange-prep.outputs.needed == 'true'
     permissions:
@@ -264,7 +264,7 @@ jobs:
           retention-days: "1"
 
   build:
-    name: "Build ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }}"
+    name: "Publish ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }}"
     needs: [melange-prep, melange-build]
     if: >-
       always() &&

--- a/internal/ci/workflowpolicy/integer_job_names_test.go
+++ b/internal/ci/workflowpolicy/integer_job_names_test.go
@@ -1,0 +1,36 @@
+package workflowpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestIntegerBuildImageReusable_jobsNameTargetAndStage(t *testing.T) {
+	// Given: the production reusable workflow expanded once per Integer target.
+	var parsed struct {
+		Jobs map[string]struct {
+			Name string `yaml:"name"`
+		} `yaml:"jobs"`
+	}
+	require.NoError(t, yaml.Unmarshal(
+		[]byte(readRepositoryIntegerWorkflowText(t, "integer-build-image-reusable.yaml")),
+		&parsed,
+	))
+
+	// When: GitHub renders each reusable job's display name.
+	want := map[string]string{
+		"validate-coordinates": "Validate ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }} coordinates",
+		"melange-prep":         "Prepare ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }} recipe",
+		"melange-build":        "Build ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }} APKs (${{ matrix.arch }})",
+		"build":                "Publish ${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }}",
+	}
+
+	// Then: every repeated job identifies both its target and its current stage.
+	for job, name := range want {
+		require.Contains(t, parsed.Jobs, job)
+		assert.Equal(t, name, parsed.Jobs[job].Name, "job %s", job)
+	}
+}


### PR DESCRIPTION
## Summary

- include image, version, and type in every reusable Integer job name
- include architecture in APK build jobs
- distinguish validation, recipe preparation, APK build, and publication stages
- add a workflow contract test for the GitHub-visible labels

The current bootstrap produced 197 identical coordinate-validation labels, 195 identical preparation labels, and 388 labels differentiated only by architecture. These names make live failure triage unnecessarily difficult.

## Verification

- go test -race -shuffle=on -count=1 ./internal/ci/workflowpolicy
- actionlint .github/workflows/integer-build-image-reusable.yaml
- go run . ci workflow validate .github/workflows
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Integer reusable workflow job names unique and readable by including the target (image:version-type) and stage. Adds a contract test to lock the GitHub-visible labels and prevent regressions.

- **Bug Fixes**
  - Job names now include `${{ inputs.image }}:${{ inputs.version }}-${{ inputs.type }}`; APK build names also include `${{ matrix.arch }}`.
  - Clear stages: Validate, Prepare, Build, Publish.
  - Added `internal/ci/workflowpolicy/integer_job_names_test.go` to assert the expected labels.

<sup>Written for commit 24b327e0d257ef4fb80bc755a02b93bd3dad40af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

