### PR TITLE
fix(ci): verify RunsOn build attestations

### DIFF
--- a/.github/actions/setup-verity/action.yml
+++ b/.github/actions/setup-verity/action.yml
@@ -100,7 +100,6 @@ runs:
         --signer-digest "$VERITY_SOURCE_SHA"
         --source-digest "$VERITY_SOURCE_SHA"
         --predicate-type "https://slsa.dev/provenance/v1"
-        --deny-self-hosted-runners
 
     - name: Activate verified Verity binary
       shell: bash

--- a/cmd/setup_verity_action_test.go
+++ b/cmd/setup_verity_action_test.go
@@ -20,4 +20,5 @@ func TestSetupVerityAction_usesOneAttestationIdentitySelector(t *testing.T) {
 
 	// Then it selects the exact workflow without combining mutually exclusive identity flags.
 	require.Equal(t, 0, strings.Count(action, "--signer-repo"))
+	require.NotContains(t, action, "--deny-self-hosted-runners")
 }

--- a/internal/ci/workflowpolicy/build_once_action.go
+++ b/internal/ci/workflowpolicy/build_once_action.go
@@ -189,7 +189,7 @@ func validateAttestationStep(name string, step *workflowStep) []Violation {
 	markers := []string{
 		`--repo "$GITHUB_REPOSITORY"`,
 		`--signer-workflow "` + setupSignerWorkflow + `"`,
-		`--signer-digest "$VERITY_SOURCE_SHA"`, `--source-digest "$VERITY_SOURCE_SHA"`, `--deny-self-hosted-runners`,
+		`--signer-digest "$VERITY_SOURCE_SHA"`, `--source-digest "$VERITY_SOURCE_SHA"`,
 		`--predicate-type "https://slsa.dev/provenance/v1"`,
 	}
 	for _, marker := range markers {
@@ -200,6 +200,9 @@ func validateAttestationStep(name string, step *workflowStep) []Violation {
 	}
 	if strings.Contains(step.Run, "--signer-repo") {
 		violations = append(violations, buildOnceViolation(name, "composite", "mutually exclusive attestation identity selectors are forbidden"))
+	}
+	if strings.Contains(step.Run, "--deny-self-hosted-runners") {
+		violations = append(violations, buildOnceViolation(name, "composite", "RunsOn producer attestations must remain verifiable"))
 	}
 	return violations
 }

--- a/internal/ci/workflowpolicy/testdata/build-once/.github/actions/consume-verity/action.yml
+++ b/internal/ci/workflowpolicy/testdata/build-once/.github/actions/consume-verity/action.yml
@@ -95,7 +95,6 @@ runs:
         --signer-digest "$VERITY_SOURCE_SHA"
         --source-digest "$VERITY_SOURCE_SHA"
         --predicate-type "https://slsa.dev/provenance/v1"
-        --deny-self-hosted-runners
     - name: Activate verified Verity binary
       shell: bash
       env:

--- a/internal/ci/workflowpolicy/testdata/build-once/action-mutations.yaml
+++ b/internal/ci/workflowpolicy/testdata/build-once/action-mutations.yaml
@@ -38,6 +38,10 @@
   old: "--predicate-type \"https://slsa.dev/provenance/v1\""
   replacement: "--predicate-type \"https://example.test/weak\""
   want: signer workflow
+- name: reject GitHub-hosted-only attestation policy
+  old: "--predicate-type \"https://slsa.dev/provenance/v1\""
+  replacement: "--predicate-type \"https://slsa.dev/provenance/v1\"\n        --deny-self-hosted-runners"
+  want: RunsOn producer attestations
 - name: mutable download path
   old: "path: ${{ runner.temp }}/setup-verity/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/download"
   replacement: "path: ${{ inputs.artifact-name }}"


### PR DESCRIPTION
## Summary

- allow exact protected Verity attestations produced by policy-verified RunsOn runners
- retain repository, signer workflow, signer/source digest, predicate, artifact digest, and current-run checks
- reject reintroducing the incompatible GitHub-hosted-only verifier flag

## Runtime evidence

Bootstrap run 30439849377 downloaded the exact artifact, then failed because `--deny-self-hosted-runners` rejects the intended RunsOn producer. The same artifact verifies with all exact provenance selectors after removing only that flag; a wrong signer digest still fails closed.

## Verification

- `go test ./...`
- `gopls check cmd/setup_verity_action_test.go internal/ci/workflowpolicy/build_once_action.go`
- `golangci-lint run --timeout=5m`
- `actionlint`
- `go run . ci workflow validate .github/workflows`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows verification of SLSA build attestations produced by RunsOn self-hosted runners. Removes the GitHub-hosted-only verifier flag and adds a policy check to keep RunsOn attestations verifiable while preserving strict provenance selectors.

- **Bug Fixes**
  - Remove `--deny-self-hosted-runners` from the setup-verity action and test fixtures.
  - Add a workflow policy rule to reject that flag; update mutation tests and action test.
  - Preserve exact provenance checks (repo, signer workflow, signer/source digest, SLSA predicate, current run).

<sup>Written for commit e21eef46470b4febc16df9374c59e7993270149b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/verity-org/verity/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

